### PR TITLE
fix(dsp): USB/AM audio broken — call RXANBPSetFreqs and disable binaural panel

### DIFF
--- a/docs/architecture/2026-04-12-fix-20m-iq-usb-demod-design.md
+++ b/docs/architecture/2026-04-12-fix-20m-iq-usb-demod-design.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-04-12
 **Branch:** `fix/20m-iq-upper-sideband`
-**Status:** Design — awaiting user review
+**Status:** **Hypothesis refuted during diagnosis — see "Diagnosis Outcome"
+at end of document. Real root cause and fix are in commit `07dbdce`.**
 **Scope:** Bug fix only. Right-side panel wiring and Setup→Display→RX1 palette
 work are explicitly out of scope and belong on separate branches.
 
@@ -288,3 +289,105 @@ the first is addressed here. The other two belong on their own branches:
   the desire to match SmartSDR / AetherSDR waterfall palette range) —
   feature work, separate design, separate branch. This may require
   revisiting the palette slider ranges in `SpectrumWidget` as a follow-up.
+
+---
+
+## 7. Diagnosis Outcome — Hypothesis Refuted
+
+**Added 2026-04-12, after live-radio diagnosis against an ANAN-G2.**
+
+The hypothesis in §2 (three disagreeing default states leaving WDSP in an
+incoherent `(mode, bandpass)` pair) was **refuted** by the Phase A
+instrumentation log. With the live app on 20m USB experiencing the Donald
+Duck symptom, `createRxChannel` logged `WDSP mode=USB(1) bounds=(100,3000)`
+and a one-shot `RESYNC PROBE` confirmed the WDSP state was exactly that —
+the "correct" state the Phase B fix would have set. Yet the audio was
+still wrong. The Phase B plan (seed channel from slice, make `RxChannel`
+cache self-consistent, resync bandpass after mode change) was abandoned
+before commit.
+
+Further diagnosis ruled out stereo decorrelation from a non-dual-mono
+`fexchange2` output (adding `SetRXAPanelBinaural(channelId, 0)` made
+`outI == outQ` per a live diagnostic log, but the audio remained garbled
+on everything except LSB). That narrowed the problem to the WDSP SSB
+filter chain itself.
+
+Reading Thetis `RXA.c` line-by-line exposed **two** bugs, both from
+NereusSDR not calling WDSP APIs that Thetis always calls:
+
+### Real root cause 1 — `nbp0` filter was never updated
+
+WDSP's RXA pipeline has two bandpass filters:
+
+- **`bp1`** — updated by `SetRXABandpassFreqs`. Only runs when `AMD`,
+  `SNBA`, `EMNR`, `ANF`, or `ANR` is enabled (`RXA.c:883-895`).
+- **`nbp0`** — updated by `RXANBPSetFreqs`. Runs unconditionally in the
+  plain SSB / AM / CW audio path (`RXA.c:624`, `xnbp`).
+
+NereusSDR only called `SetRXABandpassFreqs`, which silently updated a
+filter that wasn't even active in the audio path. `nbp0` stayed at its
+create-time default of `(-4150.0, -150.0)` forever — LSB-shaped. That
+silently broke every non-LSB demodulator:
+
+| Mode | Passband | `nbp0` stuck at `(-4150, -150)` |
+|---|---|---|
+| LSB | `(-3000, -100)` | intersects → **clean voice** |
+| USB | `(+100, +3000)` | disjoint → **Donald Duck** |
+| AM  | `(-5000, +5000)` | only negative half passes → **garbled** |
+| CW  | narrow around ±600 | partial overlap near DC → **sounds OK** |
+
+Thetis always calls both setters together (`rxa.cs:110-111`, `116-117`,
+`radio.cs:603-604`).
+
+### Real root cause 2 — RXA patch panel was in binaural mode
+
+WDSP's `create_panel` default is `copy=0` — binaural mode, where `outI`
+and `outQ` carry phase-shifted content for a headphone stereo image
+(`patchpanel.c:55-101`, `RXA.c:512-523`). Through laptop speakers, the
+two acoustically-mixed phase-shifted streams produce pitched, hollow
+comb-filtered audio.
+
+Thetis calls `SetRXAPanelBinaural(channel, false)` via its `BinOn`
+property (`radio.cs:1157`), which defaults to `false` → dual-mono
+(`copy=1`, `Q := I`).
+
+This bug was masked by root cause 1 (everything sounded broken anyway
+on USB/AM), and only became visible after the `nbp0` fix was in place.
+Both fixes are needed.
+
+### The fix
+
+Commit `07dbdce` — `fix(dsp): USB/AM audio broken — call RXANBPSetFreqs
+and disable binaural panel`. Three-file diff:
+
+- `src/core/RxChannel.cpp` — `setFilterFreqs` now calls both
+  `SetRXABandpassFreqs` and `RXANBPSetFreqs`
+- `src/core/WdspEngine.cpp` — `createRxChannel` seeds both filters at
+  create time and calls `SetRXAPanelBinaural(channelId, 0)`
+- `src/core/wdsp_api.h` — declarations for the two newly-called WDSP
+  functions
+
+The Phase A diagnostic instrumentation from commit `c3164fd` is also
+removed by `07dbdce` since it served its purpose and is no longer
+needed.
+
+### Lessons
+
+- **Don't trust equality guards on cache state when the underlying
+  resource has multiple setters.** The `setFilterFreqs` guard was
+  correctly detecting cache-equality, but the *cache* only mirrored
+  one of two WDSP filters. A guard on a single-slot cache can never
+  catch a bug caused by a second shadow filter.
+- **Follow CLAUDE.md's READ → SHOW → TRANSLATE literally, not in
+  spirit.** This bug was hiding in plain sight in `RXA.c:883-895`
+  (the comment on `bp1` says "used only with AM || ANF || ANR ||
+  EMNR") and `RXA.c:90-106` (where `nbp0` is created with LSB-shaped
+  defaults). A line-by-line read of `RXA.c` at channel-wiring time
+  would have caught this before it shipped. The temptation to reason
+  about what WDSP "probably does" instead of reading the actual source
+  is real and should be actively resisted.
+- **Acoustic bugs deserve live-radio verification early.** The original
+  hypothesis survived a plausible-sounding code review but didn't
+  survive the first live log. Phase A instrumentation was the right
+  investment — it's what caught the refutation in <10 minutes once
+  the radio was connected.

--- a/docs/architecture/2026-04-12-fix-20m-iq-usb-demod-design.md
+++ b/docs/architecture/2026-04-12-fix-20m-iq-usb-demod-design.md
@@ -1,0 +1,290 @@
+# Design: Fix USB Demod Broken On All Bands (20m I/Q Bug)
+
+**Date:** 2026-04-12
+**Branch:** `fix/20m-iq-upper-sideband`
+**Status:** Design — awaiting user review
+**Scope:** Bug fix only. Right-side panel wiring and Setup→Display→RX1 palette
+work are explicitly out of scope and belong on separate branches.
+
+---
+
+## 1. Problem Statement
+
+On NereusSDR `main` (at `a0c959c`), receiving a signal with mode = **USB** on
+any band produces unintelligible "Donald Duck" audio and the operator cannot
+tune in cleanly. **LSB** on 40m / 80m sounds normal. **CW** sounds normal —
+but its narrow filter masks any small audio-frequency offset, so this is not
+evidence of a working demod. AM / FM have not been tested yet; the report is
+framed around SSB.
+
+The user originally reported the symptom as "20m broken." Clarifying
+conversation revealed the true partition: the fault is **sideband-specific,
+not band-specific**. 20m was simply the first USB band tested.
+
+### Key observations that constrain the hypothesis
+
+| Observation | What it rules out |
+|---|---|
+| WWV 10 MHz AM carrier lands on frequency in the waterfall | Display frequency math, `SpectrumWidget` bin mapping, DDC NCO programming, `ReceiverManager` routing |
+| 20m carrier sits exactly under the VFO cursor in the waterfall | `ReceiverManager::setReceiverFrequency` path, `P2RadioConnection` NCO programming, Alex HPF/LPF |
+| 40m / 80m LSB sound normal | WDSP channel creation, `fexchange2`, audio engine, decimation, I/Q stream integrity |
+| CW demod sounds normal | Gross I/Q corruption, sample-rate mismatch, whole-channel failure |
+| "Can't ever quite get tuned in" on any USB band | Consistent with a fixed wrong-sign bandpass — no amount of retuning moves the passband to the right place |
+
+The fault must therefore be in code that behaves differently for USB vs LSB
+but is **not** in the frequency-to-bin / NCO path. That narrows it to the
+WDSP configuration path: `SetRXAMode` / `SetRXABandpassFreqs` / the cached
+state in `RxChannel`.
+
+---
+
+## 2. Root Cause Hypothesis
+
+The WDSP channel is being left in an **incoherent `(mode, bandpass)` state**
+at channel-create time: mode = USB paired with **negative-Hz** (LSB-shaped)
+bandpass bounds. In that state WDSP demodulates the image sideband, producing
+exactly the symptoms observed.
+
+The underlying root cause is **three disagreeing "default filter states"**
+distributed across the code, combined with guarded setters that early-out on
+stale cache equality.
+
+### The three disagreeing defaults
+
+| Location | Default mode | Default filter bounds |
+|---|---|---|
+| `src/models/SliceModel.h:142-144` | **USB** | `{100, 3000}` |
+| `src/core/RxChannel.h:111, 120-121` | **LSB** | `{150, 2850}` ← positive, USB-shaped, **internally inconsistent with its own mode** |
+| `src/core/WdspEngine.cpp:260-261` (pushed to WDSP on channel create) | **LSB** | `{-2850, -150}` ← LSB-shaped |
+
+The comment at `WdspEngine.cpp:256-259` claims the init block was written to
+"match RxChannel's cached defaults so subsequent setMode/setFilterFreqs calls
+work correctly" — but the values it pushes do **not** match `RxChannel`'s
+cached defaults. The `setFilterFreqs` guard
+
+```cpp
+if (m_filterLow == lowHz && m_filterHigh == highHz) { return; }
+```
+
+therefore cannot be trusted: the cache was never an accurate mirror of
+WDSP's real state to begin with.
+
+### Why this produces the observed symptom
+
+On fresh launch:
+
+1. `WdspEngine::createRxChannel` pushes `(LSB, -2850, -150)` to WDSP, but
+   leaves `RxChannel`'s cache at `(LSB, 150, 2850)` — a state that does not
+   exist in any consistent world.
+2. `RadioModel::onWdspInitialized` (around `RadioModel.cpp:162-164`) calls
+   `rxCh->setMode(USB)` then `rxCh->setFilterFreqs(100, 3000)`.
+3. `setMode(USB)` sees cache `LSB`, pushes `SetRXAMode(ch, USB)`. WDSP is now
+   USB. Depending on WDSP internals, `SetRXAMode` may or may not reset the
+   bandpass state; either way, the final state depends on what
+   `setFilterFreqs` does next.
+4. `setFilterFreqs(100, 3000)` compares against cache `(150, 2850)` — not
+   equal, so the call goes through. In the happy path WDSP is now
+   `(USB, 100, 3000)`. ✅
+
+So the **cold-boot path works** — which matches what the user reports (the
+radio isn't completely silent, it produces audio). But the system is
+fragile: any path that restores state from persisted settings, any path that
+touches the guards in a different order, or any WDSP-internal side effect
+of `SetRXAMode` that we're not accounting for, can leave the channel stuck
+in `(USB, negative-bounds)`. That is the state we need to prove out with
+logs.
+
+### Why "can't tune in"
+
+With USB selected but the bandpass set to `(-2850, -150)`, WDSP demodulates a
+slice of the *opposite* side of zero from where the user is listening. As
+the user retunes, the signal moves but the passband moves with it — the
+operator's reference for "zero Hz audio" is shifted from where it should be,
+producing the characteristic Donald Duck pitch shift and the inability to
+zero-beat.
+
+### Why CW sounds fine
+
+CW uses a ~400 Hz wide passband centered on `kCwPitch` (600 Hz). An offset
+in bandpass placement for CW just means the tone is at a slightly different
+audio frequency — which is indistinguishable from normal operator tuning.
+You can't hear a "wrong sideband" on CW.
+
+---
+
+## 3. The Two-Phase Approach
+
+The fix is split into **diagnose-first** and **fix-at-the-root**. Do not
+write a fix until the log evidence is in hand and the hypothesis is
+confirmed (or replaced).
+
+### Phase A — Instrument and prove
+
+Before touching any logic, capture ground-truth logs of what mode and
+filter bounds WDSP is in at each critical moment.
+
+**Instrumentation points** (all `qCInfo(lcDsp)`; may be demoted to
+`qCDebug` later):
+
+1. **`WdspEngine::createRxChannel`** — log `(channelId, initial mode,
+   initial filter low, initial filter high)` right after the
+   `SetRXAMode`/`SetRXABandpassFreqs` init block.
+2. **`RxChannel::setMode`** — log `(channelId, old cache mode, new mode,
+   guard-hit?)`.
+3. **`RxChannel::setFilterFreqs`** — log `(channelId, old cache low/high,
+   new low/high, guard-hit?)`.
+4. **`RadioModel::wireSliceSignals`** handlers for `dspModeChanged` and
+   `filterChanged` — log that the handler fired and with what values.
+5. **One-shot resync probe** in `RadioModel`, fired ~1 s after
+   `WdspEngine::initializedChanged(true)`: re-read `SliceModel` mode /
+   filter and push them through `setMode` / `setFilterFreqs` with guards
+   bypassed once, logging before and after. If this single probe silently
+   fixes the audio, we have directly proved the stale-cache hole.
+
+**Reproduction protocol** (user, against ANAN-G2):
+
+1. Launch fresh with clean config
+2. Connect to the radio
+3. Tune 20m USB, listen ~5 s
+4. Switch to LSB on 40m, listen ~5 s
+5. Switch back to USB on 20m, listen ~5 s
+6. Toggle mode USB ↔ LSB ↔ USB without retuning, note any change in audio
+7. Paste the `lcDsp` lines from `~/.config/NereusSDR/nereussdr.log` back
+   into the session
+
+**Expected log signatures that would confirm the hypothesis:**
+
+- `createRxChannel` logs `mode=LSB, bounds=(-2850, -150)`
+- The `dspModeChanged(USB)` handler fires; `setMode` logs `old=LSB, new=USB,
+  guard=miss`; WDSP mode flips to USB
+- The corresponding `filterChanged(100, 3000)` handler either never fires,
+  or `setFilterFreqs` logs `guard=hit` with `cache=(150, 2850)` while WDSP
+  is really at `(-2850, -150)` — leaving WDSP bounds stale
+
+**Decision gate.** No fix code until the logs are seen and the user and the
+agent agree on what they say. If the log shows something *other* than the
+hypothesis, re-plan before fixing.
+
+### Phase B — Root-cause fix
+
+Assuming Phase A confirms the hypothesis, the fix has four parts. All of
+them follow the CLAUDE.md **READ → SHOW → TRANSLATE** rule: before writing
+any of them, the agent will quote the relevant Thetis source
+(`cmaster.c` channel-create block, `console.cs` mode-change sequence,
+`RXA.c` `SetRXAMode` / `SetRXABandpassFreqs` implementations) and cite
+file and line in each code comment that lands.
+
+#### Fix B1 — Single source of truth at channel create
+
+Change `WdspEngine::createRxChannel` to accept the initial
+`(DSPMode, double filterLow, double filterHigh)` from the active
+`SliceModel`, and use **those** values for the `SetRXAMode` /
+`SetRXABandpassFreqs` init block. Delete the hardcoded `LSB / -2850..-150`
+lines and their comment. The caller at `RadioModel.cpp:158` passes
+`m_activeSlice->dspMode()`, `m_activeSlice->filterLow()`,
+`m_activeSlice->filterHigh()`.
+
+#### Fix B2 — Make `RxChannel`'s cache self-consistent and match WDSP
+
+`RxChannel` no longer holds a hardcoded-default `m_mode` /
+`m_filterLow` / `m_filterHigh`. The constructor takes the initial mode and
+filter and stores them in the atomics and members. The "cache" is then
+guaranteed to mirror WDSP's real state from the first instant the object
+exists.
+
+#### Fix B3 — Remove the redundant apply loop in `onWdspInitialized`
+
+Since the channel is now created in its correct state, the explicit
+`setMode` / `setFilterFreqs` call pair at `RadioModel.cpp:162-164` becomes
+a no-op in the happy path and can be removed. Subsequent `setAgcMode` /
+`setAgcTop` calls are unrelated and remain. After this fix, runtime mode
+and filter updates happen normally via `SliceModel::dspModeChanged` /
+`filterChanged` signals.
+
+#### Fix B4 — Belt-and-suspenders bandpass resync on mode change
+
+In `RxChannel::setMode`, after the `SetRXAMode` call, unconditionally
+push `SetRXABandpassFreqs(m_channelId, m_filterLow, m_filterHigh)` using
+the cached values, regardless of whether the filter cache "changed."
+
+**Why:** `SetRXAMode` in WDSP may internally reset or re-initialize
+bandpass state; the operator's next action after switching sideband
+is almost always retuning, and a stale bandpass at that moment is
+exactly the failure mode this bug represents. One extra WDSP call per
+mode change is free. The Thetis mode-change sequence should be quoted
+in the comment to justify the ordering.
+
+### What this change does **not** touch
+
+- `SliceModel::defaultFilterForMode` — the Thetis-cited preset table is
+  correct as written.
+- `SliceModel::setDspMode` signal-emission order — correct as written.
+- The `SetRXAShiftFreq` / CTUN shift path — innocent per the waterfall
+  evidence.
+- Any frequency / DDC / `ReceiverManager` / `P2RadioConnection` code.
+- Visual design, UX behavior, default values, or DSP constants outside
+  the direct scope of this fix. Per CLAUDE.md these are not agent-
+  autonomous changes.
+
+---
+
+## 4. Verification
+
+**Verification gates**, in order:
+
+1. **Build gate.** `cmake --build build -j` clean on macOS, no new warnings
+   in touched files. App relaunched after each successful build.
+2. **Phase A log evidence gate.** Instrumented build produces a log from
+   the reproduction protocol. Confirm hypothesis or re-plan.
+3. **Post-fix repro gate.** Re-run the reproduction protocol against the
+   radio. Acceptance:
+    - Fresh launch → tune 20m USB → intelligible voice, normal tuning feel
+    - 40m LSB still fine
+    - Toggle USB ↔ LSB ↔ USB without retuning → audio sane in both states
+    - CW / AM / FM on both a USB and an LSB band → still sane
+    - WWV 10 MHz AM carrier still on frequency in the waterfall
+      (regression check on the display path)
+4. **Phase B post-fix log gate.** The `createRxChannel` log now shows
+   mode and bounds matching the active slice. No `setFilterFreqs` guard-hits
+   on mode change that leave WDSP stale.
+5. **Core RX-path sanity.** Discovery → connect → I/Q → WDSP → audio end
+   to end, per CONTRIBUTING.md's "changes that break the core RX path"
+   clause.
+
+---
+
+## 5. Commit Plan
+
+Branch: `fix/20m-iq-upper-sideband`. All commits GPG-signed. Co-Authored-By
+on each commit.
+
+1. `diag(dsp): instrument RxChannel / WdspEngine init and mode/filter calls`
+2. `fix(dsp): seed WDSP channel from SliceModel, make RxChannel cache self-consistent`
+3. `fix(dsp): resync bandpass after SetRXAMode to avoid stale filter state`
+4. (optional) `chore(dsp): demote dsp init log lines from qCInfo to qCDebug`
+
+Each commit must build and run. Commit 2 is the commit that actually fixes
+the audio; splitting it from commit 3 keeps blame history legible.
+
+**PR.** `fix/20m-iq-upper-sideband` → `main`. Title:
+`fix(dsp): USB demod broken — WDSP bandpass stale at channel create`. PR body
+will describe the symptom, the three-way default disagreement, and the fix.
+Draft PR body shown to the user for approval before posting. PR URL opened
+in a browser after posting.
+
+**Worktree cleanup.** After merge, via
+`superpowers:finishing-a-development-branch`.
+
+---
+
+## 6. Out-of-Scope Follow-Ups
+
+The original user request bundled three workstreams into one message. Only
+the first is addressed here. The other two belong on their own branches:
+
+- **Right-side panel wiring** — feature work, separate design, separate
+  branch.
+- **Setup → General → Display → RX1 display settings wiring** (motivated by
+  the desire to match SmartSDR / AetherSDR waterfall palette range) —
+  feature work, separate design, separate branch. This may require
+  revisiting the palette slider ranges in `SpectrumWidget` as a follow-up.

--- a/docs/architecture/2026-04-12-fix-20m-iq-usb-demod-plan.md
+++ b/docs/architecture/2026-04-12-fix-20m-iq-usb-demod-plan.md
@@ -1,0 +1,765 @@
+# Fix USB Demod Broken — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the Donald-Duck USB demod bug by eliminating the three-way inconsistency between `SliceModel` defaults, `RxChannel` cached state, and the hardcoded `WdspEngine::createRxChannel` init block.
+
+**Architecture:** Two phases. Phase A instruments the DSP init / mode / filter paths with `qCInfo(lcDsp)` logs to capture ground-truth WDSP state and confirm the hypothesis against a live ANAN-G2. Phase B seeds the WDSP channel from the active `SliceModel` at create time, makes `RxChannel`'s cache self-consistent, removes the stale apply loop in `RadioModel::onWdspInitialized`, and adds an unconditional bandpass resync after every `SetRXAMode` call.
+
+**Tech Stack:** C++20, Qt6, WDSP (C), CMake + Ninja. No unit-test infrastructure in this repo — verification is log-evidence + live-radio acoustic test per the reproduction protocol in the design doc.
+
+**Design doc:** [`2026-04-12-fix-20m-iq-usb-demod-design.md`](2026-04-12-fix-20m-iq-usb-demod-design.md)
+
+**Worktree:** `/Users/j.j.boyd/NereusSDR/.worktrees/fix-20m-iq` on branch `fix/20m-iq-upper-sideband`.
+
+**Testing reality check:** This is an integration bug that cannot be exercised by a unit test without an ANAN-G2 radio and WDSP actively running. The "test" at each verification gate is a live repro with the user at the console. Plan is structured around that constraint; the user participates as the test harness in Tasks A6 and B8.
+
+---
+
+## File Structure
+
+| File | Role | Phase |
+|---|---|---|
+| `src/core/WdspEngine.cpp` | Remove hardcoded mode/filter init; take initial state from caller | A (log), B (fix) |
+| `src/core/WdspEngine.h` | New signature for `createRxChannel` | B |
+| `src/core/RxChannel.cpp` | Add instrumentation; add unconditional bandpass resync after `SetRXAMode` | A, B |
+| `src/core/RxChannel.h` | Remove hardcoded cached defaults; take initial mode/filter via constructor | B |
+| `src/models/RadioModel.cpp` | Pass slice state to `createRxChannel`; remove redundant apply loop; add instrumentation to slice signal handlers | A, B |
+| `docs/architecture/2026-04-12-fix-20m-iq-usb-demod-design.md` | Already committed — the spec | — |
+
+---
+
+## Phase A — Instrument and Prove
+
+### Task A1: Instrument `WdspEngine::createRxChannel`
+
+**Files:**
+- Modify: `src/core/WdspEngine.cpp:255-267` (area around the `SetRXAMode` init block)
+
+- [ ] **Step 1: Add a `qCInfo` log line immediately after the init block**
+
+In `WdspEngine.cpp`, find the block ending with:
+
+```cpp
+    SetRXAAGCMode(channelId, static_cast<int>(AGCMode::Med));
+    SetRXAAGCTop(channelId, 80.0);
+
+    qCInfo(lcDsp) << "Created RX channel" << channelId
+                   << "bufSize=" << inputBufferSize
+                   << "rate=" << inputSampleRate;
+#endif
+```
+
+Replace the existing `qCInfo` line with:
+
+```cpp
+    qCInfo(lcDsp) << "Created RX channel" << channelId
+                   << "bufSize=" << inputBufferSize
+                   << "rate=" << inputSampleRate
+                   << "| init WDSP mode=LSB(0) bounds=(-2850,-150)"
+                   << "| NOTE: hardcoded init — cache may diverge";
+```
+
+This makes it obvious in the log *what WDSP was actually initialized to*, not what anybody thinks it was initialized to.
+
+- [ ] **Step 2: Build the worktree for the first time**
+
+```bash
+cd /Users/j.j.boyd/NereusSDR/.worktrees/fix-20m-iq
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build -j
+```
+
+Expected: clean build, no warnings introduced by the change.
+
+- [ ] **Step 3: Do not commit yet — continue to A2.**
+
+---
+
+### Task A2: Instrument `RxChannel::setMode`
+
+**Files:**
+- Modify: `src/core/RxChannel.cpp:24-39`
+
+- [ ] **Step 1: Add guard-miss and guard-hit logging**
+
+Replace the body of `setMode` with:
+
+```cpp
+void RxChannel::setMode(DSPMode mode)
+{
+    int val = static_cast<int>(mode);
+    int oldVal = m_mode.load();
+    if (val == oldVal) {
+        qCInfo(lcDsp) << "RxChannel" << m_channelId
+                       << "setMode GUARD-HIT — cache already"
+                       << val << "— WDSP NOT updated";
+        return;
+    }
+
+    m_mode.store(val);
+
+#ifdef HAVE_WDSP
+    // From Thetis wdsp-integration.md section 4.2
+    SetRXAMode(m_channelId, val);
+    qCInfo(lcDsp) << "RxChannel" << m_channelId
+                   << "setMode MISS — old=" << oldVal
+                   << "new=" << val << "— pushed to WDSP";
+#endif
+
+    emit modeChanged(mode);
+}
+```
+
+- [ ] **Step 2: Rebuild**
+
+```bash
+cmake --build build -j
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Do not commit yet — continue.**
+
+---
+
+### Task A3: Instrument `RxChannel::setFilterFreqs`
+
+**Files:**
+- Modify: `src/core/RxChannel.cpp:45-59`
+
+- [ ] **Step 1: Add guard-miss and guard-hit logging**
+
+Replace the body of `setFilterFreqs` with:
+
+```cpp
+void RxChannel::setFilterFreqs(double lowHz, double highHz)
+{
+    if (m_filterLow == lowHz && m_filterHigh == highHz) {
+        qCInfo(lcDsp) << "RxChannel" << m_channelId
+                       << "setFilterFreqs GUARD-HIT — cache already"
+                       << lowHz << highHz << "— WDSP NOT updated";
+        return;
+    }
+
+    double oldLow = m_filterLow;
+    double oldHigh = m_filterHigh;
+    m_filterLow = lowHz;
+    m_filterHigh = highHz;
+
+#ifdef HAVE_WDSP
+    SetRXABandpassFreqs(m_channelId, lowHz, highHz);
+    qCInfo(lcDsp) << "RxChannel" << m_channelId
+                   << "setFilterFreqs MISS — old=(" << oldLow << oldHigh
+                   << ") new=(" << lowHz << highHz << ") — pushed to WDSP";
+#endif
+
+    emit filterChanged(lowHz, highHz);
+}
+```
+
+- [ ] **Step 2: Rebuild**
+
+```bash
+cmake --build build -j
+```
+
+Expected: clean.
+
+---
+
+### Task A4: Instrument `RadioModel` slice signal handlers
+
+**Files:**
+- Modify: `src/models/RadioModel.cpp:346-361` (the `dspModeChanged` and `filterChanged` lambda handlers in `wireSliceSignals`)
+
+- [ ] **Step 1: Add entry logs to both handlers**
+
+Replace the two handlers with:
+
+```cpp
+    // Mode → WDSP
+    connect(slice, &SliceModel::dspModeChanged, this, [this](DSPMode mode) {
+        qCInfo(lcDsp) << "RadioModel: dspModeChanged handler FIRED with"
+                       << static_cast<int>(mode);
+        RxChannel* rxCh = m_wdspEngine->rxChannel(0);
+        if (rxCh) {
+            rxCh->setMode(mode);
+        }
+        scheduleSettingsSave();
+    });
+
+    // Filter → WDSP
+    connect(slice, &SliceModel::filterChanged, this, [this](int low, int high) {
+        qCInfo(lcDsp) << "RadioModel: filterChanged handler FIRED with"
+                       << low << high;
+        RxChannel* rxCh = m_wdspEngine->rxChannel(0);
+        if (rxCh) {
+            rxCh->setFilterFreqs(low, high);
+        }
+        scheduleSettingsSave();
+    });
+```
+
+- [ ] **Step 2: Rebuild**
+
+```bash
+cmake --build build -j
+```
+
+Expected: clean.
+
+---
+
+### Task A5: Add a one-shot "resync probe" after WDSP init
+
+**Files:**
+- Modify: `src/models/RadioModel.cpp:158-176` (the `initializedChanged` lambda that creates the RX channel)
+
+Rationale: this probe proves the stale-cache hypothesis directly. If simply re-pushing the current `SliceModel` state with bypassed guards fixes the audio, the bug is exactly what we think it is.
+
+- [ ] **Step 1: Add the probe**
+
+Inside the `initializedChanged` lambda, after the existing `rxCh->setActive(true);` line and before `m_audioEngine->start();`, add:
+
+```cpp
+        // DIAGNOSTIC: one-shot resync probe (remove in Phase B).
+        // Forces mode/filter to match SliceModel by briefly perturbing then
+        // restoring the RxChannel cache to bypass the equality guards.
+        if (rxCh && m_activeSlice) {
+            DSPMode wantMode = m_activeSlice->dspMode();
+            int wantLow = m_activeSlice->filterLow();
+            int wantHigh = m_activeSlice->filterHigh();
+            qCInfo(lcDsp) << "RESYNC PROBE: forcing WDSP to slice state mode="
+                           << static_cast<int>(wantMode)
+                           << "bounds=(" << wantLow << wantHigh << ")";
+            // Perturb cache to force a miss on the next set call
+            rxCh->setMode(wantMode == DSPMode::USB ? DSPMode::LSB : DSPMode::USB);
+            rxCh->setMode(wantMode);
+            rxCh->setFilterFreqs(wantLow + 1, wantHigh + 1);
+            rxCh->setFilterFreqs(wantLow, wantHigh);
+            qCInfo(lcDsp) << "RESYNC PROBE: done";
+        }
+```
+
+- [ ] **Step 2: Rebuild and relaunch**
+
+```bash
+cmake --build build -j
+pkill -f NereusSDR.app 2>/dev/null
+open build/NereusSDR.app
+```
+
+Expected: clean build, app launches.
+
+---
+
+### Task A6: Live repro against the ANAN-G2 (user-in-the-loop gate)
+
+**Files:** none — this is a runtime observation task.
+
+- [ ] **Step 1: User runs the repro protocol**
+
+Ask the user to:
+
+1. Stop if already running, relaunch the app
+2. Connect to the ANAN-G2
+3. Tune 20m USB, listen ~5 s
+4. Switch to 40m LSB, listen ~5 s
+5. Switch back to 20m USB, listen ~5 s
+6. Toggle USB ↔ LSB ↔ USB on 20m without retuning
+7. Paste the `lcDsp` log lines from `~/.config/NereusSDR/nereussdr.log` into the chat
+
+- [ ] **Step 2: Diagnose the log**
+
+Confirm exactly one of these:
+
+- **(a)** Hypothesis confirmed — `createRxChannel` init logs `LSB/(-2850,-150)`, and at some point a `setFilterFreqs` or `setMode` guard-hit leaves WDSP in an incoherent state, AND the resync probe produces audible improvement when it runs
+- **(b)** Hypothesis refuted — WDSP is coherent at all times but USB audio is still wrong → re-plan before touching code
+
+Only if **(a)**: proceed to A7. If **(b)**: stop, return to brainstorming.
+
+---
+
+### Task A7: Commit the Phase A instrumentation
+
+- [ ] **Step 1: Stage and commit, GPG-signed**
+
+```bash
+git add src/core/WdspEngine.cpp src/core/RxChannel.cpp src/models/RadioModel.cpp
+git commit -S -m "$(cat <<'EOF'
+diag(dsp): instrument RxChannel / WdspEngine init and mode/filter calls
+
+Adds qCInfo(lcDsp) entries at every mode/filter set call site and at
+WDSP channel creation to capture ground-truth state during the USB
+demod bug hunt. Includes a one-shot resync probe in RadioModel that
+forces WDSP to match SliceModel by perturbing the RxChannel cache,
+used to prove the stale-cache hypothesis. Log lines and probe are
+temporary and will be cleaned up in the Phase B fix commit.
+
+Refs design: docs/architecture/2026-04-12-fix-20m-iq-usb-demod-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: signed commit with `gpg: Good signature from "JJ Boyd <kg4vcf@gmail.com>"`.
+
+---
+
+## Phase B — Root-Cause Fix
+
+Do not start Phase B until Task A6 has produced log evidence that matches the hypothesis.
+
+### Task B1: READ the Thetis source for channel create + mode change
+
+**Files (read only):**
+- `../Thetis/Project Files/Source/wdsp/cmaster.c` — channel create sequence
+- `../Thetis/Project Files/Source/Console/console.cs` — mode-change handler (search for `SetRXAMode`, `SetRXABandpassFreqs`)
+- `../Thetis/Project Files/Source/wdsp/RXA.c` — implementations of `SetRXAMode` and `SetRXABandpassFreqs`
+
+- [ ] **Step 1: Locate and quote the Thetis channel-create sequence**
+
+```bash
+grep -n "SetRXAMode\|SetRXABandpassFreqs" ../../../Thetis/Project\ Files/Source/wdsp/cmaster.c
+```
+
+Note file + line numbers and paste the relevant 10-20 lines into the chat. Per CLAUDE.md READ → SHOW → TRANSLATE, nothing new is written until this is quoted.
+
+- [ ] **Step 2: Locate and quote the mode-change handler in `console.cs`**
+
+```bash
+grep -n "SetRXAMode" "../../../Thetis/Project Files/Source/Console/console.cs" | head -30
+```
+
+Identify the function that handles mode switch (typically `radio_ModeChangeHandler` or similar) and quote the body into the chat.
+
+- [ ] **Step 3: Confirm whether `SetRXAMode` internally resets bandpass**
+
+Read the top of `SetRXAMode` in `RXA.c`:
+
+```bash
+grep -n "^void SetRXAMode\|^PORT void SetRXAMode" "../../../Thetis/Project Files/Source/wdsp/RXA.c"
+```
+
+Paste the function body. The answer to "does `SetRXAMode` reset bandpass" determines whether B4 (unconditional resync after mode change) is strictly required or merely defensive.
+
+---
+
+### Task B2: Remove hardcoded defaults from `RxChannel.h`
+
+**Files:**
+- Modify: `src/core/RxChannel.h:111, 120-121` (cached default values)
+- Modify: `src/core/RxChannel.h` constructor declaration
+- Modify: `src/core/RxChannel.cpp` constructor definition
+
+- [ ] **Step 1: Update header**
+
+In `src/core/RxChannel.h`, change the constructor signature:
+
+```cpp
+    RxChannel(int channelId, int bufferSize, int sampleRate,
+              DSPMode initialMode,
+              double initialFilterLow, double initialFilterHigh,
+              QObject* parent = nullptr);
+```
+
+Change the atomic initializer and cached filter initializers to drop the hardcoded values:
+
+```cpp
+    // Atomic flags for lock-free audio thread reads.
+    // Initial values are set by the constructor — no hardcoded defaults
+    // here, because they have caused mode/filter incoherence bugs.
+    std::atomic<int> m_mode;
+    std::atomic<int> m_agcMode{static_cast<int>(AGCMode::Med)};
+    std::atomic<bool> m_nb1Enabled{false};
+    std::atomic<bool> m_nb2Enabled{false};
+    std::atomic<bool> m_nrEnabled{false};
+    std::atomic<bool> m_anfEnabled{false};
+    std::atomic<bool> m_active{false};
+
+    // Cached filter state — set by constructor, never defaulted.
+    double m_filterLow;
+    double m_filterHigh;
+```
+
+- [ ] **Step 2: Update constructor body**
+
+In `src/core/RxChannel.cpp`, replace the constructor:
+
+```cpp
+RxChannel::RxChannel(int channelId, int bufferSize, int sampleRate,
+                     DSPMode initialMode,
+                     double initialFilterLow, double initialFilterHigh,
+                     QObject* parent)
+    : QObject(parent)
+    , m_channelId(channelId)
+    , m_bufferSize(bufferSize)
+    , m_sampleRate(sampleRate)
+    , m_mode(static_cast<int>(initialMode))
+    , m_filterLow(initialFilterLow)
+    , m_filterHigh(initialFilterHigh)
+{
+}
+```
+
+- [ ] **Step 3: Build — expect compile error at `WdspEngine` call site**
+
+```bash
+cmake --build build -j
+```
+
+Expected: failure, because `WdspEngine::createRxChannel` now calls `std::make_unique<RxChannel>(...)` with the old signature. Move on to B3.
+
+---
+
+### Task B3: Seed the WDSP channel from `SliceModel` in `createRxChannel`
+
+**Files:**
+- Modify: `src/core/WdspEngine.h` — signature of `createRxChannel`
+- Modify: `src/core/WdspEngine.cpp:220-275`
+
+- [ ] **Step 1: Update header**
+
+In `WdspEngine.h`, change `createRxChannel` signature to accept the initial mode and filter. Example (preserve existing sample-rate parameters, insert mode/filter before `parent`):
+
+```cpp
+    RxChannel* createRxChannel(int channelId,
+                               int inputBufferSize, int outputBufferSize,
+                               int inputSampleRate, int dspSampleRate,
+                               int outputSampleRate,
+                               DSPMode initialMode,
+                               double initialFilterLow,
+                               double initialFilterHigh);
+```
+
+(Use `DSPMode` from `WdspTypes.h` — include it if not already.)
+
+- [ ] **Step 2: Rewrite the init block to use the new parameters**
+
+In `WdspEngine.cpp`, replace the hardcoded `SetRXAMode(LSB)` / `SetRXABandpassFreqs(-2850, -150)` lines (currently around 256-263) with:
+
+```cpp
+    // Seed WDSP with the active slice's actual (mode, bandpass) so the
+    // channel is born in a coherent state. From Thetis cmaster.c:XX
+    // (quoted in B1) — channel create sequences SetRXAMode first, then
+    // SetRXABandpassFreqs.
+    SetRXAMode(channelId, static_cast<int>(initialMode));
+    SetRXABandpassFreqs(channelId, initialFilterLow, initialFilterHigh);
+    SetRXAAGCMode(channelId, static_cast<int>(AGCMode::Med));
+    SetRXAAGCTop(channelId, 80.0);
+
+    qCInfo(lcDsp) << "Created RX channel" << channelId
+                   << "bufSize=" << inputBufferSize
+                   << "rate=" << inputSampleRate
+                   << "| seeded mode=" << static_cast<int>(initialMode)
+                   << "bounds=(" << initialFilterLow
+                   << initialFilterHigh << ")";
+```
+
+Replace the `Thetis cmaster.c:XX` citation with the actual line number from B1 before committing.
+
+- [ ] **Step 3: Update the `std::make_unique<RxChannel>` call**
+
+Further down in `createRxChannel`, replace:
+
+```cpp
+    auto channel = std::make_unique<RxChannel>(channelId, inputBufferSize,
+                                               inputSampleRate, this);
+```
+
+with:
+
+```cpp
+    auto channel = std::make_unique<RxChannel>(channelId, inputBufferSize,
+                                               inputSampleRate,
+                                               initialMode,
+                                               initialFilterLow,
+                                               initialFilterHigh,
+                                               this);
+```
+
+- [ ] **Step 4: Build — expect compile error at `RadioModel` call site**
+
+```bash
+cmake --build build -j
+```
+
+Expected: failure at `RadioModel.cpp:158` because the call site still uses the old signature. Move on to B4.
+
+---
+
+### Task B4: Update `RadioModel::onWdspInitialized` to pass slice state
+
+**Files:**
+- Modify: `src/models/RadioModel.cpp:151-178` (the `initializedChanged` lambda)
+
+- [ ] **Step 1: Pass slice mode/filter to `createRxChannel`**
+
+Replace the current `createRxChannel` call:
+
+```cpp
+        RxChannel* rxCh = m_wdspEngine->createRxChannel(0, 1024, 4096, 768000, 48000, 48000);
+```
+
+with:
+
+```cpp
+        DSPMode initialMode = m_activeSlice ? m_activeSlice->dspMode() : DSPMode::USB;
+        double initialLow = m_activeSlice ? m_activeSlice->filterLow() : 100.0;
+        double initialHigh = m_activeSlice ? m_activeSlice->filterHigh() : 3000.0;
+        RxChannel* rxCh = m_wdspEngine->createRxChannel(
+            0, 1024, 4096, 768000, 48000, 48000,
+            initialMode, initialLow, initialHigh);
+```
+
+- [ ] **Step 2: Remove the redundant apply loop**
+
+Delete these lines:
+
+```cpp
+            // Apply slice state to WDSP channel (no longer hardcoded)
+            if (m_activeSlice) {
+                rxCh->setMode(m_activeSlice->dspMode());
+                rxCh->setFilterFreqs(m_activeSlice->filterLow(),
+                                     m_activeSlice->filterHigh());
+                rxCh->setAgcMode(m_activeSlice->agcMode());
+                rxCh->setAgcTop(m_activeSlice->rfGain());
+            }
+```
+
+Replace with the AGC-only remnant (AGC wasn't part of the bug, still needs to be applied):
+
+```cpp
+            if (m_activeSlice) {
+                rxCh->setAgcMode(m_activeSlice->agcMode());
+                rxCh->setAgcTop(m_activeSlice->rfGain());
+            }
+```
+
+- [ ] **Step 3: Remove the resync probe from A5**
+
+Delete the `// DIAGNOSTIC: one-shot resync probe` block added in Task A5. It was diagnostic scaffolding for Phase A and must not ship.
+
+- [ ] **Step 4: Build**
+
+```bash
+cmake --build build -j
+```
+
+Expected: clean build.
+
+---
+
+### Task B5: Add unconditional bandpass resync in `RxChannel::setMode`
+
+**Files:**
+- Modify: `src/core/RxChannel.cpp:24-39` (the `setMode` body, currently still carrying A2 diagnostics)
+
+- [ ] **Step 1: Replace the `setMode` body**
+
+Replace the entire `setMode` function with:
+
+```cpp
+void RxChannel::setMode(DSPMode mode)
+{
+    int val = static_cast<int>(mode);
+    if (val == m_mode.load()) {
+        return;
+    }
+
+    m_mode.store(val);
+
+#ifdef HAVE_WDSP
+    // From Thetis console.cs:XX — on mode change, Thetis sequences
+    // SetRXAMode followed immediately by the current bandpass bounds.
+    // We mirror that here unconditionally because SetRXAMode can perturb
+    // WDSP internal bandpass state, and the equality guard on
+    // setFilterFreqs is not trustworthy when mode and filter are stored
+    // as two separate caches. One extra WDSP call per mode change is
+    // negligible and eliminates a whole class of stale-state bugs.
+    SetRXAMode(m_channelId, val);
+    SetRXABandpassFreqs(m_channelId, m_filterLow, m_filterHigh);
+#endif
+
+    emit modeChanged(mode);
+}
+```
+
+Replace `console.cs:XX` with the real line number from Task B1. This also drops the A2 diagnostic log lines from `setMode`.
+
+- [ ] **Step 2: Remove the A3 diagnostic lines from `setFilterFreqs`**
+
+Restore the original terse body:
+
+```cpp
+void RxChannel::setFilterFreqs(double lowHz, double highHz)
+{
+    if (m_filterLow == lowHz && m_filterHigh == highHz) {
+        return;
+    }
+
+    m_filterLow = lowHz;
+    m_filterHigh = highHz;
+
+#ifdef HAVE_WDSP
+    SetRXABandpassFreqs(m_channelId, lowHz, highHz);
+#endif
+
+    emit filterChanged(lowHz, highHz);
+}
+```
+
+- [ ] **Step 3: Remove the A4 diagnostic log lines from `RadioModel`**
+
+Restore the original terse `dspModeChanged` and `filterChanged` handler bodies (drop the `handler FIRED with` log lines added in Task A4; keep the handlers themselves).
+
+- [ ] **Step 4: Build**
+
+```bash
+cmake --build build -j
+```
+
+Expected: clean.
+
+---
+
+### Task B6: Commit the Phase B fix
+
+- [ ] **Step 1: Split into two commits — the seed-from-slice fix, and the resync fix**
+
+First commit (B2+B3+B4 rolled together — they are a unit, the compile breaks until all three land):
+
+```bash
+git add src/core/WdspEngine.h src/core/WdspEngine.cpp \
+        src/core/RxChannel.h src/core/RxChannel.cpp \
+        src/models/RadioModel.cpp
+git commit -S -m "$(cat <<'EOF'
+fix(dsp): seed WDSP channel from SliceModel, make RxChannel cache self-consistent
+
+Eliminates the three-way default-state disagreement between SliceModel,
+RxChannel's cached m_mode/m_filterLow/m_filterHigh, and the hardcoded
+LSB/-2850..-150 init block in WdspEngine::createRxChannel. The channel
+is now born in the correct (mode, bandpass) state read from the active
+slice, and RxChannel's cache mirrors WDSP from the first instant.
+
+Removes the redundant setMode/setFilterFreqs apply loop in
+RadioModel::onWdspInitialized (no longer needed) and the diagnostic
+resync probe added in Phase A.
+
+Fixes the "Donald Duck USB" symptom: on every USB band the channel was
+left in a USB mode with an LSB-shaped bandpass (-2850..-150 Hz), which
+WDSP demodulated as the image sideband. With the correct (USB, 100..3000)
+bandpass seeded at create time the symptom is gone.
+
+Refs: docs/architecture/2026-04-12-fix-20m-iq-usb-demod-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Second commit (B5 — the defensive resync):
+
+```bash
+git add src/core/RxChannel.cpp
+git commit -S -m "$(cat <<'EOF'
+fix(dsp): resync bandpass after SetRXAMode to avoid stale filter state
+
+Thetis's mode-change handler (console.cs:XX) sequences SetRXAMode
+immediately followed by the current bandpass. Mirror that here so the
+setFilterFreqs equality guard can never strand WDSP in a stale bandpass
+if SetRXAMode perturbs internal state. One extra WDSP call per mode
+change, no hot-path cost.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Replace `console.cs:XX` in the second commit message with the line from B1 before running.
+
+Expected: two signed commits, both builds clean on their own.
+
+---
+
+### Task B7: Relaunch and run the regression protocol
+
+**Files:** none — runtime verification.
+
+- [ ] **Step 1: Relaunch the app against the radio**
+
+```bash
+pkill -f NereusSDR.app 2>/dev/null
+cmake --build build -j
+open build/NereusSDR.app
+```
+
+- [ ] **Step 2: User runs the acceptance checklist from §4 of the design doc**
+
+Ask the user to confirm each of the following:
+
+1. Fresh launch → tune 20m USB → voice is intelligible and tuning feels normal
+2. 40m LSB still sounds fine
+3. Toggle USB ↔ LSB ↔ USB on 20m without retuning — audio sane in both
+4. CW on a USB band (CWU) and an LSB band (CWL) — still sane
+5. AM on 20m, FM on a known FM repeater — sane
+6. WWV 10 MHz AM carrier still lands on frequency in the waterfall
+
+Stop and return to planning if any of these fail.
+
+---
+
+### Task B8: Draft PR, show to user, then post
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/20m-iq-upper-sideband
+```
+
+- [ ] **Step 2: Draft PR body and show it to the user for approval**
+
+Draft a PR titled `fix(dsp): USB demod broken — WDSP bandpass stale at channel create` with a body that includes:
+
+- Symptom summary (Donald Duck USB on every band, LSB fine, CW fine, waterfall placement correct)
+- Root cause: three-way default-state disagreement, stale-cache guard hole
+- Fix summary: seed channel from SliceModel, make cache self-consistent, resync bandpass after SetRXAMode
+- Verification: link to the design doc and acceptance checklist
+- Signed `JJ Boyd ~KG4VCF` + `Co-Authored with Claude Code`
+
+Per the "review public posts" memory, paste the draft body into the chat and wait for approval before running `gh pr create`.
+
+- [ ] **Step 3: Create the PR once approved**
+
+```bash
+gh pr create --title "fix(dsp): USB demod broken — WDSP bandpass stale at channel create" --body "<approved body>"
+```
+
+- [ ] **Step 4: Open the PR in the browser** (per "open links after posting" memory)
+
+```bash
+gh pr view --web
+```
+
+---
+
+### Task B9: Worktree cleanup — deferred
+
+**Files:** none.
+
+- [ ] **Step 1: After merge, run `superpowers:finishing-a-development-branch`**
+
+This removes the worktree `/Users/j.j.boyd/NereusSDR/.worktrees/fix-20m-iq` and cleans up the branch. Do not run until the PR is merged.
+
+---
+
+## Self-Review Summary
+
+- **Spec coverage:** §2 root cause → B2/B3/B4 (seed from slice). §3 Fix 4 (belt-and-suspenders) → B5. §3 Fix 3 (remove apply loop) → B4 step 2. §4 verification gates → B7. §5 commit plan → A7 + B6. §6 out-of-scope follow-ups → not in plan (correct).
+- **Placeholder scan:** Thetis file/line citations are marked `XX` in B3 and B5 and must be filled in during Task B1. No other placeholders.
+- **Type consistency:** `DSPMode` / `double initialFilterLow` used consistently across B2/B3/B4. `RxChannel` constructor signature in B2 matches the call site rewrite in B3 matches the invocation in B4.
+- **TDD waiver:** No unit tests exist for this subsystem and the fix depends on live WDSP + live radio I/Q. Verification is log-based in A6 and acoustic/live in B7. This is documented in the Testing Reality Check at the top of the plan.

--- a/src/core/RxChannel.cpp
+++ b/src/core/RxChannel.cpp
@@ -24,7 +24,11 @@ RxChannel::~RxChannel() = default;
 void RxChannel::setMode(DSPMode mode)
 {
     int val = static_cast<int>(mode);
-    if (val == m_mode.load()) {
+    int oldVal = m_mode.load();
+    if (val == oldVal) {
+        qCInfo(lcDsp) << "RxChannel" << m_channelId
+                       << "setMode GUARD-HIT — cache already"
+                       << val << "— WDSP NOT updated";
         return;
     }
 
@@ -33,6 +37,11 @@ void RxChannel::setMode(DSPMode mode)
 #ifdef HAVE_WDSP
     // From Thetis wdsp-integration.md section 4.2
     SetRXAMode(m_channelId, val);
+    qCInfo(lcDsp) << "RxChannel" << m_channelId
+                   << "setMode MISS — old=" << oldVal
+                   << "new=" << val << "— pushed to WDSP";
+#else
+    Q_UNUSED(oldVal);
 #endif
 
     emit modeChanged(mode);
@@ -45,14 +54,25 @@ void RxChannel::setMode(DSPMode mode)
 void RxChannel::setFilterFreqs(double lowHz, double highHz)
 {
     if (m_filterLow == lowHz && m_filterHigh == highHz) {
+        qCInfo(lcDsp) << "RxChannel" << m_channelId
+                       << "setFilterFreqs GUARD-HIT — cache already"
+                       << lowHz << highHz << "— WDSP NOT updated";
         return;
     }
 
+    double oldLow = m_filterLow;
+    double oldHigh = m_filterHigh;
     m_filterLow = lowHz;
     m_filterHigh = highHz;
 
 #ifdef HAVE_WDSP
     SetRXABandpassFreqs(m_channelId, lowHz, highHz);
+    qCInfo(lcDsp) << "RxChannel" << m_channelId
+                   << "setFilterFreqs MISS — old=(" << oldLow << "," << oldHigh
+                   << ") new=(" << lowHz << "," << highHz << ") — pushed to WDSP";
+#else
+    Q_UNUSED(oldLow);
+    Q_UNUSED(oldHigh);
 #endif
 
     emit filterChanged(lowHz, highHz);

--- a/src/core/RxChannel.cpp
+++ b/src/core/RxChannel.cpp
@@ -24,11 +24,7 @@ RxChannel::~RxChannel() = default;
 void RxChannel::setMode(DSPMode mode)
 {
     int val = static_cast<int>(mode);
-    int oldVal = m_mode.load();
-    if (val == oldVal) {
-        qCInfo(lcDsp) << "RxChannel" << m_channelId
-                       << "setMode GUARD-HIT — cache already"
-                       << val << "— WDSP NOT updated";
+    if (val == m_mode.load()) {
         return;
     }
 
@@ -37,11 +33,6 @@ void RxChannel::setMode(DSPMode mode)
 #ifdef HAVE_WDSP
     // From Thetis wdsp-integration.md section 4.2
     SetRXAMode(m_channelId, val);
-    qCInfo(lcDsp) << "RxChannel" << m_channelId
-                   << "setMode MISS — old=" << oldVal
-                   << "new=" << val << "— pushed to WDSP";
-#else
-    Q_UNUSED(oldVal);
 #endif
 
     emit modeChanged(mode);
@@ -54,25 +45,22 @@ void RxChannel::setMode(DSPMode mode)
 void RxChannel::setFilterFreqs(double lowHz, double highHz)
 {
     if (m_filterLow == lowHz && m_filterHigh == highHz) {
-        qCInfo(lcDsp) << "RxChannel" << m_channelId
-                       << "setFilterFreqs GUARD-HIT — cache already"
-                       << lowHz << highHz << "— WDSP NOT updated";
         return;
     }
 
-    double oldLow = m_filterLow;
-    double oldHigh = m_filterHigh;
     m_filterLow = lowHz;
     m_filterHigh = highHz;
 
 #ifdef HAVE_WDSP
+    // From Thetis rxa.cs:110-111, radio.cs:603-604 — both bp1 and nbp0
+    // filters must be updated together. SetRXABandpassFreqs only touches
+    // bp1, which runs only when AMD/SNBA/EMNR/ANF/ANR is enabled.
+    // RXANBPSetFreqs touches nbp0, the filter that runs unconditionally
+    // in the SSB/CW/AM audio path. Calling only one leaves the SSB
+    // bandpass stuck at nbp0's create-time default of -4150..-150
+    // (LSB-shaped), which silently breaks USB, AM, and FM demod.
     SetRXABandpassFreqs(m_channelId, lowHz, highHz);
-    qCInfo(lcDsp) << "RxChannel" << m_channelId
-                   << "setFilterFreqs MISS — old=(" << oldLow << "," << oldHigh
-                   << ") new=(" << lowHz << "," << highHz << ") — pushed to WDSP";
-#else
-    Q_UNUSED(oldLow);
-    Q_UNUSED(oldHigh);
+    RXANBPSetFreqs(m_channelId, lowHz, highHz);
 #endif
 
     emit filterChanged(lowHz, highHz);

--- a/src/core/WdspEngine.cpp
+++ b/src/core/WdspEngine.cpp
@@ -264,7 +264,9 @@ RxChannel* WdspEngine::createRxChannel(int channelId,
 
     qCInfo(lcDsp) << "Created RX channel" << channelId
                    << "bufSize=" << inputBufferSize
-                   << "rate=" << inputSampleRate;
+                   << "rate=" << inputSampleRate
+                   << "| init WDSP mode=LSB(0) bounds=(-2850,-150)"
+                   << "| NOTE: hardcoded init — cache may diverge";
 #endif
 
     auto channel = std::make_unique<RxChannel>(channelId, inputBufferSize,

--- a/src/core/WdspEngine.cpp
+++ b/src/core/WdspEngine.cpp
@@ -258,15 +258,24 @@ RxChannel* WdspEngine::createRxChannel(int channelId,
     // Without this, the RxChannel guard (if val == m_mode) would skip the
     // WDSP call when the requested mode matches the cached default.
     SetRXAMode(channelId, static_cast<int>(DSPMode::LSB));
+    // Both bp1 AND nbp0 must be seeded — see RxChannel::setFilterFreqs
+    // comment for why. Thetis seeds both at channel create.
     SetRXABandpassFreqs(channelId, -2850.0, -150.0);
+    RXANBPSetFreqs(channelId, -2850.0, -150.0);
     SetRXAAGCMode(channelId, static_cast<int>(AGCMode::Med));
     SetRXAAGCTop(channelId, 80.0);
 
+    // Dual-mono audio output. WDSP's create_panel default is copy=0
+    // (binaural — I and Q carry separate phase-shifted content for
+    // a headphone stereo image). Played through speakers the two
+    // channels comb-filter each other into pitched, unintelligible
+    // "Donald Duck" audio. Thetis radio.cs:1157 drives this from
+    // BinOn which defaults to false → dual-mono. Match that default.
+    SetRXAPanelBinaural(channelId, 0);
+
     qCInfo(lcDsp) << "Created RX channel" << channelId
                    << "bufSize=" << inputBufferSize
-                   << "rate=" << inputSampleRate
-                   << "| init WDSP mode=LSB(0) bounds=(-2850,-150)"
-                   << "| NOTE: hardcoded init — cache may diverge";
+                   << "rate=" << inputSampleRate;
 #endif
 
     auto channel = std::make_unique<RxChannel>(channelId, inputBufferSize,

--- a/src/core/wdsp_api.h
+++ b/src/core/wdsp_api.h
@@ -56,6 +56,12 @@ void SetRXAMode(int channel, int mode);
 
 void SetRXABandpassFreqs(int channel, double f_low, double f_high);
 
+// CRITICAL: SetRXABandpassFreqs only updates bp1, which only runs when
+// AMD/SNBA/EMNR/ANF/ANR is enabled. For plain SSB the active filter is
+// nbp0, controlled by RXANBPSetFreqs. Thetis always calls BOTH together
+// (rxa.cs:110-111, radio.cs:603-604). Call both in setFilterFreqs.
+void RXANBPSetFreqs(int channel, double flow, double fhigh);
+
 void SetRXABandpassNC(int channel, int nc);
 
 void SetRXABandpassMP(int channel, int mp);
@@ -75,6 +81,15 @@ void SetRXAShiftFreq(int channel, double fshift);
 // ---------------------------------------------------------------------------
 
 void RXANBPSetShiftFrequency(int channel, double shift);
+
+// ---------------------------------------------------------------------------
+// Patch panel (patchpanel.h) — final mix stage in RXA pipeline
+// ---------------------------------------------------------------------------
+
+// bin=0 → copy=1 → dual mono (Q := I, same audio on both channels)
+// bin=1 → copy=0 → binaural (I and Q separate, for headphone stereo image)
+// From Thetis radio.cs:1157 — Thetis default BinOn=false → dual mono
+void SetRXAPanelBinaural(int channel, int bin);
 
 // ---------------------------------------------------------------------------
 // AGC (wcpAGC.h)

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -167,6 +167,23 @@ void RadioModel::connectToRadio(const RadioInfo& info)
             }
             rxCh->setActive(true);
         }
+        // DIAGNOSTIC: one-shot resync probe (removed in Phase B).
+        // Forces mode/filter to match SliceModel by briefly perturbing
+        // then restoring the RxChannel cache to bypass the equality guards.
+        if (rxCh && m_activeSlice) {
+            DSPMode wantMode = m_activeSlice->dspMode();
+            int wantLow = m_activeSlice->filterLow();
+            int wantHigh = m_activeSlice->filterHigh();
+            qCInfo(lcDsp) << "RESYNC PROBE: forcing WDSP to slice state mode="
+                           << static_cast<int>(wantMode)
+                           << "bounds=(" << wantLow << wantHigh << ")";
+            qCInfo(lcDsp) << "RESYNC PROBE: expect 2 interim dspModeChanged + 1 interim filterChanged log entries below — these are probe artifacts";
+            rxCh->setMode(wantMode == DSPMode::USB ? DSPMode::LSB : DSPMode::USB);
+            rxCh->setMode(wantMode);
+            rxCh->setFilterFreqs(wantLow + 1, wantHigh + 1);
+            rxCh->setFilterFreqs(wantLow, wantHigh);
+            qCInfo(lcDsp) << "RESYNC PROBE: done";
+        }
         // Apply volume from slice
         if (m_activeSlice) {
             m_audioEngine->setVolume(m_activeSlice->afGain() / 100.0f);
@@ -344,6 +361,8 @@ void RadioModel::wireSliceSignals()
 
     // Mode → WDSP
     connect(slice, &SliceModel::dspModeChanged, this, [this](DSPMode mode) {
+        qCInfo(lcDsp) << "RadioModel: dspModeChanged handler FIRED with"
+                       << static_cast<int>(mode);
         RxChannel* rxCh = m_wdspEngine->rxChannel(0);
         if (rxCh) {
             rxCh->setMode(mode);
@@ -353,6 +372,8 @@ void RadioModel::wireSliceSignals()
 
     // Filter → WDSP
     connect(slice, &SliceModel::filterChanged, this, [this](int low, int high) {
+        qCInfo(lcDsp) << "RadioModel: filterChanged handler FIRED with"
+                       << low << high;
         RxChannel* rxCh = m_wdspEngine->rxChannel(0);
         if (rxCh) {
             rxCh->setFilterFreqs(low, high);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -167,23 +167,6 @@ void RadioModel::connectToRadio(const RadioInfo& info)
             }
             rxCh->setActive(true);
         }
-        // DIAGNOSTIC: one-shot resync probe (removed in Phase B).
-        // Forces mode/filter to match SliceModel by briefly perturbing
-        // then restoring the RxChannel cache to bypass the equality guards.
-        if (rxCh && m_activeSlice) {
-            DSPMode wantMode = m_activeSlice->dspMode();
-            int wantLow = m_activeSlice->filterLow();
-            int wantHigh = m_activeSlice->filterHigh();
-            qCInfo(lcDsp) << "RESYNC PROBE: forcing WDSP to slice state mode="
-                           << static_cast<int>(wantMode)
-                           << "bounds=(" << wantLow << wantHigh << ")";
-            qCInfo(lcDsp) << "RESYNC PROBE: expect 2 interim dspModeChanged + 1 interim filterChanged log entries below — these are probe artifacts";
-            rxCh->setMode(wantMode == DSPMode::USB ? DSPMode::LSB : DSPMode::USB);
-            rxCh->setMode(wantMode);
-            rxCh->setFilterFreqs(wantLow + 1, wantHigh + 1);
-            rxCh->setFilterFreqs(wantLow, wantHigh);
-            qCInfo(lcDsp) << "RESYNC PROBE: done";
-        }
         // Apply volume from slice
         if (m_activeSlice) {
             m_audioEngine->setVolume(m_activeSlice->afGain() / 100.0f);
@@ -288,7 +271,9 @@ void RadioModel::wireConnectionSignals()
             rxCh->processIq(m_iqAccumI.data(), m_iqAccumQ.data(),
                             outI.data(), outQ.data(), kWdspBufSize);
 
-            // WDSP outputs out_size samples (64 at 768k→48k decimation)
+            // WDSP outputs out_size samples (64 at 768k→48k decimation).
+            // outI == outQ because SetRXAPanelBinaural(channel, 0) puts the
+            // RXA patch panel in dual-mono mode in WdspEngine::createRxChannel.
             m_audioEngine->feedAudio(0, outI.data(), outQ.data(), kWdspOutSize);
 
             // Remove processed samples
@@ -361,8 +346,6 @@ void RadioModel::wireSliceSignals()
 
     // Mode → WDSP
     connect(slice, &SliceModel::dspModeChanged, this, [this](DSPMode mode) {
-        qCInfo(lcDsp) << "RadioModel: dspModeChanged handler FIRED with"
-                       << static_cast<int>(mode);
         RxChannel* rxCh = m_wdspEngine->rxChannel(0);
         if (rxCh) {
             rxCh->setMode(mode);
@@ -372,8 +355,6 @@ void RadioModel::wireSliceSignals()
 
     // Filter → WDSP
     connect(slice, &SliceModel::filterChanged, this, [this](int low, int high) {
-        qCInfo(lcDsp) << "RadioModel: filterChanged handler FIRED with"
-                       << low << high;
         RxChannel* rxCh = m_wdspEngine->rxChannel(0);
         if (rxCh) {
             rxCh->setFilterFreqs(low, high);


### PR DESCRIPTION
## Summary

Fixes a long-standing "Donald Duck" audio bug on every non-LSB mode. USB
voice was unintelligible, AM was garbled, FM likely similar, CW sounded
OK only because its narrow passband hid the problem. LSB voice worked
by pure accident — WDSP's default filter happened to be LSB-shaped.

## Root cause

Two WDSP APIs NereusSDR was not calling that Thetis always calls:

1. **`RXANBPSetFreqs` was never invoked.** WDSP's RXA chain has two
   bandpass filters: `bp1` (updated by `SetRXABandpassFreqs`, only
   runs when AMD/SNBA/EMNR/ANF/ANR is on — see `RXA.c:883-895`) and
   `nbp0` (updated by `RXANBPSetFreqs`, runs unconditionally in the
   plain SSB/AM/CW audio path — `RXA.c:624`). NereusSDR only called
   `SetRXABandpassFreqs`, which silently updated an inactive filter.
   `nbp0` stayed at its create-time default of `(-4150.0, -150.0)` —
   LSB-shaped — so every non-LSB demodulator was reading from a
   filter that only passed negative-frequency content. Thetis always
   calls both setters together (`rxa.cs:110-111`, `116-117`,
   `radio.cs:603-604`).

2. **The RXA patch panel was in binaural mode.** `create_panel`
   defaults to `copy=0` (binaural — `outI` and `outQ` carry
   phase-shifted content for a headphone stereo image,
   `patchpanel.c:55-101`). Through laptop speakers, the
   acoustically-mixed phase-shifted streams produce pitched, hollow
   comb-filtered audio. Thetis calls `SetRXAPanelBinaural(ch, false)`
   via `BinOn` (`radio.cs:1157`), defaulting to `false` → dual-mono.

## Changes

- `src/core/RxChannel.cpp` — `setFilterFreqs` now calls both
  `SetRXABandpassFreqs` and `RXANBPSetFreqs`, with a Thetis-citing
  comment explaining why.
- `src/core/WdspEngine.cpp` — `createRxChannel` seeds both filters at
  channel create time and calls `SetRXAPanelBinaural(channelId, 0)`
  in the WDSP init block.
- `src/core/wdsp_api.h` — adds declarations for `RXANBPSetFreqs` and
  `SetRXAPanelBinaural`.
- Phase A diagnostic instrumentation added in `c3164fd` is removed
  (GUARD-HIT/MISS logs, handler FIRED logs, RESYNC PROBE, WDSP-out
  sample dumps). It served its purpose during the hypothesis-refutation
  investigation.

## Design doc

`docs/architecture/2026-04-12-fix-20m-iq-usb-demod-design.md` — the
original hypothesis (three-way disagreeing default states leaving WDSP
in an incoherent mode/bandpass pair) was refuted by live-radio logs
during Phase A diagnosis. The doc's new §7 "Diagnosis Outcome" walks
through what actually happened, the two real root causes, and the
lessons learned from chasing the wrong hypothesis.

## Test plan

- [x] Build clean on macOS (Ninja, RelWithDebInfo)
- [x] 20m USB voice on an ANAN-G2 — intelligible natural speech
- [x] 10 MHz WWV AM — voice announcements and ticks clear
- [x] 40m LSB voice — still clean (regression check)
- [x] CW on a CWU and CWL signal — sounds right
- [ ] FM on a known repeater — sounds right
- [x] 15m/17m/10m USB spot-check — intelligible

## Out of scope

The original issue bundled three workstreams into one request. Only
the audio bug is in this PR. Right-side panel wiring and
Setup→Display→RX1 palette work are deferred to separate branches.

73 de KG4VCF

JJ Boyd ~KG4VCF
Co-Authored with Claude Code