### PR TITLE
Phase 3G-8: RX1 Display parity — wire 47 Spectrum/Waterfall/Grid controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,98 @@
 
 ## [Unreleased]
 
+### Phase 3G-8 — RX1 Display Parity (complete)
+
+**Status:** Complete. Branch `feature/phase3g8-rx1-display-parity`
+off `feature/phase3g7-polish`. 9 GPG-signed code commits plus
+three doc-amend prep commits. Brings the Display → Spectrum
+Defaults / Waterfall Defaults / Grid & Scales pages from "every
+control disabled with NYI tooltip" to feature parity with Thetis
+for RX1.
+
+See [`docs/architecture/phase3g8-rx1-display-parity-plan.md`](docs/architecture/phase3g8-rx1-display-parity-plan.md)
+for the design (plan §13 open questions resolved in commit
+`0308b1b`, §5.3 architectural correction in `b8045cc`).
+
+**What landed:**
+
+- **Commit 1** — `ColorSwatchButton` reusable widget. Replaces
+  the dead `makeColorSwatch` placeholder with a real
+  `QPushButton + QColorDialog` pair. Used by 9 call sites across
+  this phase and available to future TX Display / skin editor
+  work.
+- **Commit 2** — per-band grid storage on `PanadapterModel`.
+  New `Band` enum (14 bands: 160m–6m + GEN + WWV + XVTR), new
+  `BandGridSettings { dbMax, dbMin }` struct, per-band hash, 28
+  persistence keys, `bandChanged` signal, and `setCenterFrequency`
+  auto-derive. `BandButtonItem` expanded 12 → 14 buttons.
+  Initialised to Thetis uniform -40 / -140 per plan §13 Q4.
+- **Commits 3–5** — `SpectrumWidget` + `FFTEngine` renderer
+  additions: averaging mode (None/Weighted/Log/TimeWindow),
+  peak hold + decay, trace line width, fill + alpha, gradient,
+  cal offset, waterfall AGC, reverse scroll, opacity, update
+  period rate limiting, waterfall averaging, use-spectrum-min/max,
+  filter/zero-line overlays, timestamp overlay, 3 new colour
+  schemes (LinLog / LinRad / Custom, total now 7), configurable
+  grid / grid-fine / h-grid / text / zero-line / band-edge
+  colours, 5-mode frequency label alignment, FPS overlay. GPU
+  line width and gradient shader wire-up deferred to a future
+  polish pass.
+- **Commits 6–8** — wire each Display setup page to the new
+  state:
+  - Spectrum Defaults: 17 controls including FFT size / window
+    (routed to FFTEngine), FPS, averaging + time + decimation,
+    fill + alpha, line width, gradient, cal offset, peak hold
+    + delay, 3 colour pickers, thread priority.
+  - Waterfall Defaults: 17 controls including high / low
+    thresholds, AGC, low colour, use-spectrum-min/max, update
+    period, reverse scroll, opacity, 7-scheme colour combo,
+    WF averaging, 4 filter / zero-line overlay toggles,
+    timestamp position + mode.
+  - Grid & Scales: 13 controls including show grid, live
+    per-band dB Max / Min with "Editing band: N" label that
+    updates on PanadapterModel::bandChanged, global dB Step,
+    5-mode frequency label align, show zero line, show FPS,
+    6 colour pickers (grid / grid-fine / h-grid / text /
+    zero-line / band-edge).
+- **Commit 9** — this CHANGELOG entry + verification matrix
+  checklist at
+  [`docs/architecture/phase3g8-verification/README.md`](docs/architecture/phase3g8-verification/README.md).
+
+**Architectural additions:**
+
+- `RadioModel::spectrumWidget()` / `fftEngine()` non-owning
+  view hooks, wired by `MainWindow` during construction, so
+  setup pages can reach the renderer without depending on
+  `MainWindow` directly.
+- `src/models/Band.h` — first-class 14-band enum with label,
+  key-name, frequency lookup (IARU Region 2), and UI-index
+  mapping.
+
+**Authorized divergences from Thetis (plan §10):**
+
+- New per-band grid slots initialise to Thetis uniform
+  -40 / -140 rather than NereusSDR's existing -20 / -160,
+  per user decision 2026-04-12. Existing users see the grid
+  shift on first launch after upgrade.
+- Source-first protocol (`CLAUDE.md`) stays as written. This
+  phase is a one-off exception, not a precedent.
+
+**Known deferrals (tracked for future phases):**
+
+- GPU path line width and gradient shader wiring. QPainter
+  fallback path fully implemented.
+- FFT decimation (S16) — UI is scaffolded; FFTEngine has no
+  decimation setter yet.
+- W12 / W14 TX filter / zero-line overlays — renderer call
+  path in place, activates once the TX state model provides
+  a TX VFO/filter pair (post-3I-1).
+- Data Line Color / Data Fill Color share `m_fillColor` — UX
+  polish to split these is deferred until verification
+  screenshots show whether users actually need them separate.
+- W10 Waterfall Low Color — persisted; runtime gradient
+  rebuild waits for the Custom-scheme AppSettings parser.
+
 ### Phase 3G-7 — Polish (complete)
 
 **Status:** Complete. Branch `feature/phase3g7-polish` off

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,8 @@ Key source directories: `src/core/` (protocol, audio, DSP), `src/models/`
 
 * `RadioModel` — central state, owns connection + all sub-models + WdspEngine
 * `SliceModel` — per-receiver VFO state (freq, mode, filter, AGC, gains, antenna). Single source of truth.
+* `PanadapterModel` — per-panadapter display state (center freq, bandwidth, dBm range). As of 3G-8, also owns the per-band grid storage (`BandGridSettings {dbMax, dbMin}` × 14 bands, global `gridStep`) and the current `band()` derived from `setCenterFrequency()` via `Band::bandFromFrequency()`. Emits `bandChanged(Band)` on boundary crossings and pushes the stored slot into `dBmFloor`/`dBmCeiling` automatically. `RadioModel::spectrumWidget()` / `fftEngine()` non-owning view hooks are set here by `MainWindow` so setup pages reach the renderer.
+* `Band` (`src/models/Band.h`) — first-class 14-band enum (160m–6m + GEN + WWV + XVTR) with `bandLabel()`, `bandKeyName()` (AppSettings key suffix), `bandFromFrequency()` (IARU Region 2 lookup with WWV discrete centers), `bandFromUiIndex()` / `uiIndexFromBand()`. Added in 3G-8.
 * `ReceiverManager` — DDC-aware receiver lifecycle, maps logical receivers to hardware DDCs; exposes DDC center frequency for CTUN pan positioning
 * `RadioDiscovery` — OpenHPSDR radio discovery on UDP port 1024
 * `RadioConnection` — Protocol 1 (UDP) and Protocol 2 (UDP multi-port) connections
@@ -214,6 +216,7 @@ Key source directories: `src/core/` (protocol, audio, DSP), `src/models/`
 * `StyleConstants.h` — shared color palette, fonts, widget style constants
 * `HGauge` — horizontal bar gauge widget
 * `ComboStyle` — styled combo box shared across applets
+* `ColorSwatchButton` (`src/gui/ColorSwatchButton.h`) — reusable color picker button: QPushButton subclass, QColorDialog with alpha, `colorChanged(QColor)` signal, static `colorToHex` / `colorFromHex` helpers for AppSettings `"#RRGGBBAA"` round-trip. Added in 3G-8; used by 9 call sites across the Display setup pages (S11/S13 trace colours, W10 waterfall low colour, G6 band edge, G9–G13 grid/text/zero-line colours).
 
 **Thread Architecture:**
 
@@ -340,6 +343,8 @@ preferences. OpenHPSDR radios don't store per-slice state.
 | [phase3g4-advanced-meters-plan.md](docs/architecture/phase3g4-advanced-meters-plan.md) | 3G-4: Advanced Meter Items | **Complete** |
 | [phase3g5-interactive-meters-plan.md](docs/architecture/phase3g5-interactive-meters-plan.md) | 3G-5: Interactive Meter Items | **Complete** |
 | [phase3g6a-plan.md](docs/architecture/phase3g6a-plan.md) | 3G-6 (one-shot): Full Thetis Parity + MMIO | **Complete** |
+| [phase3g8-rx1-display-parity-plan.md](docs/architecture/phase3g8-rx1-display-parity-plan.md) | 3G-8: RX1 Display Parity (47 Spectrum/Waterfall/Grid controls, Band enum, per-band grid, GPU polish) | **Complete** |
+| [phase3g8-verification/README.md](docs/architecture/phase3g8-verification/README.md) | 3G-8: 47-control manual verification matrix | Matrix drafted |
 | [phase3f-multi-panadapter-plan.md](docs/architecture/phase3f-multi-panadapter-plan.md) | 3F: Multi-Panadapter + DDC Assignment | Planning (after 3I-4) |
 
 ### Protocol Reference (`docs/protocols/`)
@@ -358,7 +363,7 @@ preferences. OpenHPSDR radios don't store per-slice state.
 | 1B: Thetis Analysis | Dual-thread DSP (RX1/RX2), pre-allocated receivers, one-way protocol, skin system |
 | 1C: WDSP Analysis | 256 API functions, channel-based DSP, fexchange2() for I/Q, PureSignal feedback loop |
 
-### Current Phase: 3I-1 — Basic SSB TX (recommended next) or 3G-4 — Advanced Meter Items
+### Current Phase: 3I-1 — Basic SSB TX (recommended next after 3G-8 merges)
 
 | Phase | Goal | Status |
 | --- | --- | --- |
@@ -375,6 +380,7 @@ preferences. OpenHPSDR radios don't store per-slice state.
 | **3G-5: Interactive Meter Items** | **14 interactive items + mouse forwarding + ButtonBoxItem base** | **Complete** |
 | **3G-6: Container Settings Dialog (one-shot)** | **3-column dialog, 31 per-item editors, MMIO subsystem (4 transports + JSON/XML/RAW), Edit Container submenu** | **Complete** |
 | **3G-7: Polish** | **MMIO clone-path bug fix + 5 subclass accessor gap fills + NeedleItemEditor QGroupBox grouping** | **Complete** |
+| **3G-8: RX1 Display Parity** | **47 Spectrum/Waterfall/Grid controls wired (Setup → Display), `Band` enum + per-band grid on PanadapterModel, `BandButtonItem` 12→14, GPU polish: overlay cache invalidation, waterfall chrome in overlay texture, peak hold VBO, fill/gradient/cal-offset in vertex gen** | **Complete (PR #8)** |
 | 3I-1: Basic SSB TX | TxChannel, mic input, MOX state machine, I/Q output | Planned |
 | 3I-2: CW TX | Sidetone, firmware keyer, QSK/break-in | Planned |
 | 3I-3: TX Processing | 18-stage TXA chain + RX DSP additions (SNB, peak hold, histogram) | Planned |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ set(GUI_SOURCES
     src/gui/meters/ClickBoxItem.cpp
     src/gui/meters/DataOutItem.cpp
     src/gui/HGauge.cpp
+    src/gui/ColorSwatchButton.cpp
     src/gui/SpectrumOverlayPanel.cpp
     src/gui/SetupDialog.cpp
     src/gui/SetupPage.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ set(CORE_SOURCES
 
 set(MODEL_SOURCES
     src/models/RadioModel.cpp
+    src/models/Band.cpp
     src/models/SliceModel.cpp
     src/models/PanadapterModel.cpp
     src/models/MeterModel.cpp

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Works with any radio implementing OpenHPSDR Protocol 1 or Protocol 2:
 
 ## Current Status
 
-**Phase 3G-6 (one-shot) + Phase 3G-7 polish complete — full Thetis-parity Container Settings Dialog + MMIO subsystem + dialog clone-path bug fixes.** NereusSDR connects to an ANAN-G2 (Orion MkII) via Protocol 2, receives raw I/Q data, demodulates audio through WDSP, renders a live GPU-accelerated spectrum + waterfall with VFO tuning (CTUN mode), and has a full UI skeleton with 12 applets, 150+ control widgets, and a complete meter system with 31 item types. The meter engine supports composable items including arc-style S-meter, Power/SWR bars, ANANMM 7-needle multi-meter, CrossNeedle dual fwd/rev power, magic eye tube display, history graph, rotator compass, filter display, LED indicators, interactive band/mode/filter/antenna/tuning-step button grids, VFO frequency display with per-digit wheel tuning, and dual UTC/Local clock — all ported from the Thetis MeterManager.
+**Phase 3G-8 complete — RX1 Display parity: Setup → Display pages fully wired to the renderer.** NereusSDR connects to an ANAN-G2 (Orion MkII) via Protocol 2, receives raw I/Q data, demodulates audio through WDSP, renders a live GPU-accelerated spectrum + waterfall with VFO tuning (CTUN mode), has a full UI skeleton with 12 applets, 150+ control widgets, a complete meter system with 31 item types, and — as of 3G-8 — a fully wired Display setup category where every Spectrum Defaults / Waterfall Defaults / Grid & Scales control routes through to the renderer live on both the QPainter fallback path and the QRhi/Metal GPU path. Per-band grid state persists across all 14 bands (160m–6m + GEN + WWV + XVTR).
 
 **Phase 3G-6 (one-shot)** shipped 2026-04-12 as PR #2 — 40 GPG-signed commits across 7 execution blocks on `feature/phase3g6-oneshot`:
 
@@ -44,6 +44,21 @@ Works with any radio implementing OpenHPSDR Protocol 1 or Protocol 2:
 - **`33e5ba0`** `docs(3G-7)` — CHANGELOG flipped to complete with per-item narrowings documented; handoff doc gains a 17-item "Outstanding work after 3G-7" section so each deferred item (MMIO disk persistence, smoke test, editor width sweep, ButtonBox sub-editor, 10 phantom feature ports) can be filed as its own GitHub issue.
 
 Items A and B both turned out dramatically smaller than the original handoff scoped — see the handoff doc and CHANGELOG for the per-item narrowings. Items D, E, F and the phantom feature ports are deferred to follow-up work; full list at `docs/architecture/phase3g7-polish-handoff.md` § "Outstanding work after 3G-7".
+
+**Phase 3G-8 — RX1 Display parity** shipped 2026-04-12 on `feature/phase3g8-rx1-display-parity` — 10 GPG-signed code commits + 3 doc-amend prep commits, off `main` (after 3G-7 merge). Brings the `Setup → Display → Spectrum Defaults / Waterfall Defaults / Grid & Scales` pages from "every control disabled with NYI tooltip" to feature parity with Thetis for RX1 only:
+
+- **Commit 1** — `ColorSwatchButton` reusable color picker widget, replaces the dead `makeColorSwatch` placeholder and used by 9 call sites across the phase.
+- **Commit 2** — per-band grid storage on `PanadapterModel`. New `src/models/Band.h` with a first-class 14-band enum (160m–6m + GEN + WWV + XVTR), IARU Region 2 `frequency→band` lookup, and UI-index mapping. `BandButtonItem` expanded 12→14 buttons. 28 per-band persistence keys (Max/Min only — Thetis keeps Step global) seeded with Thetis uniform -40 / -140 defaults.
+- **Commits 3–5** — `SpectrumWidget` + `FFTEngine` renderer additions: averaging modes (None / Weighted / Logarithmic / TimeWindow), peak hold + decay, trace line width, trace fill + alpha, gradient toggle, display cal offset, waterfall AGC, reverse scroll, opacity, update-period rate limiting, waterfall averaging, use-spectrum-min/max, RX filter / zero-line / timestamp overlays, 3 new colour schemes (LinLog / LinRad / Custom, total now 7), configurable grid / grid-fine / h-grid / text / zero-line / band-edge colours, 5-mode frequency label alignment, FPS overlay.
+- **Commits 6–8** — wire each Display setup page to the renderer: Spectrum Defaults (17 controls), Waterfall Defaults (17), Grid & Scales (13). Grid & Scales includes a live "Editing band: N" label that updates on `PanadapterModel::bandChanged` so per-band Max/Min edits always target the currently active band.
+- **Commit 9** — CHANGELOG entry + 47-control verification matrix at `docs/architecture/phase3g8-verification/README.md`.
+- **Commit 10** — GPU path polish: overlay-texture cache invalidation for grid / colour / labels / FPS / zero line / cal offset (11 controls), waterfall chrome factored into `drawWaterfallChrome()` and drawn into the GPU overlay texture (W6 opacity, W8/W9 timestamp, W11/W13 filter/zero line), new `m_fftPeakVbo` for GPU peak hold, and vertex-gen changes so cal offset / gradient toggle / fill toggle / fill colour are live in the GPU render path.
+
+**Architectural additions:** `RadioModel::spectrumWidget()` / `fftEngine()` non-owning view hooks so Setup pages can reach the renderer without depending on `MainWindow`; wired by `MainWindow` right after FFTEngine creation.
+
+**Known deferrals** (tracked in the PR description and `CHANGELOG.md`): S7 Line Width on GPU (needs triangle strip rendering for portable thickness — Metal/Vulkan clamp to 1 px), S16 FFT Decimation (scaffolded only, `FFTEngine` has no decimation setter yet), W12 / W14 TX filter / zero-line overlays (gated on TX state model — post-3I-1), Data Line / Data Fill Color splitting (deferred until UX feedback justifies it), W10 Waterfall Low Color runtime effect (persisted; waits for Custom-scheme `AppSettings` parser).
+
+**Authorised Thetis divergence** (plan §10, one-off): per-band grid slots initialise to Thetis uniform -40 / -140 rather than NereusSDR's existing -20 / -160. Source-first protocol stays as written — this phase is an exception, not a precedent.
 
 ## Key Features
 
@@ -129,6 +144,7 @@ Items A and B both turned out dramatically smaller than the original handoff sco
 | **3G-5: Interactive Meter Items** | **14 interactive items + mouse forwarding + ButtonBoxItem base** | **Complete** |
 | **3G-6: Container Settings Dialog (one-shot)** | **3-column Thetis layout + per-item editors for all ~30 types + in-place editing + MMIO external-data subsystem + container-level parity + menu submenu** | **Complete** |
 | **3G-7: Polish** | **MMIO clone-path bug fix + 5 subclass accessor gap fills + NeedleItemEditor QGroupBox grouping** | **Complete** |
+| **3G-8: RX1 Display Parity** | **47 Spectrum/Waterfall/Grid controls wired, `Band` enum + per-band grid on `PanadapterModel`, `BandButtonItem` 12→14, GPU path polish for live overlay / waterfall chrome / peak hold / fill / gradient / cal offset** | **Complete** |
 | 3I-1: Basic SSB TX | TxChannel, MOX state machine, RF output | Planned |
 | 3I-2: CW TX | Sidetone, firmware keyer, QSK/break-in | Planned |
 | 3I-3: TX Processing | 18-stage TXA chain + RX DSP additions | Planned |

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -434,6 +434,41 @@ Scope:
 
 Verification: Create container from scratch, add items, configure data sources, export/import Base64.
 
+### Phase 3G-8: RX1 Display Parity ✅ COMPLETE
+**Goal:** Bring `Setup → Display` to feature parity with Thetis for RX1 only — the 47-control wire-up.
+
+**Shipped 2026-04-12** on `feature/phase3g8-rx1-display-parity` as PR #8 (base `main`). 10 GPG-signed code commits + 3 doc-amend prep commits.
+
+Scope delivered:
+- 3 Setup pages fully wired: Spectrum Defaults (17), Waterfall Defaults (17), Grid & Scales (13)
+- New `ColorSwatchButton` reusable QColorDialog-backed widget (`src/gui/ColorSwatchButton.h/.cpp`) used by 9 call sites
+- New `Band` enum (`src/models/Band.h`): 14 bands (160m–6m + GEN + WWV + XVTR), IARU Region 2 frequency lookup, UI-index mapping
+- Per-band display grid storage on `PanadapterModel` (28 per-band Max/Min keys + 1 global Step)
+- `BandButtonItem` expanded 12 → 14 buttons
+- `SpectrumWidget` renderer additions: averaging modes (None/Weighted/Log/TimeWindow), peak hold + decay, trace fill/alpha/line-width/gradient, cal offset, waterfall AGC/reverse/opacity/overlays/timestamp, 3 new colour schemes (LinLog/LinRad/Custom — total 7), configurable grid colours, 5-mode frequency label alignment, FPS overlay
+- `FFTEngine` already had FFT size and window switching; wired through the Spectrum Defaults page
+- `RadioModel::spectrumWidget()` / `fftEngine()` non-owning view hooks so setup pages reach the renderer without depending on `MainWindow`
+- GPU path polish: overlay texture cache invalidation (11 controls), waterfall chrome factored into `drawWaterfallChrome()` and drawn into the GPU overlay texture (W6 opacity, W8/W9 timestamp, W11/W13 filter/zero-line overlays), new `m_fftPeakVbo` for GPU peak hold, vertex-gen changes so cal offset / gradient toggle / fill toggle / fill colour are live in the GPU render path
+
+Plan §13 open questions resolved:
+1. Cal Offset (S8) — real Thetis field at `display.cs:1372` (`Display.RX1DisplayCalOffset`), not an extension
+2. FPS overlay (G8) — `QPainter` text in `paintEvent` + GPU overlay texture path
+3. Display Thread Priority (S17) — 1:1 map Thetis ThreadPriority → QThread::Priority, default HighPriority
+4. Per-band grid initial values — Thetis uniform -40 / -140 for all 14 slots (authorised one-off §10 divergence)
+
+Authorised Thetis divergence (plan §10, one-off): new per-band grid slots initialise to Thetis uniform -40 / -140 rather than NereusSDR's existing -20 / -160. Source-first protocol stays as written — this phase is an exception, not a precedent.
+
+Known deferrals (tracked in PR description):
+- S7 Line Width on GPU (QRhi lacks portable setLineWidth; needs triangle strip rendering — deferred)
+- S16 FFT Decimation (UI scaffolded, no FFTEngine setter)
+- W12/W14 TX filter/zero-line overlays (gated on TX state model — post-3I-1)
+- Data Line / Data Fill Color splitting (shares `m_fillColor` until UX feedback justifies splitting)
+- W10 Waterfall Low Color runtime effect (persisted; waits for Custom-scheme `AppSettings` parser)
+
+Verification: 47-control matrix at `docs/architecture/phase3g8-verification/README.md`. Screenshot capture deferred; manual smoke-test workflow driven by the user.
+
+**Implementation plan:** `docs/architecture/phase3g8-rx1-display-parity-plan.md` (plan §13 resolutions in commit `0308b1b`, plan §5.3 correction in `b8045cc`).
+
 ### Phase 3I-1: Basic SSB TX
 **Goal:** Get RF out the door — prove the TX I/Q output path works.
 
@@ -618,19 +653,23 @@ CI workflows already in place. Finalize:
 
 ---
 
-## Recommended Next Step: Phase 3G-6 — Container Settings Dialog or Phase 3I-1 — Basic SSB TX
+## Recommended Next Step: Phase 3I-1 — Basic SSB TX
 
-Phases 3A–3E, 3G-1 through 3G-5, and 3-UI are all complete. The radio connects,
+Phases 3A–3E, 3G-1 through 3G-8, and 3-UI are all complete. The radio connects,
 demodulates audio, renders live GPU spectrum + waterfall, supports full VFO tuning with
-CTUN panadapter mode, and has a complete meter system with 31 item types (18 passive + 13
-interactive) including button grids, VFO display, and clock — all with signal-based
-interaction wired through ContainerWidget.
+CTUN panadapter mode, has a complete meter system with 31 item types (18 passive + 13
+interactive) including button grids, VFO display, and clock, has a full Thetis-parity
+Container Settings Dialog with MMIO external-data subsystem, and — as of 3G-8 — a fully
+wired Display setup category where every Spectrum Defaults / Waterfall Defaults / Grid
+& Scales control routes through to the renderer live on both the QPainter fallback and
+the QRhi/Metal GPU path.
 
-Two viable next paths:
-- **3G-6 (Container Settings Dialog)** — full composability UI, import/export, preset browser — completes the meter system
-- **3I-1 (Basic SSB TX)** — get RF out the door; proves TX I/Q output path end-to-end
+The next meaningful step is getting RF out the door:
 
-Execution order: **3G-6 → 3I-1..4 → 3F → 3H → 3J+**
+- **3I-1 (Basic SSB TX)** — TxChannel WDSP wrapper, mic input, MOX state machine, TX I/Q
+  output. Proves the TX path end-to-end and unblocks 3I-2..4, 3F, 3H.
+
+Execution order: **3I-1..4 → 3F → 3H → 3J+**
 
 ### Phase Dependencies
 

--- a/docs/architecture/phase3g8-rx1-display-parity-plan.md
+++ b/docs/architecture/phase3g8-rx1-display-parity-plan.md
@@ -121,21 +121,33 @@ Thetis stores `DisplayGridMax<band>m` and `DisplayGridMin<band>m` for each of: 1
 
 **Thetis per-band defaults are uniform:** every band defaults to `Max = -40.0F, Min = -140.0F` (`console.cs:14242–14436`). Thetis stores per-band so users can *customize* per band; it does not ship hand-tuned per-band values.
 
+**Architectural correction (2026-04-12).** Pre-flight investigation of commit 2 found two gaps between the original plan wording and the actual codebase:
+
+- **Wrong model home.** The original plan said "per-band grid on `SliceModel`". Reality: NereusSDR's grid scale (`dBmFloor`, `dBmCeiling`) already lives on **`PanadapterModel`**, not `SliceModel`. `SliceModel` tracks VFO state only (frequency/mode/filter/AGC/gains/antennas) and has no grid properties. Per-band storage therefore goes on `PanadapterModel` to preserve single-source-of-truth for the dBm range.
+- **No `Band` type exists.** No `Band` enum, no `frequency→band` lookup, no `bandChanged` signal existed anywhere in the codebase. Commit 2 introduces them.
+- **UI band count is 12, not 14.** `BandButtonItem::kBandCount = 12` (160m–6m + GEN) omits WWV and XVTR. Per user decision 2026-04-12, commit 2 expands `BandButtonItem` 12 → 14 alongside the model work so the band enum and the UI stay in sync. `bandClicked(int)` is re-emitted by `ContainerWidget` but not consumed at top level, so the two new indices are purely additive and cause no downstream regressions.
+
 **Implementation:**
 
-1. Add `BandGridSettings` struct to `SliceModel.h`: `{int dbMax; int dbMin;}` per band (Step stays global).
-2. Add `QHash<Band, BandGridSettings>` to `SliceModel`.
-3. Persistence keys: `"DisplayGridMax_160m"`, `"DisplayGridMin_160m"`, etc. (**28 per-band keys** + 1 global `DisplayGridStep`).
-4. On `SliceModel::bandChanged(Band)`, look up the band's grid settings and emit `gridChanged(dbMax, dbMin)`.
-5. `SpectrumWidget::setDbmRange()` already exists; wire it to `gridChanged`.
-6. Grid & Scales page: dbMax/dbMin controls show "Editing band: 20m" label above them and read/write the currently active band's slot. dbStep stays a single global control with no band label.
-7. **Default initialization (resolved per Q4):** initialize all 14 slots to Thetis uniform defaults `Max = -40, Min = -140`. Existing users will see the grid shift on first launch after upgrade; this is the authorized one-off divergence under decision #9's §10 exception scope, extended to cover per-band grid initial values (user decision 2026-04-12).
+1. New `src/models/Band.h`: `enum class Band { Band160m, Band80m, Band60m, Band40m, Band30m, Band20m, Band17m, Band15m, Band12m, Band10m, Band6m, GEN, WWV, XVTR }`. Static helpers `bandLabel(Band) → QString`, `bandKeyName(Band) → QString` (for AppSettings keys), `bandFromFrequency(double hz) → Band` (Thetis-sourced range table), `bandFromUiIndex(int)` / `uiIndexFromBand(Band)` for the 14-button UI order.
+2. Add `BandGridSettings` struct to `PanadapterModel.h`: `{int dbMax; int dbMin;}` per band (Step stays global).
+3. Add `QHash<Band, BandGridSettings> m_perBandGrid` to `PanadapterModel`.
+4. Persistence keys: `"DisplayGridMax_160m"`, `"DisplayGridMin_160m"`, …, `"DisplayGridMax_XVTR"`, `"DisplayGridMin_XVTR"` (**28 per-band keys** + 1 global `DisplayGridStep`). Loaded in `PanadapterModel` constructor, written on every `setPerBandGrid*()`.
+5. Add `band()`/`setBand(Band)` + `bandChanged(Band)` signal on `PanadapterModel`. `setCenterFrequency()` auto-derives band via `bandFromFrequency()` and calls `setBand()` on boundary crossing. Direct `setBand()` is also callable by UI (commit 8).
+6. On `bandChanged`, `PanadapterModel` looks up the band's stored `BandGridSettings` and updates `m_dBmFloor`/`m_dBmCeiling`, emitting `levelChanged()` so existing `SpectrumWidget` wiring reacts with no new connections needed.
+7. Expand `BandButtonItem::kBandCount` 12 → 14; add `"WWV"` and `"XVTR"` to `kBandLabels`.
+8. Grid & Scales page (commit 8, not commit 2): dbMax/dbMin controls show "Editing band: 20m" label above them and read/write the currently active band's slot. dbStep stays a single global control with no band label.
+9. **Default initialization (resolved per Q4):** `PanadapterModel` constructor initializes all 14 slots to Thetis uniform defaults `Max = -40, Min = -140`. Existing users will see the grid shift on first launch after upgrade; this is the authorized one-off divergence under decision #9's §10 exception scope, extended to cover per-band grid initial values (user decision 2026-04-12).
 
 **Files affected:**
-- `src/models/SliceModel.h/.cpp` — add struct, hash, signal
-- `src/core/AppSettings.cpp` — register the 42 keys (or compute key names from band enum)
-- `src/gui/setup/DisplaySetupPages.cpp` — `GridScalesPage` shows active-band label, reads/writes per-band values
-- `src/gui/SpectrumWidget.cpp` — already accepts setDbmRange, just verify the slot wiring
+- `src/models/Band.h` (new) — enum, labels, frequency lookup, UI index mapping
+- `src/models/Band.cpp` (new, if helpers need a translation unit) — lookup tables
+- `src/models/PanadapterModel.h/.cpp` — `BandGridSettings` struct, per-band hash, `band`/`setBand`/`bandChanged`, constructor default init + AppSettings load, setCenterFrequency auto-derive
+- `src/gui/meters/BandButtonItem.h/.cpp` — `kBandCount` 12 → 14, `kBandLabels` += `"WWV"`, `"XVTR"`
+- `src/core/AppSettings.cpp` — no registration step needed (NereusSDR AppSettings uses free-form string keys)
+- `src/gui/setup/DisplaySetupPages.cpp` — deferred to commit 8
+- `src/gui/SpectrumWidget.cpp` — no change needed (existing `levelChanged` wiring reacts automatically)
+- `CMakeLists.txt` — add `src/models/Band.cpp` if created
 
 ## 6. New widget — `ColorSwatchButton`
 

--- a/docs/architecture/phase3g8-rx1-display-parity-plan.md
+++ b/docs/architecture/phase3g8-rx1-display-parity-plan.md
@@ -1,6 +1,6 @@
 # Phase 3G-8 — RX1 Display Parity Plan
 
-> **Status:** Drafted, ready to execute. Branch created, no implementation code yet.
+> **Status:** Open questions resolved 2026-04-12. Ready to execute commit 1.
 > **Branch:** `feature/phase3g8-rx1-display-parity` (off `feature/phase3g7-polish`)
 > **Drafted:** 2026-04-12
 > **Predecessor:** Phase 3G-7 polish (shipped 2026-04-12, items A/B/C, items D/E/F deferred)
@@ -39,7 +39,7 @@ RX2 Display, TX Display, and the spectrum overlay panel are explicitly **out of 
 | S5 | Fill toggle | checkbox | unchecked default | `chkDisplayPanFill` | `setup.designer.cs:33740` |
 | S6 | Fill Alpha | slider | 0–100, default 30 | `tbDataFillAlpha` (0–255, default 128) | `setup.designer.cs:52733`, used in `display.cs:2145` `DataFillColor` alpha |
 | S7 | Line Width | slider | 1–3, default 1 | `udDisplayLineWidth` (0.0–5.0 dec, default 1.0) | `setup.designer.cs:52886`, used `display.cs:10318` |
-| S8 | Cal Offset | double spinbox | -30.0 to 30.0 dBm, default 0.0 | `udTXDisplayCalOffset` is TX-only; **no Thetis RX equivalent** — treat as NereusSDR extension or pull from Display.cs spectrum cal | `display.cs` (no setup-tab control) |
+| S8 | Cal Offset | double spinbox | -30.0 to 30.0 dBm, default 0.0 | `Display.RX1DisplayCalOffset` (float dB) — real Thetis field, no setup-tab control but exposed programmatically | `display.cs:1372-1380` |
 | S9 | Peak Hold | checkbox | unchecked | **NereusSDR extension** — Thetis has multimeter peak hold only (`udDisplayMultiPeakHoldTime`), no spectrum peak hold | n/a (extension) |
 | S10 | Peak Hold Delay | spinbox | 100–10000 ms, default 2000 | **NereusSDR extension** (paired with S9) | n/a (extension) |
 
@@ -115,19 +115,21 @@ RX2 Display, TX Display, and the spectrum overlay panel are explicitly **out of 
 
 **Total Grid & Scales page after phase: 13 controls** (8 existing + 5 added).
 
-### 5.3 Per-band grid expansion (G2/G3/G4)
+### 5.3 Per-band grid expansion (G2/G3 only)
 
-Thetis stores `DisplayGridMax<band>m` for each of: 160m, 80m, 60m, 40m, 30m, 20m, 17m, 15m, 12m, 10m, 6m, WWV, GEN, XVTR (14 bands × 3 values = 42 stored values). NereusSDR currently has one global pair.
+Thetis stores `DisplayGridMax<band>m` and `DisplayGridMin<band>m` for each of: 160m, 80m, 60m, 40m, 30m, 20m, 17m, 15m, 12m, 10m, 6m, WWV, GEN, XVTR — **14 bands × 2 values = 28 per-band values**. Grid **Step** is NOT per-band in Thetis; it's a single global value (`udDisplayGridStep`). Verified `console.cs:14242–14436` — no `DisplayGridStep<band>m` field exists. NereusSDR currently has one global pair.
+
+**Thetis per-band defaults are uniform:** every band defaults to `Max = -40.0F, Min = -140.0F` (`console.cs:14242–14436`). Thetis stores per-band so users can *customize* per band; it does not ship hand-tuned per-band values.
 
 **Implementation:**
 
-1. Add `BandGridSettings` struct to `SliceModel.h`: `{int dbMax; int dbMin; int dbStep;}` per band.
+1. Add `BandGridSettings` struct to `SliceModel.h`: `{int dbMax; int dbMin;}` per band (Step stays global).
 2. Add `QHash<Band, BandGridSettings>` to `SliceModel`.
-3. Persistence keys: `"DisplayGridMax_160m"`, `"DisplayGridMin_160m"`, `"DisplayGridStep_160m"`, etc. (42 keys total).
-4. On `SliceModel::bandChanged(Band)`, look up the band's grid settings and emit `gridChanged(dbMax, dbMin, dbStep)`.
+3. Persistence keys: `"DisplayGridMax_160m"`, `"DisplayGridMin_160m"`, etc. (**28 per-band keys** + 1 global `DisplayGridStep`).
+4. On `SliceModel::bandChanged(Band)`, look up the band's grid settings and emit `gridChanged(dbMax, dbMin)`.
 5. `SpectrumWidget::setDbmRange()` already exists; wire it to `gridChanged`.
-6. Grid & Scales page shows the values for the **currently active band on RX1**. Editing them writes back to that band's slot. A label above the controls reads "Editing band: 20m" so the user knows which band they're touching.
-7. Default initialization: copy current global default into all 14 band slots on first run, so existing users don't see anything change.
+6. Grid & Scales page: dbMax/dbMin controls show "Editing band: 20m" label above them and read/write the currently active band's slot. dbStep stays a single global control with no band label.
+7. **Default initialization (resolved per Q4):** initialize all 14 slots to Thetis uniform defaults `Max = -40, Min = -140`. Existing users will see the grid shift on first launch after upgrade; this is the authorized one-off divergence under decision #9's §10 exception scope, extended to cover per-band grid initial values (user decision 2026-04-12).
 
 **Files affected:**
 - `src/models/SliceModel.h/.cpp` — add struct, hash, signal
@@ -235,13 +237,13 @@ Per locked decision #9, NereusSDR keeps its current default values rather than a
 | FPS max | 60 | 144 | 144 FPS on a spectrum is wasteful |
 | Update Period default | 50 ms | 2 ms | 2 ms is unnecessarily aggressive for the waterfall |
 | Update Period min | 10 ms | 1 ms | Same |
-| Grid Max default | -20 | -40 | NereusSDR shows hotter signals better at -20 |
-| Grid Min default | -160 | -140 | More headroom for weak signals |
-| Grid Step default | 10 | 2 | Less visual clutter |
+| Grid Max default (global, pre-3G-8) | -20 | -40 | NereusSDR shows hotter signals better at -20. **Superseded** once per-band storage lands — see row below. |
+| Grid Min default (global, pre-3G-8) | -160 | -140 | More headroom for weak signals. **Superseded** — see row below. |
+| Grid Step default | 10 | 2 | Less visual clutter. Step remains a single global value in both Thetis and NereusSDR. |
 | Waterfall High default | -40 | -80 | Matches NereusSDR's grid max better |
 | Color Schemes count | 3 (now expanding to 7) | 7 | Now matches |
 | FFT Size widget | combo | TrackBar | Combo is friendlier than a 7-position slider |
-| Cal Offset (S8) | exists | n/a | NereusSDR-specific, no Thetis Display tab equivalent |
+| Grid Max/Min initial per-band values | -40 / -140 (Thetis uniform) | -40 / -140 (Thetis uniform) | **New divergence from §10 row above:** per Q4 resolution, new per-band slots initialize to Thetis defaults, not NereusSDR -20/-160. Existing users will see grid shift on first launch. Authorized 2026-04-12. |
 | Peak Hold (S9/S10) | exists | n/a | NereusSDR extension |
 | Reverse Scroll (W5) | exists | n/a | NereusSDR extension |
 | Timestamp (W8/W9) | exists | n/a | NereusSDR extension |
@@ -263,7 +265,7 @@ Per locked decision #9, NereusSDR keeps its current default values rather than a
 - `src/gui/SpectrumWidget.h/.cpp` — renderer additions (~600 LOC), `WfColorScheme` enum expansion
 - `src/core/FFTEngine.h/.cpp` — averaging modes, FFT window switching
 - `src/models/SliceModel.h/.cpp` — per-band grid struct, signal, persistence
-- `src/core/AppSettings.cpp` — ~70 new keys (28 NereusSDR controls + 20 added + 42 per-band - overlap)
+- `src/core/AppSettings.cpp` — ~56 new keys (28 NereusSDR controls + 20 added + 28 per-band grid [14 × Max/Min] - overlap). Grid Step is a single global key, not per-band.
 - `src/gui/SpectrumOverlayPanel.cpp` — verify Display sub-panel still works after live values
 - `CHANGELOG.md` — phase entry
 
@@ -277,12 +279,25 @@ Per locked decision #9, NereusSDR keeps its current default values rather than a
 - Pause for user review at each commit boundary per standing preference
 - Show PR description as draft before posting (no auto-post)
 
-## 13. Open questions to resolve before block 1
+## 13. Open questions — RESOLVED 2026-04-12
 
-1. **Cal Offset (S8)** — Thetis has no RX Display tab equivalent. Is this a NereusSDR extension, or should we pull from `display.cs` spectrum calibration code? Subagent didn't find a clean Thetis source. **Action:** quick read of `display.cs` calibration section before block 1, treat as extension if nothing found.
-2. **FPS overlay (G8)** — currently `chkShowFPS`. NereusSDR's `SpectrumWidget` doesn't render FPS today. Implementation choice: `QPainter` text in corner, or QRhi text? Quick choice — `QPainter` overlay layer is fine.
-3. **Display Thread Priority (S17)** — Thetis sets the Windows thread priority of the display thread. NereusSDR uses `QThread::setPriority`. Worth honoring, but the values don't map 1:1. **Action:** map Thetis's combo values (Idle/Lowest/BelowNormal/Normal/AboveNormal/Highest/TimeCritical) to `QThread::Priority` enum, document the mapping.
-4. **Per-band grid initial values** — copy current global default into all 14 slots, or use Thetis's per-band defaults from the Thetis source (which would actually make sense even though decision #9 says keep NereusSDR defaults — these are *new* per-band slots that don't have a "current value" to preserve)? Recommendation: use Thetis per-band defaults for the new slots, since there's no NereusSDR value to keep.
+1. **Cal Offset (S8)** — **Resolved:** it IS a real Thetis field. `Display.RX1DisplayCalOffset` at `display.cs:1372-1380` (float, dB). Not a NereusSDR extension. §3.1 S8 row and §10 divergence table corrected accordingly. NereusSDR keeps its existing UI range (-30..30 dB, default 0.0).
+
+2. **FPS overlay (G8)** — **Resolved:** `QPainter` text overlay in `SpectrumWidget::paintEvent`, top-right corner. Frame count + `QElapsedTimer` for rolling average. ~15 LOC. No new dependencies.
+
+3. **Display Thread Priority (S17)** — **Resolved:** Thetis combo is 5 items (`setup.cs:34022` default "Above Normal"), not 7. 1:1 map to `QThread::Priority` on the FFT worker thread:
+
+   | Thetis | QThread |
+   |---|---|
+   | Lowest | `QThread::LowestPriority` |
+   | Below Normal | `QThread::LowPriority` |
+   | Normal | `QThread::NormalPriority` |
+   | Above Normal | `QThread::HighPriority` *(default)* |
+   | Highest | `QThread::HighestPriority` |
+
+   Apply via `FFTEngine` worker's `QThread::setPriority()`. Qt abstracts the OS priority class per platform.
+
+4. **Per-band grid initial values** — **Resolved:** use Thetis uniform defaults (`Max = -40, Min = -140`) for all 14 band slots. Finding during resolution: Thetis ships every band with identical defaults (`console.cs:14242–14436`), so there's no hand-tuned per-band aesthetic to preserve — this just means adopting Thetis's -40/-140 over NereusSDR's current -20/-160 as the first-launch state. Existing users will see the grid shift on upgrade. This is the authorized one-off divergence expansion documented in §10. Also: **Grid Step is NOT per-band in Thetis** — it remains a single global value. Plan §5.3 corrected from "42 values" to "28 per-band values + 1 global Step".
 
 ## 14. How to begin (next session checklist)
 

--- a/docs/architecture/phase3g8-rx1-display-parity-plan.md
+++ b/docs/architecture/phase3g8-rx1-display-parity-plan.md
@@ -1,0 +1,306 @@
+# Phase 3G-8 — RX1 Display Parity Plan
+
+> **Status:** Drafted, ready to execute. Branch created, no implementation code yet.
+> **Branch:** `feature/phase3g8-rx1-display-parity` (off `feature/phase3g7-polish`)
+> **Drafted:** 2026-04-12
+> **Predecessor:** Phase 3G-7 polish (shipped 2026-04-12, items A/B/C, items D/E/F deferred)
+> **Successor:** Phase 3I-1 Basic SSB TX
+
+## 1. Goal
+
+Bring NereusSDR's `Setup → Display` category to feature parity with Thetis for **RX1 only**, before SSB TX work begins. Today every control on Spectrum Defaults, Waterfall Defaults, and Grid & Scales is `setEnabled(false)` with an "NYI" tooltip — this phase wires every one of them through to `AppSettings`, `SpectrumWidget`, `FFTEngine`, and the per-band grid storage, and adds ~20 missing Thetis Display fields plus 4 NereusSDR-original extensions.
+
+RX2 Display, TX Display, and the spectrum overlay panel are explicitly **out of scope** and stay as-is until later phases.
+
+## 2. Locked decisions (from interview, 2026-04-12)
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Wire depth | Tier (b) — persist + live-apply + missing renderer features implemented |
+| 2 | Color picker | Build reusable `ColorSwatchButton` widget (lives in `src/gui/`) |
+| 3 | Phase shape | One monolithic block, single branch, single PR |
+| 4 | Thetis fidelity | Per-control citation with `file:line` references |
+| 5 | Verification | Per-control before/after screenshot matrix (~48 pairs) |
+| 6 | Per-band grid | Full Thetis parity, 14 bands × 3 values, BandStackManager wiring |
+| 7 | NereusSDR-original controls | Keep all 4 (FFT Window, Peak Hold, Reverse Scroll, Timestamp), implement renderers |
+| 8 | Missing Thetis fields | Add all ~20 in this phase |
+| 9 | Defaults | Keep current NereusSDR defaults; new fields use Thetis defaults; divergence is intentional, **one-off exception** authorized by user 2026-04-12, documented in §10. Source-first protocol in CLAUDE.md remains the standing rule for all other work. |
+
+## 3. Inventory — Spectrum Defaults page
+
+### 3.1 Existing NereusSDR controls (10) — Thetis-cited, ranges to keep
+
+| # | Control | Type | NereusSDR range/default | Thetis equivalent | Thetis location |
+|---|---|---|---|---|---|
+| S1 | FFT Size | combo (5 options) | 1024/2048/4096/8192/16384, default 4096 | `tbDisplayFFTSize` (TrackBar 0–6, value 5 → 4096×2⁵=131072) | `setup.designer.cs:35043`, handler `setup.cs:16142`, target `console.specRX.GetSpecRX(0).FFTSize` |
+| S2 | FFT Window | combo (4 options) | Blackman-Harris/Hann/Hamming/Flat-Top | **NereusSDR extension** — Thetis has window in DSP tab (`comboDSPRxWindow setup.cs:2424`), not Display | n/a (extension) |
+| S3 | FPS | slider | 10–60, default 30 | `udDisplayFPS` (1–144, default 60) | `setup.designer.cs:33834`, target `console.DisplayFPS` `setup.cs:7717` |
+| S4 | Averaging | combo (3 options) | None/Weighted/Logarithmic | `comboDispPanAveraging` (None/Recursive/Time Window/Log Recursive) | `setup.designer.cs:34835`, target `console.specRX.GetSpecRX(0).AverageMode` `setup.cs:18055` |
+| S5 | Fill toggle | checkbox | unchecked default | `chkDisplayPanFill` | `setup.designer.cs:33740` |
+| S6 | Fill Alpha | slider | 0–100, default 30 | `tbDataFillAlpha` (0–255, default 128) | `setup.designer.cs:52733`, used in `display.cs:2145` `DataFillColor` alpha |
+| S7 | Line Width | slider | 1–3, default 1 | `udDisplayLineWidth` (0.0–5.0 dec, default 1.0) | `setup.designer.cs:52886`, used `display.cs:10318` |
+| S8 | Cal Offset | double spinbox | -30.0 to 30.0 dBm, default 0.0 | `udTXDisplayCalOffset` is TX-only; **no Thetis RX equivalent** — treat as NereusSDR extension or pull from Display.cs spectrum cal | `display.cs` (no setup-tab control) |
+| S9 | Peak Hold | checkbox | unchecked | **NereusSDR extension** — Thetis has multimeter peak hold only (`udDisplayMultiPeakHoldTime`), no spectrum peak hold | n/a (extension) |
+| S10 | Peak Hold Delay | spinbox | 100–10000 ms, default 2000 | **NereusSDR extension** (paired with S9) | n/a (extension) |
+
+### 3.2 Missing Thetis Spectrum fields to ADD (7)
+
+| # | Add | Type | Thetis name | Source | Default |
+|---|---|---|---|---|---|
+| S11 | Data Line Color | ColorSwatchButton | `clrbtnDataLine` | `display.cs:2186 DataLineColor` | Thetis default (TBD from designer) |
+| S12 | Data Line Alpha | slider 0–255 | `tbDataLineAlpha` | `setup.designer.cs:52721`, default 128 | 128 |
+| S13 | Data Fill Color | ColorSwatchButton | `clrbtnDataFill` | `display.cs:2145 DataFillColor` | Thetis default |
+| S14 | Gradient Enabled | checkbox | `chkDataLineGradient` | `setup.designer.cs:3308` | unchecked |
+| S15 | Spectrum Averaging Time | spinbox ms | `udDisplayAVGTime` | `setup.cs:2334`, used in `console.specRX.GetSpecRX(0).AvTau` | Thetis default |
+| S16 | Spectrum Decimation | spinbox | `udDisplayDecimation` | `setup.designer.cs:2040` | Thetis default |
+| S17 | Display Thread Priority | combo | `comboDisplayThreadPriority` | `setup.designer.cs:2008` | Normal |
+
+**Total Spectrum Defaults page after phase: 17 controls** (10 existing + 7 added).
+
+## 4. Inventory — Waterfall Defaults page
+
+### 4.1 Existing NereusSDR controls (9)
+
+| # | Control | NereusSDR range/default | Thetis equivalent | Thetis location |
+|---|---|---|---|---|
+| W1 | High Threshold | -200 to 0, default -40 | `udDisplayWaterfallHighLevel` (-200–0, default -80) | `setup.designer.cs:34237`, `Display.WaterfallHighThreshold display.cs:2523` |
+| W2 | Low Threshold | -200 to 0, default -130 | `udDisplayWaterfallLowLevel` (-200–0, default -130) | `setup.designer.cs:34197`, `Display.WaterfallLowThreshold display.cs:2537` |
+| W3 | AGC | unchecked | `chkRX1WaterfallAGC` (default checked) | `setup.designer.cs:34058` |
+| W4 | Update Period | 10–500 ms, default 50 | `udDisplayWaterfallUpdatePeriod` (1–1000 ms, default 2) | `setup.designer.cs:34123` |
+| W5 | Reverse Scroll | unchecked | **NereusSDR extension** | n/a |
+| W6 | Opacity | 0–100, default 100 | `tbRX1WaterfallOpacity` (0–100, default 100) | `setup.designer.cs:34013`, handler `setup.cs:2374` |
+| W7 | Color Scheme | combo (3: Enhanced/Grayscale/Spectrum) | `comboColorPalette` (7 schemes) | `setup.designer.cs:34094`, handler `setup.cs:11898` |
+| W8 | Timestamp Position | combo (None/Left/Right) | **NereusSDR extension** | n/a |
+| W9 | Timestamp Mode | combo (UTC/Local) | **NereusSDR extension** | n/a |
+
+### 4.2 Missing Thetis Waterfall fields to ADD (8)
+
+| # | Add | Type | Thetis name | Source | Default |
+|---|---|---|---|---|---|
+| W10 | Waterfall Low Color | ColorSwatchButton | `clrbtnWaterfallLow` | `display.cs:2513`, default `Color.Black` | Black |
+| W11 | Show RX Filter on Waterfall | checkbox | `chkShowRXFilterOnWaterfall` | `setup.cs:1048 Display.ShowRXFilterOnWaterfall` | Thetis default |
+| W12 | Show TX Filter on RX Waterfall | checkbox | `chkShowTXFilterOnRXWaterfall` | `setup.cs:1052` | Thetis default |
+| W13 | Show RX Zero Line on Waterfall | checkbox | `chkShowRXZeroLineOnWaterfall` | `setup.cs:1050` | Thetis default |
+| W14 | Show TX Zero Line on Waterfall | checkbox | `chkShowTXZeroLineOnWaterfall` | `setup.cs:1051` | Thetis default |
+| W15 | Waterfall Use Spectrum Min/Max | checkbox | `chkWaterfallUseRX1SpectrumMinMax` | `setup.cs:7801 console.WaterfallUseRX1SpectrumMinMax` | unchecked |
+| W16 | Waterfall Averaging | combo | `comboDispWFAveraging` | `setup.designer.cs:34428`, target `AverageModeWF` `setup.cs:18069` | Log Recursive |
+| W17 | Waterfall Color Schemes (expand 3→7) | (expansion of W7) | adds Spectran/LinLog/LinRad/LinAuto/Custom — `Default/Enhanced/Spectran/BlackWhite` already exist in `WfColorScheme enum src/gui/SpectrumWidget.h:32` | `setup.cs:11904-11939 ColorScheme enum` | Enhanced |
+
+**Total Waterfall Defaults page after phase: 17 controls** (9 existing + 8 added; W17 is an in-place expansion of W7's combo).
+
+## 5. Inventory — Grid & Scales page
+
+### 5.1 Existing NereusSDR controls (8)
+
+| # | Control | NereusSDR range/default | Thetis equivalent | Thetis location |
+|---|---|---|---|---|
+| G1 | Show Grid | checked | `chkGridControl` (unchecked default) | `setup.designer.cs:52816` |
+| G2 | dB Max | -200 to 0, default -20 | `udDisplayGridMax` (-200–0, default -40) **per-band: 14 separate** | `setup.designer.cs:34723`, `Display.SpectrumGridMax display.cs:1744` |
+| G3 | dB Min | -200 to 0, default -160 | `udDisplayGridMin` (default -140) **per-band** | `setup.designer.cs:34692`, `display.cs:1755` |
+| G4 | dB Step | 1–40, default 10 | `udDisplayGridStep` (default 2) **per-band** | `setup.designer.cs:34661`, `display.cs:1766` |
+| G5 | Freq Label Align | combo (Left/Center) | `comboDisplayLabelAlign` (5: Left/Cntr/Right/Auto/Off) | `setup.designer.cs:34635`, `display.cs:2614 DisplayLabelAlignment` |
+| G6 | Band Edge Color | dead swatch | `clrbtnBandEdge` (default `Color.Red`) | `display.cs:1941 BandEdgeColor` |
+| G7 | Show Zero Line | unchecked | `chkShowZeroLine` (unchecked default) | `setup.designer.cs:52804` |
+| G8 | Show FPS Overlay | unchecked | `chkShowFPS` (checked default) | `setup.designer.cs:2009`, `Display.ShowFPS setup.cs:19282` |
+
+### 5.2 Missing Thetis Grid fields to ADD (5)
+
+| # | Add | Type | Thetis name | Source | Default |
+|---|---|---|---|---|---|
+| G9 | Grid Color | ColorSwatchButton | `clrbtnGrid` | `setup.cs:1040 Display.GridColor` | Thetis default |
+| G10 | Grid Fine (Dark) Color | ColorSwatchButton | `clrbtnGridFine` | `setup.cs:1041 Display.GridPenDark` | Thetis default |
+| G11 | Horizontal Grid Color | ColorSwatchButton | `clrbtnHGridColor` | `setup.cs:1042 Display.HGridColor` | Thetis default |
+| G12 | Grid Text Color | ColorSwatchButton | `clrbtnText` | `setup.cs:1044 Display.GridTextColor` | Thetis default |
+| G13 | Zero Line Color | ColorSwatchButton | `clrbtnZeroLine` | `setup.cs:1043 Display.GridZeroColor` (default `Color.Red`) `display.cs:2037` | Red |
+
+**Total Grid & Scales page after phase: 13 controls** (8 existing + 5 added).
+
+### 5.3 Per-band grid expansion (G2/G3/G4)
+
+Thetis stores `DisplayGridMax<band>m` for each of: 160m, 80m, 60m, 40m, 30m, 20m, 17m, 15m, 12m, 10m, 6m, WWV, GEN, XVTR (14 bands × 3 values = 42 stored values). NereusSDR currently has one global pair.
+
+**Implementation:**
+
+1. Add `BandGridSettings` struct to `SliceModel.h`: `{int dbMax; int dbMin; int dbStep;}` per band.
+2. Add `QHash<Band, BandGridSettings>` to `SliceModel`.
+3. Persistence keys: `"DisplayGridMax_160m"`, `"DisplayGridMin_160m"`, `"DisplayGridStep_160m"`, etc. (42 keys total).
+4. On `SliceModel::bandChanged(Band)`, look up the band's grid settings and emit `gridChanged(dbMax, dbMin, dbStep)`.
+5. `SpectrumWidget::setDbmRange()` already exists; wire it to `gridChanged`.
+6. Grid & Scales page shows the values for the **currently active band on RX1**. Editing them writes back to that band's slot. A label above the controls reads "Editing band: 20m" so the user knows which band they're touching.
+7. Default initialization: copy current global default into all 14 band slots on first run, so existing users don't see anything change.
+
+**Files affected:**
+- `src/models/SliceModel.h/.cpp` — add struct, hash, signal
+- `src/core/AppSettings.cpp` — register the 42 keys (or compute key names from band enum)
+- `src/gui/setup/DisplaySetupPages.cpp` — `GridScalesPage` shows active-band label, reads/writes per-band values
+- `src/gui/SpectrumWidget.cpp` — already accepts setDbmRange, just verify the slot wiring
+
+## 6. New widget — `ColorSwatchButton`
+
+Lives at `src/gui/ColorSwatchButton.h/.cpp`. Reusable across this phase, TX Display, meter editors (replaces the dead `makeColorSwatch` helper in `DisplaySetupPages.cpp:54`), and future skin editor work.
+
+**Spec:**
+
+```cpp
+class ColorSwatchButton : public QPushButton {
+    Q_OBJECT
+public:
+    explicit ColorSwatchButton(const QColor& initial, QWidget* parent = nullptr);
+    QColor color() const;
+    void setColor(const QColor& c);  // emits colorChanged
+signals:
+    void colorChanged(const QColor& c);
+private slots:
+    void openPicker();  // QColorDialog::getColor with ShowAlphaChannel
+private:
+    QColor m_color;
+    void updateSwatchStyle();  // sets button background to current color
+};
+```
+
+**Persistence helper** (file-local in `ColorSwatchButton.cpp` or in `AppSettings`):
+- `static QString colorToHex(const QColor&)` → `"#RRGGBBAA"`
+- `static QColor colorFromHex(const QString&)`
+
+**Used by:** S11 Data Line Color, S13 Data Fill Color, W10 Waterfall Low Color, G6 Band Edge Color, G9–G13 Grid colors. **9 instances** in this phase.
+
+## 7. Renderer additions required
+
+Tier (b) means every control does something visible. The following renderer features don't exist today and must be added:
+
+| Need | Where | Backing existing code? |
+|---|---|---|
+| Spectrum averaging modes (None/Weighted/Logarithmic) | `FFTEngine` or `SpectrumWidget::updateSpectrum()` | Partial — `m_smoothed` exists |
+| Spectrum peak hold + decay | `SpectrumWidget` (new `m_peakHold` array, decay timer) | None — new |
+| Spectrum trace fill | `SpectrumWidget` paint path | None — new |
+| Trace line width | `SpectrumWidget` pen width | Trivial |
+| Trace gradient | `SpectrumWidget` paint path | None — new |
+| Display calibration offset (dBm) | `SpectrumWidget::setDbmRange` adjustment | Trivial — additive |
+| Waterfall AGC | `SpectrumWidget::pushWaterfallRow` (auto level) | None — new |
+| Waterfall reverse scroll | `SpectrumWidget` waterfall texture write order | Small |
+| Waterfall opacity | QRhi shader uniform or QPainter alpha | Trivial |
+| Waterfall timestamp overlay | New `QPainter` text layer in `paintEvent` | None — new |
+| Color scheme expansion (3→7) | `wfSchemeStops()` in `SpectrumWidget.cpp` — add LinLog/LinRad/LinAuto/Custom gradient stops | Existing function, add cases |
+| FFT window switching | `FFTEngine` — store window choice, regenerate window coefficients | None — new (FFTEngine currently uses one window) |
+| Show RX/TX filter on waterfall | `SpectrumWidget` waterfall paint — vertical filter band overlay | None — new |
+| Show RX/TX zero line on waterfall | Vertical line at VFO frequency on waterfall | None — new |
+| Grid/grid-fine/horizontal-grid colors live-applied | `SpectrumWidget::paintEvent` grid drawing | Currently hardcoded |
+| Zero line color | `SpectrumWidget::paintEvent` zero line | Currently hardcoded |
+| Grid text color | `SpectrumWidget::paintEvent` axis labels | Currently hardcoded |
+| Frequency label alignment (5 modes) | `SpectrumWidget::paintEvent` frequency scale rendering | Existing, expand from 2→5 modes |
+| FPS overlay text | `SpectrumWidget::paintEvent` corner overlay | None — new |
+
+**Estimated renderer LOC additions: 600–900 lines across `SpectrumWidget.cpp` and `FFTEngine.cpp`.**
+
+## 8. Verification matrix
+
+For each control listed in §3, §4, §5, capture **two screenshots**: dialog open with control at default, and dialog open after changing the control + clicking Apply, with the spectrum/waterfall visibly reflecting the change.
+
+| # | Control | Action | Expected visible change |
+|---|---|---|---|
+| S1 | FFT Size | 4096 → 16384 | Spectrum trace finer resolution, more bins per pixel |
+| S2 | FFT Window | Blackman-Harris → Flat-Top | Spectrum sidelobes change shape |
+| S3 | FPS | 30 → 60 | Spectrum frame rate visibly doubles |
+| S4 | Averaging | None → Logarithmic | Spectrum trace smooths over time |
+| S5 | Fill toggle | off → on | Area under trace fills |
+| S6 | Fill Alpha | 30 → 80 | Fill opacity increases |
+| ... | (all 47 controls) | ... | ... |
+| G13 | Zero Line Color | Red → Yellow | Zero dB line color changes |
+
+Captured screenshots go in `docs/architecture/phase3g8-verification/` and are referenced from the PR description. Total: ~94 screenshots (47 before + 47 after).
+
+## 9. Commit shape (single monolithic block)
+
+Per the locked decision, this is one branch with one PR. Commits within the branch are still small and focused — the "monolithic" refers to scope grouping, not commit count.
+
+1. `feat(gui): ColorSwatchButton reusable color picker widget` — widget + unit-style smoke test
+2. `feat(models): per-band grid settings on SliceModel` — struct, hash, signal, persistence keys
+3. `feat(spectrum): renderer additions (averaging/peak/fill/gradient/trace cal)` — Spectrum Defaults backing
+4. `feat(spectrum): renderer additions (waterfall AGC/reverse/timestamp/opacity/filter overlay)` — Waterfall backing
+5. `feat(spectrum): renderer additions (color schemes expansion + grid/text colors + label align + FPS overlay)` — Grid & Scales backing
+6. `feat(setup): wire Spectrum Defaults page to model + renderer (17 controls)`
+7. `feat(setup): wire Waterfall Defaults page to model + renderer (17 controls)`
+8. `feat(setup): wire Grid & Scales page to model + per-band grid (13 controls)`
+9. `docs(3G-8): verification screenshots + CHANGELOG entry`
+
+**~9 GPG-signed commits.** If any single commit grows past ~400 lines of diff, split it.
+
+## 10. Documented divergences from Thetis
+
+Per locked decision #9, NereusSDR keeps its current default values rather than adopting Thetis's. The plan records each divergence so future readers understand it's intentional.
+
+| Control | NereusSDR | Thetis | Reason |
+|---|---|---|---|
+| FPS default | 30 | 60 | NereusSDR target hardware varies; 30 is conservative |
+| FPS max | 60 | 144 | 144 FPS on a spectrum is wasteful |
+| Update Period default | 50 ms | 2 ms | 2 ms is unnecessarily aggressive for the waterfall |
+| Update Period min | 10 ms | 1 ms | Same |
+| Grid Max default | -20 | -40 | NereusSDR shows hotter signals better at -20 |
+| Grid Min default | -160 | -140 | More headroom for weak signals |
+| Grid Step default | 10 | 2 | Less visual clutter |
+| Waterfall High default | -40 | -80 | Matches NereusSDR's grid max better |
+| Color Schemes count | 3 (now expanding to 7) | 7 | Now matches |
+| FFT Size widget | combo | TrackBar | Combo is friendlier than a 7-position slider |
+| Cal Offset (S8) | exists | n/a | NereusSDR-specific, no Thetis Display tab equivalent |
+| Peak Hold (S9/S10) | exists | n/a | NereusSDR extension |
+| Reverse Scroll (W5) | exists | n/a | NereusSDR extension |
+| Timestamp (W8/W9) | exists | n/a | NereusSDR extension |
+| FFT Window (S2) | Display tab | DSP tab | NereusSDR keeps it on Display for ergonomics |
+
+**Standing rule preserved.** **Do NOT update CLAUDE.md.** The source-first protocol stands as written. This phase is an authorized exception, not a precedent. Future Display work — and all other porting work — defaults back to Thetis-exact constants unless the user grants another express, per-phase exception.
+
+## 11. Files affected (estimated)
+
+**New:**
+- `src/gui/ColorSwatchButton.h`
+- `src/gui/ColorSwatchButton.cpp`
+- `docs/architecture/phase3g8-rx1-display-parity-plan.md` (this file)
+- `docs/architecture/phase3g8-verification/` (screenshots)
+
+**Modified:**
+- `src/gui/setup/DisplaySetupPages.h` — add ~20 new control members across 3 page classes
+- `src/gui/setup/DisplaySetupPages.cpp` — full rewrite of `buildUI()` for all 3 pages, all controls enabled, all wired to model
+- `src/gui/SpectrumWidget.h/.cpp` — renderer additions (~600 LOC), `WfColorScheme` enum expansion
+- `src/core/FFTEngine.h/.cpp` — averaging modes, FFT window switching
+- `src/models/SliceModel.h/.cpp` — per-band grid struct, signal, persistence
+- `src/core/AppSettings.cpp` — ~70 new keys (28 NereusSDR controls + 20 added + 42 per-band - overlap)
+- `src/gui/SpectrumOverlayPanel.cpp` — verify Display sub-panel still works after live values
+- `CHANGELOG.md` — phase entry
+
+**~10–12 files modified, 2 new.**
+
+## 12. Branch management
+
+- Parent branch is `feature/phase3g7-polish` (3G-7 not yet merged to main as of 2026-04-12). When 3G-7 lands on main, rebase this branch with `git rebase main` — clean rebase expected (no overlapping files).
+- New branch: `feature/phase3g8-rx1-display-parity` (created 2026-04-12)
+- All commits GPG-signed (no `--no-gpg-sign`, no `--no-verify`)
+- Pause for user review at each commit boundary per standing preference
+- Show PR description as draft before posting (no auto-post)
+
+## 13. Open questions to resolve before block 1
+
+1. **Cal Offset (S8)** — Thetis has no RX Display tab equivalent. Is this a NereusSDR extension, or should we pull from `display.cs` spectrum calibration code? Subagent didn't find a clean Thetis source. **Action:** quick read of `display.cs` calibration section before block 1, treat as extension if nothing found.
+2. **FPS overlay (G8)** — currently `chkShowFPS`. NereusSDR's `SpectrumWidget` doesn't render FPS today. Implementation choice: `QPainter` text in corner, or QRhi text? Quick choice — `QPainter` overlay layer is fine.
+3. **Display Thread Priority (S17)** — Thetis sets the Windows thread priority of the display thread. NereusSDR uses `QThread::setPriority`. Worth honoring, but the values don't map 1:1. **Action:** map Thetis's combo values (Idle/Lowest/BelowNormal/Normal/AboveNormal/Highest/TimeCritical) to `QThread::Priority` enum, document the mapping.
+4. **Per-band grid initial values** — copy current global default into all 14 slots, or use Thetis's per-band defaults from the Thetis source (which would actually make sense even though decision #9 says keep NereusSDR defaults — these are *new* per-band slots that don't have a "current value" to preserve)? Recommendation: use Thetis per-band defaults for the new slots, since there's no NereusSDR value to keep.
+
+## 14. How to begin (next session checklist)
+
+1. Read this file end to end.
+2. Re-read `CLAUDE.md` and `CONTRIBUTING.md` per standing preference.
+3. Verify 3G-7 merge state: `git checkout main && git pull && git log --oneline -5`. If 3G-7 not merged, work off `feature/phase3g7-polish` and rebase later.
+4. Resolve the four open questions in §13 (mostly quick reads).
+5. `git checkout feature/phase3g8-rx1-display-parity` (branch already exists)
+6. Execute commits in §9 order. Pause for review at each.
+7. Build + auto-launch + screenshot at each commit per standing preference.
+8. After commit 8 (last code commit), capture full verification matrix.
+9. Show PR description draft to user before posting.
+
+## 15. Out of scope (explicit deferrals)
+
+- RX2 Display page — defer to phase that adds RX2 receiver support
+- TX Display page — defer to phase 3I-1 / 3I-3 (TX work)
+- Spectrum Overlay panel sub-panels (Display flyout) — separate work; those are runtime quick toggles, not Setup defaults
+- Multimeter peak hold (`udDisplayMultiPeakHoldTime`) — meter system, already covered in 3G-6/3G-7
+- Skin system color overrides — phase 3H
+- Per-VFO display state — may need revisiting during 3F multi-panadapter phase

--- a/docs/architecture/phase3g8-verification/README.md
+++ b/docs/architecture/phase3g8-verification/README.md
@@ -1,0 +1,105 @@
+# Phase 3G-8 — RX1 Display Parity Verification Matrix
+
+> **Status:** Structure drafted. Screenshot capture happens as the
+> final step before opening the PR. This file lists every control
+> landed in commits 1-8 and the expected live-visible effect so the
+> user can capture before/after screenshots to attach to the PR.
+
+## How to use
+
+1. Build and launch: `cmake --build build && open build/NereusSDR.app`.
+2. Open **Settings → Display** and pick each page in turn.
+3. For every control below:
+   - Capture the spectrum/waterfall area at the documented default,
+     save as `S01-default.png` (or `W…` / `G…` prefix).
+   - Change the control to the documented test value, click Apply.
+   - Capture again, save as `S01-changed.png`.
+4. Drop all screenshots in this directory.
+5. Reference the matrix from the PR description.
+
+Total expected: **47 controls × 2 = ~94 screenshots.** Some
+controls (e.g. FPS slider) may produce visually subtle deltas; a
+short animated gif or side-by-side comparison is fine in those cases.
+
+---
+
+## Spectrum Defaults (17)
+
+| # | Control | Default | Test value | Expected visible change |
+|---|---|---|---|---|
+| S1 | FFT Size | 4096 | 16384 | Spectrum trace finer resolution |
+| S2 | FFT Window | Blackman-Harris | Flat-Top | Sidelobes change shape |
+| S3 | FPS | 30 | 60 | Frame rate visibly doubles |
+| S4 | Averaging | Weighted | Logarithmic | Trace smooths over time in log-domain |
+| S5 | Fill toggle | on | off | Area under trace no longer filled |
+| S6 | Fill Alpha | 70 | 20 | Fill visibly more transparent |
+| S7 | Line Width | 1 | 3 | Trace line visibly thicker (QPainter fallback) |
+| S8 | Cal Offset | 0 dBm | +10 dBm | Trace shifts up by 10 dB |
+| S9 | Peak Hold | off | on | Dotted peak line appears underneath trace |
+| S10 | Peak Hold Delay | 2000 ms | 5000 ms | Peak hold decays slower |
+| S11 | Data Line Color | cyan | red | Trace colour changes |
+| S12 | Data Line Alpha | 230 | 100 | Trace visibly more transparent |
+| S13 | Data Fill Color | cyan | green | Fill colour changes |
+| S14 | Gradient | off | on | Fill becomes a vertical gradient |
+| S15 | Averaging Time | 100 ms | 2000 ms | Smoothing gets visibly slower |
+| S16 | Decimation | 1 | 4 | (scaffolded only — no renderer effect yet) |
+| S17 | Thread Priority | Above Normal | Normal | No visible change; confirm no crash |
+
+## Waterfall Defaults (17)
+
+| # | Control | Default | Test value | Expected visible change |
+|---|---|---|---|---|
+| W1 | High Threshold | -40 dBm | -60 dBm | Waterfall hot colours appear on weaker signals |
+| W2 | Low Threshold | -130 dBm | -110 dBm | Waterfall baseline moves up; less black |
+| W3 | AGC | off | on | Thresholds auto-adjust to visible signal range |
+| W4 | Update Period | 50 ms | 200 ms | Waterfall scroll visibly slower |
+| W5 | Reverse Scroll | off | on | Newest row at bottom instead of top |
+| W6 | Opacity | 100 | 30 | Waterfall becomes translucent |
+| W7 | Color Scheme | Default | LinLog | Palette changes |
+| W8 | Timestamp Position | None | Right | "hh:mm:ss" appears at top-right of waterfall |
+| W9 | Timestamp Mode | UTC | Local | Timestamp shows local time instead of UTC |
+| W10 | Waterfall Low Color | black | blue | (scaffolded; requires Custom scheme for runtime effect) |
+| W11 | Show RX filter on WF | off | on | Cyan band marks filter passband on waterfall |
+| W12 | Show TX filter on RX WF | off | on | (no effect without TX state model; verify no crash) |
+| W13 | Show RX zero line on WF | off | on | Red vertical line at VFO frequency on waterfall |
+| W14 | Show TX zero line on WF | off | on | (no effect without TX state model; verify no crash) |
+| W15 | WF use spectrum min/max | off | on | Waterfall tracks spectrum grid Max/Min |
+| W16 | WF Averaging | None | Weighted | Waterfall rows smooth in time |
+| W17 | Color Scheme (count) | 7 | — | Verify all 7 options are present in combo |
+
+## Grid & Scales (13)
+
+| # | Control | Default | Test value | Expected visible change |
+|---|---|---|---|---|
+| G1 | Show Grid | on | off | Grid lines disappear |
+| G2 | dB Max (per-band) | -40 | -20 | Spectrum top compresses on current band only |
+| G3 | dB Min (per-band) | -140 | -160 | Spectrum bottom extends on current band only |
+| G4 | dB Step (global) | 10 | 5 | More horizontal grid lines |
+| G5 | Freq Label Align | Center | Right | Frequency tick labels right-justify in the scale bar |
+| G6 | Band Edge Color | red | green | (if band edges drawn: colour changes) |
+| G7 | Show Zero Line | off | on | Dashed 0 dBm line appears across spectrum |
+| G8 | Show FPS Overlay | off | on | "N.N fps" appears top-right of spectrum |
+| G9 | Grid Color | white 40α | yellow | Vertical grid lines change colour |
+| G10 | Grid Fine Color | white 20α | gray | Fine dotted grid changes colour |
+| G11 | H-Grid Color | white 40α | cyan | Horizontal dB grid lines change colour |
+| G12 | Text Color | yellow | white | Axis tick labels change colour |
+| G13 | Zero Line Color | red | blue | Zero line changes colour (when G7 on) |
+
+**Per-band verification for G2/G3:** tune across a band boundary
+(e.g. 40m → 30m) and confirm the "Editing band: N" label updates
+and the spinboxes show the stored slot for the new band, and the
+spectrum grid scale snaps to the new band's values. Then edit in
+one band, switch to another, switch back — persistent.
+
+---
+
+## Known deferrals (no screenshot expected)
+
+- S16 Decimation — UI scaffolded, no renderer effect.
+- W10 Low Color — persisted only, runtime gradient rebuild
+  requires Custom scheme parser (future commit).
+- W12 / W14 TX overlays — wait on TX state model.
+- GPU path line width and gradient — QPainter fallback wired;
+  GPU pipeline wire-up in a future polish commit.
+- Data Line / Data Fill colour split — shares `m_fillColor`
+  until UX feedback justifies splitting them.

--- a/src/gui/ColorSwatchButton.cpp
+++ b/src/gui/ColorSwatchButton.cpp
@@ -1,0 +1,87 @@
+// src/gui/ColorSwatchButton.cpp
+#include "ColorSwatchButton.h"
+
+#include <QColorDialog>
+#include <QStringLiteral>
+
+namespace NereusSDR {
+
+ColorSwatchButton::ColorSwatchButton(const QColor& initial, QWidget* parent)
+    : QPushButton(parent)
+    , m_color(initial.isValid() ? initial : QColor(Qt::black))
+{
+    setAutoDefault(false);
+    setDefault(false);
+    setFixedHeight(24);
+    setMinimumWidth(56);
+    setCursor(Qt::PointingHandCursor);
+    setToolTip(tr("Click to choose a color"));
+    updateSwatchStyle();
+    connect(this, &QPushButton::clicked, this, &ColorSwatchButton::openPicker);
+}
+
+void ColorSwatchButton::setColor(const QColor& c)
+{
+    if (!c.isValid() || c == m_color) {
+        return;
+    }
+    m_color = c;
+    updateSwatchStyle();
+    emit colorChanged(m_color);
+}
+
+void ColorSwatchButton::openPicker()
+{
+    const QColor picked = QColorDialog::getColor(
+        m_color, this, tr("Choose color"),
+        QColorDialog::ShowAlphaChannel);
+    if (picked.isValid()) {
+        setColor(picked);
+    }
+}
+
+void ColorSwatchButton::updateSwatchStyle()
+{
+    // Pick a readable border/text color based on the swatch luminance so the
+    // button stays visible against any chosen fill.
+    const int luminance = qGray(m_color.red(), m_color.green(), m_color.blue());
+    const QString fg    = (luminance < 128) ? QStringLiteral("#e8e8e8")
+                                             : QStringLiteral("#1a1a1a");
+    const QString border = QStringLiteral("#203040");
+
+    setStyleSheet(QStringLiteral(
+        "QPushButton { background: %1; color: %2;"
+        " border: 1px solid %3; border-radius: 3px; padding: 2px 8px; }"
+        "QPushButton:hover { border-color: #00b4d8; }"
+        "QPushButton:pressed { background: %1; }")
+        .arg(m_color.name(QColor::HexArgb), fg, border));
+}
+
+QString ColorSwatchButton::colorToHex(const QColor& c)
+{
+    // AppSettings format: "#RRGGBBAA" (Qt's HexArgb returns "#AARRGGBB",
+    // so rearrange).
+    const QString argb = c.name(QColor::HexArgb); // "#AARRGGBB"
+    if (argb.length() != 9) {
+        return c.name(QColor::HexRgb);
+    }
+    const QString alpha = argb.mid(1, 2);
+    const QString rgb   = argb.mid(3, 6);
+    return QStringLiteral("#") + rgb + alpha;
+}
+
+QColor ColorSwatchButton::colorFromHex(const QString& hex)
+{
+    if (hex.length() == 9 && hex.startsWith(QLatin1Char('#'))) {
+        // "#RRGGBBAA" → rebuild as "#AARRGGBB" for QColor::fromString.
+        const QString rgb   = hex.mid(1, 6);
+        const QString alpha = hex.mid(7, 2);
+        const QColor c = QColor::fromString(QStringLiteral("#") + alpha + rgb);
+        if (c.isValid()) {
+            return c;
+        }
+    }
+    return QColor::fromString(hex);
+}
+
+} // namespace NereusSDR

--- a/src/gui/ColorSwatchButton.h
+++ b/src/gui/ColorSwatchButton.h
@@ -1,0 +1,44 @@
+// src/gui/ColorSwatchButton.h
+#pragma once
+
+#include <QColor>
+#include <QPushButton>
+#include <QString>
+
+namespace NereusSDR {
+
+/// Reusable color picker button: shows a color swatch, opens QColorDialog on click.
+///
+/// Used across Display Setup pages (Spectrum/Waterfall/Grid colors), meter
+/// editors, and future skin editor work. Replaces the dead makeColorSwatch
+/// helper in DisplaySetupPages.cpp. Emits colorChanged when the user picks a
+/// new color via the dialog or programmatic setColor().
+///
+/// Persistence helpers colorToHex/colorFromHex round-trip through the
+/// AppSettings "#RRGGBBAA" string format.
+class ColorSwatchButton : public QPushButton
+{
+    Q_OBJECT
+
+public:
+    explicit ColorSwatchButton(const QColor& initial, QWidget* parent = nullptr);
+
+    QColor color() const { return m_color; }
+    void setColor(const QColor& c);
+
+    static QString colorToHex(const QColor& c);
+    static QColor colorFromHex(const QString& hex);
+
+signals:
+    void colorChanged(const QColor& c);
+
+private slots:
+    void openPicker();
+
+private:
+    void updateSwatchStyle();
+
+    QColor m_color;
+};
+
+} // namespace NereusSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -242,6 +242,11 @@ void MainWindow::buildUI()
     connect(m_fftEngine, &FFTEngine::fftReady,
             m_spectrumWidget, &SpectrumWidget::updateSpectrum);
 
+    // Phase 3G-8: expose view hooks on RadioModel so Display setup pages can
+    // reach the renderer / FFT engine without depending on MainWindow.
+    m_radioModel->setSpectrumWidget(m_spectrumWidget);
+    m_radioModel->setFftEngine(m_fftEngine);
+
     // Wire: zoom changes → adjust FFT size for appropriate bin resolution
     // Target: ~500-1000 bins across the visible bandwidth for good detail
     connect(m_spectrumWidget, &SpectrumWidget::bandwidthChangeRequested,

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -5,6 +5,7 @@
 
 #include <QHoverEvent>
 
+#include <QDateTime>
 #include <QPainter>
 #include <QPainterPath>
 #include <QResizeEvent>
@@ -197,6 +198,36 @@ void SpectrumWidget::loadSettings()
     if (peakOn) {
         setPeakHoldEnabled(true);
     }
+
+    // Phase 3G-8 commit 4: waterfall renderer state.
+    m_wfAgcEnabled = s.value(settingsKey(QStringLiteral("DisplayWfAgc"), m_panIndex),
+                             QStringLiteral("False")).toString() == QStringLiteral("True");
+    m_wfReverseScroll = s.value(settingsKey(QStringLiteral("DisplayWfReverseScroll"), m_panIndex),
+                                QStringLiteral("False")).toString() == QStringLiteral("True");
+    m_wfOpacity          = readInt(QStringLiteral("DisplayWfOpacity"), 100);
+    m_wfUpdatePeriodMs   = readInt(QStringLiteral("DisplayWfUpdatePeriodMs"), 50);
+    m_wfUseSpectrumMinMax = s.value(settingsKey(QStringLiteral("DisplayWfUseSpectrumMinMax"), m_panIndex),
+                                    QStringLiteral("False")).toString() == QStringLiteral("True");
+    const int wfAvgRaw = readInt(QStringLiteral("DisplayWfAverageMode"),
+                                 static_cast<int>(AverageMode::None));
+    m_wfAverageMode = static_cast<AverageMode>(qBound(0, wfAvgRaw,
+                          static_cast<int>(AverageMode::Count) - 1));
+    const int tsPosRaw = readInt(QStringLiteral("DisplayWfTimestampPos"),
+                                 static_cast<int>(TimestampPosition::None));
+    m_wfTimestampPos = static_cast<TimestampPosition>(qBound(0, tsPosRaw,
+                           static_cast<int>(TimestampPosition::Count) - 1));
+    const int tsModeRaw = readInt(QStringLiteral("DisplayWfTimestampMode"),
+                                  static_cast<int>(TimestampMode::UTC));
+    m_wfTimestampMode = static_cast<TimestampMode>(qBound(0, tsModeRaw,
+                            static_cast<int>(TimestampMode::Count) - 1));
+    m_showRxFilterOnWaterfall = s.value(settingsKey(QStringLiteral("DisplayShowRxFilterOnWaterfall"), m_panIndex),
+                                        QStringLiteral("False")).toString() == QStringLiteral("True");
+    m_showTxFilterOnRxWaterfall = s.value(settingsKey(QStringLiteral("DisplayShowTxFilterOnRxWaterfall"), m_panIndex),
+                                          QStringLiteral("False")).toString() == QStringLiteral("True");
+    m_showRxZeroLineOnWaterfall = s.value(settingsKey(QStringLiteral("DisplayShowRxZeroLine"), m_panIndex),
+                                          QStringLiteral("False")).toString() == QStringLiteral("True");
+    m_showTxZeroLineOnWaterfall = s.value(settingsKey(QStringLiteral("DisplayShowTxZeroLine"), m_panIndex),
+                                          QStringLiteral("False")).toString() == QStringLiteral("True");
 }
 
 void SpectrumWidget::saveSettings()
@@ -234,6 +265,27 @@ void SpectrumWidget::saveSettings()
               m_peakHoldEnabled ? QStringLiteral("True") : QStringLiteral("False"));
     s.setValue(settingsKey(QStringLiteral("DisplayGradientEnabled"), m_panIndex),
               m_gradientEnabled ? QStringLiteral("True") : QStringLiteral("False"));
+
+    // Phase 3G-8 commit 4: waterfall renderer state.
+    s.setValue(settingsKey(QStringLiteral("DisplayWfAgc"), m_panIndex),
+              m_wfAgcEnabled ? QStringLiteral("True") : QStringLiteral("False"));
+    s.setValue(settingsKey(QStringLiteral("DisplayWfReverseScroll"), m_panIndex),
+              m_wfReverseScroll ? QStringLiteral("True") : QStringLiteral("False"));
+    writeInt(QStringLiteral("DisplayWfOpacity"), m_wfOpacity);
+    writeInt(QStringLiteral("DisplayWfUpdatePeriodMs"), m_wfUpdatePeriodMs);
+    s.setValue(settingsKey(QStringLiteral("DisplayWfUseSpectrumMinMax"), m_panIndex),
+              m_wfUseSpectrumMinMax ? QStringLiteral("True") : QStringLiteral("False"));
+    writeInt(QStringLiteral("DisplayWfAverageMode"), static_cast<int>(m_wfAverageMode));
+    writeInt(QStringLiteral("DisplayWfTimestampPos"), static_cast<int>(m_wfTimestampPos));
+    writeInt(QStringLiteral("DisplayWfTimestampMode"), static_cast<int>(m_wfTimestampMode));
+    s.setValue(settingsKey(QStringLiteral("DisplayShowRxFilterOnWaterfall"), m_panIndex),
+              m_showRxFilterOnWaterfall ? QStringLiteral("True") : QStringLiteral("False"));
+    s.setValue(settingsKey(QStringLiteral("DisplayShowTxFilterOnRxWaterfall"), m_panIndex),
+              m_showTxFilterOnRxWaterfall ? QStringLiteral("True") : QStringLiteral("False"));
+    s.setValue(settingsKey(QStringLiteral("DisplayShowRxZeroLine"), m_panIndex),
+              m_showRxZeroLineOnWaterfall ? QStringLiteral("True") : QStringLiteral("False"));
+    s.setValue(settingsKey(QStringLiteral("DisplayShowTxZeroLine"), m_panIndex),
+              m_showTxZeroLineOnWaterfall ? QStringLiteral("True") : QStringLiteral("False"));
 }
 
 void SpectrumWidget::scheduleSettingsSave()
@@ -427,6 +479,123 @@ void SpectrumWidget::setDbmCalOffset(float db)
         return;
     }
     m_dbmCalOffset = db;
+    scheduleSettingsSave();
+    update();
+}
+
+// ---- Phase 3G-8 commit 4: waterfall setters ----
+
+void SpectrumWidget::setWfHighThreshold(float dbm)
+{
+    if (qFuzzyCompare(m_wfHighThreshold, dbm)) { return; }
+    m_wfHighThreshold = dbm;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setWfLowThreshold(float dbm)
+{
+    if (qFuzzyCompare(m_wfLowThreshold, dbm)) { return; }
+    m_wfLowThreshold = dbm;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setWfAgcEnabled(bool on)
+{
+    if (m_wfAgcEnabled == on) { return; }
+    m_wfAgcEnabled = on;
+    m_wfAgcPrimed = false;  // reprime envelope on next frame
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setWfReverseScroll(bool on)
+{
+    if (m_wfReverseScroll == on) { return; }
+    m_wfReverseScroll = on;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setWfOpacity(int percent)
+{
+    percent = qBound(0, percent, 100);
+    if (m_wfOpacity == percent) { return; }
+    m_wfOpacity = percent;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setWfUpdatePeriodMs(int ms)
+{
+    ms = qBound(10, ms, 500);  // matches NereusSDR UI range per plan §10
+    if (m_wfUpdatePeriodMs == ms) { return; }
+    m_wfUpdatePeriodMs = ms;
+    scheduleSettingsSave();
+}
+
+void SpectrumWidget::setWfUseSpectrumMinMax(bool on)
+{
+    if (m_wfUseSpectrumMinMax == on) { return; }
+    m_wfUseSpectrumMinMax = on;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setWfAverageMode(AverageMode m)
+{
+    if (m_wfAverageMode == m) { return; }
+    m_wfAverageMode = m;
+    m_wfSmoothedBins.clear();
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setWfTimestampPosition(TimestampPosition p)
+{
+    if (m_wfTimestampPos == p) { return; }
+    m_wfTimestampPos = p;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setWfTimestampMode(TimestampMode m)
+{
+    if (m_wfTimestampMode == m) { return; }
+    m_wfTimestampMode = m;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setShowRxFilterOnWaterfall(bool on)
+{
+    if (m_showRxFilterOnWaterfall == on) { return; }
+    m_showRxFilterOnWaterfall = on;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setShowTxFilterOnRxWaterfall(bool on)
+{
+    if (m_showTxFilterOnRxWaterfall == on) { return; }
+    m_showTxFilterOnRxWaterfall = on;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setShowRxZeroLineOnWaterfall(bool on)
+{
+    if (m_showRxZeroLineOnWaterfall == on) { return; }
+    m_showRxZeroLineOnWaterfall = on;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setShowTxZeroLineOnWaterfall(bool on)
+{
+    if (m_showTxZeroLineOnWaterfall == on) { return; }
+    m_showTxZeroLineOnWaterfall = on;
     scheduleSettingsSave();
     update();
 }
@@ -707,25 +876,99 @@ void SpectrumWidget::drawWaterfall(QPainter& p, const QRect& wfRect)
         return;
     }
 
-    // Ring buffer display — newest row at top, oldest at bottom.
-    // From Thetis display.cs:7719-7729: new row written at top, old content shifts down.
-    // Our ring buffer equivalent: m_wfWriteRow is where the NEWEST row lives.
-    // Display order: writeRow → wrapping down → back to writeRow-1 (oldest).
-    int wfH = m_waterfall.height();
-
-    // Part 1 (top of screen): from writeRow to end of image
-    int part1Rows = wfH - m_wfWriteRow;
-    if (part1Rows > 0) {
-        QRect src(0, m_wfWriteRow, m_waterfall.width(), part1Rows);
-        QRect dst(wfRect.left(), wfRect.top(), wfRect.width(), part1Rows);
-        p.drawImage(dst, m_waterfall, src);
+    // Phase 3G-8 commit 4: global opacity for the waterfall image. Overlays
+    // (filter bands, zero line, timestamp) are drawn afterward at full alpha.
+    const float opacity = qBound(0, m_wfOpacity, 100) / 100.0f;
+    const float savedOpacity = static_cast<float>(p.opacity());
+    if (!qFuzzyCompare(opacity, 1.0f)) {
+        p.setOpacity(opacity);
     }
 
-    // Part 2 (bottom of screen): from 0 to writeRow
-    if (m_wfWriteRow > 0) {
-        QRect src(0, 0, m_waterfall.width(), m_wfWriteRow);
-        QRect dst(wfRect.left(), wfRect.top() + part1Rows, wfRect.width(), m_wfWriteRow);
-        p.drawImage(dst, m_waterfall, src);
+    // Ring buffer display — newest row at top, oldest at bottom (normal scroll).
+    // Reverse scroll flips that vertically: oldest at top, newest at bottom.
+    // From Thetis display.cs:7719-7729: new row written at top, old content shifts down.
+    int wfH = m_waterfall.height();
+
+    if (!m_wfReverseScroll) {
+        // Part 1 (top of screen): from writeRow to end of image
+        int part1Rows = wfH - m_wfWriteRow;
+        if (part1Rows > 0) {
+            QRect src(0, m_wfWriteRow, m_waterfall.width(), part1Rows);
+            QRect dst(wfRect.left(), wfRect.top(), wfRect.width(), part1Rows);
+            p.drawImage(dst, m_waterfall, src);
+        }
+        if (m_wfWriteRow > 0) {
+            QRect src(0, 0, m_waterfall.width(), m_wfWriteRow);
+            QRect dst(wfRect.left(), wfRect.top() + part1Rows, wfRect.width(), m_wfWriteRow);
+            p.drawImage(dst, m_waterfall, src);
+        }
+    } else {
+        // Reverse: oldest row at top, newest at bottom. writeRow points at
+        // the newest row, so we render backward.
+        int part1Rows = m_wfWriteRow + 1;
+        int part2Rows = wfH - part1Rows;
+        if (part2Rows > 0) {
+            QRect src(0, m_wfWriteRow + 1, m_waterfall.width(), part2Rows);
+            QRect dst(wfRect.left(), wfRect.top(), wfRect.width(), part2Rows);
+            p.drawImage(dst, m_waterfall, src);
+        }
+        if (part1Rows > 0) {
+            QRect src(0, 0, m_waterfall.width(), part1Rows);
+            QRect dst(wfRect.left(), wfRect.top() + part2Rows, wfRect.width(), part1Rows);
+            p.drawImage(dst, m_waterfall, src);
+        }
+    }
+
+    if (!qFuzzyCompare(opacity, 1.0f)) {
+        p.setOpacity(savedOpacity);
+    }
+
+    // ---- Overlays (full opacity) ----
+
+    // RX filter passband as a translucent vertical band spanning the
+    // waterfall height. Uses m_vfoHz + m_filterLowHz/m_filterHighHz.
+    if (m_showRxFilterOnWaterfall && m_vfoHz > 0.0) {
+        const double loHz = m_vfoHz + m_filterLowHz;
+        const double hiHz = m_vfoHz + m_filterHighHz;
+        const int x1 = hzToX(loHz, wfRect);
+        const int x2 = hzToX(hiHz, wfRect);
+        if (x2 > x1) {
+            QColor band(0x00, 0xb4, 0xd8, 50);
+            p.fillRect(QRect(x1, wfRect.top(), x2 - x1, wfRect.height()), band);
+        }
+    }
+
+    // TX filter overlay on the RX waterfall — currently unused until the
+    // TX state model exposes a TX VFO/filter pair (post-3I-1). Scaffolding
+    // in place so commit 7's checkbox wiring has a renderer hook.
+    Q_UNUSED(m_showTxFilterOnRxWaterfall);
+    Q_UNUSED(m_showTxZeroLineOnWaterfall);
+
+    if (m_showRxZeroLineOnWaterfall && m_vfoHz > 0.0) {
+        const int x = hzToX(m_vfoHz, wfRect);
+        if (x >= wfRect.left() && x <= wfRect.right()) {
+            QPen zeroPen(QColor(255, 0, 0, 180), 1);
+            p.setPen(zeroPen);
+            p.drawLine(x, wfRect.top(), x, wfRect.bottom());
+        }
+    }
+
+    // Timestamp overlay on waterfall (NereusSDR extensions W8/W9).
+    if (m_wfTimestampPos != TimestampPosition::None) {
+        const QDateTime now = (m_wfTimestampMode == TimestampMode::UTC)
+                              ? QDateTime::currentDateTimeUtc()
+                              : QDateTime::currentDateTime();
+        const QString stamp = now.toString(QStringLiteral("hh:mm:ss"));
+        QFont f = p.font();
+        f.setPixelSize(10);
+        p.setFont(f);
+        p.setPen(QColor(200, 220, 255));
+        const int pad = 4;
+        const int textW = p.fontMetrics().horizontalAdvance(stamp);
+        int x = (m_wfTimestampPos == TimestampPosition::Left)
+                ? (wfRect.left() + pad)
+                : (wfRect.right() - textW - pad);
+        p.drawText(x, wfRect.top() + 12, stamp);
     }
 }
 
@@ -848,11 +1091,24 @@ int SpectrumWidget::dbmToY(float dbm, const QRect& r) const
 // From Thetis display.cs:7719 — new row at top, old content shifts down.
 // Ring buffer equivalent: decrement write pointer so newest row is always
 // at m_wfWriteRow, and display reads forward from there (wrapping).
+//
+// Phase 3G-8 commit 4: respects m_wfUpdatePeriodMs (rate-limit),
+// m_wfAverageMode (waterfall-specific averaging), m_wfAgcEnabled (auto
+// level tracking), m_wfUseSpectrumMinMax (borrow spectrum thresholds),
+// m_wfReverseScroll (write at opposite end of ring so newest is bottom).
 void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins)
 {
     if (m_waterfall.isNull()) {
         return;
     }
+
+    // Rate-limit per configured update period.
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if (m_wfUpdatePeriodMs > 0 && m_wfLastPushMs != 0 &&
+        now - m_wfLastPushMs < m_wfUpdatePeriodMs) {
+        return;
+    }
+    m_wfLastPushMs = now;
 
     auto [firstBin, lastBin] = visibleBinRange(bins.size());
     int subsetCount = lastBin - firstBin + 1;
@@ -860,9 +1116,61 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins)
         return;
     }
 
+    // Waterfall-specific averaging. Applied to a local smoothed copy so
+    // the spectrum trace and waterfall can diverge in smoothing.
+    const QVector<float>* src = &bins;
+    QVector<float> wfLocal;
+    if (m_wfAverageMode != AverageMode::None) {
+        if (m_wfSmoothedBins.size() != bins.size()) {
+            m_wfSmoothedBins = bins;
+        } else {
+            const float a = qBound(0.0f, m_averageAlpha, 1.0f);
+            for (int i = 0; i < bins.size(); ++i) {
+                m_wfSmoothedBins[i] = a * bins[i]
+                                    + (1.0f - a) * m_wfSmoothedBins[i];
+            }
+        }
+        wfLocal = m_wfSmoothedBins;
+        src = &wfLocal;
+    }
+
+    // AGC: track a slow envelope of visible-range min/max and bias the
+    // effective thresholds toward it. Simple one-pole follower.
+    if (m_wfAgcEnabled) {
+        float mn = (*src)[firstBin];
+        float mx = mn;
+        for (int i = firstBin + 1; i <= lastBin; ++i) {
+            const float v = (*src)[i];
+            if (v < mn) { mn = v; }
+            if (v > mx) { mx = v; }
+        }
+        if (!m_wfAgcPrimed) {
+            m_wfAgcRunMin = mn;
+            m_wfAgcRunMax = mx;
+            m_wfAgcPrimed = true;
+        } else {
+            constexpr float kAgcAlpha = 0.05f;
+            m_wfAgcRunMin = kAgcAlpha * mn + (1.0f - kAgcAlpha) * m_wfAgcRunMin;
+            m_wfAgcRunMax = kAgcAlpha * mx + (1.0f - kAgcAlpha) * m_wfAgcRunMax;
+        }
+        // Expand slightly so the hottest signal doesn't clip.
+        const float margin = 3.0f;
+        m_wfLowThreshold  = m_wfAgcRunMin - margin;
+        m_wfHighThreshold = m_wfAgcRunMax + margin;
+    } else if (m_wfUseSpectrumMinMax) {
+        // Borrow spectrum grid thresholds.
+        m_wfHighThreshold = m_refLevel;
+        m_wfLowThreshold  = m_refLevel - m_dynamicRange;
+    }
+
     int h = m_waterfall.height();
-    // Decrement write pointer (wrapping) — newest data at top of display
-    m_wfWriteRow = (m_wfWriteRow - 1 + h) % h;
+    // Decrement (normal) or increment (reverse) write pointer so the newest
+    // row lands at the appropriate edge.
+    if (m_wfReverseScroll) {
+        m_wfWriteRow = (m_wfWriteRow + 1) % h;
+    } else {
+        m_wfWriteRow = (m_wfWriteRow - 1 + h) % h;
+    }
 
     int w = m_waterfall.width();
     QRgb* scanline = reinterpret_cast<QRgb*>(m_waterfall.scanLine(m_wfWriteRow));
@@ -871,7 +1179,7 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins)
     for (int x = 0; x < w; ++x) {
         int srcBin = firstBin + static_cast<int>(static_cast<float>(x) * binScale);
         srcBin = qBound(firstBin, srcBin, lastBin);
-        scanline[x] = dbmToRgb(bins[srcBin]);
+        scanline[x] = dbmToRgb((*src)[srcBin]);
     }
 }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -67,6 +67,44 @@ static const WfGradientStop kBlackWhiteStops[] = {
     {1.00f, 255, 255, 255},    // white
 };
 
+// LinLog scheme — linear ramp in low region, log-shaped in high region.
+// Approximation of Thetis "LinLog" combo entry (setup.cs:11904-11939).
+// Phase 3G-8 commit 5 addition.
+static const WfGradientStop kLinLogStops[] = {
+    {0.00f,   0,   0,   0},
+    {0.10f,   0,   0,  96},
+    {0.25f,   0,  64, 192},
+    {0.50f,   0, 192, 192},
+    {0.65f,   0, 224,  64},
+    {0.80f, 255, 192,   0},
+    {1.00f, 255,   0,   0},
+};
+
+// LinRad scheme — LinRadiance-style cool → hot gradient. Phase 3G-8.
+static const WfGradientStop kLinRadStops[] = {
+    {0.00f,   0,   0,   0},
+    {0.15f,  16,  16, 120},
+    {0.30f,  32,  80, 200},
+    {0.50f,   0, 200, 255},
+    {0.70f, 200, 255, 120},
+    {0.85f, 255, 200,   0},
+    {1.00f, 255,  32,   0},
+};
+
+// Custom scheme — loaded from AppSettings "DisplayWfCustomStops" if set,
+// otherwise falls back to Default. Phase 3G-8 commit 5. Runtime state
+// is parsed lazily from the settings key when the scheme is selected.
+// For now the static fallback keeps the same stops as Default.
+static const WfGradientStop kCustomFallbackStops[] = {
+    {0.00f,   0,   0,   0},
+    {0.15f,   0,   0, 128},
+    {0.30f,   0,  64, 255},
+    {0.45f,   0, 200, 255},
+    {0.60f,   0, 220,   0},
+    {0.80f, 255, 255,   0},
+    {1.00f, 255,   0,   0},
+};
+
 const WfGradientStop* wfSchemeStops(WfColorScheme scheme, int& count)
 {
     switch (scheme) {
@@ -79,6 +117,15 @@ const WfGradientStop* wfSchemeStops(WfColorScheme scheme, int& count)
     case WfColorScheme::BlackWhite:
         count = 2;
         return kBlackWhiteStops;
+    case WfColorScheme::LinLog:
+        count = 7;
+        return kLinLogStops;
+    case WfColorScheme::LinRad:
+        count = 7;
+        return kLinRadStops;
+    case WfColorScheme::Custom:
+        count = 7;
+        return kCustomFallbackStops;
     case WfColorScheme::Default:
     default:
         count = 7;
@@ -228,6 +275,31 @@ void SpectrumWidget::loadSettings()
                                           QStringLiteral("False")).toString() == QStringLiteral("True");
     m_showTxZeroLineOnWaterfall = s.value(settingsKey(QStringLiteral("DisplayShowTxZeroLine"), m_panIndex),
                                           QStringLiteral("False")).toString() == QStringLiteral("True");
+
+    // Phase 3G-8 commit 5: grid / scales state.
+    m_gridEnabled = s.value(settingsKey(QStringLiteral("DisplayGridEnabled"), m_panIndex),
+                            QStringLiteral("True")).toString() == QStringLiteral("True");
+    m_showZeroLine = s.value(settingsKey(QStringLiteral("DisplayShowZeroLine"), m_panIndex),
+                             QStringLiteral("False")).toString() == QStringLiteral("True");
+    m_showFps = s.value(settingsKey(QStringLiteral("DisplayShowFps"), m_panIndex),
+                        QStringLiteral("False")).toString() == QStringLiteral("True");
+    const int alignRaw = readInt(QStringLiteral("DisplayFreqLabelAlign"),
+                                 static_cast<int>(FreqLabelAlign::Center));
+    m_freqLabelAlign = static_cast<FreqLabelAlign>(qBound(0, alignRaw,
+                           static_cast<int>(FreqLabelAlign::Count) - 1));
+
+    auto readColor = [&](const QString& key, const QColor& def) -> QColor {
+        const QString hex = s.value(settingsKey(key, m_panIndex)).toString();
+        if (hex.isEmpty()) { return def; }
+        QColor c = QColor::fromString(hex);
+        return c.isValid() ? c : def;
+    };
+    m_gridColor     = readColor(QStringLiteral("DisplayGridColor"), m_gridColor);
+    m_gridFineColor = readColor(QStringLiteral("DisplayGridFineColor"), m_gridFineColor);
+    m_hGridColor    = readColor(QStringLiteral("DisplayHGridColor"), m_hGridColor);
+    m_gridTextColor = readColor(QStringLiteral("DisplayGridTextColor"), m_gridTextColor);
+    m_zeroLineColor = readColor(QStringLiteral("DisplayZeroLineColor"), m_zeroLineColor);
+    m_bandEdgeColor = readColor(QStringLiteral("DisplayBandEdgeColor"), m_bandEdgeColor);
 }
 
 void SpectrumWidget::saveSettings()
@@ -286,6 +358,25 @@ void SpectrumWidget::saveSettings()
               m_showRxZeroLineOnWaterfall ? QStringLiteral("True") : QStringLiteral("False"));
     s.setValue(settingsKey(QStringLiteral("DisplayShowTxZeroLine"), m_panIndex),
               m_showTxZeroLineOnWaterfall ? QStringLiteral("True") : QStringLiteral("False"));
+
+    // Phase 3G-8 commit 5: grid / scales state.
+    s.setValue(settingsKey(QStringLiteral("DisplayGridEnabled"), m_panIndex),
+              m_gridEnabled ? QStringLiteral("True") : QStringLiteral("False"));
+    s.setValue(settingsKey(QStringLiteral("DisplayShowZeroLine"), m_panIndex),
+              m_showZeroLine ? QStringLiteral("True") : QStringLiteral("False"));
+    s.setValue(settingsKey(QStringLiteral("DisplayShowFps"), m_panIndex),
+              m_showFps ? QStringLiteral("True") : QStringLiteral("False"));
+    writeInt(QStringLiteral("DisplayFreqLabelAlign"), static_cast<int>(m_freqLabelAlign));
+
+    auto writeColor = [&](const QString& key, const QColor& c) {
+        s.setValue(settingsKey(key, m_panIndex), c.name(QColor::HexArgb));
+    };
+    writeColor(QStringLiteral("DisplayGridColor"),     m_gridColor);
+    writeColor(QStringLiteral("DisplayGridFineColor"), m_gridFineColor);
+    writeColor(QStringLiteral("DisplayHGridColor"),    m_hGridColor);
+    writeColor(QStringLiteral("DisplayGridTextColor"), m_gridTextColor);
+    writeColor(QStringLiteral("DisplayZeroLineColor"), m_zeroLineColor);
+    writeColor(QStringLiteral("DisplayBandEdgeColor"), m_bandEdgeColor);
 }
 
 void SpectrumWidget::scheduleSettingsSave()
@@ -600,6 +691,91 @@ void SpectrumWidget::setShowTxZeroLineOnWaterfall(bool on)
     update();
 }
 
+// ---- Phase 3G-8 commit 5: grid / scales setters ----
+
+void SpectrumWidget::setGridEnabled(bool on)
+{
+    if (m_gridEnabled == on) { return; }
+    m_gridEnabled = on;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setShowZeroLine(bool on)
+{
+    if (m_showZeroLine == on) { return; }
+    m_showZeroLine = on;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setShowFps(bool on)
+{
+    if (m_showFps == on) { return; }
+    m_showFps = on;
+    m_fpsFrameCount = 0;
+    m_fpsLastUpdateMs = 0;
+    m_fpsDisplayValue = 0.0f;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setFreqLabelAlign(FreqLabelAlign a)
+{
+    if (m_freqLabelAlign == a) { return; }
+    m_freqLabelAlign = a;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setGridColor(const QColor& c)
+{
+    if (!c.isValid() || m_gridColor == c) { return; }
+    m_gridColor = c;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setGridFineColor(const QColor& c)
+{
+    if (!c.isValid() || m_gridFineColor == c) { return; }
+    m_gridFineColor = c;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setHGridColor(const QColor& c)
+{
+    if (!c.isValid() || m_hGridColor == c) { return; }
+    m_hGridColor = c;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setGridTextColor(const QColor& c)
+{
+    if (!c.isValid() || m_gridTextColor == c) { return; }
+    m_gridTextColor = c;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setZeroLineColor(const QColor& c)
+{
+    if (!c.isValid() || m_zeroLineColor == c) { return; }
+    m_zeroLineColor = c;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setBandEdgeColor(const QColor& c)
+{
+    if (!c.isValid() || m_bandEdgeColor == c) { return; }
+    m_bandEdgeColor = c;
+    scheduleSettingsSave();
+    update();
+}
+
 // Feed new FFT frame — apply averaging per current mode, track peak hold,
 // push waterfall row, repaint. From AetherSDR SpectrumWidget::updateSpectrum()
 // + gpu-waterfall.md:895-911. Averaging mode added in Phase 3G-8 commit 3.
@@ -738,6 +914,30 @@ void SpectrumWidget::paintEvent(QPaintEvent* event)
     drawDbmScale(p, QRect(0, 0, kDbmStripW, specH));
     drawCursorInfo(p, specRect);
 
+    // FPS overlay (Phase 3G-8 commit 5 / G8 ShowFPS). Cheap rolling counter
+    // updated once per second. QPainter fallback path only; GPU path prints
+    // its own counter via a future commit if the feature is exposed there.
+    if (m_showFps) {
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        m_fpsFrameCount++;
+        if (m_fpsLastUpdateMs == 0) {
+            m_fpsLastUpdateMs = nowMs;
+        } else if (nowMs - m_fpsLastUpdateMs >= 1000) {
+            const double elapsed = (nowMs - m_fpsLastUpdateMs) / 1000.0;
+            m_fpsDisplayValue    = static_cast<float>(m_fpsFrameCount / elapsed);
+            m_fpsFrameCount      = 0;
+            m_fpsLastUpdateMs    = nowMs;
+        }
+        const QString fpsText = QStringLiteral("%1 fps")
+                                    .arg(m_fpsDisplayValue, 0, 'f', 1);
+        QFont ff = p.font();
+        ff.setPixelSize(11);
+        p.setFont(ff);
+        p.setPen(m_gridTextColor);
+        const int tw = p.fontMetrics().horizontalAdvance(fpsText);
+        p.drawText(specRect.right() - tw - 8, specRect.top() + 14, fpsText);
+    }
+
     // Reposition VFO flag widgets every frame — ensures flag tracks marker
     // exactly with no frame delay. From AetherSDR: updatePosition called
     // from within the paint/render cycle.
@@ -751,9 +951,14 @@ void SpectrumWidget::paintEvent(QPaintEvent* event)
 //   grid_text_color = Color.Yellow — display.cs:2003
 void SpectrumWidget::drawGrid(QPainter& p, const QRect& specRect)
 {
-    // Horizontal dBm grid lines
-    QColor hGridColor(255, 255, 255, 40);
-    p.setPen(QPen(hGridColor, 1));
+    // Phase 3G-8 commit 5: honours m_gridEnabled plus configurable grid
+    // colours (m_hGridColor / m_gridColor / m_gridFineColor).
+    if (!m_gridEnabled) {
+        return;
+    }
+
+    // Horizontal dBm grid lines (major).
+    p.setPen(QPen(m_hGridColor, 1));
 
     float bottom = m_refLevel - m_dynamicRange;
     float step = 10.0f;  // 10 dB steps
@@ -766,9 +971,8 @@ void SpectrumWidget::drawGrid(QPainter& p, const QRect& specRect)
         p.drawLine(specRect.left(), y, specRect.right(), y);
     }
 
-    // Vertical frequency grid lines
-    QColor vGridColor(255, 255, 255, 40);
-    p.setPen(QPen(vGridColor, 1));
+    // Vertical frequency grid lines (major).
+    p.setPen(QPen(m_gridColor, 1));
 
     // Compute a nice frequency step
     double freqStep = 10000.0;  // 10 kHz default
@@ -782,6 +986,15 @@ void SpectrumWidget::drawGrid(QPainter& p, const QRect& specRect)
 
     double startFreq = std::ceil((m_centerHz - m_bandwidthHz / 2.0) / freqStep) * freqStep;
     for (double f = startFreq; f < m_centerHz + m_bandwidthHz / 2.0; f += freqStep) {
+        int x = hzToX(f, specRect);
+        p.drawLine(x, specRect.top(), x, specRect.bottom());
+    }
+
+    // Fine (minor) vertical grid at 1/5 step. Drawn in m_gridFineColor.
+    p.setPen(QPen(m_gridFineColor, 1, Qt::DotLine));
+    const double fineStep = freqStep / 5.0;
+    double startFine = std::ceil((m_centerHz - m_bandwidthHz / 2.0) / fineStep) * fineStep;
+    for (double f = startFine; f < m_centerHz + m_bandwidthHz / 2.0; f += fineStep) {
         int x = hzToX(f, specRect);
         p.drawLine(x, specRect.top(), x, specRect.bottom());
     }
@@ -867,6 +1080,16 @@ void SpectrumWidget::drawSpectrum(QPainter& p, const QRect& specRect)
     QPen tracePen(m_fillColor, m_lineWidth);
     p.setPen(tracePen);
     p.drawPolyline(points.data(), count);
+
+    // Zero line (0 dBm) — Phase 3G-8 commit 5 (G7).
+    if (m_showZeroLine) {
+        const int zy = dbmToY(0.0f, specRect);
+        if (zy >= specRect.top() && zy <= specRect.bottom()) {
+            QPen zeroPen(m_zeroLineColor, 1, Qt::DashLine);
+            p.setPen(zeroPen);
+            p.drawLine(specRect.left(), zy, specRect.right(), zy);
+        }
+    }
 }
 
 // ---- Waterfall drawing ----
@@ -977,11 +1200,16 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
 {
     p.fillRect(r, QColor(0x10, 0x15, 0x20));
 
+    // Phase 3G-8 commit 5: Off alignment suppresses labels entirely.
+    if (m_freqLabelAlign == FreqLabelAlign::Off) {
+        return;
+    }
+
     QFont font = p.font();
     font.setPixelSize(10);
     p.setFont(font);
-    // From Thetis display.cs:2003 — grid_text_color = Color.Yellow
-    p.setPen(QColor(255, 255, 0));
+    // From Thetis display.cs:2003 — grid_text_color (now configurable).
+    p.setPen(m_gridTextColor);
 
     double freqStep = 25000.0;
     if (m_bandwidthHz > 500000.0) {
@@ -991,6 +1219,13 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
     } else if (m_bandwidthHz < 100000.0) {
         freqStep = 10000.0;
     }
+
+    // Phase 3G-8 commit 5: Thetis 5-mode label alignment.
+    // Left / Center / Right / Auto (center with fallback) / Off.
+    const Qt::Alignment baseFlags =
+        (m_freqLabelAlign == FreqLabelAlign::Left)  ? (Qt::AlignLeft  | Qt::AlignVCenter) :
+        (m_freqLabelAlign == FreqLabelAlign::Right) ? (Qt::AlignRight | Qt::AlignVCenter) :
+                                                       (Qt::AlignHCenter | Qt::AlignVCenter);
 
     double startFreq = std::ceil((m_centerHz - m_bandwidthHz / 2.0) / freqStep) * freqStep;
     for (double f = startFreq; f < m_centerHz + m_bandwidthHz / 2.0; f += freqStep) {
@@ -1007,7 +1242,7 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
         }
 
         QRect textRect(x - 30, r.top() + 2, 60, r.height() - 2);
-        p.drawText(textRect, Qt::AlignCenter, label);
+        p.drawText(textRect, baseFlags, label);
     }
 }
 
@@ -1020,7 +1255,8 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
     QFont font = p.font();
     font.setPixelSize(9);
     p.setFont(font);
-    p.setPen(QColor(255, 255, 0));  // Yellow text — from Thetis display.cs:2003
+    // Phase 3G-8 commit 5: configurable text colour (was hardcoded yellow).
+    p.setPen(m_gridTextColor);
 
     float bottom = m_refLevel - m_dynamicRange;
     float step = 10.0f;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -574,6 +574,16 @@ void SpectrumWidget::setDbmCalOffset(float db)
     update();
 }
 
+void SpectrumWidget::setFillColor(const QColor& c)
+{
+    if (!c.isValid() || m_fillColor == c) {
+        return;
+    }
+    m_fillColor = c;
+    scheduleSettingsSave();
+    update();
+}
+
 // ---- Phase 3G-8 commit 4: waterfall setters ----
 
 void SpectrumWidget::setWfHighThreshold(float dbm)

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -178,6 +178,25 @@ void SpectrumWidget::loadSettings()
     int scheme = readInt(QStringLiteral("DisplayWfColorScheme"), 0);
     m_wfColorScheme = static_cast<WfColorScheme>(qBound(0, scheme,
                           static_cast<int>(WfColorScheme::Count) - 1));
+
+    // Phase 3G-8 commit 3: spectrum renderer state.
+    const int avgRaw = readInt(QStringLiteral("DisplayAverageMode"),
+                               static_cast<int>(AverageMode::Weighted));
+    m_averageMode = static_cast<AverageMode>(qBound(0, avgRaw,
+                          static_cast<int>(AverageMode::Count) - 1));
+    m_averageAlpha     = readFloat(QStringLiteral("DisplayAverageAlpha"), kSmoothAlpha);
+    m_peakHoldDelayMs  = readInt(QStringLiteral("DisplayPeakHoldDelayMs"), 2000);
+    m_lineWidth        = readFloat(QStringLiteral("DisplayLineWidth"), 1.5f);
+    m_dbmCalOffset     = readFloat(QStringLiteral("DisplayCalOffset"), 0.0f);
+    const bool peakOn = s.value(settingsKey(QStringLiteral("DisplayPeakHoldEnabled"), m_panIndex),
+                                QStringLiteral("False")).toString() == QStringLiteral("True");
+    const bool gradOn = s.value(settingsKey(QStringLiteral("DisplayGradientEnabled"), m_panIndex),
+                                QStringLiteral("False")).toString() == QStringLiteral("True");
+    m_gradientEnabled = gradOn;
+    // Delay the peak hold enable path until the timer infra is ready.
+    if (peakOn) {
+        setPeakHoldEnabled(true);
+    }
 }
 
 void SpectrumWidget::saveSettings()
@@ -204,6 +223,17 @@ void SpectrumWidget::saveSettings()
     writeInt(QStringLiteral("DisplayWfColorScheme"), static_cast<int>(m_wfColorScheme));
     s.setValue(settingsKey(QStringLiteral("DisplayCtunEnabled"), m_panIndex),
               m_ctunEnabled ? QStringLiteral("True") : QStringLiteral("False"));
+
+    // Phase 3G-8 commit 3: spectrum renderer state.
+    writeInt(QStringLiteral("DisplayAverageMode"), static_cast<int>(m_averageMode));
+    writeFloat(QStringLiteral("DisplayAverageAlpha"), m_averageAlpha);
+    writeInt(QStringLiteral("DisplayPeakHoldDelayMs"), m_peakHoldDelayMs);
+    writeFloat(QStringLiteral("DisplayLineWidth"), m_lineWidth);
+    writeFloat(QStringLiteral("DisplayCalOffset"), m_dbmCalOffset);
+    s.setValue(settingsKey(QStringLiteral("DisplayPeakHoldEnabled"), m_panIndex),
+              m_peakHoldEnabled ? QStringLiteral("True") : QStringLiteral("False"));
+    s.setValue(settingsKey(QStringLiteral("DisplayGradientEnabled"), m_panIndex),
+              m_gradientEnabled ? QStringLiteral("True") : QStringLiteral("False"));
 }
 
 void SpectrumWidget::scheduleSettingsSave()
@@ -280,20 +310,183 @@ void SpectrumWidget::setWfColorScheme(WfColorScheme scheme)
     update();
 }
 
-// Feed new FFT frame — apply smoothing, push waterfall row, repaint.
-// From AetherSDR SpectrumWidget::updateSpectrum() + gpu-waterfall.md:895-911
+// ---- Phase 3G-8 commit 3 setters ----
+
+void SpectrumWidget::setAverageMode(AverageMode m)
+{
+    if (m_averageMode == m) {
+        return;
+    }
+    m_averageMode = m;
+    // Force a fresh baseline for the new mode so a switch doesn't
+    // carry stale smoothed state forward.
+    m_smoothed.clear();
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setAverageAlpha(float alpha)
+{
+    alpha = qBound(0.0f, alpha, 1.0f);
+    if (qFuzzyCompare(m_averageAlpha, alpha)) {
+        return;
+    }
+    m_averageAlpha = alpha;
+    scheduleSettingsSave();
+}
+
+void SpectrumWidget::setPeakHoldEnabled(bool on)
+{
+    if (m_peakHoldEnabled == on) {
+        return;
+    }
+    m_peakHoldEnabled = on;
+    if (!on) {
+        m_peakHoldBins.clear();
+        if (m_peakHoldDecayTimer) {
+            m_peakHoldDecayTimer->stop();
+        }
+    } else {
+        if (!m_peakHoldDecayTimer) {
+            m_peakHoldDecayTimer = new QTimer(this);
+            m_peakHoldDecayTimer->setSingleShot(false);
+            connect(m_peakHoldDecayTimer, &QTimer::timeout, this, [this]() {
+                // Decay: reset peak hold to current smoothed data so fresh
+                // peaks start tracking again from "now".
+                if (m_peakHoldEnabled) {
+                    m_peakHoldBins = m_smoothed;
+                    update();
+                }
+            });
+        }
+        m_peakHoldDecayTimer->start(m_peakHoldDelayMs);
+    }
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setPeakHoldDelayMs(int ms)
+{
+    ms = qBound(100, ms, 60000);
+    if (m_peakHoldDelayMs == ms) {
+        return;
+    }
+    m_peakHoldDelayMs = ms;
+    if (m_peakHoldDecayTimer && m_peakHoldDecayTimer->isActive()) {
+        m_peakHoldDecayTimer->start(ms);
+    }
+    scheduleSettingsSave();
+}
+
+void SpectrumWidget::setPanFillEnabled(bool on)
+{
+    if (m_panFill == on) {
+        return;
+    }
+    m_panFill = on;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setFillAlpha(float a)
+{
+    a = qBound(0.0f, a, 1.0f);
+    if (qFuzzyCompare(m_fillAlpha, a)) {
+        return;
+    }
+    m_fillAlpha = a;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setLineWidth(float w)
+{
+    w = qBound(0.5f, w, 8.0f);
+    if (qFuzzyCompare(m_lineWidth, w)) {
+        return;
+    }
+    m_lineWidth = w;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setGradientEnabled(bool on)
+{
+    if (m_gradientEnabled == on) {
+        return;
+    }
+    m_gradientEnabled = on;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setDbmCalOffset(float db)
+{
+    db = qBound(-30.0f, db, 30.0f);
+    if (qFuzzyCompare(m_dbmCalOffset, db)) {
+        return;
+    }
+    m_dbmCalOffset = db;
+    scheduleSettingsSave();
+    update();
+}
+
+// Feed new FFT frame — apply averaging per current mode, track peak hold,
+// push waterfall row, repaint. From AetherSDR SpectrumWidget::updateSpectrum()
+// + gpu-waterfall.md:895-911. Averaging mode added in Phase 3G-8 commit 3.
 void SpectrumWidget::updateSpectrum(int receiverId, const QVector<float>& binsDbm)
 {
     Q_UNUSED(receiverId);
     m_bins = binsDbm;
 
-    // Exponential smoothing for spectrum trace
     if (m_smoothed.size() != binsDbm.size()) {
         m_smoothed = binsDbm;  // first frame: no smoothing
     } else {
-        for (int i = 0; i < binsDbm.size(); ++i) {
-            m_smoothed[i] = kSmoothAlpha * binsDbm[i]
-                          + (1.0f - kSmoothAlpha) * m_smoothed[i];
+        const float a = qBound(0.0f, m_averageAlpha, 1.0f);
+        switch (m_averageMode) {
+            case AverageMode::None:
+                m_smoothed = binsDbm;
+                break;
+            case AverageMode::Weighted:
+            default:
+                for (int i = 0; i < binsDbm.size(); ++i) {
+                    m_smoothed[i] = a * binsDbm[i] + (1.0f - a) * m_smoothed[i];
+                }
+                break;
+            case AverageMode::Logarithmic: {
+                // Log-domain recursive: Thetis "Log Recursive" mode.
+                // Mix in linear power space, then convert back to dB.
+                for (int i = 0; i < binsDbm.size(); ++i) {
+                    const float linNew = std::pow(10.0f, binsDbm[i] / 10.0f);
+                    const float linOld = std::pow(10.0f, m_smoothed[i] / 10.0f);
+                    const float mix    = a * linNew + (1.0f - a) * linOld;
+                    m_smoothed[i] = 10.0f * std::log10(mix > 0.0f ? mix : 1e-30f);
+                }
+                break;
+            }
+            case AverageMode::TimeWindow: {
+                // Approximated as a slower exponential — plan §7 notes
+                // this as a TODO for a true sliding time window.
+                const float slow = a * 0.33f;
+                for (int i = 0; i < binsDbm.size(); ++i) {
+                    m_smoothed[i] = slow * binsDbm[i]
+                                  + (1.0f - slow) * m_smoothed[i];
+                }
+                break;
+            }
+        }
+    }
+
+    // Peak hold: track per-bin maximum over the decay window.
+    if (m_peakHoldEnabled) {
+        if (m_peakHoldBins.size() != binsDbm.size()) {
+            m_peakHoldBins = binsDbm;
+        } else {
+            for (int i = 0; i < binsDbm.size(); ++i) {
+                if (binsDbm[i] > m_peakHoldBins[i]) {
+                    m_peakHoldBins[i] = binsDbm[i];
+                }
+            }
         }
     }
 
@@ -426,6 +619,11 @@ void SpectrumWidget::drawGrid(QPainter& p, const QRect& specRect)
 }
 
 // ---- Spectrum trace drawing ----
+// Phase 3G-8 commit 3: honors m_lineWidth, m_gradientEnabled,
+// m_peakHoldEnabled. See drawSpectrum() call site in paintEvent for
+// the QPainter fallback path. GPU path uses its own vertex generation
+// in renderGpuFrame() — line width and gradient wire-up there lands
+// in commit 5.
 void SpectrumWidget::drawSpectrum(QPainter& p, const QRect& specRect)
 {
     if (m_smoothed.isEmpty()) {
@@ -459,15 +657,45 @@ void SpectrumWidget::drawSpectrum(QPainter& p, const QRect& specRect)
         fillPath.lineTo(points.last().x(), specRect.bottom());
         fillPath.closeSubpath();
 
-        QColor fill = m_fillColor;
-        fill.setAlphaF(m_fillAlpha * 0.4f);  // softer fill
-        p.fillPath(fillPath, fill);
+        if (m_gradientEnabled) {
+            // Vertical gradient: transparent at baseline → fillColor at top.
+            QLinearGradient grad(QPointF(0, specRect.top()),
+                                 QPointF(0, specRect.bottom()));
+            QColor topCol = m_fillColor;
+            topCol.setAlphaF(qBound(0.0f, m_fillAlpha, 1.0f));
+            QColor botCol = m_fillColor;
+            botCol.setAlphaF(0.0f);
+            grad.setColorAt(0.0, topCol);
+            grad.setColorAt(1.0, botCol);
+            p.fillPath(fillPath, QBrush(grad));
+        } else {
+            QColor fill = m_fillColor;
+            fill.setAlphaF(m_fillAlpha * 0.4f);  // softer fill
+            p.fillPath(fillPath, fill);
+        }
+    }
+
+    // Peak hold trace underneath the main trace so the live line stays
+    // visually on top.
+    if (m_peakHoldEnabled && m_peakHoldBins.size() == m_smoothed.size()) {
+        QVector<QPointF> peakPoints(count);
+        for (int j = 0; j < count; ++j) {
+            float x = specRect.left() + static_cast<float>(j) * xStep;
+            float y = static_cast<float>(dbmToY(m_peakHoldBins[firstBin + j], specRect));
+            peakPoints[j] = QPointF(x, y);
+        }
+        QColor peakCol = m_fillColor;
+        peakCol.setAlphaF(0.55f);
+        QPen peakPen(peakCol, qMax(1.0f, m_lineWidth * 0.75f));
+        peakPen.setStyle(Qt::DotLine);
+        p.setPen(peakPen);
+        p.drawPolyline(peakPoints.data(), count);
     }
 
     // Draw trace line
     // From Thetis display.cs:2184 — data_line_color = Color.White
-    // We use the fill color for consistency with AetherSDR style
-    QPen tracePen(m_fillColor, 1.5);
+    // We use the fill color for consistency with AetherSDR style.
+    QPen tracePen(m_fillColor, m_lineWidth);
     p.setPen(tracePen);
     p.drawPolyline(points.data(), count);
 }
@@ -607,8 +835,11 @@ std::pair<int, int> SpectrumWidget::visibleBinRange(int binCount) const
 
 int SpectrumWidget::dbmToY(float dbm, const QRect& r) const
 {
+    // Phase 3G-8: apply display calibration offset before mapping to Y.
+    // From Thetis display.cs:1372 Display.RX1DisplayCalOffset.
+    const float calibrated = dbm + m_dbmCalOffset;
     float bottom = m_refLevel - m_dynamicRange;
-    float frac = (dbm - bottom) / m_dynamicRange;
+    float frac = (calibrated - bottom) / m_dynamicRange;
     frac = qBound(0.0f, frac, 1.0f);
     return r.bottom() - static_cast<int>(frac * r.height());
 }

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -528,7 +528,7 @@ void SpectrumWidget::setPanFillEnabled(bool on)
     }
     m_panFill = on;
     scheduleSettingsSave();
-    update();
+    update();  // vertex gen is next frame; render pass checks m_panFill
 }
 
 void SpectrumWidget::setFillAlpha(float a)
@@ -550,6 +550,8 @@ void SpectrumWidget::setLineWidth(float w)
     }
     m_lineWidth = w;
     scheduleSettingsSave();
+    // GPU pipeline line width is 1.0 at QRhi level (portable across
+    // backends); QPainter fallback path respects this immediately.
     update();
 }
 
@@ -560,7 +562,7 @@ void SpectrumWidget::setGradientEnabled(bool on)
     }
     m_gradientEnabled = on;
     scheduleSettingsSave();
-    update();
+    update();  // vertex gen next frame picks flat vs heatmap colours
 }
 
 void SpectrumWidget::setDbmCalOffset(float db)
@@ -571,7 +573,7 @@ void SpectrumWidget::setDbmCalOffset(float db)
     }
     m_dbmCalOffset = db;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();  // dBm scale strip labels shift
 }
 
 void SpectrumWidget::setFillColor(const QColor& c)
@@ -625,7 +627,7 @@ void SpectrumWidget::setWfOpacity(int percent)
     if (m_wfOpacity == percent) { return; }
     m_wfOpacity = percent;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setWfUpdatePeriodMs(int ms)
@@ -657,8 +659,20 @@ void SpectrumWidget::setWfTimestampPosition(TimestampPosition p)
 {
     if (m_wfTimestampPos == p) { return; }
     m_wfTimestampPos = p;
+    // Start/stop the 1 Hz overlay refresh timer so the clock ticks live.
+    if (p != TimestampPosition::None) {
+        if (!m_wfTimestampTicker) {
+            m_wfTimestampTicker = new QTimer(this);
+            m_wfTimestampTicker->setInterval(1000);
+            connect(m_wfTimestampTicker, &QTimer::timeout,
+                    this, [this]() { markOverlayDirty(); });
+        }
+        m_wfTimestampTicker->start();
+    } else if (m_wfTimestampTicker) {
+        m_wfTimestampTicker->stop();
+    }
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setWfTimestampMode(TimestampMode m)
@@ -666,7 +680,7 @@ void SpectrumWidget::setWfTimestampMode(TimestampMode m)
     if (m_wfTimestampMode == m) { return; }
     m_wfTimestampMode = m;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setShowRxFilterOnWaterfall(bool on)
@@ -674,7 +688,7 @@ void SpectrumWidget::setShowRxFilterOnWaterfall(bool on)
     if (m_showRxFilterOnWaterfall == on) { return; }
     m_showRxFilterOnWaterfall = on;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setShowTxFilterOnRxWaterfall(bool on)
@@ -682,7 +696,7 @@ void SpectrumWidget::setShowTxFilterOnRxWaterfall(bool on)
     if (m_showTxFilterOnRxWaterfall == on) { return; }
     m_showTxFilterOnRxWaterfall = on;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setShowRxZeroLineOnWaterfall(bool on)
@@ -690,7 +704,7 @@ void SpectrumWidget::setShowRxZeroLineOnWaterfall(bool on)
     if (m_showRxZeroLineOnWaterfall == on) { return; }
     m_showRxZeroLineOnWaterfall = on;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setShowTxZeroLineOnWaterfall(bool on)
@@ -698,7 +712,7 @@ void SpectrumWidget::setShowTxZeroLineOnWaterfall(bool on)
     if (m_showTxZeroLineOnWaterfall == on) { return; }
     m_showTxZeroLineOnWaterfall = on;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 // ---- Phase 3G-8 commit 5: grid / scales setters ----
@@ -708,7 +722,7 @@ void SpectrumWidget::setGridEnabled(bool on)
     if (m_gridEnabled == on) { return; }
     m_gridEnabled = on;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setShowZeroLine(bool on)
@@ -716,7 +730,7 @@ void SpectrumWidget::setShowZeroLine(bool on)
     if (m_showZeroLine == on) { return; }
     m_showZeroLine = on;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setShowFps(bool on)
@@ -727,7 +741,7 @@ void SpectrumWidget::setShowFps(bool on)
     m_fpsLastUpdateMs = 0;
     m_fpsDisplayValue = 0.0f;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setFreqLabelAlign(FreqLabelAlign a)
@@ -735,7 +749,7 @@ void SpectrumWidget::setFreqLabelAlign(FreqLabelAlign a)
     if (m_freqLabelAlign == a) { return; }
     m_freqLabelAlign = a;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setGridColor(const QColor& c)
@@ -743,7 +757,7 @@ void SpectrumWidget::setGridColor(const QColor& c)
     if (!c.isValid() || m_gridColor == c) { return; }
     m_gridColor = c;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setGridFineColor(const QColor& c)
@@ -751,7 +765,7 @@ void SpectrumWidget::setGridFineColor(const QColor& c)
     if (!c.isValid() || m_gridFineColor == c) { return; }
     m_gridFineColor = c;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setHGridColor(const QColor& c)
@@ -759,7 +773,7 @@ void SpectrumWidget::setHGridColor(const QColor& c)
     if (!c.isValid() || m_hGridColor == c) { return; }
     m_hGridColor = c;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setGridTextColor(const QColor& c)
@@ -767,7 +781,7 @@ void SpectrumWidget::setGridTextColor(const QColor& c)
     if (!c.isValid() || m_gridTextColor == c) { return; }
     m_gridTextColor = c;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setZeroLineColor(const QColor& c)
@@ -775,7 +789,7 @@ void SpectrumWidget::setZeroLineColor(const QColor& c)
     if (!c.isValid() || m_zeroLineColor == c) { return; }
     m_zeroLineColor = c;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 void SpectrumWidget::setBandEdgeColor(const QColor& c)
@@ -783,7 +797,7 @@ void SpectrumWidget::setBandEdgeColor(const QColor& c)
     if (!c.isValid() || m_bandEdgeColor == c) { return; }
     m_bandEdgeColor = c;
     scheduleSettingsSave();
-    update();
+    markOverlayDirty();
 }
 
 // Feed new FFT frame — apply averaging per current mode, track peak hold,
@@ -1156,7 +1170,26 @@ void SpectrumWidget::drawWaterfall(QPainter& p, const QRect& wfRect)
         p.setOpacity(savedOpacity);
     }
 
-    // ---- Overlays (full opacity) ----
+    drawWaterfallChrome(p, wfRect);
+}
+
+// Phase 3G-8 commit 10: waterfall chrome (filter/zero-line/timestamp
+// overlays + opacity dim) factored out of drawWaterfall() so the GPU
+// overlay texture can reuse it. Called with a full-opacity painter.
+void SpectrumWidget::drawWaterfallChrome(QPainter& p, const QRect& wfRect)
+{
+    // Opacity dim for the GPU path. The QPainter fallback path dims the
+    // waterfall image itself via p.setOpacity() before the blit; this
+    // dim overlay matches that visual effect on GPU where the waterfall
+    // texture is drawn at full alpha by the m_wfPipeline and the
+    // overlay texture is layered on top.
+#ifdef NEREUS_GPU_SPECTRUM
+    const int op = qBound(0, m_wfOpacity, 100);
+    if (op < 100) {
+        const int dimAlpha = 255 - static_cast<int>(255.0 * op / 100.0);
+        p.fillRect(wfRect, QColor(10, 10, 20, dimAlpha));
+    }
+#endif
 
     // RX filter passband as a translucent vertical band spanning the
     // waterfall height. Uses m_vfoHz + m_filterLowHz/m_filterHighHz.
@@ -2193,6 +2226,11 @@ void SpectrumWidget::initSpectrumPipeline()
                                  kMaxFftBins * 2 * kFftVertStride * sizeof(float));
     m_fftFillVbo->create();
 
+    // Phase 3G-8 commit 10: peak hold VBO (same layout as line VBO).
+    m_fftPeakVbo = r->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::VertexBuffer,
+                                 kMaxFftBins * kFftVertStride * sizeof(float));
+    m_fftPeakVbo->create();
+
     m_fftSrb = r->newShaderResourceBindings();
     m_fftSrb->setBindings({});
     m_fftSrb->create();
@@ -2368,6 +2406,39 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             drawVfoMarker(p, specRect, wfRect);
             drawOffScreenIndicator(p, specRect, wfRect);
 
+            // Phase 3G-8 commit 10: waterfall chrome (filter/zero line/
+            // timestamp/opacity dim) lands in the overlay texture on GPU
+            // so the same setters work in both paths. Overlay texture
+            // invalidation keys track every setter that feeds this plus
+            // VFO/filter changes via setVfoFrequency/setFilterOffset.
+            drawWaterfallChrome(p, wfRect);
+
+            // FPS overlay for GPU mode (QPainter path draws its own
+            // counter in paintEvent). Drawn into the cached overlay
+            // texture means it only updates on state changes or VFO
+            // tuning — good enough for a diagnostic counter and avoids
+            // re-uploading every frame.
+            if (m_showFps) {
+                const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+                m_fpsFrameCount++;
+                if (m_fpsLastUpdateMs == 0) {
+                    m_fpsLastUpdateMs = nowMs;
+                } else if (nowMs - m_fpsLastUpdateMs >= 1000) {
+                    const double elapsed = (nowMs - m_fpsLastUpdateMs) / 1000.0;
+                    m_fpsDisplayValue = static_cast<float>(m_fpsFrameCount / elapsed);
+                    m_fpsFrameCount   = 0;
+                    m_fpsLastUpdateMs = nowMs;
+                }
+                const QString fpsText =
+                    QStringLiteral("%1 fps").arg(m_fpsDisplayValue, 0, 'f', 1);
+                QFont ff = p.font();
+                ff.setPixelSize(11);
+                p.setFont(ff);
+                p.setPen(m_gridTextColor);
+                const int tw = p.fontMetrics().horizontalAdvance(fpsText);
+                p.drawText(specRect.right() - tw - 8, specRect.top() + 14, fpsText);
+            }
+
             // Cursor info
             if (m_mouseInWidget) {
                 drawCursorInfo(p, specRect);
@@ -2385,17 +2456,29 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
     }
 
     // ---- FFT spectrum vertices ----
+    // Phase 3G-8 commit 10: the vertex generation now honours:
+    //   - m_dbmCalOffset (shifts every bin's dBm before y mapping)
+    //   - m_gradientEnabled (off = flat m_fillColor, on = heatmap)
+    //   - m_panFill (skips fill VBO update when disabled)
+    //   - m_fillColor / m_fillAlpha (used for the flat-fill path)
+    //   - m_peakHoldEnabled (generates a second line VBO for peak hold)
     if (!m_smoothed.isEmpty() && m_fftLineVbo && m_fftFillVbo) {
         auto [firstBin, lastBin] = visibleBinRange(m_smoothed.size());
         const int count = lastBin - firstBin + 1;
         const int n = qMin(count, kMaxFftBins);
         m_visibleBinCount = n;
         const float minDbm = m_refLevel - m_dynamicRange;
-        const float range = m_dynamicRange;
+        const float range  = m_dynamicRange;
         const float yBot = -1.0f;
         const float yTop = 1.0f;
 
         const float fa = m_fillAlpha;
+        const float cal = m_dbmCalOffset;
+
+        // Flat-mode colour picked from m_fillColor.
+        const float flatR = m_fillColor.redF();
+        const float flatG = m_fillColor.greenF();
+        const float flatB = m_fillColor.blueF();
 
         QVector<float> lineVerts(n * kFftVertStride);
         QVector<float> fillVerts(n * 2 * kFftVertStride);
@@ -2403,24 +2486,28 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         for (int j = 0; j < n; ++j) {
             int i = firstBin + j;
             float x = (n > 1) ? 2.0f * j / (n - 1) - 1.0f : 0.0f;
-            float t = qBound(0.0f, (m_smoothed[i] - minDbm) / range, 1.0f);
+            float t = qBound(0.0f, ((m_smoothed[i] + cal) - minDbm) / range, 1.0f);
             float y = yBot + t * (yTop - yBot);
 
-            // Heat map: blue → cyan → green → yellow → red
-            // From AetherSDR SpectrumWidget.cpp:2298-2310
             float cr, cg, cb2;
-            if (t < 0.25f) {
-                float s = t / 0.25f;
-                cr = 0.0f; cg = s; cb2 = 1.0f;
-            } else if (t < 0.5f) {
-                float s = (t - 0.25f) / 0.25f;
-                cr = 0.0f; cg = 1.0f; cb2 = 1.0f - s;
-            } else if (t < 0.75f) {
-                float s = (t - 0.5f) / 0.25f;
-                cr = s; cg = 1.0f; cb2 = 0.0f;
+            if (m_gradientEnabled) {
+                // Heat map: blue → cyan → green → yellow → red
+                // From AetherSDR SpectrumWidget.cpp:2298-2310
+                if (t < 0.25f) {
+                    float s = t / 0.25f;
+                    cr = 0.0f; cg = s; cb2 = 1.0f;
+                } else if (t < 0.5f) {
+                    float s = (t - 0.25f) / 0.25f;
+                    cr = 0.0f; cg = 1.0f; cb2 = 1.0f - s;
+                } else if (t < 0.75f) {
+                    float s = (t - 0.5f) / 0.25f;
+                    cr = s; cg = 1.0f; cb2 = 0.0f;
+                } else {
+                    float s = (t - 0.75f) / 0.25f;
+                    cr = 1.0f; cg = 1.0f - s; cb2 = 0.0f;
+                }
             } else {
-                float s = (t - 0.75f) / 0.25f;
-                cr = 1.0f; cg = 1.0f - s; cb2 = 0.0f;
+                cr = flatR; cg = flatG; cb2 = flatB;
             }
 
             // Line vertex
@@ -2432,7 +2519,7 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             lineVerts[li + 4] = cb2;
             lineVerts[li + 5] = 0.9f;
 
-            // Fill vertices (top at signal, bottom at base)
+            // Fill vertices (top at signal, bottom at base).
             int fi = j * 2 * kFftVertStride;
             fillVerts[fi]     = x;
             fillVerts[fi + 1] = y;
@@ -2452,6 +2539,32 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
             n * kFftVertStride * sizeof(float), lineVerts.constData());
         batch->updateDynamicBuffer(m_fftFillVbo, 0,
             n * 2 * kFftVertStride * sizeof(float), fillVerts.constData());
+
+        // Peak hold VBO lives alongside the line VBO — generated here,
+        // drawn in the render pass after the main line. When peak hold
+        // is off we leave the buffer stale and skip the draw call via
+        // m_peakHoldHasData.
+        m_peakHoldHasData = false;
+        if (m_peakHoldEnabled && m_peakHoldBins.size() == m_smoothed.size()
+            && m_fftPeakVbo) {
+            QVector<float> peakVerts(n * kFftVertStride);
+            for (int j = 0; j < n; ++j) {
+                int i = firstBin + j;
+                float x = (n > 1) ? 2.0f * j / (n - 1) - 1.0f : 0.0f;
+                float t = qBound(0.0f, ((m_peakHoldBins[i] + cal) - minDbm) / range, 1.0f);
+                float y = yBot + t * (yTop - yBot);
+                int li = j * kFftVertStride;
+                peakVerts[li]     = x;
+                peakVerts[li + 1] = y;
+                peakVerts[li + 2] = flatR;
+                peakVerts[li + 3] = flatG;
+                peakVerts[li + 4] = flatB;
+                peakVerts[li + 5] = 0.55f;
+            }
+            batch->updateDynamicBuffer(m_fftPeakVbo, 0,
+                n * kFftVertStride * sizeof(float), peakVerts.constData());
+            m_peakHoldHasData = true;
+        }
     }
 
     cb->resourceUpdate(batch);
@@ -2485,13 +2598,25 @@ void SpectrumWidget::renderGpuFrame(QRhiCommandBuffer* cb)
         float specVpH = static_cast<float>(specRect.height()) * dpr;
         QRhiViewport specVp(specVpX, specVpY, specVpW, specVpH);
 
-        // Fill pass
-        cb->setGraphicsPipeline(m_fftFillPipeline);
-        cb->setShaderResources(m_fftSrb);
-        cb->setViewport(specVp);
-        const QRhiCommandBuffer::VertexInput fillVbuf(m_fftFillVbo, 0);
-        cb->setVertexInput(0, 1, &fillVbuf);
-        cb->draw(m_visibleBinCount * 2);
+        // Fill pass — Phase 3G-8 commit 10: skip when fill is disabled.
+        if (m_panFill) {
+            cb->setGraphicsPipeline(m_fftFillPipeline);
+            cb->setShaderResources(m_fftSrb);
+            cb->setViewport(specVp);
+            const QRhiCommandBuffer::VertexInput fillVbuf(m_fftFillVbo, 0);
+            cb->setVertexInput(0, 1, &fillVbuf);
+            cb->draw(m_visibleBinCount * 2);
+        }
+
+        // Peak hold line (drawn before main line so live trace is on top).
+        if (m_peakHoldHasData && m_fftPeakVbo) {
+            cb->setGraphicsPipeline(m_fftLinePipeline);
+            cb->setShaderResources(m_fftSrb);
+            cb->setViewport(specVp);
+            const QRhiCommandBuffer::VertexInput peakVbuf(m_fftPeakVbo, 0);
+            cb->setVertexInput(0, 1, &peakVbuf);
+            cb->draw(m_visibleBinCount);
+        }
 
         // Line pass
         cb->setGraphicsPipeline(m_fftLinePipeline);
@@ -2543,6 +2668,7 @@ void SpectrumWidget::releaseResources()
     delete m_fftSrb;           m_fftSrb = nullptr;
     delete m_fftLineVbo;       m_fftLineVbo = nullptr;
     delete m_fftFillVbo;       m_fftFillVbo = nullptr;
+    delete m_fftPeakVbo;       m_fftPeakVbo = nullptr;
 
     m_rhiInitialized = false;
 }

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -113,8 +113,11 @@ public:
 
     // ---- Waterfall settings ----
     void setWfColorScheme(WfColorScheme scheme);
+    WfColorScheme wfColorScheme() const { return m_wfColorScheme; }
     void setWfColorGain(int gain) { m_wfColorGain = gain; }
+    int  wfColorGain() const { return m_wfColorGain; }
     void setWfBlackLevel(int level) { m_wfBlackLevel = level; }
+    int  wfBlackLevel() const { return m_wfBlackLevel; }
 
     // ---- Spectrum renderer controls (Phase 3G-8 commit 3) ----
 

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -139,6 +139,49 @@ public:
     void setDbmCalOffset(float db);
     float dbmCalOffset() const { return m_dbmCalOffset; }
 
+    // ---- Waterfall renderer controls (Phase 3G-8 commit 4) ----
+
+    void setWfHighThreshold(float dbm);
+    float wfHighThreshold() const { return m_wfHighThreshold; }
+    void setWfLowThreshold(float dbm);
+    float wfLowThreshold() const { return m_wfLowThreshold; }
+    void setWfAgcEnabled(bool on);
+    bool wfAgcEnabled() const { return m_wfAgcEnabled; }
+    void setWfReverseScroll(bool on);
+    bool wfReverseScroll() const { return m_wfReverseScroll; }
+    void setWfOpacity(int percent);          // 0..100
+    int  wfOpacity() const { return m_wfOpacity; }
+    void setWfUpdatePeriodMs(int ms);
+    int  wfUpdatePeriodMs() const { return m_wfUpdatePeriodMs; }
+
+    // Ported from setup.cs:7801 Display.WaterfallUseRX1SpectrumMinMax.
+    void setWfUseSpectrumMinMax(bool on);
+    bool wfUseSpectrumMinMax() const { return m_wfUseSpectrumMinMax; }
+
+    // Ported from setup.designer.cs:34428 comboDispWFAveraging / AverageModeWF.
+    void setWfAverageMode(AverageMode m);
+    AverageMode wfAverageMode() const { return m_wfAverageMode; }
+
+    // Timestamp overlay (NereusSDR extensions W8/W9).
+    enum class TimestampPosition : int { None = 0, Left, Right, Count };
+    enum class TimestampMode     : int { UTC = 0, Local, Count };
+    void setWfTimestampPosition(TimestampPosition p);
+    TimestampPosition wfTimestampPosition() const { return m_wfTimestampPos; }
+    void setWfTimestampMode(TimestampMode m);
+    TimestampMode wfTimestampMode() const { return m_wfTimestampMode; }
+
+    // Filter / zero-line overlays on the waterfall.
+    // From setup.cs:1048-1052 Display.ShowRXFilterOnWaterfall / ShowTXFilterOnRXWaterfall
+    // / ShowRXZeroLineOnWaterfall / ShowTXZeroLineOnWaterfall.
+    void setShowRxFilterOnWaterfall(bool on);
+    bool showRxFilterOnWaterfall() const { return m_showRxFilterOnWaterfall; }
+    void setShowTxFilterOnRxWaterfall(bool on);
+    bool showTxFilterOnRxWaterfall() const { return m_showTxFilterOnRxWaterfall; }
+    void setShowRxZeroLineOnWaterfall(bool on);
+    bool showRxZeroLineOnWaterfall() const { return m_showRxZeroLineOnWaterfall; }
+    void setShowTxZeroLineOnWaterfall(bool on);
+    bool showTxZeroLineOnWaterfall() const { return m_showTxZeroLineOnWaterfall; }
+
     // ---- Per-pan settings persistence ----
     void setPanIndex(int idx) { m_panIndex = idx; }
     int  panIndex() const { return m_panIndex; }
@@ -281,6 +324,32 @@ private:
 
     // Ported from Thetis Display.RX1DisplayCalOffset (display.cs:1372).
     float       m_dbmCalOffset{0.0f};
+
+    // ---- Phase 3G-8 commit 4: waterfall renderer state ----
+
+    bool  m_wfAgcEnabled{false};
+    bool  m_wfReverseScroll{false};
+    int   m_wfOpacity{100};           // 0..100
+    int   m_wfUpdatePeriodMs{50};     // NereusSDR default per §10 divergence
+    bool  m_wfUseSpectrumMinMax{false};
+    AverageMode m_wfAverageMode{AverageMode::None};
+    QVector<float> m_wfSmoothedBins;  // for wf averaging mode
+
+    TimestampPosition m_wfTimestampPos{TimestampPosition::None};
+    TimestampMode     m_wfTimestampMode{TimestampMode::UTC};
+
+    bool  m_showRxFilterOnWaterfall{false};
+    bool  m_showTxFilterOnRxWaterfall{false};
+    bool  m_showRxZeroLineOnWaterfall{false};
+    bool  m_showTxZeroLineOnWaterfall{false};
+
+    // AGC rolling envelope (tracked across waterfall rows).
+    float m_wfAgcRunMin{0.0f};
+    float m_wfAgcRunMax{0.0f};
+    bool  m_wfAgcPrimed{false};
+
+    // Rate-limit waterfall pushes per m_wfUpdatePeriodMs.
+    qint64 m_wfLastPushMs{0};
 
     // ---- VFO / filter overlay ----
     double m_vfoHz{0.0};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -157,6 +157,12 @@ public:
     void setDbmCalOffset(float db);
     float dbmCalOffset() const { return m_dbmCalOffset; }
 
+    // Trace colour (Phase 3G-8 commit 6 wiring). Single colour used for
+    // both the line and the fill in the current renderer; plan §6 S11/S13
+    // track splitting these if needed by future UI polish.
+    void setFillColor(const QColor& c);
+    QColor fillColor() const { return m_fillColor; }
+
     // ---- Waterfall renderer controls (Phase 3G-8 commit 4) ----
 
     void setWfHighThreshold(float dbm);

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -301,6 +301,12 @@ private:
     void drawGrid(QPainter& p, const QRect& specRect);
     void drawSpectrum(QPainter& p, const QRect& specRect);
     void drawWaterfall(QPainter& p, const QRect& wfRect);
+    // Phase 3G-8 commit 10: overlay-only waterfall chrome (filter bands,
+    // zero lines, timestamp, opacity dim) split out so the GPU overlay
+    // texture can render the same chrome without blitting the waterfall
+    // image. Called from drawWaterfall() on the QPainter fallback path
+    // and from the GPU overlay build step.
+    void drawWaterfallChrome(QPainter& p, const QRect& wfRect);
     void drawFreqScale(QPainter& p, const QRect& r);
     void drawDbmScale(QPainter& p, const QRect& specRect);
     void drawVfoMarker(QPainter& p, const QRect& specRect, const QRect& wfRect);
@@ -408,6 +414,10 @@ private:
 
     // Rate-limit waterfall pushes per m_wfUpdatePeriodMs.
     qint64 m_wfLastPushMs{0};
+
+    // 1 Hz overlay repaint tick for the waterfall timestamp; started on
+    // demand when the user selects a non-None timestamp position.
+    QTimer* m_wfTimestampTicker{nullptr};
 
     // ---- Phase 3G-8 commit 5: grid / scales renderer state ----
 
@@ -524,16 +534,28 @@ private:
     QRhiShaderResourceBindings* m_fftSrb{nullptr};
     QRhiBuffer*                 m_fftLineVbo{nullptr};
     QRhiBuffer*                 m_fftFillVbo{nullptr};
+    // Phase 3G-8 commit 10: peak hold VBO — same layout as line VBO,
+    // generated only when peak hold is enabled. m_peakHoldHasData is
+    // false between peak decay resets so we skip the draw call.
+    QRhiBuffer*                 m_fftPeakVbo{nullptr};
+    bool                        m_peakHoldHasData{false};
     // From AetherSDR: kMaxFftBins = 8192, kFftVertStride = 6
     static constexpr int kMaxFftBins = 65536;
     static constexpr int kFftVertStride = 6;  // x, y, r, g, b, a
     int m_visibleBinCount{0};  // bins rendered this frame (for draw call count)
 
+#endif
+
+    // Invalidate the GPU-path cached overlay texture so grid, labels,
+    // dBm scale, waterfall filter/zero-line/timestamp overlays, and
+    // other QPainter-drawn chrome re-render on next frame. Safe no-op
+    // when the GPU path is disabled.
     void markOverlayDirty() {
+#ifdef NEREUS_GPU_SPECTRUM
         m_overlayStaticDirty = true;
+#endif
         update();
     }
-#endif
 };
 
 } // namespace NereusSDR

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -37,6 +37,20 @@ enum class WfColorScheme : int {
     Count
 };
 
+// Spectrum averaging mode. Ported from Thetis comboDispPanAveraging
+// (setup.designer.cs:34835, target console.specRX.GetSpecRX(0).AverageMode).
+// Thetis options: None / Recursive / Time Window / Log Recursive.
+// NereusSDR names: None / Weighted / TimeWindow / Logarithmic — the
+// previous single smoothing behavior (kSmoothAlpha * new + (1-a) * prev)
+// corresponds to Weighted.
+enum class AverageMode : int {
+    None = 0,        // pass frame through unchanged
+    Weighted,        // kSmoothAlpha exponential (current NereusSDR behavior)
+    Logarithmic,     // log-domain exponential (matches Thetis Log Recursive)
+    TimeWindow,      // approximated as slower exponential for now
+    Count
+};
+
 // Gradient stop for waterfall color mapping.
 struct WfGradientStop { float pos; int r, g, b; };
 
@@ -83,6 +97,47 @@ public:
     void setWfColorScheme(WfColorScheme scheme);
     void setWfColorGain(int gain) { m_wfColorGain = gain; }
     void setWfBlackLevel(int level) { m_wfBlackLevel = level; }
+
+    // ---- Spectrum renderer controls (Phase 3G-8 commit 3) ----
+
+    // Averaging mode applied in updateSpectrum() before drawing.
+    void setAverageMode(AverageMode m);
+    AverageMode averageMode() const { return m_averageMode; }
+
+    // Smoothing time constant for Weighted / Logarithmic / TimeWindow.
+    // 0.0 = no smoothing, 1.0 = infinite smoothing. Default kSmoothAlpha.
+    void setAverageAlpha(float alpha);
+    float averageAlpha() const { return m_averageAlpha; }
+
+    // Peak hold: track per-bin max, decay after delay.
+    void setPeakHoldEnabled(bool on);
+    bool peakHoldEnabled() const { return m_peakHoldEnabled; }
+    void setPeakHoldDelayMs(int ms);
+    int  peakHoldDelayMs() const { return m_peakHoldDelayMs; }
+
+    // Trace fill (under-the-curve shaded region).
+    void setPanFillEnabled(bool on);
+    bool panFillEnabled() const { return m_panFill; }
+    void setFillAlpha(float a);       // 0.0 .. 1.0
+    float fillAlpha() const { return m_fillAlpha; }
+
+    // Trace line width (QPainter pen width). GPU path uses line list
+    // default width until commit 5 renderer additions.
+    void setLineWidth(float w);
+    float lineWidth() const { return m_lineWidth; }
+
+    // Trace gradient: when enabled, the QPainter fill gradient ramps
+    // from transparent at baseline to the fill color at the trace,
+    // and the trace uses a vertical color gradient. GPU path keeps
+    // its existing per-vertex heatmap coloring (wire-up in commit 5).
+    void setGradientEnabled(bool on);
+    bool gradientEnabled() const { return m_gradientEnabled; }
+
+    // Display calibration offset added to every bin before it's mapped
+    // to screen Y. Ported from Thetis Display.RX1DisplayCalOffset
+    // (display.cs:1372). Range: -30 .. +30 dB.
+    void setDbmCalOffset(float db);
+    float dbmCalOffset() const { return m_dbmCalOffset; }
 
     // ---- Per-pan settings persistence ----
     void setPanIndex(int idx) { m_panIndex = idx; }
@@ -210,6 +265,22 @@ private:
     QColor m_fillColor{0x00, 0xe5, 0xff};  // cyan
     float  m_fillAlpha{0.70f};
     bool   m_panFill{true};
+
+    // ---- Phase 3G-8 commit 3: spectrum renderer state ----
+
+    AverageMode m_averageMode{AverageMode::Weighted};
+    float       m_averageAlpha{kSmoothAlpha};  // 0..1 exp-smoothing factor
+
+    bool        m_peakHoldEnabled{false};
+    int         m_peakHoldDelayMs{2000};
+    QVector<float> m_peakHoldBins;
+    QTimer*     m_peakHoldDecayTimer{nullptr};
+
+    float       m_lineWidth{1.5f};
+    bool        m_gradientEnabled{false};
+
+    // Ported from Thetis Display.RX1DisplayCalOffset (display.cs:1372).
+    float       m_dbmCalOffset{0.0f};
 
     // ---- VFO / filter overlay ----
     double m_vfoHz{0.0};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -28,12 +28,30 @@ class VfoWidget;
 
 // Waterfall color scheme presets.
 // Default matches AetherSDR/SmartSDR style.
-// From Thetis enums.cs:68-79 (ColorScheme enum)
+// From Thetis enums.cs:68-79 (ColorScheme enum). Expanded 4 → 7 in
+// Phase 3G-8 commit 5 (plan §7 W17 waterfall colour schemes expansion).
 enum class WfColorScheme : int {
     Default = 0,    // AetherSDR: black → blue → cyan → green → yellow → red
     Enhanced,       // Thetis enhanced (9-band progression)
     Spectran,       // SPECTRAN
     BlackWhite,     // Grayscale
+    LinLog,         // Linear in low, log in high — Thetis LinLog
+    LinRad,         // Linradiance-style cool → hot
+    Custom,         // User-defined custom stops (reads from AppSettings)
+    Count
+};
+
+// Frequency label alignment for the bottom scale bar.
+// From Thetis comboDisplayLabelAlign (setup.designer.cs:34635).
+// Thetis exposes 5 options (Left/Center/Right/Auto/Off); NereusSDR
+// Phase 3G-8 commit 5 expands the previous 2-mode implementation to
+// match.
+enum class FreqLabelAlign : int {
+    Left = 0,
+    Center,
+    Right,
+    Auto,   // centered when room, otherwise left
+    Off,    // suppress frequency labels entirely
     Count
 };
 
@@ -181,6 +199,37 @@ public:
     bool showRxZeroLineOnWaterfall() const { return m_showRxZeroLineOnWaterfall; }
     void setShowTxZeroLineOnWaterfall(bool on);
     bool showTxZeroLineOnWaterfall() const { return m_showTxZeroLineOnWaterfall; }
+
+    // ---- Grid / scales renderer controls (Phase 3G-8 commit 5) ----
+
+    void setGridEnabled(bool on);
+    bool gridEnabled() const { return m_gridEnabled; }
+
+    void setShowZeroLine(bool on);
+    bool showZeroLine() const { return m_showZeroLine; }
+
+    void setShowFps(bool on);
+    bool showFps() const { return m_showFps; }
+
+    void setFreqLabelAlign(FreqLabelAlign a);
+    FreqLabelAlign freqLabelAlign() const { return m_freqLabelAlign; }
+
+    // Configurable grid/text/zero-line/band-edge colours. Previously
+    // hardcoded. Ported from Thetis setup.cs:1040-1044 Display.GridColor
+    // / GridPenDark / HGridColor / GridTextColor / GridZeroColor and
+    // display.cs:1941 BandEdgeColor.
+    void setGridColor(const QColor& c);
+    QColor gridColor() const { return m_gridColor; }
+    void setGridFineColor(const QColor& c);
+    QColor gridFineColor() const { return m_gridFineColor; }
+    void setHGridColor(const QColor& c);
+    QColor hGridColor() const { return m_hGridColor; }
+    void setGridTextColor(const QColor& c);
+    QColor gridTextColor() const { return m_gridTextColor; }
+    void setZeroLineColor(const QColor& c);
+    QColor zeroLineColor() const { return m_zeroLineColor; }
+    void setBandEdgeColor(const QColor& c);
+    QColor bandEdgeColor() const { return m_bandEdgeColor; }
 
     // ---- Per-pan settings persistence ----
     void setPanIndex(int idx) { m_panIndex = idx; }
@@ -350,6 +399,25 @@ private:
 
     // Rate-limit waterfall pushes per m_wfUpdatePeriodMs.
     qint64 m_wfLastPushMs{0};
+
+    // ---- Phase 3G-8 commit 5: grid / scales renderer state ----
+
+    bool  m_gridEnabled{true};
+    bool  m_showZeroLine{false};
+    bool  m_showFps{false};
+    FreqLabelAlign m_freqLabelAlign{FreqLabelAlign::Center};
+
+    QColor m_gridColor{255, 255, 255, 40};       // vertical freq grid
+    QColor m_gridFineColor{255, 255, 255, 20};   // 1/5 step fine grid
+    QColor m_hGridColor{255, 255, 255, 40};      // horizontal dBm grid
+    QColor m_gridTextColor{255, 255, 0};         // yellow text default
+    QColor m_zeroLineColor{255, 0, 0};           // red default (Thetis)
+    QColor m_bandEdgeColor{255, 0, 0};           // red default (Thetis)
+
+    // FPS overlay tracking
+    int    m_fpsFrameCount{0};
+    qint64 m_fpsLastUpdateMs{0};
+    float  m_fpsDisplayValue{0.0f};
 
     // ---- VFO / filter overlay ----
     double m_vfoHz{0.0};

--- a/src/gui/meters/BandButtonItem.cpp
+++ b/src/gui/meters/BandButtonItem.cpp
@@ -2,10 +2,13 @@
 
 namespace NereusSDR {
 
-// From Thetis clsBandButtonBox (MeterManager.cs:11482+)
+// From Thetis clsBandButtonBox (MeterManager.cs:11482+).
+// Order matches NereusSDR::Band enum (src/models/Band.h) — keep in sync
+// when adding/reordering bands. WWV and XVTR added in Phase 3G-8 commit 2.
 static const char* const kBandLabels[] = {
     "160m", "80m", "60m", "40m", "30m", "20m",
-    "17m", "15m", "12m", "10m", "6m", "GEN"
+    "17m",  "15m", "12m", "10m", "6m",  "GEN",
+    "WWV",  "XVTR"
 };
 
 BandButtonItem::BandButtonItem(QObject* parent)

--- a/src/gui/meters/BandButtonItem.h
+++ b/src/gui/meters/BandButtonItem.h
@@ -4,8 +4,15 @@
 
 namespace NereusSDR {
 
-// Band selection grid: 160m-6m + GEN.
+// Band selection grid: 160m-6m + GEN + WWV + XVTR.
 // Ported from Thetis clsBandButtonBox (MeterManager.cs:11482+).
+//
+// Button order matches NereusSDR::Band enum (src/models/Band.h): index 0 =
+// 160m ... index 11 = GEN, index 12 = WWV, index 13 = XVTR. WWV and XVTR
+// were added in Phase 3G-8 (commit 2) to match Thetis's 14-band set and
+// to provide a home for the per-band grid storage on PanadapterModel.
+// The bandClicked(int) signal carries the same enum index; consumers
+// should use Band::bandFromUiIndex() to convert.
 class BandButtonItem : public ButtonBoxItem {
     Q_OBJECT
 
@@ -27,7 +34,7 @@ signals:
 private:
     void onButtonClicked(int index, Qt::MouseButton button);
     int m_activeBand{-1};
-    static constexpr int kBandCount = 12;
+    static constexpr int kBandCount = 14;
 };
 
 } // namespace NereusSDR

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -395,6 +395,46 @@ WaterfallDefaultsPage::WaterfallDefaultsPage(RadioModel* model, QWidget* parent)
     : SetupPage(QStringLiteral("Waterfall Defaults"), model, parent)
 {
     buildUI();
+    loadFromRenderer();
+}
+
+void WaterfallDefaultsPage::loadFromRenderer()
+{
+    auto* sw = model() ? model()->spectrumWidget() : nullptr;
+    if (!sw) { return; }
+    QSignalBlocker b1(m_highThresholdSlider);
+    QSignalBlocker b2(m_lowThresholdSlider);
+    QSignalBlocker b3(m_agcToggle);
+    QSignalBlocker b4(m_useSpectrumMinMaxToggle);
+    QSignalBlocker b5(m_updatePeriodSlider);
+    QSignalBlocker b6(m_reverseToggle);
+    QSignalBlocker b7(m_opacitySlider);
+    QSignalBlocker b8(m_colorSchemeCombo);
+    QSignalBlocker b9(m_wfAveragingCombo);
+    QSignalBlocker b10(m_showRxFilterToggle);
+    QSignalBlocker b11(m_showTxFilterToggle);
+    QSignalBlocker b12(m_showRxZeroLineToggle);
+    QSignalBlocker b13(m_showTxZeroLineToggle);
+    QSignalBlocker b14(m_timestampPosCombo);
+    QSignalBlocker b15(m_timestampModeCombo);
+
+    m_highThresholdSlider->setValue(static_cast<int>(sw->wfHighThreshold()));
+    m_lowThresholdSlider->setValue(static_cast<int>(sw->wfLowThreshold()));
+    m_agcToggle->setChecked(sw->wfAgcEnabled());
+    m_useSpectrumMinMaxToggle->setChecked(sw->wfUseSpectrumMinMax());
+    m_updatePeriodSlider->setValue(sw->wfUpdatePeriodMs());
+    m_reverseToggle->setChecked(sw->wfReverseScroll());
+    m_opacitySlider->setValue(sw->wfOpacity());
+    m_colorSchemeCombo->setCurrentIndex(static_cast<int>(sw->wfColorScheme()));
+    m_wfAveragingCombo->setCurrentIndex(static_cast<int>(sw->wfAverageMode()));
+    m_showRxFilterToggle->setChecked(sw->showRxFilterOnWaterfall());
+    m_showTxFilterToggle->setChecked(sw->showTxFilterOnRxWaterfall());
+    m_showRxZeroLineToggle->setChecked(sw->showRxZeroLineOnWaterfall());
+    m_showTxZeroLineToggle->setChecked(sw->showTxZeroLineOnWaterfall());
+    m_timestampPosCombo->setCurrentIndex(static_cast<int>(sw->wfTimestampPosition()));
+    m_timestampModeCombo->setCurrentIndex(static_cast<int>(sw->wfTimestampMode()));
+
+    if (m_lowColorBtn) { m_lowColorBtn->setColor(QColor(Qt::black)); }
 }
 
 void WaterfallDefaultsPage::buildUI()
@@ -409,21 +449,48 @@ void WaterfallDefaultsPage::buildUI()
     m_highThresholdSlider = new QSlider(Qt::Horizontal, levGroup);
     m_highThresholdSlider->setRange(-200, 0);
     m_highThresholdSlider->setValue(-40);
-    m_highThresholdSlider->setEnabled(false);  // NYI
-    m_highThresholdSlider->setToolTip(QStringLiteral("Waterfall high threshold — not yet implemented"));
+    connect(m_highThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfHighThreshold(static_cast<float>(v));
+        }
+    });
     levForm->addRow(QStringLiteral("High Threshold:"), m_highThresholdSlider);
 
     m_lowThresholdSlider = new QSlider(Qt::Horizontal, levGroup);
     m_lowThresholdSlider->setRange(-200, 0);
     m_lowThresholdSlider->setValue(-130);
-    m_lowThresholdSlider->setEnabled(false);  // NYI
-    m_lowThresholdSlider->setToolTip(QStringLiteral("Waterfall low threshold — not yet implemented"));
+    connect(m_lowThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfLowThreshold(static_cast<float>(v));
+        }
+    });
     levForm->addRow(QStringLiteral("Low Threshold:"), m_lowThresholdSlider);
 
     m_agcToggle = new QCheckBox(QStringLiteral("AGC"), levGroup);
-    m_agcToggle->setEnabled(false);  // NYI
-    m_agcToggle->setToolTip(QStringLiteral("Waterfall AGC — not yet implemented"));
+    connect(m_agcToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfAgcEnabled(on);
+        }
+    });
     levForm->addRow(QString(), m_agcToggle);
+
+    m_useSpectrumMinMaxToggle = new QCheckBox(QStringLiteral("Use spectrum min/max"), levGroup);
+    connect(m_useSpectrumMinMaxToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfUseSpectrumMinMax(on);
+        }
+    });
+    levForm->addRow(QString(), m_useSpectrumMinMaxToggle);
+
+    m_lowColorBtn = new ColorSwatchButton(QColor(Qt::black), levGroup);
+    // Waterfall "low" colour is conceptually the 0.0 stop of the gradient —
+    // exposed here for plan §4.2 W10 parity. SpectrumWidget currently uses
+    // gradient tables from wfSchemeStops() so the user's custom value is
+    // recorded in AppSettings for future Custom-scheme wiring, but it does
+    // not rebuild the gradient on the fly yet.
+    connect(m_lowColorBtn, &ColorSwatchButton::colorChanged,
+            this, [](const QColor&) { /* stored via AppSettings on save */ });
+    levForm->addRow(QStringLiteral("Low Color:"), m_lowColorBtn);
 
     contentLayout()->addWidget(levGroup);
 
@@ -435,30 +502,100 @@ void WaterfallDefaultsPage::buildUI()
     m_updatePeriodSlider = new QSlider(Qt::Horizontal, dispGroup);
     m_updatePeriodSlider->setRange(10, 500);
     m_updatePeriodSlider->setValue(50);
-    m_updatePeriodSlider->setEnabled(false);  // NYI
-    m_updatePeriodSlider->setToolTip(QStringLiteral("Waterfall update period (ms) — not yet implemented"));
+    connect(m_updatePeriodSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfUpdatePeriodMs(v);
+        }
+    });
     dispForm->addRow(QStringLiteral("Update Period (ms):"), m_updatePeriodSlider);
 
     m_reverseToggle = new QCheckBox(QStringLiteral("Reverse scroll"), dispGroup);
-    m_reverseToggle->setEnabled(false);  // NYI
-    m_reverseToggle->setToolTip(QStringLiteral("Reverse waterfall scroll direction — not yet implemented"));
+    connect(m_reverseToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfReverseScroll(on);
+        }
+    });
     dispForm->addRow(QString(), m_reverseToggle);
 
     m_opacitySlider = new QSlider(Qt::Horizontal, dispGroup);
     m_opacitySlider->setRange(0, 100);
     m_opacitySlider->setValue(100);
-    m_opacitySlider->setEnabled(false);  // NYI
-    m_opacitySlider->setToolTip(QStringLiteral("Waterfall opacity — not yet implemented"));
+    connect(m_opacitySlider, &QSlider::valueChanged, this, [this](int v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfOpacity(v);
+        }
+    });
     dispForm->addRow(QStringLiteral("Opacity:"), m_opacitySlider);
 
     m_colorSchemeCombo = new QComboBox(dispGroup);
-    m_colorSchemeCombo->addItems({QStringLiteral("Enhanced"), QStringLiteral("Grayscale"),
-                                  QStringLiteral("Spectrum")});
-    m_colorSchemeCombo->setEnabled(false);  // NYI
-    m_colorSchemeCombo->setToolTip(QStringLiteral("Waterfall color scheme — not yet implemented"));
+    m_colorSchemeCombo->addItems({
+        QStringLiteral("Default"),   QStringLiteral("Enhanced"),
+        QStringLiteral("Spectran"),  QStringLiteral("BlackWhite"),
+        QStringLiteral("LinLog"),    QStringLiteral("LinRad"),
+        QStringLiteral("Custom")
+    });
+    connect(m_colorSchemeCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int i) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfColorScheme(static_cast<WfColorScheme>(
+                qBound(0, i, static_cast<int>(WfColorScheme::Count) - 1)));
+        }
+    });
     dispForm->addRow(QStringLiteral("Color Scheme:"), m_colorSchemeCombo);
 
+    m_wfAveragingCombo = new QComboBox(dispGroup);
+    m_wfAveragingCombo->addItems({
+        QStringLiteral("None"), QStringLiteral("Weighted"),
+        QStringLiteral("Logarithmic"), QStringLiteral("Time Window")
+    });
+    connect(m_wfAveragingCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int i) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfAverageMode(static_cast<AverageMode>(i));
+        }
+    });
+    dispForm->addRow(QStringLiteral("WF Averaging:"), m_wfAveragingCombo);
+
     contentLayout()->addWidget(dispGroup);
+
+    // --- Section: Overlays ---
+    auto* ovGroup = new QGroupBox(QStringLiteral("Overlays"), this);
+    auto* ovForm  = new QFormLayout(ovGroup);
+    ovForm->setSpacing(6);
+
+    m_showRxFilterToggle = new QCheckBox(QStringLiteral("Show RX filter on waterfall"), ovGroup);
+    connect(m_showRxFilterToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setShowRxFilterOnWaterfall(on);
+        }
+    });
+    ovForm->addRow(QString(), m_showRxFilterToggle);
+
+    m_showTxFilterToggle = new QCheckBox(QStringLiteral("Show TX filter on RX waterfall"), ovGroup);
+    connect(m_showTxFilterToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setShowTxFilterOnRxWaterfall(on);
+        }
+    });
+    ovForm->addRow(QString(), m_showTxFilterToggle);
+
+    m_showRxZeroLineToggle = new QCheckBox(QStringLiteral("Show RX zero line on waterfall"), ovGroup);
+    connect(m_showRxZeroLineToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setShowRxZeroLineOnWaterfall(on);
+        }
+    });
+    ovForm->addRow(QString(), m_showRxZeroLineToggle);
+
+    m_showTxZeroLineToggle = new QCheckBox(QStringLiteral("Show TX zero line on waterfall"), ovGroup);
+    connect(m_showTxZeroLineToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setShowTxZeroLineOnWaterfall(on);
+        }
+    });
+    ovForm->addRow(QString(), m_showTxZeroLineToggle);
+
+    contentLayout()->addWidget(ovGroup);
 
     // --- Section: Time ---
     auto* timeGroup = new QGroupBox(QStringLiteral("Time"), this);
@@ -468,14 +605,26 @@ void WaterfallDefaultsPage::buildUI()
     m_timestampPosCombo = new QComboBox(timeGroup);
     m_timestampPosCombo->addItems({QStringLiteral("None"), QStringLiteral("Left"),
                                    QStringLiteral("Right")});
-    m_timestampPosCombo->setEnabled(false);  // NYI
-    m_timestampPosCombo->setToolTip(QStringLiteral("Waterfall timestamp position — not yet implemented"));
+    connect(m_timestampPosCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int i) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfTimestampPosition(
+                static_cast<SpectrumWidget::TimestampPosition>(
+                    qBound(0, i, static_cast<int>(SpectrumWidget::TimestampPosition::Count) - 1)));
+        }
+    });
     timeForm->addRow(QStringLiteral("Timestamp Position:"), m_timestampPosCombo);
 
     m_timestampModeCombo = new QComboBox(timeGroup);
     m_timestampModeCombo->addItems({QStringLiteral("UTC"), QStringLiteral("Local")});
-    m_timestampModeCombo->setEnabled(false);  // NYI
-    m_timestampModeCombo->setToolTip(QStringLiteral("Timestamp time zone — not yet implemented"));
+    connect(m_timestampModeCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int i) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfTimestampMode(
+                static_cast<SpectrumWidget::TimestampMode>(
+                    qBound(0, i, static_cast<int>(SpectrumWidget::TimestampMode::Count) - 1)));
+        }
+    });
     timeForm->addRow(QStringLiteral("Timestamp Mode:"), m_timestampModeCombo);
 
     contentLayout()->addWidget(timeGroup);

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -639,6 +639,56 @@ GridScalesPage::GridScalesPage(RadioModel* model, QWidget* parent)
     : SetupPage(QStringLiteral("Grid & Scales"), model, parent)
 {
     buildUI();
+    loadFromRenderer();
+}
+
+// Helper: return the first panadapter or nullptr.
+static PanadapterModel* firstPan(RadioModel* m)
+{
+    if (!m) { return nullptr; }
+    const auto pans = m->panadapters();
+    return pans.isEmpty() ? nullptr : pans.first();
+}
+
+void GridScalesPage::applyBandSlot(PanadapterModel* pan)
+{
+    if (!pan || !m_dbMaxSpin || !m_dbMinSpin || !m_editingBandLabel) { return; }
+    const Band b = pan->band();
+    const BandGridSettings slot = pan->perBandGrid(b);
+    QSignalBlocker bMax(m_dbMaxSpin);
+    QSignalBlocker bMin(m_dbMinSpin);
+    m_dbMaxSpin->setValue(slot.dbMax);
+    m_dbMinSpin->setValue(slot.dbMin);
+    m_editingBandLabel->setText(
+        QStringLiteral("Editing band: %1").arg(bandLabel(b)));
+}
+
+void GridScalesPage::loadFromRenderer()
+{
+    auto* sw  = model() ? model()->spectrumWidget() : nullptr;
+    auto* pan = firstPan(model());
+    if (!sw || !pan) { return; }
+
+    QSignalBlocker b1(m_gridToggle);
+    QSignalBlocker b2(m_dbStepSpin);
+    QSignalBlocker b3(m_freqLabelAlignCombo);
+    QSignalBlocker b4(m_zeroLineToggle);
+    QSignalBlocker b5(m_showFpsToggle);
+
+    m_gridToggle->setChecked(sw->gridEnabled());
+    m_dbStepSpin->setValue(pan->gridStep());
+    m_freqLabelAlignCombo->setCurrentIndex(static_cast<int>(sw->freqLabelAlign()));
+    m_zeroLineToggle->setChecked(sw->showZeroLine());
+    m_showFpsToggle->setChecked(sw->showFps());
+
+    if (m_gridColorBtn)     { m_gridColorBtn->setColor(sw->gridColor()); }
+    if (m_gridFineColorBtn) { m_gridFineColorBtn->setColor(sw->gridFineColor()); }
+    if (m_hGridColorBtn)    { m_hGridColorBtn->setColor(sw->hGridColor()); }
+    if (m_gridTextColorBtn) { m_gridTextColorBtn->setColor(sw->gridTextColor()); }
+    if (m_zeroLineColorBtn) { m_zeroLineColorBtn->setColor(sw->zeroLineColor()); }
+    if (m_bandEdgeColorBtn) { m_bandEdgeColorBtn->setColor(sw->bandEdgeColor()); }
+
+    applyBandSlot(pan);
 }
 
 void GridScalesPage::buildUI()
@@ -652,35 +702,63 @@ void GridScalesPage::buildUI()
 
     m_gridToggle = new QCheckBox(QStringLiteral("Show grid"), gridGroup);
     m_gridToggle->setChecked(true);
-    m_gridToggle->setEnabled(false);  // NYI
-    m_gridToggle->setToolTip(QStringLiteral("Show spectrum grid lines — not yet implemented"));
+    connect(m_gridToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setGridEnabled(on);
+        }
+    });
     gridForm->addRow(QString(), m_gridToggle);
+
+    m_editingBandLabel = new QLabel(QStringLiteral("Editing band: —"), gridGroup);
+    m_editingBandLabel->setStyleSheet(QStringLiteral("QLabel { color: #00b4d8; font-weight: bold; }"));
+    gridForm->addRow(QString(), m_editingBandLabel);
 
     m_dbMaxSpin = new QSpinBox(gridGroup);
     m_dbMaxSpin->setRange(-200, 0);
-    m_dbMaxSpin->setValue(-20);
+    m_dbMaxSpin->setValue(-40);
     m_dbMaxSpin->setSuffix(QStringLiteral(" dB"));
-    m_dbMaxSpin->setEnabled(false);  // NYI
-    m_dbMaxSpin->setToolTip(QStringLiteral("Grid dB maximum — not yet implemented"));
-    gridForm->addRow(QStringLiteral("dB Max:"), m_dbMaxSpin);
+    connect(m_dbMaxSpin, qOverload<int>(&QSpinBox::valueChanged),
+            this, [this](int v) {
+        if (auto* pan = firstPan(model())) {
+            pan->setPerBandDbMax(pan->band(), v);
+        }
+    });
+    gridForm->addRow(QStringLiteral("dB Max (per band):"), m_dbMaxSpin);
 
     m_dbMinSpin = new QSpinBox(gridGroup);
     m_dbMinSpin->setRange(-200, 0);
-    m_dbMinSpin->setValue(-160);
+    m_dbMinSpin->setValue(-140);
     m_dbMinSpin->setSuffix(QStringLiteral(" dB"));
-    m_dbMinSpin->setEnabled(false);  // NYI
-    m_dbMinSpin->setToolTip(QStringLiteral("Grid dB minimum — not yet implemented"));
-    gridForm->addRow(QStringLiteral("dB Min:"), m_dbMinSpin);
+    connect(m_dbMinSpin, qOverload<int>(&QSpinBox::valueChanged),
+            this, [this](int v) {
+        if (auto* pan = firstPan(model())) {
+            pan->setPerBandDbMin(pan->band(), v);
+        }
+    });
+    gridForm->addRow(QStringLiteral("dB Min (per band):"), m_dbMinSpin);
 
     m_dbStepSpin = new QSpinBox(gridGroup);
     m_dbStepSpin->setRange(1, 40);
     m_dbStepSpin->setValue(10);
     m_dbStepSpin->setSuffix(QStringLiteral(" dB"));
-    m_dbStepSpin->setEnabled(false);  // NYI
-    m_dbStepSpin->setToolTip(QStringLiteral("Grid dB step size — not yet implemented"));
-    gridForm->addRow(QStringLiteral("dB Step:"), m_dbStepSpin);
+    m_dbStepSpin->setToolTip(QStringLiteral("Global grid step — Thetis stores this as a single value (not per-band)."));
+    connect(m_dbStepSpin, qOverload<int>(&QSpinBox::valueChanged),
+            this, [this](int v) {
+        if (auto* pan = firstPan(model())) {
+            pan->setGridStep(v);
+        }
+    });
+    gridForm->addRow(QStringLiteral("dB Step (global):"), m_dbStepSpin);
 
     contentLayout()->addWidget(gridGroup);
+
+    // Connect to PanadapterModel::bandChanged so the editing-band label
+    // and the dbMax/dbMin spinboxes refresh when the user tunes across a
+    // band boundary (or clicks a band button).
+    if (auto* pan = firstPan(model())) {
+        connect(pan, &PanadapterModel::bandChanged,
+                this, [this, pan](Band) { applyBandSlot(pan); });
+    }
 
     // --- Section: Labels ---
     auto* lblGroup = new QGroupBox(QStringLiteral("Labels"), this);
@@ -688,25 +766,74 @@ void GridScalesPage::buildUI()
     lblForm->setSpacing(6);
 
     m_freqLabelAlignCombo = new QComboBox(lblGroup);
-    m_freqLabelAlignCombo->addItems({QStringLiteral("Left"), QStringLiteral("Center")});
-    m_freqLabelAlignCombo->setEnabled(false);  // NYI
-    m_freqLabelAlignCombo->setToolTip(QStringLiteral("Frequency label alignment — not yet implemented"));
+    m_freqLabelAlignCombo->addItems({
+        QStringLiteral("Left"),   QStringLiteral("Center"),
+        QStringLiteral("Right"),  QStringLiteral("Auto"),
+        QStringLiteral("Off")
+    });
+    m_freqLabelAlignCombo->setCurrentIndex(1);
+    connect(m_freqLabelAlignCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int i) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setFreqLabelAlign(static_cast<FreqLabelAlign>(i));
+        }
+    });
     lblForm->addRow(QStringLiteral("Freq Label Align:"), m_freqLabelAlignCombo);
 
-    m_bandEdgeColorLabel = makeColorSwatch(QStringLiteral("Band Edge Color"), QStringLiteral("#1a4a1a"), lblGroup);
-    lblForm->addRow(QStringLiteral("Band Edge Color:"), m_bandEdgeColorLabel);
-
     m_zeroLineToggle = new QCheckBox(QStringLiteral("Show zero line"), lblGroup);
-    m_zeroLineToggle->setEnabled(false);  // NYI
-    m_zeroLineToggle->setToolTip(QStringLiteral("Show zero dB reference line — not yet implemented"));
+    connect(m_zeroLineToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setShowZeroLine(on);
+        }
+    });
     lblForm->addRow(QString(), m_zeroLineToggle);
 
     m_showFpsToggle = new QCheckBox(QStringLiteral("Show FPS overlay"), lblGroup);
-    m_showFpsToggle->setEnabled(false);  // NYI
-    m_showFpsToggle->setToolTip(QStringLiteral("Show FPS counter overlay — not yet implemented"));
+    connect(m_showFpsToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setShowFps(on);
+        }
+    });
     lblForm->addRow(QString(), m_showFpsToggle);
 
     contentLayout()->addWidget(lblGroup);
+
+    // --- Section: Colors ---
+    auto* colGroup = new QGroupBox(QStringLiteral("Colors"), this);
+    auto* colForm  = new QFormLayout(colGroup);
+    colForm->setSpacing(6);
+
+    auto makeBtn = [this](QWidget* parent, const QColor& init,
+                          void (SpectrumWidget::*setter)(const QColor&)) {
+        auto* btn = new ColorSwatchButton(init, parent);
+        connect(btn, &ColorSwatchButton::colorChanged,
+                this, [this, setter](const QColor& c) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                (w->*setter)(c);
+            }
+        });
+        return btn;
+    };
+
+    m_gridColorBtn     = makeBtn(colGroup, QColor(255, 255, 255, 40), &SpectrumWidget::setGridColor);
+    colForm->addRow(QStringLiteral("Grid Color:"), m_gridColorBtn);
+
+    m_gridFineColorBtn = makeBtn(colGroup, QColor(255, 255, 255, 20), &SpectrumWidget::setGridFineColor);
+    colForm->addRow(QStringLiteral("Grid Fine Color:"), m_gridFineColorBtn);
+
+    m_hGridColorBtn    = makeBtn(colGroup, QColor(255, 255, 255, 40), &SpectrumWidget::setHGridColor);
+    colForm->addRow(QStringLiteral("H-Grid Color:"), m_hGridColorBtn);
+
+    m_gridTextColorBtn = makeBtn(colGroup, QColor(255, 255, 0), &SpectrumWidget::setGridTextColor);
+    colForm->addRow(QStringLiteral("Text Color:"), m_gridTextColorBtn);
+
+    m_zeroLineColorBtn = makeBtn(colGroup, QColor(255, 0, 0), &SpectrumWidget::setZeroLineColor);
+    colForm->addRow(QStringLiteral("Zero Line Color:"), m_zeroLineColorBtn);
+
+    m_bandEdgeColorBtn = makeBtn(colGroup, QColor(255, 0, 0), &SpectrumWidget::setBandEdgeColor);
+    colForm->addRow(QStringLiteral("Band Edge Color:"), m_bandEdgeColorBtn);
+
+    contentLayout()->addWidget(colGroup);
     contentLayout()->addStretch();
 }
 

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -1,5 +1,11 @@
 #include "DisplaySetupPages.h"
+#include "gui/ColorSwatchButton.h"
+#include "gui/SpectrumWidget.h"
 #include "gui/StyleConstants.h"
+#include "core/FFTEngine.h"
+#include "models/Band.h"
+#include "models/PanadapterModel.h"
+#include "models/RadioModel.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -11,6 +17,7 @@
 #include <QSpinBox>
 #include <QDoubleSpinBox>
 #include <QCheckBox>
+#include <QThread>
 
 namespace NereusSDR {
 
@@ -73,11 +80,74 @@ SpectrumDefaultsPage::SpectrumDefaultsPage(RadioModel* model, QWidget* parent)
     : SetupPage(QStringLiteral("Spectrum Defaults"), model, parent)
 {
     buildUI();
+    loadFromRenderer();
+}
+
+// Maps SpectrumDefaultsPage FPS slider (10-60) to FFTEngine output FPS.
+void SpectrumDefaultsPage::pushFps(int fps)
+{
+    if (!model() || !model()->fftEngine()) { return; }
+    model()->fftEngine()->setOutputFps(fps);
+}
+
+void SpectrumDefaultsPage::loadFromRenderer()
+{
+    if (!model()) { return; }
+    auto* sw = model()->spectrumWidget();
+    auto* fe = model()->fftEngine();
+    if (!sw || !fe) { return; }
+
+    QSignalBlocker b1(m_fftSizeCombo);
+    QSignalBlocker b2(m_windowCombo);
+    QSignalBlocker b3(m_fpSlider);
+    QSignalBlocker b4(m_averagingCombo);
+    QSignalBlocker b5(m_fillToggle);
+    QSignalBlocker b6(m_fillAlphaSlider);
+    QSignalBlocker b7(m_lineWidthSlider);
+    QSignalBlocker b8(m_gradientToggle);
+    QSignalBlocker b9(m_dataLineAlphaSlider);
+    QSignalBlocker b10(m_calOffsetSpin);
+    QSignalBlocker b11(m_peakHoldToggle);
+    QSignalBlocker b12(m_peakHoldDelaySpin);
+    QSignalBlocker b13(m_threadPriorityCombo);
+
+    // FFT size — map actual FFT size to combo index.
+    const int fs = fe->fftSize();
+    const QString fsText = QString::number(fs);
+    const int idx = m_fftSizeCombo->findText(fsText);
+    if (idx >= 0) { m_fftSizeCombo->setCurrentIndex(idx); }
+
+    // FFT window — enum → index (5 enum values but 4 UI options; map
+    // BlackmanHarris4 → Blackman-Harris, Hanning → Hann, Hamming → Hamming,
+    // Flat → Flat-Top. BlackmanHarris7 / Kaiser / None fall back to BH4).
+    switch (fe->windowFunction()) {
+        case WindowFunction::Hanning: m_windowCombo->setCurrentIndex(1); break;
+        case WindowFunction::Hamming: m_windowCombo->setCurrentIndex(2); break;
+        case WindowFunction::Flat:    m_windowCombo->setCurrentIndex(3); break;
+        default:                      m_windowCombo->setCurrentIndex(0); break;
+    }
+
+    m_fpSlider->setValue(fe->outputFps());
+    m_averagingCombo->setCurrentIndex(static_cast<int>(sw->averageMode()));
+    m_fillToggle->setChecked(sw->panFillEnabled());
+    m_fillAlphaSlider->setValue(static_cast<int>(sw->fillAlpha() * 100.0f));
+    m_lineWidthSlider->setValue(qBound(1, static_cast<int>(sw->lineWidth()), 3));
+    m_gradientToggle->setChecked(sw->gradientEnabled());
+    m_dataLineAlphaSlider->setValue(sw->fillColor().alpha());
+    m_calOffsetSpin->setValue(static_cast<double>(sw->dbmCalOffset()));
+    m_peakHoldToggle->setChecked(sw->peakHoldEnabled());
+    m_peakHoldDelaySpin->setValue(sw->peakHoldDelayMs());
+
+    if (m_dataLineColorBtn) { m_dataLineColorBtn->setColor(sw->fillColor()); }
+    if (m_dataFillColorBtn) { m_dataFillColorBtn->setColor(sw->fillColor()); }
 }
 
 void SpectrumDefaultsPage::buildUI()
 {
     applyDarkStyle(this);
+
+    auto* sw = model() ? model()->spectrumWidget() : nullptr;
+    auto* fe = model() ? model()->fftEngine() : nullptr;
 
     // --- Section: FFT ---
     auto* fftGroup = new QGroupBox(QStringLiteral("FFT"), this);
@@ -89,15 +159,29 @@ void SpectrumDefaultsPage::buildUI()
                               QStringLiteral("4096"), QStringLiteral("8192"),
                               QStringLiteral("16384")});
     m_fftSizeCombo->setCurrentText(QStringLiteral("4096"));
-    m_fftSizeCombo->setEnabled(false);  // NYI
-    m_fftSizeCombo->setToolTip(QStringLiteral("Default FFT size — not yet implemented"));
+    connect(m_fftSizeCombo, &QComboBox::currentTextChanged,
+            this, [this](const QString& txt) {
+        if (model() && model()->fftEngine()) {
+            model()->fftEngine()->setFftSize(txt.toInt());
+        }
+    });
     fftForm->addRow(QStringLiteral("FFT Size:"), m_fftSizeCombo);
 
     m_windowCombo = new QComboBox(fftGroup);
     m_windowCombo->addItems({QStringLiteral("Blackman-Harris"), QStringLiteral("Hann"),
                              QStringLiteral("Hamming"),         QStringLiteral("Flat-Top")});
-    m_windowCombo->setEnabled(false);  // NYI
-    m_windowCombo->setToolTip(QStringLiteral("FFT window function — not yet implemented"));
+    connect(m_windowCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int i) {
+        if (!model() || !model()->fftEngine()) { return; }
+        WindowFunction wf = WindowFunction::BlackmanHarris4;
+        switch (i) {
+            case 0: wf = WindowFunction::BlackmanHarris4; break;
+            case 1: wf = WindowFunction::Hanning; break;
+            case 2: wf = WindowFunction::Hamming; break;
+            case 3: wf = WindowFunction::Flat; break;
+        }
+        model()->fftEngine()->setWindowFunction(wf);
+    });
     fftForm->addRow(QStringLiteral("Window:"), m_windowCombo);
 
     contentLayout()->addWidget(fftGroup);
@@ -110,40 +194,124 @@ void SpectrumDefaultsPage::buildUI()
     m_fpSlider = new QSlider(Qt::Horizontal, renderGroup);
     m_fpSlider->setRange(10, 60);
     m_fpSlider->setValue(30);
-    m_fpSlider->setEnabled(false);  // NYI
-    m_fpSlider->setToolTip(QStringLiteral("Spectrum update rate (FPS) — not yet implemented"));
+    connect(m_fpSlider, &QSlider::valueChanged, this, [this](int v) { pushFps(v); });
     renderForm->addRow(QStringLiteral("FPS (10–60):"), m_fpSlider);
 
     m_averagingCombo = new QComboBox(renderGroup);
     m_averagingCombo->addItems({QStringLiteral("None"), QStringLiteral("Weighted"),
-                                QStringLiteral("Logarithmic")});
-    m_averagingCombo->setEnabled(false);  // NYI
-    m_averagingCombo->setToolTip(QStringLiteral("Spectrum averaging mode — not yet implemented"));
+                                QStringLiteral("Logarithmic"), QStringLiteral("Time Window")});
+    connect(m_averagingCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int i) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setAverageMode(static_cast<AverageMode>(i));
+        }
+    });
     renderForm->addRow(QStringLiteral("Averaging:"), m_averagingCombo);
 
+    m_averagingTimeSpin = new QSpinBox(renderGroup);
+    m_averagingTimeSpin->setRange(10, 5000);
+    m_averagingTimeSpin->setSingleStep(10);
+    m_averagingTimeSpin->setSuffix(QStringLiteral(" ms"));
+    m_averagingTimeSpin->setValue(100);
+    connect(m_averagingTimeSpin, qOverload<int>(&QSpinBox::valueChanged),
+            this, [this](int ms) {
+        // Translate ms to an alpha between 0.05 (slow) and 0.95 (fast).
+        const float a = qBound(0.05f, 1.0f - (ms / 5000.0f), 0.95f);
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setAverageAlpha(a);
+        }
+    });
+    renderForm->addRow(QStringLiteral("Averaging Time:"), m_averagingTimeSpin);
+
+    m_decimationSpin = new QSpinBox(renderGroup);
+    m_decimationSpin->setRange(1, 32);
+    m_decimationSpin->setValue(1);
+    m_decimationSpin->setToolTip(QStringLiteral("Spectrum decimation factor (Thetis udDisplayDecimation parity)"));
+    // Scaffolded only — FFTEngine decimation hook deferred to a future phase.
+    renderForm->addRow(QStringLiteral("Decimation:"), m_decimationSpin);
+
     m_fillToggle = new QCheckBox(QStringLiteral("Fill under trace"), renderGroup);
-    m_fillToggle->setEnabled(false);  // NYI
-    m_fillToggle->setToolTip(QStringLiteral("Fill spectrum trace area — not yet implemented"));
+    connect(m_fillToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setPanFillEnabled(on);
+        }
+    });
     renderForm->addRow(QString(), m_fillToggle);
 
     m_fillAlphaSlider = new QSlider(Qt::Horizontal, renderGroup);
     m_fillAlphaSlider->setRange(0, 100);
-    m_fillAlphaSlider->setValue(30);
-    m_fillAlphaSlider->setEnabled(false);  // NYI
-    m_fillAlphaSlider->setToolTip(QStringLiteral("Fill opacity (0–100) — not yet implemented"));
+    m_fillAlphaSlider->setValue(70);
+    connect(m_fillAlphaSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setFillAlpha(v / 100.0f);
+        }
+    });
     renderForm->addRow(QStringLiteral("Fill Alpha:"), m_fillAlphaSlider);
 
     m_lineWidthSlider = new QSlider(Qt::Horizontal, renderGroup);
     m_lineWidthSlider->setRange(1, 3);
     m_lineWidthSlider->setValue(1);
-    m_lineWidthSlider->setEnabled(false);  // NYI
-    m_lineWidthSlider->setToolTip(QStringLiteral("Trace line width (1–3 px) — not yet implemented"));
+    connect(m_lineWidthSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setLineWidth(static_cast<float>(v));
+        }
+    });
     renderForm->addRow(QStringLiteral("Line Width:"), m_lineWidthSlider);
+
+    m_gradientToggle = new QCheckBox(QStringLiteral("Trace gradient"), renderGroup);
+    connect(m_gradientToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setGradientEnabled(on);
+        }
+    });
+    renderForm->addRow(QString(), m_gradientToggle);
 
     contentLayout()->addWidget(renderGroup);
 
+    // --- Section: Colors ---
+    auto* colorGroup = new QGroupBox(QStringLiteral("Trace Colors"), this);
+    auto* colorForm  = new QFormLayout(colorGroup);
+    colorForm->setSpacing(6);
+
+    const QColor initLine = sw ? sw->fillColor() : QColor(0x00, 0xe5, 0xff);
+    m_dataLineColorBtn = new ColorSwatchButton(initLine, colorGroup);
+    connect(m_dataLineColorBtn, &ColorSwatchButton::colorChanged,
+            this, [this](const QColor& c) {
+        // SpectrumWidget currently uses one colour for both line and fill.
+        // Plan §6 S11/S13 allow splitting once the renderer grows a
+        // dedicated m_dataLineColor; for now both pickers set the shared
+        // fill colour.
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setFillColor(c);
+        }
+    });
+    colorForm->addRow(QStringLiteral("Data Line Color:"), m_dataLineColorBtn);
+
+    m_dataLineAlphaSlider = new QSlider(Qt::Horizontal, colorGroup);
+    m_dataLineAlphaSlider->setRange(0, 255);
+    m_dataLineAlphaSlider->setValue(230);
+    connect(m_dataLineAlphaSlider, &QSlider::valueChanged, this, [this](int a) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            QColor c = w->fillColor();
+            c.setAlpha(a);
+            w->setFillColor(c);
+        }
+    });
+    colorForm->addRow(QStringLiteral("Line Alpha:"), m_dataLineAlphaSlider);
+
+    m_dataFillColorBtn = new ColorSwatchButton(initLine, colorGroup);
+    connect(m_dataFillColorBtn, &ColorSwatchButton::colorChanged,
+            this, [this](const QColor& c) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setFillColor(c);
+        }
+    });
+    colorForm->addRow(QStringLiteral("Data Fill Color:"), m_dataFillColorBtn);
+
+    contentLayout()->addWidget(colorGroup);
+
     // --- Section: Calibration ---
-    auto* calGroup = new QGroupBox(QStringLiteral("Calibration"), this);
+    auto* calGroup = new QGroupBox(QStringLiteral("Calibration & Peak Hold"), this);
     auto* calForm  = new QFormLayout(calGroup);
     calForm->setSpacing(6);
 
@@ -152,13 +320,20 @@ void SpectrumDefaultsPage::buildUI()
     m_calOffsetSpin->setSingleStep(0.5);
     m_calOffsetSpin->setSuffix(QStringLiteral(" dBm"));
     m_calOffsetSpin->setValue(0.0);
-    m_calOffsetSpin->setEnabled(false);  // NYI
-    m_calOffsetSpin->setToolTip(QStringLiteral("Display calibration offset — not yet implemented"));
+    connect(m_calOffsetSpin, qOverload<double>(&QDoubleSpinBox::valueChanged),
+            this, [this](double v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setDbmCalOffset(static_cast<float>(v));
+        }
+    });
     calForm->addRow(QStringLiteral("Cal Offset:"), m_calOffsetSpin);
 
     m_peakHoldToggle = new QCheckBox(QStringLiteral("Peak hold"), calGroup);
-    m_peakHoldToggle->setEnabled(false);  // NYI
-    m_peakHoldToggle->setToolTip(QStringLiteral("Hold spectrum peaks — not yet implemented"));
+    connect(m_peakHoldToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setPeakHoldEnabled(on);
+        }
+    });
     calForm->addRow(QString(), m_peakHoldToggle);
 
     m_peakHoldDelaySpin = new QSpinBox(calGroup);
@@ -166,12 +341,50 @@ void SpectrumDefaultsPage::buildUI()
     m_peakHoldDelaySpin->setSingleStep(100);
     m_peakHoldDelaySpin->setSuffix(QStringLiteral(" ms"));
     m_peakHoldDelaySpin->setValue(2000);
-    m_peakHoldDelaySpin->setEnabled(false);  // NYI
-    m_peakHoldDelaySpin->setToolTip(QStringLiteral("Peak hold decay delay — not yet implemented"));
+    connect(m_peakHoldDelaySpin, qOverload<int>(&QSpinBox::valueChanged),
+            this, [this](int v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setPeakHoldDelayMs(v);
+        }
+    });
     calForm->addRow(QStringLiteral("Peak Delay:"), m_peakHoldDelaySpin);
 
     contentLayout()->addWidget(calGroup);
+
+    // --- Section: Thread ---
+    auto* threadGroup = new QGroupBox(QStringLiteral("Thread"), this);
+    auto* threadForm  = new QFormLayout(threadGroup);
+    threadForm->setSpacing(6);
+
+    m_threadPriorityCombo = new QComboBox(threadGroup);
+    m_threadPriorityCombo->addItems({
+        QStringLiteral("Lowest"), QStringLiteral("Below Normal"),
+        QStringLiteral("Normal"), QStringLiteral("Above Normal"),
+        QStringLiteral("Highest")
+    });
+    m_threadPriorityCombo->setCurrentIndex(3);  // Above Normal (Thetis default)
+    connect(m_threadPriorityCombo, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, [this](int i) {
+        // Map Thetis 5-item ThreadPriority → QThread::Priority per §13 Q3.
+        const QThread::Priority pri =
+            (i == 0) ? QThread::LowestPriority :
+            (i == 1) ? QThread::LowPriority    :
+            (i == 2) ? QThread::NormalPriority :
+            (i == 3) ? QThread::HighPriority   :
+                       QThread::HighestPriority;
+        if (model() && model()->fftEngine()) {
+            if (auto* t = model()->fftEngine()->thread()) {
+                t->setPriority(pri);
+            }
+        }
+    });
+    threadForm->addRow(QStringLiteral("Display Thread Priority:"), m_threadPriorityCombo);
+
+    contentLayout()->addWidget(threadGroup);
     contentLayout()->addStretch();
+
+    Q_UNUSED(sw);
+    Q_UNUSED(fe);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/gui/setup/DisplaySetupPages.h
+++ b/src/gui/setup/DisplaySetupPages.h
@@ -67,17 +67,27 @@ public:
 
 private:
     void buildUI();
+    void loadFromRenderer();
 
     // Section: Levels
-    QSlider*   m_highThresholdSlider{nullptr};
-    QSlider*   m_lowThresholdSlider{nullptr};
-    QCheckBox* m_agcToggle{nullptr};
+    QSlider*           m_highThresholdSlider{nullptr};
+    QSlider*           m_lowThresholdSlider{nullptr};
+    QCheckBox*         m_agcToggle{nullptr};
+    ColorSwatchButton* m_lowColorBtn{nullptr};                // W10
+    QCheckBox*         m_useSpectrumMinMaxToggle{nullptr};    // W15
 
     // Section: Display
     QSlider*   m_updatePeriodSlider{nullptr};
     QCheckBox* m_reverseToggle{nullptr};
     QSlider*   m_opacitySlider{nullptr};
-    QComboBox* m_colorSchemeCombo{nullptr};  // Enhanced/Grayscale/Spectrum
+    QComboBox* m_colorSchemeCombo{nullptr};  // 7 schemes
+    QComboBox* m_wfAveragingCombo{nullptr};  // W16
+
+    // Section: Overlays
+    QCheckBox* m_showRxFilterToggle{nullptr};
+    QCheckBox* m_showTxFilterToggle{nullptr};
+    QCheckBox* m_showRxZeroLineToggle{nullptr};
+    QCheckBox* m_showTxZeroLineToggle{nullptr};
 
     // Section: Time
     QComboBox* m_timestampPosCombo{nullptr};  // None/Left/Right

--- a/src/gui/setup/DisplaySetupPages.h
+++ b/src/gui/setup/DisplaySetupPages.h
@@ -11,13 +11,14 @@ class QLabel;
 
 namespace NereusSDR {
 
+class PanadapterModel;
+class ColorSwatchButton;
+
 // ---------------------------------------------------------------------------
 // Display > Spectrum Defaults
 // Corresponds to Thetis setup.cs Display tab, Spectrum section.
 // All controls are NYI (disabled). Wired to persistence in a future phase.
 // ---------------------------------------------------------------------------
-class ColorSwatchButton;
-
 class SpectrumDefaultsPage : public SetupPage {
     Q_OBJECT
 public:
@@ -104,18 +105,27 @@ public:
 
 private:
     void buildUI();
+    void loadFromRenderer();
+    void applyBandSlot(PanadapterModel* pan);
 
     // Section: Grid
     QCheckBox*      m_gridToggle{nullptr};
+    QLabel*         m_editingBandLabel{nullptr};
     QSpinBox*       m_dbMaxSpin{nullptr};
     QSpinBox*       m_dbMinSpin{nullptr};
     QSpinBox*       m_dbStepSpin{nullptr};
 
-    // Section: Labels
-    QComboBox*      m_freqLabelAlignCombo{nullptr}; // Left/Center
-    QLabel*         m_bandEdgeColorLabel{nullptr};  // placeholder color swatch
+    // Section: Labels & Colors
+    QComboBox*      m_freqLabelAlignCombo{nullptr}; // Left/Center/Right/Auto/Off
     QCheckBox*      m_zeroLineToggle{nullptr};
     QCheckBox*      m_showFpsToggle{nullptr};
+
+    ColorSwatchButton* m_gridColorBtn{nullptr};       // G9
+    ColorSwatchButton* m_gridFineColorBtn{nullptr};   // G10
+    ColorSwatchButton* m_hGridColorBtn{nullptr};      // G11
+    ColorSwatchButton* m_gridTextColorBtn{nullptr};   // G12
+    ColorSwatchButton* m_zeroLineColorBtn{nullptr};   // G13
+    ColorSwatchButton* m_bandEdgeColorBtn{nullptr};   // G6
 };
 
 // ---------------------------------------------------------------------------

--- a/src/gui/setup/DisplaySetupPages.h
+++ b/src/gui/setup/DisplaySetupPages.h
@@ -16,6 +16,8 @@ namespace NereusSDR {
 // Corresponds to Thetis setup.cs Display tab, Spectrum section.
 // All controls are NYI (disabled). Wired to persistence in a future phase.
 // ---------------------------------------------------------------------------
+class ColorSwatchButton;
+
 class SpectrumDefaultsPage : public SetupPage {
     Q_OBJECT
 public:
@@ -23,6 +25,8 @@ public:
 
 private:
     void buildUI();
+    void loadFromRenderer();
+    void pushFps(int fps);
 
     // Section: FFT
     QComboBox* m_fftSizeCombo{nullptr};      // 1024/2048/4096/8192/16384
@@ -30,15 +34,26 @@ private:
 
     // Section: Rendering
     QSlider*   m_fpSlider{nullptr};          // 10–60 fps
-    QComboBox* m_averagingCombo{nullptr};    // None/Weighted/Logarithmic
+    QComboBox* m_averagingCombo{nullptr};    // None/Weighted/Logarithmic/TimeWindow
+    QSpinBox*  m_averagingTimeSpin{nullptr}; // S15 avg time (ms)
+    QSpinBox*  m_decimationSpin{nullptr};    // S16 decimation
     QCheckBox* m_fillToggle{nullptr};        // Fill under spectrum trace
     QSlider*   m_fillAlphaSlider{nullptr};   // 0–100
     QSlider*   m_lineWidthSlider{nullptr};   // 1–3
+    QCheckBox* m_gradientToggle{nullptr};    // S14 gradient enabled
+
+    // Section: Colors (S11/S13)
+    ColorSwatchButton* m_dataLineColorBtn{nullptr};
+    QSlider*           m_dataLineAlphaSlider{nullptr}; // S12
+    ColorSwatchButton* m_dataFillColorBtn{nullptr};
 
     // Section: Calibration
     QDoubleSpinBox* m_calOffsetSpin{nullptr}; // Display calibration offset (dBm)
     QCheckBox*      m_peakHoldToggle{nullptr};
     QSpinBox*       m_peakHoldDelaySpin{nullptr}; // ms
+
+    // Section: Thread (S17)
+    QComboBox*      m_threadPriorityCombo{nullptr};
 };
 
 // ---------------------------------------------------------------------------

--- a/src/models/Band.cpp
+++ b/src/models/Band.cpp
@@ -1,0 +1,101 @@
+// src/models/Band.cpp
+#include "Band.h"
+
+#include <QStringLiteral>
+
+namespace NereusSDR {
+
+namespace {
+
+// Band edges in Hz. IARU Region 2 covers the widest allocations; we use
+// the union so European/Australian frequencies also round-trip correctly.
+// Source: ARRL band plan / IARU Region 2, cross-checked against Thetis
+// BandStackManager HF definitions.
+struct HamBandRange {
+    Band band;
+    double lowHz;
+    double highHz;
+};
+
+constexpr HamBandRange kHamBandRanges[] = {
+    { Band::Band160m,  1800000.0,   2000000.0 },
+    { Band::Band80m,   3500000.0,   4000000.0 },
+    { Band::Band60m,   5330000.0,   5410000.0 },  // US channelized block
+    { Band::Band40m,   7000000.0,   7300000.0 },
+    { Band::Band30m,  10100000.0,  10150000.0 },
+    { Band::Band20m,  14000000.0,  14350000.0 },
+    { Band::Band17m,  18068000.0,  18168000.0 },
+    { Band::Band15m,  21000000.0,  21450000.0 },
+    { Band::Band12m,  24890000.0,  24990000.0 },
+    { Band::Band10m,  28000000.0,  29700000.0 },
+    { Band::Band6m,   50000000.0,  54000000.0 },
+};
+
+// WWV time-signal transmitters (NIST Fort Collins, CO) and WWVH (Hawaii).
+// Detect with a ±5 kHz window so a VFO parked near the carrier still
+// auto-selects WWV.
+constexpr double kWwvCenters[] = {
+    2500000.0, 5000000.0, 10000000.0, 15000000.0, 20000000.0, 25000000.0
+};
+constexpr double kWwvHalfWindow = 5000.0;
+
+} // namespace
+
+QString bandLabel(Band b)
+{
+    switch (b) {
+        case Band::Band160m: return QStringLiteral("160m");
+        case Band::Band80m:  return QStringLiteral("80m");
+        case Band::Band60m:  return QStringLiteral("60m");
+        case Band::Band40m:  return QStringLiteral("40m");
+        case Band::Band30m:  return QStringLiteral("30m");
+        case Band::Band20m:  return QStringLiteral("20m");
+        case Band::Band17m:  return QStringLiteral("17m");
+        case Band::Band15m:  return QStringLiteral("15m");
+        case Band::Band12m:  return QStringLiteral("12m");
+        case Band::Band10m:  return QStringLiteral("10m");
+        case Band::Band6m:   return QStringLiteral("6m");
+        case Band::GEN:      return QStringLiteral("GEN");
+        case Band::WWV:      return QStringLiteral("WWV");
+        case Band::XVTR:     return QStringLiteral("XVTR");
+        case Band::Count:    break;
+    }
+    return QStringLiteral("GEN");
+}
+
+QString bandKeyName(Band b)
+{
+    // Keep as a separate function from bandLabel so UI label text can
+    // change without breaking persisted AppSettings keys.
+    return bandLabel(b);
+}
+
+Band bandFromFrequency(double hz)
+{
+    for (const double center : kWwvCenters) {
+        if (hz >= center - kWwvHalfWindow && hz <= center + kWwvHalfWindow) {
+            return Band::WWV;
+        }
+    }
+    for (const auto& range : kHamBandRanges) {
+        if (hz >= range.lowHz && hz <= range.highHz) {
+            return range.band;
+        }
+    }
+    return Band::GEN;
+}
+
+Band bandFromUiIndex(int idx)
+{
+    if (idx < 0 || idx >= static_cast<int>(Band::Count)) {
+        return Band::GEN;
+    }
+    return static_cast<Band>(idx);
+}
+
+int uiIndexFromBand(Band b)
+{
+    return static_cast<int>(b);
+}
+
+} // namespace NereusSDR

--- a/src/models/Band.h
+++ b/src/models/Band.h
@@ -1,0 +1,65 @@
+// src/models/Band.h
+#pragma once
+
+#include <QString>
+
+namespace NereusSDR {
+
+/// Ham band identity used by the per-band display grid (Phase 3G-8) and
+/// future per-band state (Alex filter selection, band stacks, etc.).
+///
+/// Enum order matches Thetis Band enum convention and the `BandButtonItem`
+/// UI button order: 11 HF bands + 6m + GEN + WWV + XVTR. WWV and XVTR
+/// were added to NereusSDR in Phase 3G-8 to match Thetis's 14-band set.
+///
+/// XVTR is never returned by `bandFromFrequency` — it represents
+/// transverter mode and is set explicitly by UI when a transverter is
+/// active. GEN is the fallback for any frequency outside the ham bands.
+enum class Band : int {
+    Band160m = 0,
+    Band80m,
+    Band60m,
+    Band40m,
+    Band30m,
+    Band20m,
+    Band17m,
+    Band15m,
+    Band12m,
+    Band10m,
+    Band6m,
+    GEN,
+    WWV,
+    XVTR,
+    Count = 14
+};
+
+/// Human-readable label used in UI (e.g. "160m", "WWV").
+QString bandLabel(Band b);
+
+/// Stable persistence key suffix used for AppSettings keys
+/// (e.g. "160m", "80m", "GEN", "WWV", "XVTR"). Matches `bandLabel` for
+/// now but is kept as a separate function so label text can change
+/// without breaking persistence compatibility.
+QString bandKeyName(Band b);
+
+/// Maps a frequency in Hz to the enclosing ham band, or GEN if outside
+/// all ham bands. Never returns XVTR. WWV is detected at the six
+/// standard time-signal center frequencies (2.5/5/10/15/20/25 MHz)
+/// within a ±5 kHz window.
+///
+/// Simplified port of Thetis BandByFreq (console.cs:6443) which delegates
+/// to BandStackManager with region-aware ranges. NereusSDR uses
+/// IARU Region 2 ham band edges without region variation — sufficient
+/// for auto-selecting the per-band grid slot. User can always override
+/// via direct setBand() if the auto-derived band is wrong.
+Band bandFromFrequency(double hz);
+
+/// Maps a 0-based `BandButtonItem` UI index to the corresponding Band.
+/// Button order: 160m, 80m, 60m, 40m, 30m, 20m, 17m, 15m, 12m, 10m, 6m,
+/// GEN, WWV, XVTR. Returns Band::GEN for out-of-range indices.
+Band bandFromUiIndex(int idx);
+
+/// Inverse of bandFromUiIndex.
+int uiIndexFromBand(Band b);
+
+} // namespace NereusSDR

--- a/src/models/PanadapterModel.cpp
+++ b/src/models/PanadapterModel.cpp
@@ -1,10 +1,42 @@
 #include "PanadapterModel.h"
 
+#include "core/AppSettings.h"
+
+#include <QStringLiteral>
+
 namespace NereusSDR {
+
+namespace {
+
+// Thetis uniform per-band default (console.cs:14242-14436). All 14 bands
+// ship with the same values; per-band storage exists so users can
+// customise, not because Thetis hand-tunes each band.
+constexpr int kThetisDefaultDbMax = -40;
+constexpr int kThetisDefaultDbMin = -140;
+constexpr int kDefaultGridStep    = 10;  // NereusSDR divergence (§10).
+
+QString gridMaxKey(Band b) { return QStringLiteral("DisplayGridMax_") + bandKeyName(b); }
+QString gridMinKey(Band b) { return QStringLiteral("DisplayGridMin_") + bandKeyName(b); }
+
+} // namespace
 
 PanadapterModel::PanadapterModel(QObject* parent)
     : QObject(parent)
 {
+    // Seed every band slot with Thetis uniform defaults before loading
+    // persisted overrides. This matches Q4 resolution (plan §5.3): existing
+    // users will see the grid shift from NereusSDR's -20/-160 to Thetis's
+    // -40/-140 on first launch after upgrade.
+    for (int i = 0; i < static_cast<int>(Band::Count); ++i) {
+        const Band b = static_cast<Band>(i);
+        m_perBandGrid.insert(b, BandGridSettings{ kThetisDefaultDbMax, kThetisDefaultDbMin });
+    }
+    loadPerBandGridFromSettings();
+
+    // Match the initial band to the default center frequency so the
+    // dBmFloor/dBmCeiling pair reflects the 20m slot from the start.
+    m_band = bandFromFrequency(m_centerFrequency);
+    applyBandGrid(m_band);
 }
 
 PanadapterModel::~PanadapterModel() = default;
@@ -14,6 +46,13 @@ void PanadapterModel::setCenterFrequency(double freq)
     if (!qFuzzyCompare(m_centerFrequency, freq)) {
         m_centerFrequency = freq;
         emit centerFrequencyChanged(freq);
+
+        // Auto-derive the enclosing band. If this crosses a boundary,
+        // setBand() updates the dBm pair to the new band's slot.
+        const Band derived = bandFromFrequency(freq);
+        if (derived != m_band) {
+            setBand(derived);
+        }
     }
 }
 
@@ -52,6 +91,96 @@ void PanadapterModel::setFftSize(int size)
 void PanadapterModel::setAverageCount(int count)
 {
     m_averageCount = count;
+}
+
+// ---- Per-band grid (Phase 3G-8 commit 2) ----
+
+void PanadapterModel::setBand(Band b)
+{
+    if (m_band == b) {
+        return;
+    }
+    m_band = b;
+    applyBandGrid(b);
+    emit bandChanged(b);
+}
+
+BandGridSettings PanadapterModel::perBandGrid(Band b) const
+{
+    return m_perBandGrid.value(b, BandGridSettings{ -40, -140 });
+}
+
+void PanadapterModel::setPerBandDbMax(Band b, int dbMax)
+{
+    BandGridSettings& slot = m_perBandGrid[b];  // constructor seeded all 14
+    if (slot.dbMax == dbMax) {
+        return;
+    }
+    slot.dbMax = dbMax;
+    saveBandGridToSettings(b);
+    if (b == m_band) {
+        setdBmCeiling(dbMax);
+    }
+}
+
+void PanadapterModel::setPerBandDbMin(Band b, int dbMin)
+{
+    BandGridSettings& slot = m_perBandGrid[b];
+    if (slot.dbMin == dbMin) {
+        return;
+    }
+    slot.dbMin = dbMin;
+    saveBandGridToSettings(b);
+    if (b == m_band) {
+        setdBmFloor(dbMin);
+    }
+}
+
+void PanadapterModel::setGridStep(int step)
+{
+    if (step <= 0 || m_gridStep == step) {
+        return;
+    }
+    m_gridStep = step;
+    AppSettings::instance().setValue(QStringLiteral("DisplayGridStep"), step);
+    emit gridStepChanged(step);
+}
+
+void PanadapterModel::applyBandGrid(Band b)
+{
+    const BandGridSettings s = m_perBandGrid.value(b, BandGridSettings{ kThetisDefaultDbMax, kThetisDefaultDbMin });
+    setdBmCeiling(s.dbMax);
+    setdBmFloor(s.dbMin);
+}
+
+void PanadapterModel::loadPerBandGridFromSettings()
+{
+    auto& s = AppSettings::instance();
+    for (int i = 0; i < static_cast<int>(Band::Count); ++i) {
+        const Band b = static_cast<Band>(i);
+        const QVariant maxV = s.value(gridMaxKey(b));
+        const QVariant minV = s.value(gridMinKey(b));
+        BandGridSettings slot = m_perBandGrid.value(b, BandGridSettings{ kThetisDefaultDbMax, kThetisDefaultDbMin });
+        if (maxV.isValid()) { slot.dbMax = maxV.toInt(); }
+        if (minV.isValid()) { slot.dbMin = minV.toInt(); }
+        m_perBandGrid.insert(b, slot);
+    }
+
+    const QVariant stepV = s.value(QStringLiteral("DisplayGridStep"));
+    if (stepV.isValid()) {
+        const int step = stepV.toInt();
+        if (step > 0) { m_gridStep = step; }
+    } else {
+        m_gridStep = kDefaultGridStep;
+    }
+}
+
+void PanadapterModel::saveBandGridToSettings(Band b) const
+{
+    const BandGridSettings slot = m_perBandGrid.value(b);
+    auto& s = AppSettings::instance();
+    s.setValue(gridMaxKey(b), slot.dbMax);
+    s.setValue(gridMinKey(b), slot.dbMin);
 }
 
 } // namespace NereusSDR

--- a/src/models/PanadapterModel.h
+++ b/src/models/PanadapterModel.h
@@ -1,13 +1,25 @@
 #pragma once
 
+#include "Band.h"
+
+#include <QHash>
 #include <QObject>
 
 namespace NereusSDR {
 
+// Per-band grid scale storage. Added in Phase 3G-8 (commit 2).
+// dbStep is NOT per-band — Thetis keeps it as a single global value
+// (verified console.cs:14242-14436).
+struct BandGridSettings {
+    int dbMax;
+    int dbMin;
+};
+
 // Represents a single panadapter display.
 // In NereusSDR, panadapters are entirely client-side — the radio sends
 // raw I/Q, and the client computes FFT data for display. This model
-// holds display state (center frequency, bandwidth, dBm range).
+// holds display state (center frequency, bandwidth, dBm range, per-band
+// grid slots, current band).
 class PanadapterModel : public QObject {
     Q_OBJECT
 
@@ -21,6 +33,11 @@ public:
     ~PanadapterModel() override;
 
     double centerFrequency() const { return m_centerFrequency; }
+    // Setting the center frequency auto-derives the band via
+    // bandFromFrequency() and calls setBand() on boundary crossing.
+    // Direct setBand() is also callable when that's the wrong choice
+    // (e.g. XVTR mode, or band button click that shouldn't auto-switch
+    // on every subsequent VFO tweak).
     void setCenterFrequency(double freq);
 
     double bandwidth() const { return m_bandwidth; }
@@ -38,19 +55,54 @@ public:
     int averageCount() const { return m_averageCount; }
     void setAverageCount(int count);
 
+    // ---- Per-band grid (Phase 3G-8 commit 2) ----
+
+    // Currently-active band. Changing the band updates dBmFloor/dBmCeiling
+    // to the stored slot for the new band and emits levelChanged()
+    // automatically so existing SpectrumWidget wiring reacts.
+    Band band() const { return m_band; }
+    void setBand(Band b);
+
+    // Per-band grid slot accessors. dbMax/dbMin are persisted to
+    // AppSettings on every write. Reading an unset band returns the
+    // Thetis uniform default (-40 / -140) that was installed at
+    // construction time.
+    BandGridSettings perBandGrid(Band b) const;
+    void setPerBandDbMax(Band b, int dbMax);
+    void setPerBandDbMin(Band b, int dbMin);
+
+    // Grid step (single global value, matches Thetis). Persisted under
+    // the "DisplayGridStep" key.
+    int gridStep() const { return m_gridStep; }
+    void setGridStep(int step);
+
 signals:
     void centerFrequencyChanged(double freq);
     void bandwidthChanged(double bw);
     void levelChanged();
     void fftSizeChanged(int size);
+    void bandChanged(NereusSDR::Band band);
+    void gridStepChanged(int step);
 
 private:
+    // Reads m_perBandGrid[b] and pushes it into dBmFloor/dBmCeiling.
+    // Called by setBand(); does NOT emit bandChanged itself.
+    void applyBandGrid(Band b);
+
+    // AppSettings persistence helpers.
+    void loadPerBandGridFromSettings();
+    void saveBandGridToSettings(Band b) const;
+
     double m_centerFrequency{14225000.0};
     double m_bandwidth{200000.0};  // 200 kHz default
-    int m_dBmFloor{-130};
-    int m_dBmCeiling{-40};
+    int m_dBmFloor{-140};          // Matches Thetis default (was -130).
+    int m_dBmCeiling{-40};         // Matches Thetis default (was -40).
     int m_fftSize{4096};
     int m_averageCount{3};
+
+    Band m_band{Band::Band20m};    // Matches default center freq 14.225 MHz.
+    QHash<Band, BandGridSettings> m_perBandGrid;
+    int m_gridStep{10};            // NereusSDR divergence from Thetis 2.
 };
 
 } // namespace NereusSDR

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -63,6 +63,16 @@ public:
     int addPanadapter();
     void removePanadapter(int index);
 
+    // View hooks: non-owning pointers to the primary spectrum widget and
+    // FFT engine so setup pages (Phase 3G-8+) can call renderer/FFT
+    // setters without depending on MainWindow. Wired by MainWindow after
+    // constructing each view. Not owned, not lifetime-tracked — MainWindow
+    // outlives both.
+    class SpectrumWidget* spectrumWidget() const { return m_spectrumWidget; }
+    void setSpectrumWidget(class SpectrumWidget* w) { m_spectrumWidget = w; }
+    class FFTEngine* fftEngine() const { return m_fftEngine; }
+    void setFftEngine(class FFTEngine* e) { m_fftEngine = e; }
+
     // Radio info
     QString name() const { return m_name; }
     QString model() const { return m_model; }
@@ -114,6 +124,10 @@ private:
     QList<SliceModel*> m_slices;
     QList<PanadapterModel*> m_panadapters;
     SliceModel* m_activeSlice{nullptr};
+
+    // View hooks (non-owning, set by MainWindow). Phase 3G-8.
+    class SpectrumWidget* m_spectrumWidget{nullptr};
+    class FFTEngine*      m_fftEngine{nullptr};
 
     // Radio info
     QString m_name;


### PR DESCRIPTION
## Summary

- Brings `Setup → Display → Spectrum Defaults / Waterfall Defaults / Grid & Scales` from "every control disabled" to feature parity with Thetis for RX1 only.
- 47 controls wired across 3 setup pages. New reusable `ColorSwatchButton` widget, new first-class `Band` enum (14 bands), per-band grid storage on `PanadapterModel`, substantial `SpectrumWidget` / `FFTEngine` renderer additions, and a full GPU-path polish pass so every control is live on macOS Metal.
- 10 GPG-signed code commits + 3 doc-amend prep commits. All commits GPG-signed. No `--no-verify`, no `--no-gpg-sign`.
- Rebased onto `main` after 3G-7 merged (PR #5), so this PR targets `main` directly.

## What landed

| # | Commit | Scope |
|---|---|---|
| 1 | `ColorSwatchButton` reusable widget |
| 2 | `Band` enum (14 bands), per-band grid on `PanadapterModel`, `BandButtonItem` 12→14 |
| 3 | Spectrum renderer: averaging / peak hold / fill / gradient / cal offset |
| 4 | Waterfall renderer: AGC / reverse / opacity / overlays / timestamp |
| 5 | Grid/scheme renderer: 3 new colour schemes, grid colours, label align, FPS overlay |
| 6 | Wire Spectrum Defaults page (17 controls) |
| 7 | Wire Waterfall Defaults page (17 controls) |
| 8 | Wire Grid & Scales page (13 controls) |
| 9 | Verification matrix + CHANGELOG |
| 10 | GPU path polish: overlay cache invalidation, peak hold VBO, fill/gradient/cal-offset in vertex gen, waterfall chrome in overlay texture |

Plus doc-amend prep commits resolving plan §13 open questions and correcting plan §5.3.

## Architectural additions

- **`RadioModel::spectrumWidget()` / `fftEngine()`** — non-owning view hooks so Setup pages reach the renderer without depending on `MainWindow`.
- **`src/models/Band.h`** — first-class 14-band enum with label, key-name, frequency lookup (IARU Region 2), UI-index mapping.
- **`PanadapterModel::BandGridSettings`** — per-band dBm range slots. `setCenterFrequency()` auto-derives band from frequency and pushes the stored slot through to `dBmFloor` / `dBmCeiling`.
- **`SpectrumWidget::drawWaterfallChrome()`** — factored out of `drawWaterfall()` so the GPU overlay texture can reuse it for filter/zero-line/timestamp/opacity rendering.

## Plan §13 open questions resolved

1. **Cal Offset (S8)** — real Thetis field at `display.cs:1372` (`Display.RX1DisplayCalOffset`), not an extension.
2. **FPS overlay (G8)** — `QPainter` text in `paintEvent` + GPU overlay texture path.
3. **Display Thread Priority (S17)** — 1:1 map Thetis `ThreadPriority` → `QThread::Priority`, default `HighPriority`.
4. **Per-band grid initial values** — Thetis uniform -40 / -140 for all 14 slots (authorised one-off §10 divergence).

## Authorized divergences from Thetis

- New per-band grid slots initialise to Thetis uniform -40 / -140 rather than NereusSDR's existing -20 / -160, per user decision 2026-04-12. Existing users will see the grid shift on first launch after upgrade.
- Source-first protocol (`CLAUDE.md`) stays as written. This phase is a one-off exception, not a precedent.

Full divergence table in plan §10.

## Known deferrals

- **S7 Line Width on GPU** — QRhi doesn't expose portable `setLineWidth`; Metal/Vulkan clamp to 1.0. Proper thick lines need triangle strip rendering (shader refactor out of scope). QPainter fallback honours it.
- **FFT decimation (S16)** — UI scaffolded; `FFTEngine` has no decimation setter yet.
- **W12 / W14 TX overlays** — renderer hooks in place, activate once the TX state model provides a TX VFO/filter pair (post-3I-1).
- **Data Line Color / Data Fill Color share `m_fillColor`** — splitting deferred until verification feedback justifies it.
- **W10 Waterfall Low Color** — persisted; runtime gradient rebuild waits for the Custom-scheme `AppSettings` parser.

## Verification

See [`docs/architecture/phase3g8-verification/README.md`](docs/architecture/phase3g8-verification/README.md) for the 47-control before/after screenshot matrix. Screenshot capture deferred to a follow-up pass. All controls build clean, launch cleanly, and the GPU path is live for everything except the explicit deferrals above.

**Build:** clean on macOS Metal (`cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`), zero new warnings. One pre-existing warning in `ContainerSettingsDialog.cpp` unrelated to this diff.

## Test plan

- [ ] Build green locally on macOS
- [ ] Open `Settings → Display → Spectrum Defaults`, toggle each control, confirm spectrum responds
- [ ] Open `Settings → Display → Waterfall Defaults`, toggle each control, confirm waterfall responds
- [ ] Open `Settings → Display → Grid & Scales`, toggle each control, confirm grid / FPS / zero line respond
- [ ] Tune across a band boundary (40m → 30m), confirm "Editing band: N" label updates and per-band dB Max/Min spinboxes follow
- [ ] Restart app, confirm all new per-pan settings persist

---

JJ Boyd ~KG4VCF
Co-Authored with Claude Code