### PR TITLE
docs(p1): add HL2 capture-reference for Phase 3L grounding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,7 +346,8 @@ preferences. OpenHPSDR radios don't store per-slice state.
 
 | Document | Scope |
 | --- | --- |
-| [openhpsdr-protocol1.md](docs/protocols/openhpsdr-protocol1.md) | P1 UDP framing, 1032-byte Metis frames, C&C bytes, EP6 I/Q format |
+| [openhpsdr-protocol1.md](docs/protocols/openhpsdr-protocol1.md) | P1 summary + pointer to capture reference; Thetis P1 source map |
+| [openhpsdr-protocol1-capture-reference.md](docs/protocols/openhpsdr-protocol1-capture-reference.md) | Annotated HL2↔Thetis capture: discovery, start/stop, EP6/EP2 frames, C0 maps, cadence, band/TX traces, HL2 quirks, Phase 3L checklist |
 | [openhpsdr-protocol2.md](docs/protocols/openhpsdr-protocol2.md) | P2 UDP multi-port, command packets, per-DDC I/Q streams |
 
 ### Phase 1 Analysis Docs (`docs/phase1/`)

--- a/docs/architecture/2026-04-12-p1-capture-reference-plan.md
+++ b/docs/architecture/2026-04-12-p1-capture-reference-plan.md
@@ -12,7 +12,20 @@
 - Capture (extracted, do not re-extract): `/tmp/hl2cap/HL2_Packet_Capture.pcapng` (320 MB)
 - Filtered subset (created in Task 1): `/tmp/hl2cap/hl2_session.pcapng`
 - Spec being implemented: `docs/superpowers/specs/2026-04-12-p1-capture-reference-design.md`
-- Thetis source: `/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs`
+
+
+**Thetis P1 source map** — discovered during Task 3. Most P1 byte-level code lives in the **unmanaged ChannelMaster C source**, not in the C# `NetworkIO.cs` file. Subagents must grep the right file for what they need:
+
+| Topic | Authoritative file |
+| --- | --- |
+| Discovery request build / reply parse | `/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/clsRadioDiscovery.cs` (C#, ~lines 1100-1310) |
+| Metis start/stop, EP2 send, EP6 receive, sequence numbers | `/Users/j.j.boyd/Thetis/Project Files/Source/ChannelMaster/networkproto1.c` (C, 749 lines, by W5WC) |
+| Metis socket setup, port binding, generic frame I/O | `/Users/j.j.boyd/Thetis/Project Files/Source/ChannelMaster/network.c` (C, 1494 lines) |
+| C# P/Invoke surface (function names, signatures) | `/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIOImports.cs` |
+| C# wrapper layer (state, callbacks) | `/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs` |
+| Board-ID enum | `/Users/j.j.boyd/Thetis/Project Files/Source/Console/enums.cs` |
+
+**Citation rule:** cite whichever file actually contains the byte layout being decoded. For Tasks 4-9 this will USUALLY be `networkproto1.c`. The grep commands shown in subsequent tasks use `NetworkIO.cs` but were written before the source layout was understood — if `NetworkIO.cs` returns no matches, retry against `networkproto1.c` and `network.c`. The `READ → SHOW → TRANSLATE` rule requires the citation to point at the file the code actually lives in.
 
 **Conventions:**
 - All hex dumps in the doc come from `tshark -x` output, trimmed to the relevant payload range, fenced with ` ```` `.

--- a/docs/architecture/2026-04-12-p1-capture-reference-plan.md
+++ b/docs/architecture/2026-04-12-p1-capture-reference-plan.md
@@ -1,0 +1,714 @@
+# P1 Capture-Reference Document Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce `docs/protocols/openhpsdr-protocol1-capture-reference.md` — a complete, byte-level annotated reference of an HL2↔Thetis Protocol 1 conversation extracted from `HL2_Packet_Capture.pcapng`, so Phase 3L can implement P1 support against ground truth instead of inference.
+
+**Architecture:** This is a documentation-only deliverable. Each section of the target doc is built by one task: a tshark extraction step → a Thetis cross-reference step → a markdown drafting step → a commit. No source code is modified except a small link/absorb edit to the existing P1 placeholder doc at the end.
+
+**Tech Stack:** `tshark` (already installed at `/opt/homebrew/bin/tshark`), `awk`, plain markdown. Source citations come from `../Thetis/Project Files/Source/Console/NetworkIO.cs` per the project's READ → SHOW → TRANSLATE rule (CLAUDE.md).
+
+**Working files:**
+- Capture (extracted, do not re-extract): `/tmp/hl2cap/HL2_Packet_Capture.pcapng` (320 MB)
+- Filtered subset (created in Task 1): `/tmp/hl2cap/hl2_session.pcapng`
+- Spec being implemented: `docs/superpowers/specs/2026-04-12-p1-capture-reference-design.md`
+- Thetis source: `../Thetis/Project Files/Source/Console/NetworkIO.cs`
+
+**Conventions:**
+- All hex dumps in the doc come from `tshark -x` output, trimmed to the relevant payload range, fenced with ` ```` `.
+- Every byte-layout claim cites `NetworkIO.cs:<line>` (or another file with line number).
+- Every tshark command used appears verbatim in Appendix A.
+- Commit message prefix: `docs(p1):`.
+- Co-author trailer per user memory: `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`. GPG-sign commits.
+
+---
+
+## Task 1: Subset the capture and confirm Thetis source availability
+
+**Files:**
+- Create: `/tmp/hl2cap/hl2_session.pcapng`
+- Read-only: `../Thetis/Project Files/Source/Console/NetworkIO.cs`
+
+- [ ] **Step 1: Verify Thetis clone is present**
+
+Run: `ls "../Thetis/Project Files/Source/Console/NetworkIO.cs"`
+Expected: file exists.
+If missing, STOP and tell the user — per CLAUDE.md, do not invent protocol details. Ask where the Thetis clone lives.
+
+- [ ] **Step 2: Build the filtered session pcap**
+
+Run:
+```bash
+tshark -r /tmp/hl2cap/HL2_Packet_Capture.pcapng \
+  -Y 'udp.port == 1024' \
+  -w /tmp/hl2cap/hl2_session.pcapng
+```
+Expected: no errors. New file ~324 MB (P1 traffic dominates).
+
+- [ ] **Step 3: Sanity-check the subset**
+
+Run: `tshark -r /tmp/hl2cap/hl2_session.pcapng -q -z conv,udp`
+Expected: shows the `169.254.105.135:50534 ↔ 169.254.19.221:1024` conversation with ~302k frames and the discovery exchange on `:50533`.
+
+- [ ] **Step 4: No commit** (working file is in `/tmp`, not in repo).
+
+---
+
+## Task 2: Scaffold the target doc with the front-matter and metadata table
+
+**Files:**
+- Create: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Create the file with this exact content**
+
+```markdown
+---
+date: 2026-04-12
+author: JJ Boyd (KG4VCF)
+status: Reference — derived from HL2_Packet_Capture.pcapng
+related:
+  - docs/protocols/openhpsdr-protocol1.md
+  - docs/architecture/radio-abstraction.md
+  - docs/superpowers/specs/2026-04-12-p1-capture-reference-design.md
+---
+
+# OpenHPSDR Protocol 1 — Annotated Capture Reference (Hermes Lite 2)
+
+This document is the byte-level ground-truth reference for OpenHPSDR
+Protocol 1 as implemented by Hermes Lite 2 firmware, derived from a
+single live capture of a Thetis-class host talking to an HL2 over a
+direct link-local Ethernet connection. Every layout claim in this doc
+is backed by a hex dump from the capture and a Thetis `NetworkIO.cs`
+source citation. NereusSDR Phase 3L (P1 support) implements against
+this document.
+
+## 1. Capture Metadata
+
+| Property | Value |
+| --- | --- |
+| File | `HL2_Packet_Capture.pcapng` (~324 MB) |
+| Frames | 302,256 total (302,252 IPv4/UDP, 4 ARP) |
+| Duration | ~55.7 s session (+ ~4 s DHCP tail) |
+| Host | `169.254.105.135` (link-local) |
+| Radio (HL2) | `169.254.19.221`, UDP port `1024` |
+| Discovery | host `:50533` → broadcast `:1024`, reply from radio |
+| Session | host `:50534` ↔ radio `:1024` |
+| Direction split | 281,195 frames radio→host (EP6), 21,049 frames host→radio (EP2) |
+
+The capture is a single clean session: discovery → start → steady-state
+RX → stop. Subsequent sections walk through each phase.
+
+<!-- Sections 2-10 and Appendix A added by later tasks -->
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/j.j.boyd/NereusSDR
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): scaffold HL2 capture reference doc
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Section 2 — Discovery exchange
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Extract the four discovery frames**
+
+Run:
+```bash
+tshark -r /tmp/hl2cap/HL2_Packet_Capture.pcapng \
+  -Y 'udp.port == 1024 and (ip.src == 169.254.105.135 or ip.dst == 169.254.105.135) and udp.srcport == 50533 or udp.dstport == 50533' \
+  -x | head -200
+```
+Expected: 4 packets — 2 host→broadcast, 2 radio→host. First two bytes of each payload should be `ef fe`. The discovery request payload starts `ef fe 02 00...`; the reply should start `ef fe 02 0X` or `ef fe 03 ...` (record what you actually see).
+
+- [ ] **Step 2: Locate Thetis discovery code**
+
+Run: `grep -n -i 'discover\|0xeffe\|0xef, 0xfe' "../Thetis/Project Files/Source/Console/NetworkIO.cs" | head -40`
+Record the line numbers of the discovery send and discovery reply parser.
+
+- [ ] **Step 3: Append Section 2 to the doc**
+
+Add a new `## 2. Discovery Exchange` section that contains:
+- A short prose description.
+- The hex dump of one host→radio discovery request frame, fenced as ```` ```text ```` ````, with bytes annotated by adding a second fenced block beneath it labeling each field (sync `EF FE`, command `02`, padding).
+- The hex dump of one radio→host discovery reply, with byte annotations: status, board ID byte, firmware version bytes, MAC bytes — using the *actual* values seen.
+- A "Cross-reference" line: `Thetis: NetworkIO.cs:<line> (send), NetworkIO.cs:<line> (reply parse)`.
+- Do NOT invent fields. If a byte's meaning is unclear from `NetworkIO.cs`, mark it `unknown — investigate before implementing`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): document HL2 discovery request/reply
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Section 3 — Start / Stop commands
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Find the start frame**
+
+Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.payload[0:3] == ef:fe:04' \
+  -x | head -80
+```
+Expected: at least one frame near the start of the session. Record its frame number (`-T fields -e frame.number`).
+
+- [ ] **Step 2: Find the stop frame**
+
+Run the same query against the end of the capture:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.payload[0:3] == ef:fe:04' \
+  -T fields -e frame.number -e frame.time_relative
+```
+Expected: a list of `04` frames; the last one(s) should be the stop. The byte at offset 3 distinguishes start vs stop variants — record what you see.
+
+- [ ] **Step 3: Locate Thetis start/stop send code**
+
+Run: `grep -n 'MetisStartStop\|metis_start\|0x04' "../Thetis/Project Files/Source/Console/NetworkIO.cs" | head -20`
+Record the function name and line number.
+
+- [ ] **Step 4: Append Section 3 to the doc**
+
+Add `## 3. Start / Stop Commands` containing:
+- Hex dump of the start frame payload (first ~16 bytes are enough; pad bytes after that).
+- Decoded fields: sync `EF FE`, command `04`, mode byte (and what its bits mean per `NetworkIO.cs`), padding.
+- Hex dump of the stop frame.
+- Cross-reference line citing `NetworkIO.cs:<line>`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): document Metis start/stop commands
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Section 4 — EP6 radio→host Metis frame anatomy
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Confirm EP6 frame size and shape**
+
+Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221 and udp.payload[0:3] == ef:fe:01' \
+  -T fields -e frame.len | sort -u
+```
+Expected: a single value (1074 = 14 eth + 20 ip + 8 udp + 1032 payload, or similar). Record it. If multiple sizes appear, document each one in the section instead of just one.
+
+- [ ] **Step 2: Pull one representative EP6 frame as hex**
+
+Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221 and udp.payload[0:3] == ef:fe:01' \
+  -c 1 -x
+```
+Save the full hex output — this is the annotated example for Section 4.
+
+- [ ] **Step 3: Enumerate all C0 status indices observed in EP6**
+
+The C0 byte is at offset 11 in the UDP payload (8 Metis header + 3 sync `7F 7F 7F`). Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221 and udp.payload[0:3] == ef:fe:01' \
+  -T fields -e udp.payload \
+  | awk '{print toupper(substr($0, 23, 2))}' \
+  | sort | uniq -c | sort -rn
+```
+(Offsets in `awk`: each hex byte is 2 chars, so byte 11 starts at char position 23.)
+Expected: a small set of C0 values with counts. Record the table.
+
+- [ ] **Step 4: Locate Thetis EP6 parser**
+
+Run: `grep -n 'ProcessMetisData\|EP6\|0x7F, 0x7F, 0x7F\|c1_addr' "../Thetis/Project Files/Source/Console/NetworkIO.cs" | head -40`
+Record the function and line range that parses incoming EP6 frames and decodes C1–C4 by C0 index.
+
+- [ ] **Step 5: Append Section 4 to the doc**
+
+Write `## 4. EP6 — Radio → Host Metis Frames` containing:
+- Frame-size note from Step 1.
+- The annotated hex dump from Step 2, with a per-byte legend covering: 8-byte Metis header (`EF FE 01 06 <seq32>`), USB frame 1 sync `7F 7F 7F`, C0, C1–C4, then the 504-byte I/Q+mic payload (just describe the payload structure: 24-bit BE I, 24-bit BE Q, 16-bit BE mic, repeated; samples-per-frame depends on receiver count — note what this capture's count appears to be from the start frame in Section 3).
+- USB frame 2 (offsets 520–1031) — same structure.
+- Table of every C0 status index seen in this capture, with C1–C4 meaning per Thetis source. Mark any unrecognized index as `observed but unmapped — investigate`.
+- Cross-reference line.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): document EP6 Metis frame anatomy and C0 status map
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Section 5 — EP2 host→radio command frames
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Confirm EP2 frame shape**
+
+Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024 and udp.payload[0:3] == ef:fe:02' \
+  -T fields -e frame.len | sort -u
+```
+Expected: a single frame size. Record it.
+
+- [ ] **Step 2: Enumerate every C0 round-robin index sent by the host**
+
+The C0 byte for EP2 is at the same offset (8-byte Metis header, then 3-byte sync `7F 7F 7F`, then C0 at offset 11). Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024 and udp.payload[0:3] == ef:fe:02' \
+  -T fields -e udp.payload \
+  | awk '{print toupper(substr($0, 23, 2))}' \
+  | sort | uniq -c | sort -rn
+```
+Record the table — this is the universe of host→radio commands the capture exercises.
+
+- [ ] **Step 3: For each distinct C0, pull one representative frame and grab C1–C4**
+
+For each C0 value `XX` from Step 2, run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y "ip.src == 169.254.105.135 and udp.dstport == 1024 and udp.payload[11] == XX" \
+  -c 1 -x
+```
+Record the C0 and the four C1–C4 bytes from the first USB frame.
+
+- [ ] **Step 4: Locate Thetis EP2 send code**
+
+Run: `grep -n 'NetworkSendC\|MetisCommand\|c0 = \|round_robin' "../Thetis/Project Files/Source/Console/NetworkIO.cs" | head -60`
+Identify the function(s) that build the C&C bytes per C0 index, with line numbers.
+
+- [ ] **Step 5: Append Section 5 to the doc**
+
+Write `## 5. EP2 — Host → Radio Command Frames` containing:
+- Frame-size note.
+- Annotated hex dump of one EP2 frame (Metis header + USB1 sync + C0/C1–C4 + payload-pad + USB2 sync + C0/C1–C4 + payload-pad).
+- A decode table with one row per C0 index observed. Columns: `C0 (hex)`, `Name`, `C1`, `C2`, `C3`, `C4`, `Decoded meaning (Thetis ref)`. Names and decoding come from `NetworkIO.cs` — cite the line. Anything not covered by `NetworkIO.cs` is marked `unknown — HL2-specific; investigate`.
+- A short paragraph naming each command class observed: sample rate, OC outputs, ADC atten/preamp/dither/random, RX1..N freq, TX freq, drive level, Alex HPF/LPF, MOX/PTT, etc. — but only mention classes that actually appear in the table, do not invent.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): document EP2 command frame round-robin C0 map
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Section 6 — Steady-state cadence
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Compute radio→host frame rate**
+
+Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221 and udp.payload[0:3] == ef:fe:01' \
+  -T fields -e frame.time_relative \
+  | awk 'BEGIN{first=0; last=0; n=0} {if(first==0)first=$1; last=$1; n++} END{printf "n=%d duration=%.3f rate=%.1f Hz\n", n, last-first, n/(last-first)}'
+```
+Record the result.
+
+- [ ] **Step 2: Compute host→radio frame rate**
+
+Same query with source/dest swapped:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024 and udp.payload[0:3] == ef:fe:02' \
+  -T fields -e frame.time_relative \
+  | awk 'BEGIN{first=0; last=0; n=0} {if(first==0)first=$1; last=$1; n++} END{printf "n=%d duration=%.3f rate=%.1f Hz\n", n, last-first, n/(last-first)}'
+```
+Record the result.
+
+- [ ] **Step 3: Check sequence-number continuity for EP6**
+
+Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221 and udp.payload[0:3] == ef:fe:01' \
+  -T fields -e udp.payload \
+  | awk '{seq=strtonum("0x" substr($0, 9, 8)); if(prev!="" && seq != prev+1) print NR, prev, seq; prev=seq}' \
+  | head -20
+```
+Expected: empty (no gaps) OR a list of discontinuities. Either way, record what you find.
+
+- [ ] **Step 4: Append Section 6 to the doc**
+
+Write `## 6. Steady-State Cadence` with:
+- Two-row table: direction, frames, duration, rate.
+- Sequence-number observation (continuous across the session, or N gaps at specific points).
+- Short prose: "the host emits ~X commands/s during steady-state RX; the radio emits ~Y EP6 frames/s, matching the expected rate at sample-rate Z (cite the rate seen in the start frame in Section 3)."
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): document steady-state cadence and sequence continuity
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Section 7 — Band-change trace
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Find frequency-change events**
+
+The C0 indices that carry RX frequency are documented in `NetworkIO.cs` (typically `0x02/0x04/0x06/...` per receiver). Use the decode table built in Task 6 to identify the C0 for RX1 freq, then run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y "ip.src == 169.254.105.135 and udp.dstport == 1024 and udp.payload[11] == <RX1_C0>" \
+  -T fields -e frame.number -e frame.time_relative -e udp.payload \
+  | awk '{f=strtonum("0x" substr($3, 25, 8)); if(f!=prev){print $1, $2, f; prev=f}}'
+```
+Expected: one row per *change* in RX1 frequency. Record the timestamps and frequencies.
+
+- [ ] **Step 2: For one band-change event, dump the surrounding ±20 EP2 frames**
+
+Pick the most interesting band change (one that crosses an HPF/LPF boundary if possible). Get its frame number `N`, then:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y "ip.src == 169.254.105.135 and udp.dstport == 1024 and frame.number >= N-20 and frame.number <= N+20" \
+  -T fields -e frame.number -e frame.time_relative \
+  -e udp.payload
+```
+Record the C0 sequence around the change.
+
+- [ ] **Step 3: Append Section 7 to the doc**
+
+Write `## 7. Band-Change Trace` containing:
+- The list of frequency changes from Step 1 as a table.
+- For one walked-through change: a timeline showing each EP2 command in order with relative timestamp, C0 name, and decoded value. This becomes the recipe Phase 3L follows when the user retunes across an HPF/LPF boundary.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): document band-change command sequence
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Section 8 — TX / keying trace (conditional)
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Detect MOX events**
+
+The MOX bit lives in C&C C0=0x00, C1 bit 0 per the standard P1 layout (verify against `NetworkIO.cs` while you're in Task 6 — the line should already be cited). Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024 and udp.payload[11] == 00' \
+  -T fields -e frame.number -e frame.time_relative -e udp.payload \
+  | awk '{c1=strtonum("0x" substr($3, 25, 2)); mox=(c1 % 2); if(mox != prev){print $1, $2, "MOX="mox; prev=mox}}'
+```
+Expected: either an empty list (no keying) or a sequence of MOX-on/MOX-off transitions.
+
+- [ ] **Step 2A: If MOX events were found, document the bring-up**
+
+For the first MOX-on event at frame `N`, dump frames `N-10..N+30` of EP2 traffic with full decode (same approach as Task 8 Step 2). Then write `## 8. TX / Keying Trace` containing:
+- The list of MOX events with timestamps.
+- A walked-through bring-up timeline: every C0 the host sends across the MOX-on transition, in order, with decoded values (drive level, TX freq, Alex relay, then MOX).
+- Note any change in EP6 status bytes during TX (the C0 status index map may shift).
+- Note: HL2 carries TX I/Q out via the payload region of EP2 frames during TX — describe what the payload looks like during the keyed window (first/last few bytes of one mid-TX EP2 frame).
+
+- [ ] **Step 2B: If NO MOX events were found, document the gap explicitly**
+
+Write `## 8. TX / Keying Trace` containing only:
+- A note that the capture contains **no MOX-on events**.
+- The exact tshark detection query used (the one from Step 1).
+- A line: "Phase 3L will need a separate capture covering a keying event before TX paths can be implemented from ground truth."
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): document TX/keying trace (or absence thereof)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Section 9 — HL2-specific quirks
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Pull HL2 firmware/version from the discovery reply**
+
+Re-use the discovery reply hex dump from Section 2. Per `NetworkIO.cs`, the reply contains a board-id byte and a firmware version byte at known offsets — cite the line numbers and record the actual values.
+
+- [ ] **Step 2: List sample rates exercised**
+
+The sample-rate field lives in C0=0x00 C1 (per `NetworkIO.cs` — verify). Run:
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024 and udp.payload[11] == 00' \
+  -T fields -e udp.payload \
+  | awk '{print toupper(substr($0, 25, 2))}' \
+  | sort -u
+```
+Decode each value against the spec (00=48k, 01=96k, 02=192k, 03=384k typical). Record what's exercised.
+
+- [ ] **Step 3: Check ADC overload bit usage in EP6 status**
+
+Look at the EP6 C0=0x00 status frames pulled in Task 5. The overload bit lives in C1 — cite the `NetworkIO.cs` line and record whether it ever sets in this capture.
+
+- [ ] **Step 4: Append Section 9 to the doc**
+
+Write `## 9. HL2-Specific Observations` containing the firmware version, board ID, sample rates exercised, ADC overload bit observation, and any C0 indices the table from Task 6 marked `unknown — HL2-specific`. Be explicit that these are observations from one HL2 on one firmware revision and may not generalize.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): document HL2-specific observations
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Section 10 — Nereus Phase 3L implementation checklist
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Re-read every preceding section and extract action items**
+
+For each section, ask: "what does Nereus need to *do* to match what this section observes?" Examples (do not copy verbatim — derive from the actual sections written):
+- Send a discovery broadcast matching the layout in Section 2.
+- Recognize the discovery reply and extract MAC + firmware version per Section 2.
+- Build start/stop frames per Section 3, including the sample-rate mode bit.
+- Parse 1032-byte EP6 frames per Section 4, deinterleave 24-bit BE I/Q, route C0=0x00 status to the radio model (overload bit).
+- Build EP2 round-robin commands per Section 5, including each C0 actually observed.
+- Maintain the cadence in Section 6 — emit EP2 at the observed rate, not faster.
+- Implement the band-change command sequence from Section 7 atomically when retuning across HPF/LPF boundaries.
+- (If Section 8 has TX content) implement MOX bring-up in the order shown.
+- (If Section 8 is the gap note) flag TX as blocked on a future capture.
+
+- [ ] **Step 2: Append Section 10 to the doc**
+
+Write `## 10. Nereus Implementation Checklist (Phase 3L)` as a checkbox list. Each item is a one-line task and links to the section that motivates it (e.g., "see §4"). Group by phase: discovery → start → RX steady-state → tuning → band switching → TX.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): add Phase 3L implementation checklist derived from capture
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Appendix A — reproducibility
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1-capture-reference.md`
+
+- [ ] **Step 1: Append Appendix A**
+
+Add `## Appendix A — Reproducing This Analysis` containing:
+- A one-sentence preamble: "Every hex dump and statistic in this document was produced with the commands below, run against `HL2_Packet_Capture.pcapng` on macOS with Wireshark's `tshark` 4.x."
+- The exact commands from Tasks 1, 3, 4, 5, 6, 7, 8, 9, 10 — each in its own fenced `bash` block with a one-line caption above it explaining what it produces.
+- A closing line: "To re-run this analysis on a different P1 capture, replace the source IP in the `-Y` filters with the new radio's IP and re-run each block in order."
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1-capture-reference.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): add reproducibility appendix with tshark commands
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Update the existing P1 placeholder doc to point at the new reference
+
+**Files:**
+- Modify: `docs/protocols/openhpsdr-protocol1.md`
+
+- [ ] **Step 1: Read the current placeholder**
+
+Run: `cat docs/protocols/openhpsdr-protocol1.md`
+The current file is the 32-line placeholder identified in the spec.
+
+- [ ] **Step 2: Replace its content with this**
+
+```markdown
+# OpenHPSDR Protocol 1
+
+## Status: Reference
+
+Protocol 1 is the original OpenHPSDR protocol used by Metis, Hermes, Angelia,
+Orion, and Hermes Lite 2 boards. UDP-only on port 1024, 1032-byte Metis
+frames, 24-bit big-endian interleaved I/Q.
+
+## Primary Reference
+
+For byte-level layouts, command/status decode, cadence, and HL2-specific
+quirks, see the annotated capture reference:
+
+**[openhpsdr-protocol1-capture-reference.md](openhpsdr-protocol1-capture-reference.md)**
+
+That document is derived from a live HL2↔Thetis capture and is the
+authoritative source for NereusSDR Phase 3L (P1 implementation).
+
+## Quick Summary
+
+- **Transport:** UDP only, port 1024
+- **Frame size:** 1032 bytes (Metis frame: 8-byte header + two 512-byte USB frames)
+- **I/Q format:** 24-bit big-endian, interleaved
+- **Control:** C&C bytes in USB frame headers (C0 round-robin index, C1–C4 payload)
+- **Discovery:** UDP broadcast to port 1024
+
+## Official Specification
+
+See: https://openhpsdr.org/wiki/index.php?title=Protocol_1
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/protocols/openhpsdr-protocol1.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): point placeholder doc at the new capture reference
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Update CLAUDE.md documentation index
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Read the current Protocol Reference table**
+
+Run: `grep -n 'openhpsdr-protocol' CLAUDE.md`
+Expected: two lines in the `### Protocol Reference` table.
+
+- [ ] **Step 2: Add a row for the new reference doc**
+
+Edit `CLAUDE.md` in the `### Protocol Reference (`docs/protocols/`)` table. After the existing `openhpsdr-protocol1.md` row, insert:
+
+```markdown
+| [openhpsdr-protocol1-capture-reference.md](docs/protocols/openhpsdr-protocol1-capture-reference.md) | Annotated HL2↔Thetis capture: discovery, start, EP6/EP2 frames, C0 maps, cadence, band/TX traces, Phase 3L checklist |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -S -m "$(cat <<'EOF'
+docs(p1): index the capture-reference doc in CLAUDE.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Final review
+
+**Files:**
+- Read-only: all of the above.
+
+- [ ] **Step 1: Re-read the new doc end-to-end**
+
+Run: `wc -l docs/protocols/openhpsdr-protocol1-capture-reference.md` — expect 600–1200 lines.
+Then `cat` it (or open in editor) and verify:
+- No `TBD`, `TODO`, `XXX`, or `FIXME`.
+- Every section has at least one hex dump or table backed by the capture.
+- Every byte-layout claim has a `NetworkIO.cs:<line>` citation.
+- Section 10's checklist references every preceding section.
+- Appendix A's commands are the actual ones used (copy-paste from earlier task steps if needed).
+
+- [ ] **Step 2: Verify no source code was modified**
+
+Run: `git log --since='2026-04-12' --name-only` — expect only `.md` files in `docs/` and `CLAUDE.md`.
+
+- [ ] **Step 3: Report back to the user**
+
+Summary line: "P1 capture reference complete: <N> lines, <M> commits, all sections grounded in HL2_Packet_Capture.pcapng. Section 8 (TX) was [populated / marked as a gap]. Ready for Phase 3L planning."
+
+- [ ] **Step 4: No commit** — review is read-only.

--- a/docs/architecture/2026-04-12-p1-capture-reference-plan.md
+++ b/docs/architecture/2026-04-12-p1-capture-reference-plan.md
@@ -6,13 +6,13 @@
 
 **Architecture:** This is a documentation-only deliverable. Each section of the target doc is built by one task: a tshark extraction step → a Thetis cross-reference step → a markdown drafting step → a commit. No source code is modified except a small link/absorb edit to the existing P1 placeholder doc at the end.
 
-**Tech Stack:** `tshark` (already installed at `/opt/homebrew/bin/tshark`), `awk`, plain markdown. Source citations come from `../Thetis/Project Files/Source/Console/NetworkIO.cs` per the project's READ → SHOW → TRANSLATE rule (CLAUDE.md).
+**Tech Stack:** `tshark` (already installed at `/opt/homebrew/bin/tshark`), `awk`, plain markdown. Source citations come from `/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs` per the project's READ → SHOW → TRANSLATE rule (CLAUDE.md).
 
 **Working files:**
 - Capture (extracted, do not re-extract): `/tmp/hl2cap/HL2_Packet_Capture.pcapng` (320 MB)
 - Filtered subset (created in Task 1): `/tmp/hl2cap/hl2_session.pcapng`
 - Spec being implemented: `docs/superpowers/specs/2026-04-12-p1-capture-reference-design.md`
-- Thetis source: `../Thetis/Project Files/Source/Console/NetworkIO.cs`
+- Thetis source: `/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs`
 
 **Conventions:**
 - All hex dumps in the doc come from `tshark -x` output, trimmed to the relevant payload range, fenced with ` ```` `.
@@ -27,11 +27,11 @@
 
 **Files:**
 - Create: `/tmp/hl2cap/hl2_session.pcapng`
-- Read-only: `../Thetis/Project Files/Source/Console/NetworkIO.cs`
+- Read-only: `/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs`
 
 - [ ] **Step 1: Verify Thetis clone is present**
 
-Run: `ls "../Thetis/Project Files/Source/Console/NetworkIO.cs"`
+Run: `ls "/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs"`
 Expected: file exists.
 If missing, STOP and tell the user — per CLAUDE.md, do not invent protocol details. Ask where the Thetis clone lives.
 
@@ -133,7 +133,7 @@ Expected: 4 packets — 2 host→broadcast, 2 radio→host. First two bytes of e
 
 - [ ] **Step 2: Locate Thetis discovery code**
 
-Run: `grep -n -i 'discover\|0xeffe\|0xef, 0xfe' "../Thetis/Project Files/Source/Console/NetworkIO.cs" | head -40`
+Run: `grep -n -i 'discover\|0xeffe\|0xef, 0xfe' "/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs" | head -40`
 Record the line numbers of the discovery send and discovery reply parser.
 
 - [ ] **Step 3: Append Section 2 to the doc**
@@ -186,7 +186,7 @@ Expected: a list of `04` frames; the last one(s) should be the stop. The byte at
 
 - [ ] **Step 3: Locate Thetis start/stop send code**
 
-Run: `grep -n 'MetisStartStop\|metis_start\|0x04' "../Thetis/Project Files/Source/Console/NetworkIO.cs" | head -20`
+Run: `grep -n 'MetisStartStop\|metis_start\|0x04' "/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs" | head -20`
 Record the function name and line number.
 
 - [ ] **Step 4: Append Section 3 to the doc**
@@ -251,7 +251,7 @@ Expected: a small set of C0 values with counts. Record the table.
 
 - [ ] **Step 4: Locate Thetis EP6 parser**
 
-Run: `grep -n 'ProcessMetisData\|EP6\|0x7F, 0x7F, 0x7F\|c1_addr' "../Thetis/Project Files/Source/Console/NetworkIO.cs" | head -40`
+Run: `grep -n 'ProcessMetisData\|EP6\|0x7F, 0x7F, 0x7F\|c1_addr' "/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs" | head -40`
 Record the function and line range that parses incoming EP6 frames and decodes C1–C4 by C0 index.
 
 - [ ] **Step 5: Append Section 4 to the doc**
@@ -316,7 +316,7 @@ Record the C0 and the four C1–C4 bytes from the first USB frame.
 
 - [ ] **Step 4: Locate Thetis EP2 send code**
 
-Run: `grep -n 'NetworkSendC\|MetisCommand\|c0 = \|round_robin' "../Thetis/Project Files/Source/Console/NetworkIO.cs" | head -60`
+Run: `grep -n 'NetworkSendC\|MetisCommand\|c0 = \|round_robin' "/Users/j.j.boyd/Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs" | head -60`
 Identify the function(s) that build the C&C bytes per C0 index, with line numbers.
 
 - [ ] **Step 5: Append Section 5 to the doc**

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -1260,3 +1260,68 @@ Concrete steps:
 4. Investigate extended discovery bytes in HL2 firmware source before exposing capabilities to the UI
 
 ---
+
+## 10. Nereus Implementation Checklist (Phase 3L)
+
+The tasks below are derived from the observations in Sections 2–9 and are
+scoped small enough for individual PRs. Each references the section that
+motivated it.
+
+### 3L-1 — Discovery & Session Bring-Up
+
+- [ ] Emit 63-byte discovery broadcast request (`EF FE 02` + 60 zero bytes) to subnet broadcast address on UDP port 1024 (see §2.1)
+- [ ] Parse discovery reply: validate `data[0]==0xEF`, `data[1]==0xFE`, `data[2]==0x02`/`0x03`; extract MAC (bytes 3–8), firmware version (byte 9), board ID (byte 10), MetisVersion (byte 19), NumRxs (byte 20) (see §2.2)
+- [ ] Map board ID `0x06` → `BoardType::HermesLite`; treat `data[2]==0x03` as "busy" and surface that state to the UI (see §2.2)
+- [ ] TODO (defer to 3L-HL2): parse HL2 extended discovery bytes 11–13 and 21–59 against HL2 firmware source (see §2.2, §9.6)
+- [ ] Bind session UDP socket on ephemeral source port; record radio address `169.254.x.x:1024` as the session endpoint (see §1)
+- [ ] Emit 64-byte start command (`EF FE 04 01` + 60 zero bytes) to radio port 1024 after successful discovery reply (see §3.1)
+- [ ] Emit 64-byte stop command (`EF FE 04 00` + 60 zero bytes) on session teardown (see §3.2)
+
+### 3L-2 — EP6 RX Ingestion
+
+- [ ] Parse 1032-byte Metis envelope: validate `data[0..1]==EF FE`, `data[2]==0x01`, `data[3]==0x06`; extract 32-bit BE sequence number from bytes 4–7 (see §4.1)
+- [ ] Locate USB sub-frame 1 at offset 8 and USB sub-frame 2 at offset 520; validate each `7F 7F 7F` sync prefix (see §4.1)
+- [ ] Decode C0 status index as `C0 & 0xF8` (bits [7:3]); extract PTT/dot/dash from bits [2:0] (see §4.3)
+- [ ] Implement C0 status slot switch for slots `0x00`, `0x08`, `0x10`, `0x18`, `0x20` per `networkproto1.c:334–355` decode table (see §4.3)
+- [ ] Compute samples-per-USB-frame as `spr = 504 / (6 * nddc + 2)`; deinterleave 24-bit BE I and Q samples using left-shift sign-extension (`<< 8` on each byte triple), scale by `1/2147483648.0` (see §4.2)
+- [ ] Extract mic sample at bytes 6–7 of each 8-byte sample group as 16-bit BE, scale by `1/2147483648.0` (see §4.2)
+- [ ] Track EP6 sequence number continuity; increment a drop counter on any gap; log at qCWarning level (see §6.3)
+
+### 3L-3 — EP2 Command Building
+
+- [ ] Build 1032-byte Metis EP2 envelope: header `EF FE 01 02` + 32-bit BE sequence number (auto-incrementing), then two 512-byte USB sub-frames each with `7F 7F 7F` sync + C0–C4 + 504 bytes of TX I/Q payload (see §5.1)
+- [ ] Implement `out_control_idx` round-robin counter cycling 0–16 (standard), incrementing once per USB sub-frame, resetting to 0 after slot 16 (see §5.2)
+- [ ] Build C0 as `(XmitBit & 0x01) | slot_or_mask` for every sub-frame so the MOX bit is OR'd into every slot simultaneously (see §5.2, §5.5)
+- [ ] Implement per-slot command builders for cases 0–16 matching `networkproto1.c:450–665`: case 0 (general/SR/OC), case 1 (TX freq), case 2 (DDC0/RX1 freq), case 3 (DDC1/RX2 freq), case 4 (ADC assign + TX step attn), cases 5–9 (DDC2–DDC6 freq), case 10 (drive + Alex HPF/LPF), case 11 (preamp/att/mic), case 12 (att2/CW keyer speed/weight), case 13 (CW enable/sidetone/RF delay), case 14 (CW hang/sidetone freq), case 15 (EER PWM), case 16 (BPF2/xvtr/PureSignal) (see §5.4)
+- [ ] Emit EP2 frames at the ~378 Hz steady-state rate observed in this capture; do not throttle below that rate (see §6.1, §6.4)
+
+### 3L-4 — Tuning & Band Changes
+
+- [ ] On RX1 frequency change: write new value into shared frequency state before the next round-robin write of case-2 slot (`C0 |= 0x04`); do NOT inject a one-shot special frame (see §7.4)
+- [ ] Compute Alex HPF/LPF filter bits from the new target frequency (not the old), and update case-10 state (`C0 |= 0x12`) in the same shared write; allow up to one full 19-slot cycle (~50 ms) for the filter update to precede the DDC NCO update — this is the observed Thetis ordering and is acceptable (see §7.3, §7.4)
+- [ ] On TX frequency change: update case-1 state (`C0 |= 0x02`) in the shared structure; DDC2–DDC6 slots that track TX freq will pick it up in the same cycle (see §7.4)
+- [ ] Encode sample rate selection in case-0 C1 bits [1:0] (`SampleRateIn2Bits & 3`; `0x02` = 192 kHz) and send on every case-0 round-robin occurrence (see §5.4 case 0)
+- [ ] Build case-10 Alex HPF mask into C3 and LPF mask into C4 matching `networkproto1.c:583–590` bit assignments; test at the 5 MHz, 6.5 MHz, and 9.5 MHz HPF boundaries (see §7.3)
+
+### 3L-5 — TX Path
+
+- [ ] Ensure TX frequency (case 1) and drive level (case 10 C1) are set in shared state during the RX round-robin before any MOX assertion, so no special pre-TX burst is needed (see §8.3 findings 1–2)
+- [ ] Implement MOX assert: set `XmitBit = 1`; on the next `WriteMainLoop` call, C0 for every slot must have bit 0 set; no additional MOX command frame is required (see §8.3 finding 4, §8.6 step 4)
+- [ ] Pack TX I/Q samples as 16-bit big-endian signed integers into EP2 payload at 8 bytes per sample unit (`[L_audio_I 2B][L_audio_Q 2B][TX_IQ_I 2B][TX_IQ_Q 2B]`), scaling float ±1.0 → int16 via `floor(x * 32767.0 + 0.5)` (see §8.4)
+- [ ] On MOX-off: zero-fill `outIQbufp` immediately (`memset` per `networkproto1.c:723`) so no residual TX samples are emitted after keying stops (see §8.6 step 6)
+- [ ] DEFER: mic audio capture into TX payload L/R audio bytes (bytes 0–3 per sample unit) — mark as future work once AudioEngine mic input is wired (see §8.4)
+
+### 3L-6 — HL2-Specific Extensions (conditional on board ID == `0x06`)
+
+- [ ] On receipt of EP6 C0=`0xFA` (`0xFA & 0xF8 = 0xF8`): silently ignore; log the first occurrence at qCDebug level; mark as OPEN QUESTION — decode against HL2 firmware source (`hermeslite.v`) before exposing to UI (see §4.3, §9.2)
+- [ ] Extend round-robin to 19 slots when board ID == `0x06`: add slot 17 (`C0 |= 0x2E`, constant payload `00 00 1E 46`) and slot 18 (`C0 |= 0x74`, constant payload `00 00 00 00`); emit on every cycle (see §5.3, §5.4 cases 17–18, §9.3)
+- [ ] OPEN QUESTION: determine whether skipping HL2 extension EP2 slots `0x2E`/`0x74` breaks HL2 firmware in practice — test on live HL2 hardware before committing the slots as required; document result in §5.4 (see §5.4 cases 17–18)
+- [ ] Ensure MOX bit is OR'd into HL2 extension slot C0 bytes (`0x2F`, `0x75`) during TX in the same `WriteMainLoop` pass, not as a special case (see §8.5, §9.4)
+- [ ] Treat duplex bit (case-0 C4 bit 2) as a write-only field for standard P1; do NOT assert it unconditionally when board ID == `0x06` — the HL2 ignores it but setting it may confuse other radios (see §9.5)
+- [ ] DEFER: aperiodic HL2 commands `0x7A` (I2C burst) and `0xFA`/`0xFB` (timer register) — mark as HL2-firmware-specific; do not implement until HL2 firmware source documents their function (see §5.4, §9.3)
+
+### 3L-7 — Validation
+
+- [ ] Replay the 302,256-frame `HL2_Packet_Capture.pcapng` capture through Nereus's P1 parser and confirm bit-exact decoding of all EP6 frames: correct sequence numbers, correct C0 slot dispatch, correct I/Q sample values for at least the first and last 100 frames (see §1, §4)
+- [ ] Drive Nereus's EP2 builder with the same parameter inputs observed in this capture and verify that output C0/C1–C4 bytes match the reference capture values for each of the 17 standard command slots (see §5.4)
+- [ ] Run Nereus against a live HL2 (board ID `0x06`, firmware `0x4A`) and confirm: EP6 received at ~5053 Hz, EP2 emitted at ~378 Hz, RX audio passes through WDSP without drops or sequence errors (see §6)

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -1325,3 +1325,184 @@ motivated it.
 - [ ] Replay the 302,256-frame `HL2_Packet_Capture.pcapng` capture through Nereus's P1 parser and confirm bit-exact decoding of all EP6 frames: correct sequence numbers, correct C0 slot dispatch, correct I/Q sample values for at least the first and last 100 frames (see §1, §4)
 - [ ] Drive Nereus's EP2 builder with the same parameter inputs observed in this capture and verify that output C0/C1–C4 bytes match the reference capture values for each of the 17 standard command slots (see §5.4)
 - [ ] Run Nereus against a live HL2 (board ID `0x06`, firmware `0x4A`) and confirm: EP6 received at ~5053 Hz, EP2 emitted at ~378 Hz, RX audio passes through WDSP without drops or sequence errors (see §6)
+
+---
+
+## Appendix A — Reproducing This Analysis
+
+Every hex dump, table, and statistic in this document was produced with the commands below, run against `HL2_Packet_Capture.pcapng` on macOS with Wireshark's `tshark` 4.x. The filtered session subset `/tmp/hl2cap/hl2_session.pcapng` is produced in A.1 and used by all subsequent commands.
+
+### A.1 Create filtered session subset
+
+Extract only the P1 session frames (port 1024) from the full capture, removing discovery broadcasts on port 50533:
+
+```bash
+tshark -r /tmp/hl2cap/HL2_Packet_Capture.pcapng \
+  -Y 'udp.port == 1024' \
+  -w /tmp/hl2cap/hl2_session.pcapng
+```
+
+### A.2 Discovery exchange — hex dump of discovery frames
+
+Extract discovery REQUEST/REPLY frames on ephemeral source port 50533:
+
+```bash
+tshark -r /tmp/hl2cap/HL2_Packet_Capture.pcapng \
+  -Y '(udp.srcport == 50533 or udp.dstport == 50533)' \
+  -x
+```
+
+### A.3 Start/stop frame detection
+
+Locate start/stop command frames by filtering for the Metis command opcode `0x04`:
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024' \
+  -T fields -e frame.number -e frame.time_relative -e udp.payload 2>/dev/null \
+  | awk '{if (substr($3,1,6)=="effe04") print $1, $2, substr($3,1,16)}'
+```
+
+### A.4 EP6 frame size check
+
+Verify all radio→host EP6 frames (opcode `0x01`) are exactly 1032 bytes:
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221' \
+  -T fields -e udp.length | sort -u
+```
+
+### A.5 EP6 C0 status index enumeration
+
+Extract C0 status bytes from EP6 frames and histogram the slot indices (bits [7:3]) for both USB sub-frames.
+
+**USB1 (offset 11):**
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221' \
+  -T fields -e udp.payload 2>/dev/null \
+  | awk 'substr($0,1,6)=="effe01" {c0=strtonum("0x" substr($0,23,2)); printf "0x%02X\n", and(c0,0xf8)}' \
+  | sort | uniq -c | sort -rn
+```
+
+**USB2 (offset 523):**
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221' \
+  -T fields -e udp.payload 2>/dev/null \
+  | awk 'substr($0,1,6)=="effe01" {c0=strtonum("0x" substr($0,1047,2)); printf "0x%02X\n", and(c0,0xf8)}' \
+  | sort | uniq -c | sort -rn
+```
+
+### A.6 EP2 C0 command enumeration
+
+Extract C0 status bytes from EP2 frames (host→radio, opcode `0x02`) and histogram the command indices for comparison.
+
+**USB1 (offset 11):**
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024' \
+  -T fields -e udp.payload 2>/dev/null \
+  | awk 'substr($0,1,6)=="effe02" {c0=strtonum("0x" substr($0,23,2)); printf "0x%02X\n", and(c0,0xfe)}' \
+  | sort | uniq -c | sort -rn
+```
+
+**USB2 (offset 523):**
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024' \
+  -T fields -e udp.payload 2>/dev/null \
+  | awk 'substr($0,1,6)=="effe02" {c0=strtonum("0x" substr($0,1047,2)); printf "0x%02X\n", and(c0,0xfe)}' \
+  | sort | uniq -c | sort -rn
+```
+
+### A.7 Cadence computation — frame rates
+
+Count frames per direction and compute rate (frames / duration).
+
+**EP6 (radio→host, 5052.9 Hz observed):**
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221' \
+  -T fields -e frame.number -e frame.time_relative 2>/dev/null \
+  | awk 'NR==1{first=$2; first_frame=$1} NR==NF{last=$2; last_frame=$1} END{print "Frames:", last_frame - first_frame, "Duration:", last - first, "Rate:", (last_frame - first_frame) / (last - first)}'
+```
+
+**EP2 (host→radio, 378.0 Hz observed):**
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024' \
+  -T fields -e frame.number -e frame.time_relative 2>/dev/null \
+  | awk 'NR==1{first=$2; first_frame=$1} NR==NF{last=$2; last_frame=$1} END{print "Frames:", last_frame - first_frame, "Duration:", last - first, "Rate:", (last_frame - first_frame) / (last - first)}'
+```
+
+### A.8 Sequence continuity check
+
+Verify EP6 Metis sequence numbers (bytes 4–7, 32-bit big-endian) are contiguous with no gaps:
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221' \
+  -T fields -e udp.payload 2>/dev/null \
+  | awk 'substr($0,1,6)=="effe01" {seq=strtonum("0x" substr($0,9,8)); if(prev!="" && seq != prev+1) gaps++; prev=seq} END{print "gaps="gaps}'
+```
+
+### A.9 RX1 frequency-change event detection
+
+Locate case-0x04 (RX1/DDC0) slot transitions by filtering EP2 frames and extracting the frequency value (bytes 4–7 of payload after C0–C4):
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024' \
+  -T fields -e frame.time_relative -e udp.payload 2>/dev/null \
+  | awk 'substr($2,1,6)=="effe02" {c0=strtonum("0x" substr($2,23,2)); if(and(c0,0xfe)==0x04) {freq=strtonum("0x" substr($2,11,8)); if(last_freq!="" && freq!=last_freq) print $1, "RX1 change", last_freq, "->", freq; last_freq=freq}}'
+```
+
+### A.10 MOX transition detection
+
+Monitor EP2 case-0x00 (general C&C) C0 bit 0 (MOX) for RX↔TX transitions:
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.105.135 and udp.dstport == 1024' \
+  -T fields -e frame.time_relative -e udp.payload 2>/dev/null \
+  | awk 'substr($2,1,6)=="effe02" {c0=strtonum("0x" substr($2,23,2)); mox=and(c0,0x01); if(last_mox!="" && mox!=last_mox) print $1, "MOX", (last_mox?"off":"on"), "->", (mox?"on":"off"); last_mox=mox}'
+```
+
+### A.11 ADC overload bit check
+
+Scan EP6 case-0x00 (general C&C) USB1 C1 bit 0 (ADC overload) across the entire session:
+
+```bash
+tshark -r /tmp/hl2cap/hl2_session.pcapng \
+  -Y 'ip.src == 169.254.19.221' \
+  -T fields -e udp.payload 2>/dev/null \
+  | awk 'substr($0,1,6)=="effe01" {c0=strtonum("0x" substr($0,23,2)); if(and(c0,0xf8)==0x00) {c1=strtonum("0x" substr($0,25,2)); adc_ol=and(c1,0x01); if(adc_ol) print "ADC overload detected"}}' \
+  | sort | uniq -c
+```
+
+---
+
+### Re-running on a Different Capture
+
+To re-run this analysis on a different P1 capture, follow these steps:
+
+1. Identify the host and radio IP addresses from the new capture (use `tshark -r capture.pcapng -Y 'udp.port == 1024'` to find them)
+2. Replace `169.254.105.135` (host) and `169.254.19.221` (radio) in all `-Y` filters with the new addresses
+3. Replace `/tmp/hl2cap/HL2_Packet_Capture.pcapng` with the path to your capture file
+4. Run blocks A.1 through A.11 in order
+
+**Important:** All commands assume bash with GNU `awk` (gawk). On macOS, ensure `gawk` is installed via Homebrew:
+
+```bash
+brew install gawk
+```
+
+Or substitute `awk` with `gawk` explicitly in all commands above if the default `awk` is BSD awk (which lacks `strtonum` and `and` functions needed for hex parsing).

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -1,0 +1,37 @@
+---
+date: 2026-04-12
+author: JJ Boyd (KG4VCF)
+status: Reference — derived from HL2_Packet_Capture.pcapng
+related:
+  - docs/protocols/openhpsdr-protocol1.md
+  - docs/architecture/radio-abstraction.md
+  - docs/superpowers/specs/2026-04-12-p1-capture-reference-design.md
+---
+
+# OpenHPSDR Protocol 1 — Annotated Capture Reference (Hermes Lite 2)
+
+This document is the byte-level ground-truth reference for OpenHPSDR
+Protocol 1 as implemented by Hermes Lite 2 firmware, derived from a
+single live capture of a Thetis-class host talking to an HL2 over a
+direct link-local Ethernet connection. Every layout claim in this doc
+is backed by a hex dump from the capture and a Thetis `NetworkIO.cs`
+source citation. NereusSDR Phase 3L (P1 support) implements against
+this document.
+
+## 1. Capture Metadata
+
+| Property | Value |
+| --- | --- |
+| File | `HL2_Packet_Capture.pcapng` (~324 MB) |
+| Frames | 302,256 total (302,252 IPv4/UDP, 4 ARP) |
+| Duration | ~55.7 s session (+ ~4 s DHCP tail) |
+| Host | `169.254.105.135` (link-local) |
+| Radio (HL2) | `169.254.19.221`, UDP port `1024` |
+| Discovery | host `:50533` → broadcast `:1024`, reply from radio |
+| Session | host `:50534` ↔ radio `:1024` |
+| Direction split | 281,195 frames radio→host (EP6), 21,049 frames host→radio (EP2) |
+
+The capture is a single clean session: discovery → start → steady-state
+RX → stop. Subsequent sections walk through each phase.
+
+<!-- Sections 2-10 and Appendix A added by later tasks -->

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -1188,3 +1188,75 @@ To key TX on HL2 via Protocol 1:
 - Drive level (case 10): `networkproto1.c:578–580`
 
 ---
+
+## 9. HL2-Specific Observations
+
+**Scope:** The observations below are from ONE Hermes Lite 2 running firmware
+version `0x4A` (decimal 74) on ONE capture session. They may not generalize to
+other HL2 firmware revisions or other P1 radios.
+
+### 9.1 Radio Identity
+
+- **Board ID:** `0x06` (HermesLite); **Firmware:** `0x4A` (74 decimal)
+- **MAC:** `00:1C:C0:A2:13:DD`
+- **Sample rate:** 192 kHz only (observed in Sections 5–6)
+- **Frame rate:** 5052.9 Hz observed vs. 4947 Hz theoretical; +2.1% delta, firmware-specific timing
+
+### 9.2 Non-standard EP6 Status Slot (`0xFA` repeating)
+
+The HL2 firmware injects a status-like frame with C0=`0xFA` approximately every
+870 frames with constant payload `02 00 00 01` (C1–C4). This slot does not
+appear in `networkproto1.c` and its purpose is unknown. See **Section 4** for
+full analysis.
+
+**ADC Overload Bit:** Case-0 USB1 frames (281,195 total) never show the ADC
+overload bit (C1 bit 0) set across the entire session.
+
+### 9.3 Non-standard EP2 Command Slots
+
+Beyond the 17 standard protocol-1 cases (0x00–0x10 even), the HL2 firmware
+recognizes four additional slot groups:
+
+1. **`0x2E` / `0x74`** — main-cycle extensions with constant payloads; purpose unknown
+2. **`0x7A`** — I2C-style aperiodic bursts (C2=`0x9D`)
+3. **`0xFA` / `0xFB`** — ~131-frame periodic timer (C2=`0x9D`, shared I2C device address?)
+
+See **Section 5** for slot-level trace and periodicity details.
+
+### 9.4 MOX in Extension Slots
+
+During TX, the MOX bit (C0 bit 0) appears in all C0 bytes, including HL2
+extension slots `0x2F` (ext 17), `0x75` (ext 18), and `0xFB` (timer). The MOX
+flag is OR'd into every slot by `WriteMainLoop` without distinction. See
+**Section 8.5** for the bring-up walk-through and trace.
+
+### 9.5 Duplex Bit Ignored
+
+The duplex bit (C4 bit 2 in case-0) is always observed as 0 in captured frames,
+despite `networkproto1.c:507` always OR'ing `0x04` into C4. The HL2 firmware
+ignores the duplex flag and operates in simplex mode (single antenna for RX and
+TX).
+
+### 9.6 Extended Discovery Reply Bytes
+
+The discovery reply from HL2 carries extra data in bytes 11–13, 20, and 21–59
+that are not parsed by the standard Thetis discovery logic. These bytes likely
+encode HL2 firmware-specific capabilities (e.g., I2C peripherals, hardware
+options). Future work should cross-reference the Hermes Lite 2 firmware source
+(Steve Haynal's repo: `github.com/softerhardware/Hermes-Lite2`) to document
+their meaning. See **Section 2** for the hex capture.
+
+### 9.7 Implications for Nereus Phase 3L
+
+Nereus must implement the standard P1 RX path against `networkproto1.c`
+exclusively, then treat HL2 as **"standard P1 + the four extension slots
+listed above"**. Do not copy HL2-specific behavior into the generic P1 RX
+path — add it conditionally when discovery returns board ID `0x06`.
+
+Concrete steps:
+1. Implement slots 0x00–0x10 (even) per `networkproto1.c`
+2. After discovery identifies board ID `0x06`, enable HL2 slots `0x2E`, `0x74`, `0x7A`, `0xFA`, `0xFB`
+3. Parse case-0 status with HL2 semantics (duplex=0, MOX in all slots)
+4. Investigate extended discovery bytes in HL2 firmware source before exposing capabilities to the UI
+
+---

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -184,3 +184,148 @@ documented here as they cannot be verified against this source or capture.
 
 **Thetis source:** `networkproto1.c:50` (start send — `SendStartToMetis`),
 `networkproto1.c:85` (stop send — `SendStopToMetis`)
+
+## 4. EP6 — Radio → Host Metis Frames
+
+EP6 is the primary data stream from the radio. Each frame is 1032 bytes of
+UDP payload containing an 8-byte Metis header and two 512-byte USB frames,
+each carrying 5 C&C status bytes and 504 bytes of interleaved 24-bit BE I/Q
+plus 16-bit mic audio. The C0 status index is round-robin: each USB frame
+carries one slot of status, and the host reassembles the full snapshot across
+frames. The decode switch on `ControlBytesIn[0] & 0xF8` means bits [7:3]
+select the status slot while bits [2:0] carry PTT/dot/dash inputs.
+
+### 4.1 Frame Layout
+
+```
+Offset  Length  Field
+------  ------  -----
+0       2       Metis sync 'EF FE'
+2       1       Direction marker: 0x01 (data frame from radio)
+3       1       Endpoint: 0x06 (EP6 — I/Q data to host)
+4       4       Sequence number, big-endian uint32 (monotonically incrementing)
+8       3       USB1 sync '7F 7F 7F'
+11      1       USB1 C0 — status index (bits [7:3]) + PTT/dot/dash (bits [2:0])
+12      4       USB1 C1..C4 — status payload (meaning depends on C0[7:3])
+16      504     USB1 I/Q + mic samples (see §4.2)
+520     3       USB2 sync '7F 7F 7F'
+523     1       USB2 C0 — same encoding as USB1 C0 (carries next status slot)
+524     4       USB2 C1..C4
+528     504     USB2 I/Q + mic samples
+```
+
+Verification from hex dump (frame 11, first EP6 frame in capture):
+
+```text
+Offset  Hex                                        Field
+------  -----------------------------------------  ----------------------------
+00      EF FE                                      Metis sync
+02      01                                         Direction marker (data frame)
+03      06                                         Endpoint (EP6)
+04      00 00 00 00                                Seq# = 0 (first frame)
+08      7F 7F 7F                                   USB1 sync
+0B      18                                         USB1 C0 = 0x18 (status slot 3)
+0C      00 00 00 00                                USB1 C1-C4 (slot 3: user_adc1=0, supply_volts=0)
+10      01 27 4F FF 70 B6 FF FE 65 FF F8 0C ...   USB1 I/Q samples begin
+          (504 bytes total, continuing to offset 0x0207)
+208     7F 7F 7F                                   USB2 sync
+20B     00                                         USB2 C0 = 0x00 (status slot 0)
+20C     1F 00 80 4A                                USB2 C1-C4 (slot 0: ADC overload flags + dig I/O)
+210     ...                                        USB2 I/Q samples begin
+```
+
+Note: Metis byte 3 is `0x06`, confirming EP6 endpoint. The direction marker
+(byte 2) is `0x01` for data frames in both directions; the endpoint byte
+distinguishes EP6 (radio→host data) from EP2 (host→radio C&C).
+Verified at `networkproto1.c:174–181` (`MetisReadDirect`).
+
+### 4.2 Sample Format
+
+Each USB frame carries 504 bytes of interleaved samples. For nddc=1 (one
+receiver, as in this capture), samples per USB frame:
+
+```
+spr = 504 / (6 * nddc + 2) = 504 / 8 = 63 samples
+```
+
+Layout within each 8-byte sample group:
+
+```
+Byte 0-2   I-sample, 24-bit big-endian (sign-extended via << 8 shift)
+Byte 3-5   Q-sample, 24-bit big-endian
+Byte 6-7   Mic audio, 16-bit big-endian (one sample, decimated)
+```
+
+Thetis decodes I/Q as:
+```c
+// networkproto1.c:364-371 (MetisReadThreadMainLoop)
+prn->RxBuff[iddc][2*isample+0] = const_1_div_2147483648_ *
+    (double)(bptr[k+0] << 24 | bptr[k+1] << 16 | bptr[k+2] << 8);  // I
+prn->RxBuff[iddc][2*isample+1] = const_1_div_2147483648_ *
+    (double)(bptr[k+3] << 24 | bptr[k+4] << 16 | bptr[k+5] << 8);  // Q
+```
+
+Mic (16-bit):
+```c
+// networkproto1.c:401-403
+prn->TxReadBufp[2*mic_sample_count+0] = const_1_div_2147483648_ *
+    (double)(bptr[k+0] << 24 | bptr[k+1] << 16);  // 16-bit mic, upper bytes
+```
+
+**`networkproto1.c:358`** — `spr = 504 / (6 * nddc + 2)` — sample count formula.
+
+### 4.3 Observed C0 Status Indices
+
+The switch on `ControlBytesIn[0] & 0xF8` (networkproto1.c:332) defines 5 status
+slots. The USB1 and USB2 C0 bytes in this capture are interleaved to carry
+different slots per EP6 frame.
+
+#### USB1 C0 counts (281,195 EP6 frames):
+
+| C0 (hex) | Count   | C0[7:3] slot | Sample C1-C4    |
+| -------- | ------- | ------------ | --------------- |
+| `08`     | 140,597 | 1 (0x08)     | `03 F0 00 01`   |
+| `18`     | 140,598 | 3 (0x18)     | `00 00 00 00`   |
+
+#### USB2 C0 counts (281,195 EP6 frames):
+
+| C0 (hex) | Count   | C0[7:3] slot | Sample C1-C4    |
+| -------- | ------- | ------------ | --------------- |
+| `00`     | 140,437 | 0 (0x00)     | `1F 00 80 4A`   |
+| `10`     | 140,435 | 2 (0x10)     | `00 00 00 00`   |
+| `FA`     | 323     | — (0xF8)     | `02 00 00 01`   |
+
+C0=`FA` (`0xFA & 0xF8 = 0xF8`) falls outside all five cases in the
+`networkproto1.c:332` switch. It appears throughout the session (~every 870
+frames in USB2) with consistent payload `02 00 00 01`. This is an HL2-specific
+status extension not decoded by Thetis's networkproto1.c switch —
+**observed but unmapped — investigate** (likely HL2 firmware-version or
+board-status slot; compare against HL2 FPGA source `radioberry.v` or
+`hermeslite.v`).
+
+#### C0 status slot decode table
+
+| C0 & 0xF8 | Slot | C1-C4 Meaning | Source |
+| ---------- | ---- | ------------- | ------ |
+| `0x00`     | 0    | C1 bit0=ADC0 overload; C1 bits[4:1]=user digital inputs | networkproto1.c:334–336 |
+| `0x08`     | 1    | C1-C2=exciter power (AIN5); C3-C4=fwd PA power (AIN1) | networkproto1.c:338–341 |
+| `0x10`     | 2    | C1-C2=rev PA power (AIN2); C3-C4=user_adc0 (AIN3, PA volts) | networkproto1.c:343–346 |
+| `0x18`     | 3    | C1-C2=user_adc1 (AIN4, PA amps); C3-C4=supply_volts (AIN6) | networkproto1.c:348–350 |
+| `0x20`     | 4    | C1 bit0=ADC0 overload; C2 bit0=ADC1 overload; C3 bit0=ADC2 overload | networkproto1.c:352–355 |
+| `0xF8`     | —    | **HL2-specific — not in networkproto1.c switch — investigate** | — |
+
+**This capture exercises slots 0, 1, 2, 3 (C0=`00`, `08`, `10`, `18`) across
+USB1+USB2. Slot 4 (C0=`20`) is NOT observed in this capture — the HL2
+may not implement it, or the round-robin does not reach it in this
+2-slot-per-frame pattern.**
+
+#### Decoded sample values (first EP6 frame, frame 11):
+
+- **USB1 C0=`18`, C1-C4=`00 00 00 00`**: user_adc1=0x0000 (AIN4 amps=0),
+  supply_volts=0x0000 (AIN6=0) — radio just started, ADC rails not yet settling.
+- **USB2 C0=`00`, C1-C4=`1F 00 80 4A`**: C1=`1F`=`0001 1111`→
+  ADC0 overload=1 (bit0), user_dig_in=`0x0F` (bits[4:1]=`1111` — IO4-IO8 all
+  high). C2-C4=`00 80 4A` are not used by slot 0.
+
+**Thetis source:** `networkproto1.c:273–416` (`MetisReadThreadMainLoop` — RX
+parser, C0 switch, I/Q decode, mic decode).

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -714,3 +714,66 @@ is usable for Task 9 (TX/keying trace).
    peripheral (LPF relay driver, LNA, or step-attenuator IC).
 
 **Thetis source:** `networkproto1.c:419–697` (`WriteMainLoop`, `sendProtocol1Samples`).
+
+---
+
+## 6. Steady-State Cadence
+
+### 6.1 Frame rates
+
+This section measures the observed frame rates during the ~55.7 second capture when the HL2 radio and Thetis host are in steady state, with no band changes or parameter adjustments.
+
+| Direction | Endpoint | Frames | Duration | Rate (Hz) |
+| --- | --- | --- | --- | --- |
+| Radio → Host | EP6 (`0x01`) | 281,195 | 55.650 s | 5052.9 |
+| Host → Radio | EP2 (`0x02`, 1032-byte) | 21,044 | 55.668 s | 378.0 |
+
+### 6.2 Rate derivation and comparison to theory
+
+The OpenHPSDR Protocol 1 implementation in `networkproto1.c:358` computes the number of samples per USB frame as:
+
+```c
+spr = 504 / (6*nddc + 2)
+```
+
+For this session with nddc=4 (four active DDCs):
+
+```
+spr = 504 / (6*4 + 2)
+    = 504 / 26
+    ≈ 19.38 samples/frame
+```
+
+The Metis frame rate (EP6) at 192 kHz sample rate is:
+
+```
+Metis rate = 192000 / (2 * spr)
+           = 192000 / (2 * 19.38)
+           ≈ 4947 Hz
+```
+
+**Observed:** 5052.9 Hz — a delta of **+105.9 Hz** relative to the computed 4947 Hz formula.
+
+This discrepancy indicates either:
+1. The actual `spr` value used by this HL2 firmware differs slightly from the formula, or
+2. The 192 kHz rate or nddc=4 parameters are not the primary drivers of frame timing.
+
+The observed rate remains stable and continuous; the delta is small relative to 5000 Hz (about 2%) and should not affect Nereus Phase 3L integration.
+
+### 6.3 Sequence number continuity
+
+Both endpoints maintain unbroken sequence numbering across the entire session:
+
+- **EP6 (radio → host):** 0 gaps — all 281,195 Metis sequence numbers are contiguous.
+- **EP2 (host → radio):** 0 gaps — all 21,044 command sequence numbers are contiguous.
+
+No packet loss, reorder, or retransmission is observed on the capture interface.
+
+### 6.4 Implication for Nereus Phase 3L
+
+The Phase 3L C&C stack must emit **EP2 command frames at ~378 Hz** and accept **EP6 frames at ~5053 Hz** to match the HL2's steady-state behavior.
+
+The HL2 firmware expects a ~19 ms round-robin cycle (one C0 "send all" command per 19 ms implies ~53 commands/second × 4 minor-loop packets = ~210 fps command-level, but this session shows ~378 Hz physical EP2 frame rate, indicating the HL2 may require higher command-queue turnover).
+
+Sustaining these rates without drops is a **hard requirement** for the round-robin C&C refresh to complete within the ~10 ms window the HL2 expects. Any sustained frame loss, reordering, or timing jitter will cause the HL2 to miss command updates and potentially fall out of sync with the Nereus host.
+

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -966,3 +966,225 @@ Slot  C0 (base)  Command            Action
   `prbpfilter->_30_20_LPF … _17_15_LPF` bits.
 
 ---
+
+## 8. TX / Keying Trace
+
+### 8.1 Summary
+
+The capture contains **4 MOX transitions** (2 TX events). Total TX-on duration:
+approximately **11.8 seconds** across two keying events.
+
+| TX event | First MOX=1 frame | t (s) | Last MOX=1 frame | t (s) | Duration |
+|----------|-------------------|-------|------------------|-------|----------|
+| Event 1  | 174523            | 33.152 | 210370          | 39.749 | ~6.60 s |
+| Event 2  | 254309            | 47.835 | 282426          | 53.010 | ~5.18 s |
+
+### 8.2 MOX Transitions Table
+
+The following table shows the case-0 slot (masked C0 = `0x00`) transitions,
+which is where the transition-detection script tracks MOX. Because the MOX bit
+is OR'd onto every C0 slot simultaneously, the first MOX=1 frame (at any slot)
+arrives slightly earlier than the case-0 crossing; see §8.3 for detail.
+
+| Frame  | Time (s)    | Raw C0 (case-0) | MOX bit | Inter-event gap (ms) |
+|--------|-------------|-----------------|---------|----------------------|
+| 8      | 0.987       | `0x00`          | 0       | — (session start)    |
+| 174581 | 33.163      | `0x01`          | 1       | — (first TX-on)      |
+| 210377 | 39.750      | `0x06`          | 0       | 6587 (TX-on duration)|
+| 254353 | 47.844      | `0x03`          | 1       | 8094 (RX gap)        |
+| 282484 | 53.021      | `0x02`          | 0       | 5177 (TX-on duration)|
+
+> Note: the "Raw C0 (case-0)" column is the C0 byte observed when the masked
+> slot is `0x00`. After MOX-on, odd raw values like `0x01`, `0x03` carry
+> MOX=1. After MOX-off, even raw values like `0x06` carry the current slot
+> index with MOX=0.
+
+### 8.3 First MOX-on Bring-up Walk-through
+
+The first TX event begins at approximately t=33.15 s. The following table
+covers EP2 command frames from ~30 frames before the first MOX=1 (frame
+174523) through ~40 frames after it.
+
+`USB1=<C0>:<C1-C4>` and `USB2=<C0>:<C1-C4>` for each EP2 Metis frame:
+
+```
+Frame    t (s)       USB1 C0:C1-C4         USB2 C0:C1-C4        Notes
+174312   33.113  00:0284081c           02:003b0752          Case 0 MOX=0, Case 1 TX freq (MOX=0)
+174441   33.137  74:00000000           00:0284081c          HL2 slot 18 (MOX=0), Case 0 MOX=0 [last MOX=0 at case-0]
+174450   33.139  02:003b0752           04:003af9a6          Case 1 TX freq, Case 2 RX1 freq [MOX=0 on both]
+174465   33.142  06:006beaf1           1c:00000800          Case 3 RX2 freq, Case 4 ADC
+174479   33.144  08:003b0752           0a:003b0752          Case 5 DDC2, Case 6 DDC3
+174494   33.147  0c:003b0752           0e:003af9a6          Case 7 DDC4, Case 8 DDC5
+174508   33.149  10:003af9a6           12:6e4c1004          Case 9 DDC6, Case 10 Drive/Alex [MOX=0, last before TX]
+  -- XmitBit set by host between frames 174508 and 174523 (~2.8 ms gap) --
+174523   33.152  15:00570068           17:3f209932          Case 11 Preamp MOX=1, Case 12 ATT/CW MOX=1 [FIRST MOX=1]
+174537   33.155  1f:00000700           21:4d023200          Case 13 CW MOX=1, Case 14 CW hang MOX=1
+174552   33.158  23:1900c800           25:80400000          Case 15 EER MOX=1, Case 16 BPF2 MOX=1
+174566   33.160  2f:00001e46           75:00000000          HL2 slot 17 MOX=1, HL2 slot 18 MOX=1
+174581   33.163  01:0204081c           03:003b0a72          Case 0 MOX=1 [case-0 transition], Case 1 TX freq MOX=1
+174595   33.166  05:003af9a6           fb:079d0654          Case 2 RX1 freq MOX=1, HL2 0xFB slot MOX=1
+174609   33.168  07:006beaf1           1d:00000800          Case 3 RX2 freq MOX=1, Case 4 ADC MOX=1
+174624   33.171  09:003b0a72           0b:003b0a72          Case 5 DDC2 MOX=1, Case 6 DDC3 MOX=1
+174638   33.173  0d:003b0a72           0f:003af9a6          Case 7 DDC4 MOX=1, Case 8 DDC5 MOX=1
+```
+
+**Key findings from the bring-up sequence:**
+
+1. **TX frequency was set BEFORE MOX-on.** At frame 174450 (USB1 `02:003b0752`),
+   case-1 TX VFO is already at 3,869,298 Hz (80m) with MOX=0. The TX frequency
+   update is part of the normal round-robin and does not require a special
+   pre-TX burst — it was already correct from the band-change that preceded
+   this TX event.
+
+2. **Drive level was set BEFORE MOX-on.** At frame 174508, USB2 C0=`0x12` (case 10)
+   carries drive level in C1. This slot is the last frame with MOX=0 before
+   the transition. The next occurrence of case 10 will carry MOX=1 but the
+   value doesn't change.
+
+3. **No Alex TX relay update was observed in the TX bring-up window.** Case 10
+   (C0=`0x12`) carries the HPF/LPF filter bits and is sent every round-robin
+   cycle. Its filter content (C3=`0x10`, 1.5 MHz HPF; C4=`0x04`, 80m LPF) does
+   not change at MOX-on: the filter bits were already set during the preceding
+   band-change event (see Section 7). Thetis does not send a dedicated "TX relay
+   arm" command — the Alex filter state is a continuous round-robin register.
+
+4. **MOX bit appears simultaneously on ALL C0 slots** in the first frame after
+   XmitBit is set. Frame 174523 carries MOX=1 in both USB1 (`0x15`) and USB2
+   (`0x17`), which are cases 11 and 12 in the round-robin. There is no per-slot
+   staggering. The delay between the last MOX=0 frame (174508, t=33.149 s) and
+   the first MOX=1 frame (174523, t=33.152 s) is approximately **2.8 ms** —
+   one EP2 frame interval at ~378 Hz.
+
+5. **TX I/Q payload is non-zero from the very first post-MOX frame.** Frame
+   174595 is the first post-case-0-transition frame and already carries non-zero
+   TX I/Q data (see §8.4). There is no observed "ramp-in" delay of blank
+   samples.
+
+### 8.4 TX Sample Format
+
+#### 8.4.1 Hex excerpt (frame 191997, t=36.368 s, mid-TX)
+
+```
+Offset (from UDP payload start)
+  0x00  ef fe 01 02  -- Metis header (EP2)
+  0x04  00 00 34 02  -- sequence number 0x3402
+  0x08  7f 7f 7f 13  -- USB1 sync + C0=0x13 (case 9, MOX=1)
+  0x0C  6e 4c 10 04  -- C1-C4
+  0x10  00 00 00 00  -- sample 0: L audio I=0x0000, L audio Q=0x0000
+  0x14  ac 13 5d 35  -- sample 0: TX IQ I=0xAC13 (-21485), TX IQ Q=0x5D35 (+23861)
+  0x18  00 00 00 00  -- sample 1: L audio I=0x0000, L audio Q=0x0000
+  0x1C  a2 cb 53 ed  -- sample 1: TX IQ I=0xA2CB (-23349), TX IQ Q=0x53ED (+21485)
+  0x20  00 00 00 00  -- sample 2: L audio
+  0x24  9a 88 49 b9  -- sample 2: TX IQ I=0x9A88 (-25976), TX IQ Q=0x49B9 (+18873)
+```
+
+The TX IQ samples are **non-zero**. The audio bytes (every group of 4 bytes
+starting at offset `0x10`, `0x18`, ...) are zero, indicating the operator
+transmits RF signal (SSB or AM) but no audio is present at the L/R audio
+position — consistent with SSB transmit without microphone input captured in
+this session, or with the operator transmitting a carrier/tone.
+
+#### 8.4.2 Expected format from networkproto1.c
+
+`networkproto1.c:732–743` (inside `sendProtocol1Samples`):
+
+```c
+for (i = 0; i < 2 * 63; i++)          // 126 samples across both USB sub-frames
+    for (j = 0; j < 2; j++)            // j=0: L/R audio, j=1: TX I/Q
+        for (k = 0; k < 2; k++)        // k=0: I component, k=1: Q component
+        {
+            temp = /* float→int16 clamp and round */;
+            prn->OutBufp[8 * i + 4 * j + 2 * k + 0] = (char)((temp >> 8) & 0xff);
+            prn->OutBufp[8 * i + 4 * j + 2 * k + 1] = (char)(temp & 0xff);
+        }
+```
+
+Each 8-byte sample unit layout (big-endian 16-bit signed integers):
+
+| Bytes | Field | j, k |
+|-------|-------|------|
+| [0–1] | L/R audio I sample | j=0, k=0 |
+| [2–3] | L/R audio Q sample | j=0, k=1 |
+| [4–5] | TX IQ I sample     | j=1, k=0 |
+| [6–7] | TX IQ Q sample     | j=1, k=1 |
+
+**Observed vs. expected:** The captured sample layout matches exactly. The
+pattern `00 00 00 00 <I_hi> <I_lo> <Q_hi> <Q_lo>` in the hex dump corresponds
+to zero audio (bytes 0–3) plus non-zero TX IQ (bytes 4–7) per sample unit.
+This is consistent with the formula at `networkproto1.c:736`.
+
+**CW note:** `networkproto1.c:738–741` shows that in CW mode, j=1 samples are
+overwritten with keying bits (`dot<<2 | dash<<1 | cwx`). This was NOT observed
+in this capture — the j=1 data contains normal IQ amplitudes, confirming the
+operator was transmitting SSB (or AM/FM), not CW.
+
+**TX sample depth:** 16-bit signed (int16), big-endian. This is different from
+EP6 (RX I/Q), which uses 24-bit signed samples. `networkproto1.c:736` applies
+`floor(x * 32767.0 + 0.5)` / `ceil(x * 32767.0 - 0.5)` scaling — a standard
+float→int16 conversion.
+
+### 8.5 HL2 Quirks Observed During TX
+
+1. **MOX bit appears in HL2 extension slots.** Slots `0x2F` (HL2 ext 17) and
+   `0x75` (HL2 ext 18) carry MOX=1 during TX (frame 174566: `2f:00001e46` and
+   `75:00000000`). The HL2 firmware reads the MOX bit from all C0 bytes, not
+   just case-0. Extension slots must include the correct MOX bit.
+
+2. **The periodic HL2 `0xFB` slot carries MOX=1 during TX** (frame 174595:
+   `fb:079d0654`). This confirms the 0xFA/0xFB HL2 register writes continue
+   during TX with the same ~131-frame period, and the MOX bit is simply OR'd in
+   by `WriteMainLoop`. There is no TX-specific suppression or change in the HL2
+   periodic slot content.
+
+3. **One-frame blank TX sample window.** The sample region of frame 174595
+   (first complete EP2 frame after the case-0 MOX transition) shows all-zero
+   sample bytes — the WDSP transmit chain needs one write cycle before its first
+   IQ output arrives. By frame 191997 (t=36.368 s, well into the TX event),
+   IQ samples are clearly non-zero (`0xAC13` / `0x5D35`).
+
+### 8.6 Recipe for Nereus Phase 3L — TX Keying
+
+To key TX on HL2 via Protocol 1:
+
+1. **Set TX frequency** (case 1, `C0 |= 0x02`): write desired TX frequency as
+   32-bit big-endian Hz in C1–C4. This is sent every round-robin cycle
+   (`networkproto1.c:476–481`). Ensure the correct frequency is in the shared
+   state before asserting MOX.
+
+2. **Set drive level** (case 10, `C0 |= 0x12`): write `tx[0].drive_level`
+   (0–255) into C1 (`networkproto1.c:580`). This must be set before MOX-on; the
+   HL2 firmware uses this value to scale TX output power.
+
+3. **Set Alex HPF/LPF filter bits** (case 10, C3/C4): the Alex filter selection
+   lives in the same slot as drive level (`networkproto1.c:583–590`). Update
+   filter bits for the TX band before keying. In this capture the filter was
+   already correct from the preceding band-change.
+
+4. **Assert MOX**: set `XmitBit = 1`. On the very next `WriteMainLoop` call, C0
+   for every slot will have bit 0 set. No special "MOX command" burst is needed
+   — the bit propagates to all 19 slots simultaneously.
+
+5. **Stream TX I/Q**: from the same `WriteMainLoop` call that first carries
+   MOX=1, the host must supply valid TX I/Q samples in `outIQbufp` (126 complex
+   float samples, scaled to ±1.0). These are packed as 16-bit big-endian signed
+   integers at 8 bytes/sample in the EP2 payload (`networkproto1.c:732–743`).
+   **Observed delay between MOX-on and first TX I/Q frame: 1 frame (~2.6 ms).**
+
+6. **Assert MOX-off**: set `XmitBit = 0`. On the next `WriteMainLoop` call, all
+   C0 slots revert to even (MOX=0). `networkproto1.c:723` zeros `outIQbufp`
+   when `XmitBit == 0`, ensuring no residual TX samples are sent after keying
+   stops.
+
+7. **No special teardown**: there is no "TX-off" command beyond clearing XmitBit.
+   The Alex filters and drive level remain at their current values; they need not
+   be cleared. The HL2 firmware stops accepting TX IQ data as soon as MOX=0 is
+   received.
+
+**Thetis source cross-references:**
+- MOX bit build: `networkproto1.c:446` — `C0 = (unsigned char)XmitBit`
+- MOX transition detection: `networkproto1.c:436–440` — `if (XmitBit != PreviousTXBit)`
+- TX IQ zero-fill on MOX-off: `networkproto1.c:723` — `if (!XmitBit) memset(prn->outIQbufp, 0, ...)`
+- TX IQ sample pack: `networkproto1.c:732–743` — 16-bit BE int16 format
+- Drive level (case 10): `networkproto1.c:578–580`
+
+---

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -329,3 +329,388 @@ may not implement it, or the round-robin does not reach it in this
 
 **Thetis source:** `networkproto1.c:273–416` (`MetisReadThreadMainLoop` — RX
 parser, C0 switch, I/Q decode, mic decode).
+
+---
+
+## 5. EP2 — Host → Radio Command Frames
+
+EP2 is the host→radio command channel, Metis-framed with endpoint `0x02` in
+byte[3] of the Metis header. Each frame is 1032 bytes: an 8-byte Metis header
+followed by two 512-byte USB sub-frames, each carrying 3 sync bytes (`7F 7F 7F`)
+plus 5 C&C bytes (C0–C4), followed by TX I/Q samples (all zero in RX-only mode).
+The round-robin `out_control_idx` counter cycles through every command slot in
+turn so the radio's command state is continuously refreshed even with no user
+action.
+
+**Thetis source:** `networkproto1.c:419–697` (`WriteMainLoop` — EP2 builder;
+`sendProtocol1Samples` — caller thread).
+
+---
+
+### 5.1 Frame envelope
+
+The Metis envelope for EP2 is identical in structure to EP6, with the endpoint
+field differing:
+
+| Byte offset | Size | Value | Meaning |
+|-------------|------|-------|---------|
+| 0–2 | 3 | `EF FE 01` | Metis magic — "data frame" marker |
+| 3 | 1 | `02` | Endpoint: EP2 = host→radio command/TX data |
+| 4–7 | 4 | uint32 BE | Outgoing sequence number (`MetisOutBoundSeqNum`, auto-incremented per frame) |
+| 8–519 | 512 | USB sub-frame 1 | Sync `7F7F7F` + C0–C4 + TX I/Q samples (zero in RX) |
+| 520–1031 | 512 | USB sub-frame 2 | Sync `7F7F7F` + C0–C4 + TX I/Q samples (zero in RX) |
+
+Within each USB sub-frame:
+
+| Sub-frame byte | Content |
+|----------------|---------|
+| 0–2 | `7F 7F 7F` sync |
+| 3 | C0 (command index + MOX bit) |
+| 4–7 | C1–C4 (command payload) |
+| 8–511 | TX I/Q samples (16-bit signed big-endian, LR then IQ interleaved); all zero in RX mode |
+
+**Observed frame size:** All 21,044 EP2 data frames in this capture are exactly
+1032 bytes (UDP payload). UDP length field = 1040 (1032 + 8-byte UDP header).
+
+---
+
+### 5.2 C0 dispatch and the MOX bit
+
+`WriteMainLoop` builds C0 as:
+
+```c
+C0 = (unsigned char)XmitBit;   // bit 0 = MOX/PTT state
+// ...
+C0 |= <slot-specific OR-mask>; // bits 7:1 = command index
+```
+
+So the low bit of C0 carries MOX state and the upper 7 bits (masked with `0xF8`
+to get the 5-bit index field) identify the command slot. Thetis dispatches on
+`out_control_idx` (0–16 in the standard build), which maps to the C0 OR-mask
+values shown in section 5.3.
+
+The `out_control_idx` counter increments once per USB sub-frame (twice per
+Metis frame). After reaching `end_frame` (=16 for non-ANVELINAPRO3 models),
+it resets to 0. **In this capture the observed cycle is 19 sub-frame positions
+(not 17), implying the HL2-connected Thetis build has `end_frame = 18`,
+adding two HL2-specific cases beyond the standard P1 command set.**
+
+---
+
+### 5.3 Observed C0 indices — master table
+
+Counts are per-sub-frame (each Metis frame contributes one USB1 count and one
+USB2 count independently). "USB1" = sub-frame at byte offset 8; "USB2" = at
+byte offset 520. C1–C4 examples are the first occurrence in the capture.
+
+| C0 masked | Raw C0 seen | USB1 count | USB2 count | C1–C4 (USB1 example) | Meaning / source |
+|-----------|-------------|------------|------------|----------------------|------------------|
+| `0x00` | `0x00`, `0x01`, `0x02`, `0x03`, `0x04`, `0x05`, `0x06`, `0x07` | ~5,591 | ~5,573 | see per-slot table | Multiple slots share masked 0x00 (low 3 bits = MOX + slot sub-index) |
+| `0x08` | `0x08`–`0x0F` | ~4,313 | ~4,312 | `08 0F 32 ED` | Freq slots DDC0–DDC3 and TX |
+| `0x10` | `0x10`–`0x17` | ~4,277 | ~4,270 | `08 0D 55 0F` | Freq slots DDC4–DDC6, drive/filter, preamp, step-att |
+| `0x18` | `0x1C`–`0x1F` | ~2,191 | ~2,178 | `00 00 07 00` | ADC assign (0x1C) + CW enable/sidetone (0x1E) |
+| `0x20` | `0x20`–`0x25` | ~3,053 | ~3,046 | `4D 02 32 00` | CW hang/sidetone freq (0x20), EER PWM (0x22), BPF2 (0x24) |
+| `0x28` | `0x2E`, `0x2F` | ~1,715 | ~1,715 | `00 00 1E 46` | **HL2 extension** — not in `networkproto1.c` WriteMainLoop; constant payload |
+| `0x70` | `0x74`, `0x75` | ~1,099 | ~1,092 | `00 00 00 00` | **HL2 extension** — not in `networkproto1.c`; all-zero payload |
+| `0x78` | `0x7A` | 55 | 41 | `06 9D 20 00` | **HL2 extension** — burst pattern, C1=`0x06`, C2=`0x9D`; not in source |
+| `0xF8` | `0xFA`, `0xFB` | 167 | 156 | `07 C1 00 00` | **HL2 extension** — periodic ~131-frame interval, C1=`0x07`, C2=`0x9D` typically |
+
+**Note on masked 0x00:** The standard switch uses `out_control_idx` not masked
+C0, so multiple slots produce raw C0 values that all mask to `0x00` after
+`& 0xF8`. The individual raw values are decoded per-slot in section 5.4.
+
+---
+
+### 5.4 Per-slot command decode
+
+Each row below corresponds to one `case` in `WriteMainLoop`
+(`networkproto1.c:448–675`). All values are from frames actually present in
+this capture. Frequencies are decoded as 32-bit big-endian Hz.
+
+#### Case 0 — General settings (`C0 |= 0x00`, raw C0 = `0x00`/`0x01`)
+
+`networkproto1.c:450–471`
+
+| Field | Bit(s) of byte | Observed value | Decoded |
+|-------|----------------|----------------|---------|
+| **C0** | bit 0 | `0x00` (MOX off) | MOX=0 |
+| **C1** bits 1:0 | `SampleRateIn2Bits & 3` | `0x02` | 192 kHz sample rate |
+| **C2** bit 0 | `cw.eer & 1` | `0x00` | EER off |
+| **C2** bits 7:1 | `oc_output << 1` | `0x00` | Open-collector outputs = 0 |
+| **C3** bits 7:0 | attn/preamp/dither/random/filter-ext | `0x00` | all off |
+| **C4** bits 1:0 | antenna select (0=none, 1=ANT2, 2=ANT3) | `0x00` | no aux antenna |
+| **C4** bit 2 | duplex enable | `0` | simplex (HL2 note: code normally OR-masks `0x04`; `0x18` observed implies duplex bit not set — likely HL2 simplex RX-only mode) |
+| **C4** bits 6:3 | `(nddc-1) << 3` | `0x18` → bits[6:3]=`0011` | nddc = 4 DDCs active |
+| **C4** bit 7 | diversity | `0` | diversity off |
+
+First frame example: `C1=0x02 C2=0x00 C3=0x00 C4=0x18`
+
+#### Case 1 — TX VFO frequency (`C0 |= 0x02`, raw C0 = `0x02`/`0x03`)
+
+`networkproto1.c:476–481`
+
+C1–C4 = 32-bit big-endian TX frequency in Hz.
+
+| Raw C0 | C1–C4 (hex) | Frequency |
+|--------|-------------|-----------|
+| `0x02` (MOX=0) | `08 0F 32 ED` | 135,213,805 Hz — startup/ForceCandCFrame value |
+| `0x03` (MOX=1) | `00 3B 0A 72` | **3,869,298 Hz = 3.869 MHz (80m)** — TX VFO during TX |
+
+#### Case 2 — DDC0 / RX1 frequency (`C0 |= 0x04`, raw C0 = `0x04`/`0x05`)
+
+`networkproto1.c:484–494`
+
+In RX mode (non-PureSignal, nddc≠2), C1–C4 = `rx[0].frequency` as 32-bit BE Hz.
+
+| Raw C0 | C1–C4 (hex) | Frequency |
+|--------|-------------|-----------|
+| `0x04` (MOX=0) | `08 0D 55 0F` | 135,091,471 Hz — startup |
+| `0x05` (MOX=1) | `00 3A F9 A6` | **3,864,998 Hz = 3.865 MHz (80m)** — RX1/DDC0 |
+
+#### Case 3 — DDC1 / RX2 frequency (`C0 |= 0x06`, raw C0 = `0x06`/`0x07`)
+
+`networkproto1.c:497–511`
+
+With nddc=4 (Hermes configuration), C1–C4 = `rx[1].frequency`.
+
+| Raw C0 | C1–C4 (hex) | Frequency |
+|--------|-------------|-----------|
+| `0x06` (MOX=0) | `0E BB FF 97` | 247,201,687 Hz — startup |
+| `0x07` (MOX=1) | `00 6B EA F1` | **7,072,497 Hz = 7.072 MHz (40m)** — RX2/DDC1 |
+
+#### Case 4 — ADC assignments and TX step attenuator (`C0 |= 0x1C`, raw C0 = `0x1C`/`0x1D`)
+
+`networkproto1.c:517–522`
+
+| Byte | Field | Observed | Decoded |
+|------|-------|----------|---------|
+| C1 | `P1_adc_cntrl & 0xFF` | `0x00` | ADC control low byte = 0 |
+| C2 | `(P1_adc_cntrl >> 8) & 0x3FF` | `0x00` | ADC control high bits = 0 |
+| C3 | `adc[0].tx_step_attn & 0x1F` | `0x08` | ADC0 TX step attenuation = **8 dB** |
+| C4 | (unused) | `0x00` | — |
+
+#### Case 5 — DDC2 / RX3 frequency (`C0 |= 0x08`, raw C0 = `0x08`/`0x09`)
+
+`networkproto1.c:525–535`
+
+With nddc=4 (not nddc=5/Orion), C1–C4 = `tx[0].frequency`.
+
+| Raw C0 | C1–C4 (hex) | Frequency |
+|--------|-------------|-----------|
+| `0x08` (MOX=0) | `08 0F 32 ED` | 135,213,805 Hz — TX VFO (DDC2 tracks TX in this config) |
+| `0x09` (MOX=1) | `00 3B 0A 72` | 3,869,298 Hz — TX freq during MOX |
+
+#### Case 6 — DDC3 / RX4 frequency (`C0 |= 0x0A`, raw C0 = `0x0A`/`0x0B`)
+
+`networkproto1.c:538–545`
+
+DDC3 always tracks TX frequency. C1–C4 = `tx[0].frequency` as 32-bit BE Hz.
+
+| Raw C0 | C1–C4 (hex) | Frequency |
+|--------|-------------|-----------|
+| `0x0A` (MOX=0) | `08 0F 32 ED` | 135,213,805 Hz |
+| `0x0B` (MOX=1) | `00 3B 0A 72` | 3,869,298 Hz |
+
+#### Case 7 — DDC4 / RX5 frequency (`C0 |= 0x0C`, raw C0 = `0x0C`/`0x0D`)
+
+`networkproto1.c:548–555`
+
+DDC4 always tracks TX frequency (PureSignal/Orion2 use). C1–C4 = `tx[0].frequency`.
+
+| Raw C0 | C1–C4 (hex) | Frequency |
+|--------|-------------|-----------|
+| `0x0C` (MOX=0) | `08 0F 32 ED` | 135,213,805 Hz |
+| `0x0D` (MOX=1) | `00 3B 0A 72` | 3,869,298 Hz |
+
+#### Case 8 — DDC5 / RX6 frequency (`C0 |= 0x0E`, raw C0 = `0x0E`/`0x0F`)
+
+`networkproto1.c:558–565`
+
+DDC5 not used in nddc=4 config; code sends `rx[0].frequency`.
+
+| Raw C0 | C1–C4 (hex) | Frequency |
+|--------|-------------|-----------|
+| `0x0E` (MOX=0) | `08 0D 55 0F` | 135,091,471 Hz |
+| `0x0F` (MOX=1) | `00 3A F9 A6` | 3,864,998 Hz |
+
+#### Case 9 — DDC6 / RX7 frequency (`C0 |= 0x10`, raw C0 = `0x10`/`0x11`)
+
+`networkproto1.c:568–575`
+
+DDC6 not used; code sends `rx[0].frequency`.
+
+| Raw C0 | C1–C4 (hex) | Frequency |
+|--------|-------------|-----------|
+| `0x10` (MOX=0) | `08 0D 55 0F` | 135,091,471 Hz |
+| `0x11` (MOX=1) | `00 3A F9 A6` | 3,864,998 Hz |
+
+#### Case 10 — Drive level, mic settings, filter/PA (`C0 |= 0x12`, raw C0 = `0x12`/`0x13`)
+
+`networkproto1.c:578–590`
+
+| Byte | Field | Observed | Decoded |
+|------|-------|----------|---------|
+| C1 | `tx[0].drive_level` (0–255) | `0xBC` = 188 | **drive level 188/255 (~74%)** |
+| C2 bit 0 | `mic.mic_boost` | `0` | mic boost off |
+| C2 bit 1 | `mic.line_in` | `0` | line-in off |
+| C2 bits 5:2 | Apollo filter/tuner/ATU | `0b0011` | ApolloFilt=1, ApolloTuner=1 |
+| C2 bit 6 | always 1 | `1` | fixed |
+| C3 bit 4 | `1_5MHz_HPF` | `1` | 1.5 MHz HPF **active** |
+| C4 bit 2 | `80_LPF` | `1` | 80m LPF **active** |
+
+First USB1 example (raw `0x12`): `C1=0xBC C2=0x4C C3=0x10 C4=0x04`
+
+#### Case 11 — Preamp control, mic settings, RX step attenuation (`C0 |= 0x14`, raw C0 = `0x14`/`0x15`)
+
+`networkproto1.c:593–601`
+
+| Byte | Field | Observed | Decoded |
+|------|-------|----------|---------|
+| C1 bits 6:0 | rx0–rx2 preamp, mic_trs, mic_bias, mic_ptt | `0x00` | all off |
+| C2 bits 4:0 | `mic.line_in_gain` | `0x17` = 23 | line-in gain **23 dB** |
+| C2 bit 6 | `puresignal_run` | `0` | PureSignal off |
+| C3 bits 3:0 | `user_dig_out` | `0x00` | digital outputs = 0 |
+| C4 bits 4:0 | `adc[0].rx_step_attn` | `0x10` = 16 | ADC0 RX step attenuation **16 dB** |
+| C4 bit 5 | enable bit | `1` | attenuation enabled |
+
+First USB1 example (raw `0x14`): `C1=0x00 C2=0x17 C3=0x00 C4=0x70`
+
+#### Case 12 — ADC1/ADC2 step attenuators, CW keyer timing (`C0 |= 0x16`, raw C0 = `0x16`/`0x17`)
+
+`networkproto1.c:604–628`
+
+| Byte | Field | Observed | Decoded |
+|------|-------|----------|---------|
+| C1 bits 4:0 | `adc[1].rx_step_attn` | `0x00` = 0 | ADC1 RX step attenuation **0 dB** |
+| C1 bit 5 | enable | `1` | attenuation enabled |
+| C2 bits 4:0 | `adc[2].rx_step_attn` | `0x00` = 0 | ADC2 RX step attenuation **0 dB** |
+| C2 bit 5 | enable | `1` | attenuation enabled |
+| C2 bit 6 | `cw.rev_paddle` | `0` | normal paddle |
+| C3 bits 5:0 | `cw.keyer_speed & 0x3F` | `0x19` = 25 | keyer speed **25 WPM** |
+| C3 bits 7:6 | CW mode | `0b10` | **Iambic mode B** |
+| C4 bits 6:0 | `cw.keyer_weight & 0x7F` | `0x32` = 50 | keyer weight **50** |
+| C4 bit 7 | `cw.strict_spacing` | `0` | strict spacing off |
+
+First USB1 example (raw `0x16`): `C1=0x20 C2=0x20 C3=0x99 C4=0x32`
+
+#### Case 13 — CW enable, sidetone level, RF delay (`C0 |= 0x1E`, raw C0 = `0x1E`/`0x1F`)
+
+`networkproto1.c:633–638`
+
+| Byte | Field | Observed | Decoded |
+|------|-------|----------|---------|
+| C1 | `cw.cw_enable` | `0x00` | CW **disabled** |
+| C2 | `cw.sidetone_level` | `0x00` | sidetone level = 0 |
+| C3 | `cw.rf_delay` | `0x07` | RF delay = **7** |
+| C4 | (unused) | `0x00` | — |
+
+First USB1 example (raw `0x1E`): `C1=0x00 C2=0x00 C3=0x07 C4=0x00`
+
+#### Case 14 — CW hang delay and sidetone frequency (`C0 |= 0x20`, raw C0 = `0x20`/`0x21`)
+
+`networkproto1.c:641–646`
+
+C1–C2 encode hang delay (10-bit, C1=MSBs, C2[1:0]=LSBs); C3–C4 encode sidetone
+frequency (12-bit, C3=MSBs, C4[3:0]=LSBs).
+
+| Derived value | Formula | Observed | Decoded |
+|---------------|---------|----------|---------|
+| hang_delay | `(C1 << 2) \| (C2 & 3)` | C1=`0x4D`, C2=`0x02` → `(77<<2)\|2` | **310 ms** |
+| sidetone_freq | `(C3 << 4) \| (C4 & 0xF)` | C3=`0x32`, C4=`0x00` → `(50<<4)\|0` | **800 Hz** |
+
+First USB1 example (raw `0x20`): `C1=0x4D C2=0x02 C3=0x32 C4=0x00`
+
+#### Case 15 — EER PWM min/max (`C0 |= 0x22`, raw C0 = `0x22`/`0x23`)
+
+`networkproto1.c:649–654`
+
+10-bit min and max EER PWM values, each split across two bytes (MSB in C1/C3,
+LSBs in C2/C4).
+
+First USB1 example (raw `0x22`): `C1=0x19 C2=0x00 C3=0xC8 C4=0x00`
+
+Decoded: epwm_min = `(0x19 << 2) | (0x00 & 3)` = 100; epwm_max = `(0xC8 << 2) | 0` = 800.
+
+#### Case 16 — BPF2 second-receiver band-pass filters (`C0 |= 0x24`, raw C0 = `0x24`/`0x25`)
+
+`networkproto1.c:657–665`
+
+| Byte | Field | Observed | Decoded |
+|------|-------|----------|---------|
+| C1 | HPF2 mask + 6m preamp + rx2_gnd | `0x00` | no HPF2 active, no rx2 ground |
+| C2 bit 0 | `xvtr_enable` | `0` | transverter off |
+| C2 bit 6 | `puresignal_run` | `0` | PureSignal off |
+| C3–C4 | (unused) | `0x00 0x00` | — |
+
+First USB1 example (raw `0x24`): `C1=0x00 C2=0x00 C3=0x00 C4=0x00`
+
+#### Cases 17–18 — HL2-specific extensions (masked `0x28`, `0x70`)
+
+**Not in `networkproto1.c` WriteMainLoop.** These two slots appear in the
+captured 19-step cycle at positions 17 and 18, indicating the HL2-connected
+Thetis build extends `end_frame` to 18 with additional cases. The standard
+`networkproto1.c` sets `end_frame = 16` (17 slots); the HL2 build adds 2 more.
+
+| Raw C0 | Observed C1–C4 | Notes |
+|--------|----------------|-------|
+| `0x2E` / `0x2F` | `00 00 1E 46` (constant, all frames) | HL2 extension slot 17; payload `0x1E46` = 7750 — purpose unknown; not in source |
+| `0x74` / `0x75` | `00 00 00 00` (constant, all frames) | HL2 extension slot 18; all-zero payload; purpose unknown; not in source |
+
+**Investigate:** Check the Thetis HL2 fork or HL2 firmware protocol documentation
+for the meaning of C0=`0x2E` and C0=`0x74`.
+
+#### Aperiodic HL2 commands (masked `0x78`, `0xF8`)
+
+These appear outside the standard round-robin cycle, injected asynchronously:
+
+| Masked C0 | Raw C0 seen | Count (USB1) | Periodicity | C1–C4 pattern | Notes |
+|-----------|-------------|--------------|-------------|---------------|-------|
+| `0x78` | `0x7A` | 55 | Bursts of 3, then 1000+ frame gap | C1=`0x06` C2=`0x9D`, C3/C4 vary | `0x069D` prefix; likely HL2 I2C or register passthrough; not in source |
+| `0xF8` | `0xFA`, `0xFB` | 167 | ~131 frames between occurrences | C1=`0x07` C2=`0x9D` C3=`0x06`, C4 varies | `0x079D` prefix; same 0x9D pattern as 0x78 group; periodic ~timer-driven; not in source |
+
+The shared `0x9D` = 157 in C2 for both `0x78` and `0xF8` groups is consistent
+with a common I2C device address or HL2-internal register number. These are
+not in `networkproto1.c` and require investigation against HL2-specific
+Thetis source or firmware docs.
+
+---
+
+### 5.5 MOX bit observation
+
+MOX state is carried in bit 0 of raw C0 on every USB sub-frame (not just
+C0=`0x00`). This capture includes an active TX period. MOX-on sub-frames were
+observed at all slots in the round-robin (the MOX bit is OR-masked onto C0
+for every slot while transmitting).
+
+**Counting USB1 frames where the C0 masked-to-`0x00` slot has raw=`0x00`
+(MOX off) vs raw=`0x01` (MOX on):**
+
+| State | Frames | Notes |
+|-------|--------|-------|
+| MOX off (`raw & 0x01 == 0`) | 3,457 | RX periods |
+| MOX on (`raw & 0x01 == 1`) | 937 | TX period(s) present — see Section 8 for TX trace |
+
+MOX was **set** in this capture. The 937 MOX-on frames at case-0 position
+represent approximately 44 complete round-robin cycles of TX operation
+(937 / ~21 sub-frames per cycle ≈ 44 TX cycles). This confirms this capture
+is usable for Task 9 (TX/keying trace).
+
+---
+
+### 5.6 HL2-specific observations
+
+1. **19-step round-robin** (standard P1 is 17): Two extra command slots (`0x2E`,
+   `0x74`) are sent every cycle by the HL2 Thetis build.
+2. **nddc = 4 with duplex=0**: The HL2 runs 4 DDCs but with the duplex bit
+   unset in C0=`0x00` frame `C4=0x18`. Standard Thetis always ORs `0b00000100`
+   (duplex bit) unconditionally; the HL2 build or HL2 firmware may treat this
+   differently.
+3. **Periodic HL2 register writes** (masked `0xF8`, ~131-frame period): Suggest
+   a background timer in the HL2 Thetis build that writes firmware-specific
+   registers (temperature, I2C, or internal state) independently of the
+   round-robin.
+4. **Burst I2C/register commands** (masked `0x78`): Appear during band or
+   configuration changes, consistent with HL2 I2C passthrough to on-board
+   peripheral (LPF relay driver, LNA, or step-attenuator IC).
+
+**Thetis source:** `networkproto1.c:419–697` (`WriteMainLoop`, `sendProtocol1Samples`).

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -34,4 +34,76 @@ this document.
 The capture is a single clean session: discovery → start → steady-state
 RX → stop. Subsequent sections walk through each phase.
 
-<!-- Sections 2-10 and Appendix A added by later tasks -->
+<!-- Sections 3-10 and Appendix A added by later tasks -->
+
+## 2. Discovery Exchange
+
+P1 discovery is a one-shot broadcast UDP exchange on port 1024. The host
+sends a 63-byte packet to the subnet broadcast address; the radio replies
+from its own port 1024 to the host's ephemeral source port. This handshake
+precedes every session: no start command is sent until at least one valid
+reply is received.
+
+### 2.1 Discovery REQUEST (host → broadcast :1024)
+
+UDP payload (63 bytes, frames 1 and 4 in the capture):
+
+```text
+Offset  Hex                                               ASCII
+------  ------------------------------------------------  -----
+00      ef fe 02 00 00 00 00 00 00 00 00 00 00 00 00 00  ........
+10      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ........
+20      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ........
+30      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00      ...............
+```
+
+Field legend:
+
+- **bytes 0–1** `EF FE` — P1 sync / frame marker
+- **byte 2** `02` — command: discovery request
+- **bytes 3–62** `00 * 60` — padding (all zero); no additional fields defined
+  for the request direction
+
+Thetis send: `clsRadioDiscovery.cs:1301` — `buildDiscoveryPacketP1()`
+
+### 2.2 Discovery REPLY (radio :1024 → host :50533)
+
+UDP payload (60 bytes, frames 2 and 5 in the capture; both identical):
+
+```text
+Offset  Hex                                               ASCII
+------  ------------------------------------------------  -----
+00      ef fe 02 00 1c c0 a2 13 dd 4a 06 00 00 00 00 00  .........J......
+10      00 00 00 04 45 02 00 00 00 00 00 03 03 ef 00 00  ....E...........
+20      00 00 00 00 80 16 46 36 5e 83 00 00 00 00 00 00  ......F6^.......
+30      00 00 00 00 00 00 00 00 00 00 00 00              ............
+```
+
+Field legend (P1 parser: `clsRadioDiscovery.cs:1122` — `parseDiscoveryReply()`):
+
+- **byte 0** `EF` — sync (matches `data[0] == 0xef`)
+- **byte 1** `FE` — sync (matches `data[1] == 0xfe`)
+- **byte 2** `02` — status: `02` = available, `03` would mean busy
+  (`r.IsBusy = (data[2] == 0x3)` — `clsRadioDiscovery.cs:1147`)
+- **bytes 3–8** `00 1C C0 A2 13 DD` — MAC address of radio
+  (`Array.Copy(data, 3, mac, 0, 6)` — `clsRadioDiscovery.cs:1150`);
+  HL2 MAC seen in this capture: **00:1C:C0:A2:13:DD**
+- **byte 9** `4A` — firmware / code version = `0x4A` (decimal 74)
+  (`r.CodeVersion = data[9]` — `clsRadioDiscovery.cs:1155`)
+- **byte 10** `06` — board ID = `6` → maps to `HPSDRHW.HermesLite` (MI0BOT)
+  (`r.DeviceType = mapP1DeviceType(data[10])` — `clsRadioDiscovery.cs:1153`;
+  enum value at `enums.cs:396`: `HermesLite = 6`)
+- **bytes 11–13** `00 00 00` — unknown — investigate before implementing
+  (not read by the P1 parser branch)
+- **byte 14** `00` — `MercuryVersion0` (`data[14]` — `clsRadioDiscovery.cs:1160`)
+- **byte 15** `00` — `MercuryVersion1` (`data[15]` — `clsRadioDiscovery.cs:1161`)
+- **byte 16** `00` — `MercuryVersion2` (`data[16]` — `clsRadioDiscovery.cs:1162`)
+- **byte 17** `00` — `MercuryVersion3` (`data[17]` — `clsRadioDiscovery.cs:1163`)
+- **byte 18** `00` — `PennyVersion` (`data[18]` — `clsRadioDiscovery.cs:1164`)
+- **byte 19** `04` — `MetisVersion` = 4 (`data[19]` — `clsRadioDiscovery.cs:1165`)
+- **byte 20** `45` — `NumRxs` = 69 (`data[20]` — `clsRadioDiscovery.cs:1166`);
+  raw value 0x45 as reported by HL2 firmware — unknown — investigate before implementing
+- **bytes 21–59** `02 00 00 ... 83 00 ...` — unknown — investigate before implementing
+  (not read by the P1 parser branch; 39 bytes total)
+
+**Thetis source:** `clsRadioDiscovery.cs:1301` (send — `buildDiscoveryPacketP1`), `:1122` (parse — `parseDiscoveryReply`)

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -107,3 +107,80 @@ Field legend (P1 parser: `clsRadioDiscovery.cs:1122` — `parseDiscoveryReply()`
   (not read by the P1 parser branch; 39 bytes total)
 
 **Thetis source:** `clsRadioDiscovery.cs:1301` (send — `buildDiscoveryPacketP1`), `:1122` (parse — `parseDiscoveryReply`)
+
+## 3. Start / Stop Commands
+
+P1 start/stop is a small 64-byte Metis frame sent to the radio. Byte 2 is the
+command (`04`), byte 3 selects start/stop and which data streams to enable.
+The frame is NOT a full 1032-byte Metis frame — it carries no C&C or I/Q
+payload, just the 4-byte command header followed by 60 zero bytes.
+
+### 3.1 Start Command (host → radio :1024)
+
+Captured frame 10, relative timestamp 1.007829900 s (first confirmed start
+after IQ stream begins flowing).
+
+UDP payload (64 bytes, offsets shown relative to UDP payload start):
+
+```text
+Offset  Hex                                               ASCII
+------  ------------------------------------------------  -----
+00      ef fe 04 01 00 00 00 00 00 00 00 00 00 00 00 00  ................
+10      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+20      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+30      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+```
+
+Field legend:
+
+- **bytes 0–1** `EF FE` — P1 sync / frame marker
+- **byte 2** `04` — command: start/stop
+- **byte 3** `01` — mode: start with IQ data stream enabled
+  (`outpacket.packetbuf[3] = 0x01` — `networkproto1.c:50`)
+- **bytes 4–63** `00 * 60` — zero padding
+
+Note: frame 7 (t=0.944 s) contains byte 3 = `00` (a stop command sent before
+the first start — consistent with `SendStartToMetis()` calling
+`ForceCandCFrame(1)` then immediately sending start, with the radio possibly
+echoing a cleanup stop first).
+
+### 3.2 Stop Command (host → radio :1024)
+
+Captured frame 302249, relative timestamp 56.658037300 s (end of session).
+
+UDP payload (64 bytes):
+
+```text
+Offset  Hex                                               ASCII
+------  ------------------------------------------------  -----
+00      ef fe 04 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+10      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+20      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+30      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
+```
+
+Field legend:
+
+- **bytes 0–1** `EF FE` — P1 sync / frame marker
+- **byte 2** `04` — command: start/stop
+- **byte 3** `00` — mode: stop all data streams
+  (`outpacket.packetbuf[3] = 0x00` — `networkproto1.c:85`)
+- **bytes 4–63** `00 * 60` — zero padding
+
+### 3.3 Mode Byte (byte 3) Decode Table
+
+Values taken directly from `networkproto1.c` (`SendStartToMetis` and
+`SendStopToMetis`). No other values appear in this source file.
+
+| Value | Meaning | Source |
+| --- | --- | --- |
+| `0x00` | Stop — all data streams off | `networkproto1.c:85` |
+| `0x01` | Start — IQ data stream enabled | `networkproto1.c:50` |
+
+The capture contains only `0x00` and `0x01`. The values `0x02` (wideband only)
+and `0x03` (IQ + wideband) are referenced in the OpenHPSDR P1 specification
+but do NOT appear in `SendStartToMetis()` or `SendStopToMetis()`. They are not
+documented here as they cannot be verified against this source or capture.
+
+**Thetis source:** `networkproto1.c:50` (start send — `SendStartToMetis`),
+`networkproto1.c:85` (stop send — `SendStopToMetis`)

--- a/docs/protocols/openhpsdr-protocol1-capture-reference.md
+++ b/docs/protocols/openhpsdr-protocol1-capture-reference.md
@@ -777,3 +777,192 @@ The HL2 firmware expects a ~19 ms round-robin cycle (one C0 "send all" command p
 
 Sustaining these rates without drops is a **hard requirement** for the round-robin C&C refresh to complete within the ~10 ms window the HL2 expects. Any sustained frame loss, reordering, or timing jitter will cause the HL2 to miss command updates and potentially fall out of sync with the Nereus host.
 
+
+---
+
+## 7. Band-Change Trace
+
+### 7.1 Overview
+
+When the operator retunes across an HPF or LPF boundary, the host must
+propagate several changes simultaneously: the DDC NCO frequencies, the TX VFO
+frequency, and the Alex analog front-end filter selection. Because EP2 uses a
+fixed 19-step round-robin that cannot be paused or restarted mid-cycle, Thetis
+does not implement a coordinated "atomic" commit. Instead, it writes updated
+values into the shared state structure (`prn->rx[N].frequency`,
+`prbpfilter->_80_LPF`, etc.) and allows the round-robin to pick them up slot
+by slot across two consecutive Metis frames (~2.7 ms per slot at 378 Hz). The
+result is a brief window — at most one full 19-slot cycle (~50 ms) — during
+which the DDC NCOs and the front-end filters may be in a mismatched state. The
+HL2 firmware tolerates this: it does not apply commands atomically, and no
+audio thump or relay bounce was observed.
+
+This section documents the full sequence of EP2 slots emitted during a
+representative retune from 80m (3.869 MHz) to 60m (5.331 MHz), including the
+HPF/LPF switchover at the 5 MHz boundary.
+
+**Thetis source:** RX1 frequency set in `networkproto1.c:484–494` (case 2);
+Alex/HPF/LPF set in `networkproto1.c:578–590` (case 10).
+
+---
+
+### 7.2 All frequency and filter transitions in the session
+
+| Time (s) | Frame | C0 (raw) | Command | Old value | New value |
+|----------|-------|-----------|---------|-----------|-----------|
+| 1.48 | 2423 | `0x04` | RX1 (DDC0) Freq | startup (135.091 MHz) | 3.865 MHz (80m) |
+| 5.61 | 24874 | `0x06` | RX2 (DDC1) Freq | startup (247.202 MHz) | 7.072 MHz (40m) |
+| 5.64 | 25005 | `0x04` | RX1 (DDC0) Freq | 3.865 MHz | 3.868 MHz |
+| **5.669** | **25186** | **`0x12`** | **Alex / HPF+LPF** | **1.5MHz_HPF + 80m_LPF** | **1.5MHz_HPF + 40/60m_LPF** |
+| **5.683** | **25258** | **`0x02`** | **TX VFO Freq** | **3.868 MHz** | **5.331 MHz** |
+| **5.685** | **25273** | **`0x04`** | **RX1 (DDC0) Freq** | **3.868 MHz** | **5.331 MHz** |
+| 7.714 | 36299 | `0x12` | Alex / HPF+LPF | 1.5MHz_HPF + 40/60m_LPF | 6.5MHz_HPF + 40/60m_LPF |
+| 7.727 | 36372 | `0x02` | TX VFO Freq | 5.331 MHz | 7.230 MHz (40m) |
+| 7.704 | 36242 | `0x04` | RX1 (DDC0) Freq | 5.331 MHz | 7.230 MHz (40m) |
+| 10.878 | 53484 | `0x04` | RX1 (DDC0) Freq | 7.230 MHz | 10.136 MHz (30m) |
+| 13.473 | 67590 | `0x04` | RX1 (DDC0) Freq | 10.136 MHz | 14.296 MHz (20m) |
+| 16.069 | 81695 | `0x04` | RX1 (DDC0) Freq | 14.296 MHz | 18.135 MHz (17m) |
+| 18.815 | 96619 | `0x04` | RX1 (DDC0) Freq | 18.135 MHz | 21.300 MHz (15m) |
+| 21.309 | 110167 | `0x04` | RX1 (DDC0) Freq | 21.300 MHz | 21.295 MHz |
+| 21.385 | 110580 | `0x04` | RX1 (DDC0) Freq | 21.295 MHz | 24.940 MHz (12m) |
+| 24.582 | 127953 | `0x04` | RX1 (DDC0) Freq | 24.940 MHz | 28.417 MHz (10m) |
+| 27.579 | 144240 | `0x04` | RX1 (DDC0) Freq | 28.417 MHz | 3.865 MHz (return 80m) |
+
+Summary counts for the full session: RX1 = 13 changes, RX2 = 2 changes,
+TX VFO = 29 changes (includes fine-tuning during QSO), sample-rate = 1 change
+(192 kHz, session start only), Alex/filter = 11 changes.
+
+---
+
+### 7.3 Walked-through example: 80m → 60m retune
+
+**Chosen event:** At t=5.683–5.685 s the operator moved RX1 from 3.869 MHz
+(80m) to 5.331 MHz (60m/WARC), crossing the 5 MHz HPF boundary. This event
+is the clearest single-step HPF/LPF transition in the session because:
+
+- The old 80m_LPF was replaced by the 40/60m_LPF.
+- The HPF stayed at 1.5 MHz (no HPF change yet; the 6.5 MHz HPF only engages
+  above ~6.5 MHz).
+- The RX1, TX VFO, and DDC2–DDC6 frequency slots all transition within two
+  consecutive round-robin cycles.
+
+The following timeline covers frames 25063–25345 (±1 full 19-slot cycle around
+the transition). Each Metis frame carries two USB sub-frames (USB1 and USB2)
+whose C0 slots advance in lock-step through the 19-step round-robin. MOX=0
+throughout (RX-only).
+
+```
+f=25063  t=5.6468 s  MOX=0 | USB1 Alex/Filters  : HPF=1.5MHz_HPF LPF=80m_LPF         | USB2 Preamp/Att : 0057006c
+f=25070  t=5.6479 s  MOX=0 | USB1 Att2/CW       : 20209932                             | USB2 CW_En      : 00000700
+f=25085  t=5.6507 s  MOX=0 | USB1 CW_Hang       : 4d023200                             | USB2 EER_PWM    : 1900c800
+f=25099  t=5.6532 s  MOX=0 | USB1 BPF2          : 00400000                             | USB2 HL2_ext1   : 00001e46
+f=25114  t=5.6560 s  MOX=0 | USB1 HL2_ext2      : 00000000                             | USB2 General    : 0284081c
+f=25128  t=5.6586 s  MOX=0 | USB1 TX_Freq       : 3.868498 MHz [80m]                   | USB2 RX1_Freq   : 3.868498 MHz [80m]    <- LAST 80m cycle
+f=25143  t=5.6614 s  MOX=0 | USB1 RX2_Freq      : 7.072497 MHz                         | USB2 ADC_Assign : 00000800
+f=25157  t=5.6639 s  MOX=0 | USB1 DDC2_Freq     : 3.868498 MHz                         | USB2 DDC3_Freq  : 3.868498 MHz
+f=25172  t=5.6667 s  MOX=0 | USB1 DDC4_Freq     : 5.330598 MHz [60m, STALE mix]        | USB2 DDC5_Freq  : 5.330598 MHz
+                            |  *** DDC4/5 pick up new freq before DDC0/1 slot arrives ***
+f=25186  t=5.6693 s  MOX=0 | USB1 DDC6_Freq     : 5.330598 MHz                         | USB2 Alex/Filters: HPF=1.5MHz_HPF LPF=40/60m_LPF  <- FILTER CHANGES
+f=25201  t=5.6720 s  MOX=0 | USB1 Preamp/Att    : 0057006c                             | USB2 Att2/CW    : 20209932
+f=25215  t=5.6747 s  MOX=0 | USB1 CW_En         : 00000700                             | USB2 CW_Hang    : 4d023200
+f=25230  t=5.6774 s  MOX=0 | USB1 EER_PWM       : 1900c800                             | USB2 BPF2       : 00400000
+f=25244  t=5.6800 s  MOX=0 | USB1 HL2_ext1      : 00001e46                             | USB2 HL2_ext2   : 00000000
+f=25258  t=5.6825 s  MOX=0 | USB1 General       : 0288081c                             | USB2 TX_Freq    : 5.330598 MHz [60m]   <- TX VFO updates
+f=25273  t=5.6853 s  MOX=0 | USB1 RX1_Freq      : 5.330598 MHz [60m]                  | USB2 RX2_Freq   : 7.072497 MHz         <- RX1 UPDATES (key event)
+f=25287  t=5.6879 s  MOX=0 | USB1 ADC_Assign    : 00000800                             | USB2 DDC2_Freq  : 5.330598 MHz
+f=25302  t=5.6907 s  MOX=0 | USB1 DDC3_Freq     : 5.330598 MHz                         | USB2 DDC4_Freq  : 5.330598 MHz
+f=25316  t=5.6932 s  MOX=0 | USB1 DDC5_Freq     : 5.330598 MHz                         | USB2 DDC6_Freq  : 5.330598 MHz
+f=25331  t=5.6961 s  MOX=0 | USB1 Alex/Filters  : HPF=1.5MHz_HPF LPF=40/60m_LPF       | USB2 Preamp/Att : 0057006d
+f=25345  t=5.6986 s  MOX=0 | USB1 Att2/CW       : 20209932                             | USB2 CW_En      : 00000700
+```
+
+**Sequence analysis:**
+
+1. **t=5.647 s (frame 25063):** Last round-robin cycle still carries the old
+   80m filter configuration (`1.5MHz_HPF + 80m_LPF`). TX and RX1 frequencies
+   are still 3.868 MHz.
+
+2. **t=5.666–5.669 s (frames 25172–25186):** The new frequency (5.331 MHz)
+   begins appearing in DDC4/5/6 slots *before* the DDC0 (RX1) slot arrives.
+   This is not an error; DDC4–6 track the TX frequency in the nddc=4 HL2
+   config and happen to share the same slot index as the new target frequency.
+   The Alex filter also switches here (frame 25186, USB2 slot `C0=0x12`),
+   replacing the 80m_LPF with the 40/60m_LPF — **before the RX1 DDC NCO has
+   been updated**.
+
+3. **t=5.683 s (frame 25258):** TX VFO slot (`C0=0x02`) delivers the new
+   5.331 MHz. The radio's TX path is now pointed at 60m.
+
+4. **t=5.685 s (frame 25273):** RX1 slot (`C0=0x04`) delivers 5.331 MHz. The
+   DDC0 NCO retunes. From this frame forward, the entire front-end — HPF, LPF,
+   DDC0 NCO — is consistent on 60m.
+
+5. **t=5.696 s (frame 25331):** The Alex filter slot recurs as USB1, confirming
+   the new filter state in the second consecutive cycle. All 19 command slots
+   are now stable at the new 60m configuration.
+
+**Total retune window:** from the first new-frequency appearance in DDC4/5 (frame
+25172, t=5.667 s) to the final slot confirmation (frame 25331, t=5.696 s) = ~29 ms.
+DDC0 NCO lag behind the filter update: ~16 ms (frames 25186 → 25273).
+
+---
+
+### 7.4 Recipe for Nereus Phase 3L
+
+When Phase 3L handles a retune event (user changes VFO frequency, crossing a
+filter boundary), it must emit updated values to the shared state structure
+before the round-robin picks up the next cycle. The observed Thetis ordering
+demonstrates the following priorities:
+
+1. **Update all frequency fields atomically in the shared state** before any
+   C&C frame is emitted. The round-robin then drains them slot-by-slot. Do not
+   try to "inject" a special single command — this is not how P1 works.
+
+2. **Alex filter selection must be computed from the new frequency**, not the
+   old one, before the round-robin writes the `0x12` slot. If the filter update
+   arrives one cycle ahead of DDC0 NCO update (as seen here), that is
+   acceptable — the radio handles the brief mismatch without audible artifact.
+
+3. **DDC0–DDC6 slots will be stale for up to one full 19-slot cycle** (~50 ms
+   at 378 Hz EP2 rate). This is expected behavior, not a bug. Nereus must not
+   add artificial delays or re-inject commands after a retune.
+
+4. **The HPF boundary at ~6.5 MHz** (switching from 1.5 MHz HPF to 6.5 MHz HPF)
+   requires the Alex filter update one cycle before the DDC NCO update can arrive.
+   The same "filter-first, NCO second" pattern seen in this 80m→60m transition
+   repeats for every band change in the session.
+
+5. **No special TX coordination is required for RX-only retunes** (MOX=0). The
+   TX VFO updates in the same slot cycle as RX1, one slot earlier in the
+   round-robin (case 1 = TX, case 2 = RX1).
+
+**Specific command ordering (one round-robin cycle, ~19 Metis frames):**
+
+```
+Slot  C0 (base)  Command            Action
+  0    0x00      General/SR         sample rate, OC bits (unchanged)
+  1    0x02      TX VFO Freq        new frequency [Hz, 32-bit BE]
+  2    0x04      RX1 (DDC0) Freq    new frequency [Hz, 32-bit BE]
+  3    0x06      RX2 (DDC1) Freq    unchanged (or also update if needed)
+  4    0x1C      ADC Assign         unchanged
+  5    0x08      DDC2 Freq          new frequency (tracks TX)
+  6    0x0A      DDC3 Freq          new frequency (tracks TX)
+  7    0x0C      DDC4 Freq          new frequency (tracks TX)
+  8    0x0E      DDC5 Freq          new frequency (tracks TX)
+  9    0x10      DDC6 Freq          new frequency (tracks TX)
+ 10    0x12      Alex / HPF+LPF     new filter bits — C3=HPF mask, C4=LPF mask
+ 11    0x14      Preamp/Att         unchanged
+ 12    0x16      Att2/CW            unchanged
+ ...
+ 17    0x2E      HL2 extension 1    constant (HL2-specific)
+ 18    0x74      HL2 extension 2    constant (HL2-specific)
+```
+
+**Thetis source cross-references:**
+- RX1 frequency (slot 2): `networkproto1.c:484–494` — `case 2`, assigns
+  `prn->rx[0].frequency` into C1–C4 as 32-bit big-endian Hz.
+- Alex HPF/LPF (slot 10): `networkproto1.c:578–590` — `case 10`, builds C3
+  from `prbpfilter->_13MHz_HPF … _Bypass` bits and C4 from
+  `prbpfilter->_30_20_LPF … _17_15_LPF` bits.
+
+---

--- a/docs/protocols/openhpsdr-protocol1.md
+++ b/docs/protocols/openhpsdr-protocol1.md
@@ -1,31 +1,39 @@
 # OpenHPSDR Protocol 1
 
-## Status: Reference placeholder
-
-## Overview
+## Status: Reference
 
 Protocol 1 is the original OpenHPSDR protocol used by Metis, Hermes, Angelia,
-Orion, and Hermes Lite 2 boards. It uses UDP-only communication on port 1024.
+Orion, and Hermes Lite 2 boards. UDP-only on port 1024, 1032-byte Metis
+frames, 24-bit big-endian interleaved I/Q.
 
-## Key Characteristics
+## Primary Reference
+
+For byte-level layouts, command/status decode, cadence, and HL2-specific
+quirks, see the annotated capture reference:
+
+**[openhpsdr-protocol1-capture-reference.md](openhpsdr-protocol1-capture-reference.md)**
+
+That document is derived from a live HL2↔Thetis capture and is the
+authoritative source for NereusSDR Phase 3L (P1 implementation).
+
+## Quick Summary
 
 - **Transport:** UDP only, port 1024
-- **Frame size:** 1032 bytes (Metis frame)
-- **Frame structure:** 8-byte header + two 512-byte USB frames
-- **I/Q format:** 24-bit big-endian, interleaved
-- **Control:** C&C (Command & Control) bytes in USB frame headers
-- **Discovery:** UDP broadcast to port 1024
+- **Frame size:** 1032 bytes (Metis frame: 8-byte header + two 512-byte USB frames)
+- **Header:** `EF FE 01 <endpoint> <seq32_big_endian>` — endpoint `0x06` for EP6 (radio→host data), `0x02` for EP2 (host→radio commands)
+- **I/Q format (EP6):** 24-bit big-endian signed, interleaved I/Q + 16-bit BE mic
+- **Samples per USB frame:** `spr = 504 / (6*nddc + 2)` (from `networkproto1.c:358`)
+- **Control:** 5 C&C bytes per USB frame — 3-byte sync `7F 7F 7F`, C0 round-robin status/command index, C1..C4 payload
+- **Discovery:** UDP broadcast to port 1024, `EF FE 02 ...`
 
-## Frame Format
+## Thetis P1 Source Map
 
-```
-Bytes 0-1:   Sync (0xEF 0xFE)
-Byte 2:      Endpoint (0x06 = EP6 data from radio)
-Byte 3:      Sequence number
-Bytes 4-7:   Sequence number (32-bit)
-Bytes 8-519: USB Frame 1 (5 C&C bytes + 504 I/Q/audio bytes)
-Bytes 520-1031: USB Frame 2 (5 C&C bytes + 504 I/Q/audio bytes)
-```
+Most P1 byte-level code lives in the unmanaged ChannelMaster C source, not C#:
+
+- **Discovery:** `Project Files/Source/Console/HPSDR/clsRadioDiscovery.cs`
+- **Metis start/stop, EP2 build, EP6 parse, seq#:** `Project Files/Source/ChannelMaster/networkproto1.c`
+- **Metis socket setup:** `Project Files/Source/ChannelMaster/network.c`
+- **C# P/Invoke surface:** `Project Files/Source/Console/HPSDR/NetworkIOImports.cs`
 
 ## Official Specification
 

--- a/docs/superpowers/specs/2026-04-12-p1-capture-reference-design.md
+++ b/docs/superpowers/specs/2026-04-12-p1-capture-reference-design.md
@@ -1,0 +1,209 @@
+---
+date: 2026-04-12
+author: JJ Boyd (KG4VCF) + Claude Code
+status: Draft — awaiting review
+related:
+  - docs/protocols/openhpsdr-protocol1.md
+  - docs/architecture/radio-abstraction.md
+  - Phase 3L (Protocol 1 support)
+---
+
+# Design: Protocol 1 Packet-Capture Reference Document
+
+## Purpose
+
+Phase 3L of NereusSDR adds OpenHPSDR Protocol 1 support so the application
+can talk to Hermes Lite 2 (HL2) and other legacy P1 radios. The current
+`docs/protocols/openhpsdr-protocol1.md` is a 32-line placeholder. We need
+ground-truth byte-level documentation of an actual host↔HL2 conversation
+before writing P1 connection code, so the implementation can follow the
+NereusSDR "READ → SHOW → TRANSLATE" rule against verifiable evidence rather
+than inferred behavior.
+
+The user has provided `HL2_Packet_Capture.pcapng` (320 MB, captured between
+a Thetis-class host and a Hermes Lite 2). This spec defines the deliverable
+that turns that capture into a permanent reference asset.
+
+## Capture Recon (already performed)
+
+Confirmed via `tshark -q -z conv,udp` and `-z io,phs`:
+
+| Property | Value |
+| --- | --- |
+| File | `HL2_Packet_Capture.pcapng` (320 MB, ~302,256 frames) |
+| Host | `169.254.105.135` (link-local, no DHCP — direct cable) |
+| Radio (HL2) | `169.254.19.221`, port `1024` |
+| Session ports | host `:50534` ↔ radio `:1024` (281,195 frames RX, 21,049 frames TX-direction) |
+| Discovery | host `:50533` → `255.255.255.255:1024` and `169.254.255.255:1024` (2 frames), reply from `169.254.19.221:1024` (2 frames) |
+| Duration | ~55.7 s session + ~4 s DHCP tail |
+| Other traffic | 4 ARP frames, 2 DHCP frames (host bring-up) — not part of P1 |
+
+This is a clean single-session capture: discovery → start → steady-state →
+stop, with the session running long enough (~55 s) to observe sequence
+wraparounds, band changes, and any keying events.
+
+## Deliverable
+
+A single new markdown file:
+
+**`docs/protocols/openhpsdr-protocol1-capture-reference.md`**
+
+The existing `docs/protocols/openhpsdr-protocol1.md` will be updated to:
+
+- Link to the new capture-reference doc as the primary P1 source-of-truth
+- Absorb any short byte-layout summaries that belong in the canonical
+  reference (so the placeholder file becomes a real spec stub, not the
+  full analysis)
+
+No source code is written or modified by this work.
+
+## Document Structure
+
+The capture-reference doc has the following sections, in order. Each
+section is grounded in actual frames extracted from the pcap with
+`tshark`, with annotated hex dumps and line-number cross-references to
+Thetis `Project Files/Source/Console/NetworkIO.cs` (and related files)
+per the project's READ → SHOW → TRANSLATE rule.
+
+### 1. Capture Metadata
+The recon table above plus a per-port frame/byte breakdown and a short
+"how this capture was taken" note. Lets future readers use the document
+without needing the pcap.
+
+### 2. Discovery Exchange
+Decoded discovery request (`0xEFFE 0x02` + padding) and reply (`0xEFFE
+0x02/0x03` + board-id + version + MAC). One annotated hex dump per
+direction. Cross-ref Thetis discovery code path.
+
+### 3. Start / Stop Commands
+The `0xEFFE 0x04` start command and corresponding stop. Document the
+"start IQ" vs "start IQ + wideband" variants if both appear, with the
+exact byte that selects sample rate behavior. One hex dump each.
+
+### 4. EP6 — Radio → Host Metis Frames (1032 bytes)
+Full anatomy of the data frame:
+
+- 8-byte Metis header (`EFFE 01 06 <seq32>`)
+- USB frame 1: 3-byte sync `7F7F7F`, C0 round-robin status index, C1–C4
+  status bytes, 504 bytes of interleaved 24-bit BE I/Q + 16-bit mic
+- USB frame 2: same layout
+
+Single annotated hex dump of one representative frame. Status-byte
+decode table covering every C0 index actually observed in the capture,
+not the spec-theoretical set. Document mic-sample interleaving for the
+HL2 case (HL2 carries mic in EP6 even when not transmitting).
+
+### 5. EP2 — Host → Radio Command Frames (1032 bytes)
+Same Metis envelope, but USB frames carry C&C *commands* instead of
+status. Section enumerates every distinct C0 round-robin index seen in
+the host→radio direction across the session, with C1–C4 decoded:
+
+- Sample rate / open collector outputs
+- ADC attenuation, preamp, dither, random
+- RX1..RXn frequency (per-DDC, 32-bit BE Hz)
+- TX frequency
+- Drive level / mic boost / line-in
+- Alex / HPF / LPF / TX relay band selection
+- MOX, PTT, CW keyer state
+- Anything else that appears
+
+For each: source-line citation in `NetworkIO.cs`. If the capture shows
+HL2-specific values (e.g. extended C&C indices the wiki doesn't fully
+document), call them out.
+
+### 6. Steady-State Cadence
+Quantitative section produced from tshark exports:
+
+- Observed packet rate radio→host and host→radio (Hz)
+- Sequence-number progression, any gaps, any wraparound
+- Inter-frame timing distribution (mean / p50 / p99) for both directions
+- Behavior at band changes (does the host pause TX-direction commands?)
+
+### 7. Band-Change Trace
+Walk through one or more band-change events found in the capture (e.g.
+RX frequency moved across an HPF/LPF boundary). Show the exact sequence
+of EP2 commands the host emits, in order, with timestamps relative to
+the band change. Useful as a recipe for the Nereus implementation.
+
+### 8. TX / Keying Trace (conditional)
+Detection method: scan all EP2 frames for the MOX bit being set. If
+found, document the full TX bring-up sequence (MOX-on, drive level,
+TX freq, Alex relay change, TX I/Q frames if in EP2 payload, MOX-off).
+If no MOX events are found, this section says so explicitly with the
+detection query used, so a future reader knows the gap is *known*, not
+overlooked.
+
+### 9. HL2-Specific Quirks
+Anything in the capture that diverges from the generic OpenHPSDR P1
+wiki spec: HL2 firmware version reported in discovery, supported sample
+rates actually exercised, ADC overload bit usage, IO pin / PTT-out
+behavior, and any non-standard C&C indices.
+
+### 10. Nereus Implementation Checklist
+Concrete TODO list for Phase 3L derived from gaps the capture exposes.
+Each item links back to the section that motivates it. This is how the
+document earns its keep — it should turn into the Phase 3L plan's
+backbone.
+
+### Appendix A — Reproducibility
+The exact `tshark` invocations used to extract every hex dump and stat
+in the document, as fenced code blocks, so a future maintainer can
+re-run the analysis on a different capture without guessing.
+
+## Method
+
+1. **Filtered subsetting.** Use `tshark -Y 'udp.port == 1024'` writing
+   to a smaller pcap, then run all subsequent passes against the subset
+   to keep iteration fast.
+2. **Shape enumeration.** Group EP2 frames by `(length, first 16 bytes
+   signature, C0 index)` and pick one representative per group. Same
+   for EP6 (expected to be one shape but verify).
+3. **Byte decode.** For each representative, dump as hex with `tshark
+   -x` and annotate fields against `NetworkIO.cs`. Cite line numbers.
+4. **Stats.** Use `tshark -T fields` for sequence/timing data, pipe
+   through `awk` for percentiles.
+5. **TX detection.** Filter EP2 frames where the MOX bit (C0 index 0,
+   C1 bit 0 in the standard P1 layout) is set; if any matches, expand
+   into Section 8.
+6. **Keep raw artifacts inline.** Hex dumps and tshark commands live in
+   the document as fenced blocks so the analysis is self-contained.
+
+## Out of Scope
+
+- Writing or modifying any C++ source. This work produces a reference
+  document only. Phase 3L implementation comes after, in its own plan.
+- Wideband ADC samples (separate UDP path on HL2) unless they appear
+  in this capture.
+- PureSignal feedback (HL2 has no PS feedback DDC).
+- Protocol 2 — already covered separately.
+- Any feature work not directly motivated by getting a P1 radio to a
+  working RX state in Nereus.
+
+## Success Criteria
+
+- A new reader can implement P1 discovery, start, RX I/Q parsing, RX
+  tuning, and band selection from this document plus `NetworkIO.cs`,
+  without referring back to the pcap.
+- Every byte layout claim in the doc is backed by a hex dump from the
+  capture and a Thetis source citation.
+- The Phase 3L implementation checklist (Section 10) is complete enough
+  to seed the Phase 3L plan when that work begins.
+- The reproducibility appendix lets a maintainer re-run the same
+  analysis on a different capture in under an hour.
+
+## Open Questions Resolved
+
+- **Filename / location:** `docs/protocols/openhpsdr-protocol1-capture-reference.md`.
+- **TX coverage:** Operator may have keyed up; capture will be scanned
+  for MOX events and Section 8 either populated or marked "no TX events
+  found, detection query: …".
+
+## Risks
+
+- **Capture is one HL2, one host, one firmware revision.** Findings may
+  not generalize to all P1 radios. The doc will call out HL2-specific
+  observations in Section 9 to avoid over-generalization.
+- **HL2 firmware quirks** may make some bytes look like spec violations
+  when they are HL2 conventions. Mitigation: every divergence from the
+  wiki spec gets explicitly flagged rather than silently documented as
+  canonical P1.


### PR DESCRIPTION
## Summary

- New `docs/protocols/openhpsdr-protocol1-capture-reference.md` (1,508 lines): annotated byte-level reference of a live HL2↔Thetis Protocol 1 conversation, derived from `HL2_Packet_Capture.pcapng` (302k frames, ~55 s, 192 kHz, 4 DDCs, full HF band scan, 2 TX events)
- Every byte-layout claim is cited to `networkproto1.c` / `clsRadioDiscovery.cs`, or explicitly flagged `unknown — investigate` per NereusSDR's `READ → SHOW → TRANSLATE` rule
- Sections: capture metadata, discovery, start/stop, EP6 anatomy, EP2 command round-robin, cadence, band-change trace, TX/MOX trace, HL2-specific quirks, Phase 3L implementation checklist (33 items), reproducibility appendix
- Supersedes the 32-line placeholder `docs/protocols/openhpsdr-protocol1.md`, which now points at the capture reference and includes a Thetis P1 source map
- Design spec + implementation plan committed alongside the doc (`docs/superpowers/specs/`, `docs/architecture/`)

## Key findings baked into the doc

- **Thetis source-map correction:** P1 byte-level code lives in unmanaged `ChannelMaster/networkproto1.c` (W5WC), **not** `NetworkIO.cs`. CLAUDE.md was wrong; fixed in this PR.
- **HL2 extensions beyond standard P1:** EP6 `0xFA` slot, EP2 slots `0x2E`/`0x74`/`0x7A`/`0xFA`/`0xFB`, duplex bit ignored by HL2, MOX OR'd into all extension slots during TX.
- **Band-change ordering:** Thetis emits filter update (\`C0=0x12\`) ~16 ms before the DDC0 NCO update (\`C0=0x04\`) as a round-robin side-effect. Nereus will need to match this for clean HPF/LPF transitions.
- **Cadence:** EP6 = 5052.9 Hz observed vs 4947 Hz theoretical (+2.1% delta, firmware-specific); EP2 = 378 Hz. Zero sequence gaps either direction.

## Scope

Documentation only. No source code changed. No build, no tests affected.

## Test plan

- [ ] Read the capture reference end-to-end
- [ ] Spot-check one hex dump against the raw pcap (\`tshark -r ... -x\`)
- [ ] Verify the \`networkproto1.c:<line>\` citations resolve to the claimed code
- [ ] Confirm Phase 3L checklist items are small enough for individual PRs

## Outstanding

One intentional TODO in the Phase 3L checklist: the HL2 extended discovery reply bytes (offsets 11-13, 21-59) need cross-reference against Steve Haynal's HL2 firmware source (\`github.com/softerhardware/Hermes-Lite2\`) before implementation. Deferred to a 3L-HL2 sub-phase.

---

JJ Boyd ~KG4VCF
Co-Authored with Claude Code