### PR TITLE
fix(meters): orphan poller, calibrated needle clamp, container UX cleanup

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -196,6 +196,31 @@ void MainWindow::buildUI()
 
     // --- Container Infrastructure (Phase 3G-1) ---
     m_containerManager = new ContainerManager(spectrumPane, m_mainSplitter, this);
+
+    // Create the MeterPoller BEFORE restoreState / populateDefaultMeter
+    // so the meterReadyForPolling signal fires into a live poller as
+    // each container's MeterWidget is materialized. Previously the
+    // poller was created later and only the panel container's
+    // m_meterWidget was registered manually — every user-created
+    // container's meter sat orphaned and bars never received setValue()
+    // calls, the root of the "BarMeter not drawing" symptom.
+    m_meterPoller = new MeterPoller(this);
+    connect(m_containerManager, &ContainerManager::meterReadyForPolling,
+            this, [this](MeterWidget* meter) {
+        if (!meter || !m_meterPoller) { return; }
+        m_meterPoller->addTarget(meter);
+        // Auto-unregister when the meter is destroyed (e.g.
+        // ContainerWidget::setContent deleteLater()s a previous
+        // content during a swap). Without this the poller would
+        // dereference a dangling pointer on its next tick.
+        connect(meter, &QObject::destroyed, m_meterPoller,
+                [this](QObject* obj) {
+            if (m_meterPoller) {
+                m_meterPoller->removeTarget(static_cast<MeterWidget*>(obj));
+            }
+        });
+    });
+
     m_containerManager->restoreState();
     if (m_containerManager->containerCount() == 0) {
         createDefaultContainers();
@@ -268,9 +293,11 @@ void MainWindow::buildUI()
     m_fftThread->start();
 
     // --- Meter Poller (Phase 3G-2) ---
-    m_meterPoller = new MeterPoller(this);
-    populateDefaultMeter();
-
+    // Poller was created earlier so the meterReadyForPolling signal
+    // could catch container restore + populateDefaultMeter emits.
+    // m_meterWidget is registered automatically via that signal —
+    // the call here is a defensive belt only and dedupes inside
+    // MeterPoller::addTarget.
     if (m_meterWidget) {
         m_meterPoller->addTarget(m_meterWidget);
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -137,6 +137,22 @@ MainWindow::MainWindow(QWidget* parent)
 
     // Auto-reconnect to last radio if it appears
     tryAutoReconnect();
+
+    // Defensive save on aboutToQuit. closeEvent is fine for ⌘Q but
+    // does NOT run when the process is signaled (SIGTERM from
+    // pkill, Activity Monitor force-quit, debugger detach). Without
+    // this hook, any container/state change made mid-session is
+    // lost on signal-based shutdown — which is exactly the symptom
+    // we hit during automated test cycles where pkill killed the
+    // app before saveState ran. saveState is idempotent so the
+    // ⌘Q path (closeEvent → saveState; aboutToQuit → saveState
+    // again) is harmless.
+    connect(qApp, &QCoreApplication::aboutToQuit, this, [this]() {
+        if (m_containerManager) {
+            m_containerManager->saveState();
+        }
+        AppSettings::instance().save();
+    });
 }
 
 MainWindow::~MainWindow() = default;

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -61,6 +61,16 @@ void ContainerManager::wireContainer(ContainerWidget* container)
             [this, container](const QString& notes) {
         emit containerTitleChanged(container->id(), notes);
     });
+    // Announce any MeterWidget that becomes a (descendant of) the
+    // container's content. Listens for both the create path
+    // (createContainer + caller setContent) and the restore path
+    // (ContainerManager itself calls setContent after wireContainer).
+    connect(container, &ContainerWidget::contentChanged, this,
+            [this](QWidget* content) {
+        if (auto* meter = innerMeterWidget(content)) {
+            emit meterReadyForPolling(meter);
+        }
+    });
 }
 
 ContainerWidget* ContainerManager::duplicateContainer(const QString& sourceId)
@@ -472,6 +482,12 @@ void ContainerManager::restoreState()
             continue;
         }
 
+        // wireContainer BEFORE setContent so the contentChanged
+        // listener catches the meterReadyForPolling emit on the
+        // restore path. (Originally wireContainer ran after setContent
+        // and listeners missed the announcement.)
+        wireContainer(container);
+
         // Materialize the inner content widget. MainWindow registers a
         // factory so the panel container gets an AppletPanelWidget;
         // when no factory is set (tests, headless tools) we default to
@@ -498,7 +514,6 @@ void ContainerManager::restoreState()
         auto* floatingForm = new FloatingContainer(container->rxSource());
         floatingForm->setId(container->id());
 
-        wireContainer(container);
         m_containers.insert(container->id(), container);
         m_floatingForms.insert(container->id(), floatingForm);
 

--- a/src/gui/containers/ContainerManager.h
+++ b/src/gui/containers/ContainerManager.h
@@ -14,6 +14,7 @@ namespace NereusSDR {
 
 class ContainerWidget;
 class FloatingContainer;
+class MeterWidget;
 enum class DockMode;
 
 // Factory that materializes the inner content widget for a restored
@@ -81,6 +82,15 @@ signals:
     // of the display title). MainWindow consumes this in commit 45 to
     // rebuild the Containers → Edit Container submenu.
     void containerTitleChanged(const QString& id, const QString& title);
+    // Emitted whenever a MeterWidget becomes (or appears as a
+    // descendant of) a container's content. MainWindow connects this
+    // to MeterPoller::addTarget so user-created and restored
+    // containers both flow into the WDSP/MMIO poll loop. Without this
+    // hookup the poller only knew about the panel container's initial
+    // m_meterWidget and every other container's items sat at default
+    // values forever — symptom: bars frozen at frac=0, needles never
+    // moving.
+    void meterReadyForPolling(MeterWidget* meter);
 
 private:
     void setMeterFloating(ContainerWidget* container, FloatingContainer* form);

--- a/src/gui/containers/ContainerSettingsDialog.cpp
+++ b/src/gui/containers/ContainerSettingsDialog.cpp
@@ -1855,9 +1855,21 @@ void ContainerSettingsDialog::loadPresetByName(const QString& name)
     }
 
     if (group) {
+        // Offset every cloned preset item by the current stack
+        // position so the preset doesn't overlap existing narrow
+        // items at the top of the container. Without this offset, a
+        // user who adds a single Bar (lands at y=0) and then loads
+        // the Clock preset (factory items also at y=0) sees the bar
+        // and clocks piled on top of each other. Computed BEFORE the
+        // loop so the offset is constant for all items in the preset.
+        const float yOffset = nextStackYPos(m_workingItems);
         for (MeterItem* src : group->items()) {
             MeterItem* clone = createItemFromSerialized(src->serialize());
             if (clone) {
+                clone->setRect(clone->x(),
+                               clone->y() + yOffset,
+                               clone->itemWidth(),
+                               clone->itemHeight());
                 // Phase 3G-7: factory presets won't normally have MMIO
                 // bindings, but copy them defensively in case a future
                 // preset wires one.

--- a/src/gui/containers/ContainerSettingsDialog.cpp
+++ b/src/gui/containers/ContainerSettingsDialog.cpp
@@ -973,19 +973,37 @@ void ContainerSettingsDialog::onMoveItemDown()
 // addNewItem — create and insert a new item after the current selection
 // ---------------------------------------------------------------------------
 
-void ContainerSettingsDialog::addNewItem(const QString& typeTag)
+float ContainerSettingsDialog::nextStackYPos(const QVector<MeterItem*>& items)
 {
-    // Calculate yPos: max (y + height) of existing items, clamped to 0.9
+    // Compute the next vertical-stack y-position. Skip items that
+    // span more than 70% of the container vertically — those are
+    // background / overlay-style items (ImageItem backgrounds, ANANMM
+    // full-container needles) and don't participate in the stack.
+    // Without this filter the next-position math would clamp every
+    // newly-added item at y=0.9 the moment a full-container item
+    // existed, piling new items on top of each other.
+    constexpr float kBackgroundSpanThreshold = 0.7f;
+    constexpr float kBottomClamp = 0.9f;
     float yPos = 0.0f;
-    for (const MeterItem* item : m_workingItems) {
+    for (const MeterItem* item : items) {
+        if (!item) { continue; }
+        if (item->itemHeight() > kBackgroundSpanThreshold) {
+            continue;
+        }
         const float bottom = item->y() + item->itemHeight();
         if (bottom > yPos) {
             yPos = bottom;
         }
     }
-    if (yPos > 0.9f) {
-        yPos = 0.9f;
+    if (yPos > kBottomClamp) {
+        yPos = kBottomClamp;
     }
+    return yPos;
+}
+
+void ContainerSettingsDialog::addNewItem(const QString& typeTag)
+{
+    const float yPos = nextStackYPos(m_workingItems);
 
     MeterItem* newItem = nullptr;
 

--- a/src/gui/containers/ContainerSettingsDialog.h
+++ b/src/gui/containers/ContainerSettingsDialog.h
@@ -45,6 +45,17 @@ public:
                                      ContainerManager* manager = nullptr);
     ~ContainerSettingsDialog() override;
 
+    // Compute the next y-position for an item being appended to a
+    // vertically-stacked layout. Items spanning more than 70% of the
+    // container vertically are treated as background / overlay-style
+    // items (ANANMM's full-container needles, ImageItem backgrounds,
+    // etc.) and excluded from the stack calculation — otherwise an
+    // ANANMM container would clamp every newly-added item to y=0.9
+    // and pile them on top of each other. Public + static so the
+    // tst_container_persistence suite can exercise it without
+    // instantiating the dialog.
+    static float nextStackYPos(const QVector<MeterItem*>& items);
+
 private slots:
     void onItemSelectionChanged();
     void onAddItem();

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -175,6 +175,7 @@ void ContainerWidget::setContent(QWidget* widget)
         }
         layout->addWidget(m_content);
     }
+    emit contentChanged(m_content);
 }
 
 void ContainerWidget::updateTitleBar()

--- a/src/gui/containers/ContainerWidget.h
+++ b/src/gui/containers/ContainerWidget.h
@@ -141,6 +141,10 @@ signals:
     void titleBarVisibilityChanged(bool visible);
     void minimisedChanged(bool minimised);
     void notesChanged(const QString& notes);
+    // Emitted from setContent() after the new content widget is
+    // installed. ContainerManager listens so it can scan for an inner
+    // MeterWidget and announce it for poller registration.
+    void contentChanged(QWidget* widget);
 
     // --- Phase 3G-5 interactive item signals ---
     void bandClicked(int bandIndex);

--- a/src/gui/containers/meter_property_editors/BaseItemEditor.cpp
+++ b/src/gui/containers/meter_property_editors/BaseItemEditor.cpp
@@ -92,6 +92,10 @@ void BaseItemEditor::buildBaseForm()
     m_comboBinding = new QComboBox(this);
     m_comboBinding->setStyleSheet(kComboStyle);
     m_comboBinding->setMinimumWidth(kDefaultFieldWidth);
+    m_comboBinding->setToolTip(QStringLiteral(
+        "Built-in meter source: WDSP RX/TX channels, PA hardware "
+        "(volts/amps/temp), and rotator readings. For external MMIO "
+        "endpoint variables use the MMIO Variable\u2026 button."));
     populateBindingCombo();
     connect(m_comboBinding, qOverload<int>(&QComboBox::currentIndexChanged),
             this, [this](int) {
@@ -108,9 +112,10 @@ void BaseItemEditor::buildBaseForm()
     bindingLay->setContentsMargins(0, 0, 0, 0);
     bindingLay->setSpacing(4);
     bindingLay->addWidget(m_comboBinding, 1);
-    auto* btnVariable = new QPushButton(QStringLiteral("Variable\u2026"), bindingRow);
-    btnVariable->setToolTip(
-        QStringLiteral("Bind this item to an MMIO endpoint variable"));
+    auto* btnVariable = new QPushButton(QStringLiteral("MMIO Variable\u2026"), bindingRow);
+    btnVariable->setToolTip(QStringLiteral(
+        "Bind this item to an MMIO endpoint variable. For built-in "
+        "WDSP / PA / rotator meters use the dropdown to the left."));
     bindingLay->addWidget(btnVariable);
     connect(btnVariable, &QPushButton::clicked, this, [this, btnVariable]() {
         if (!m_item) { return; }

--- a/src/gui/meters/ItemGroup.cpp
+++ b/src/gui/meters/ItemGroup.cpp
@@ -1259,14 +1259,21 @@ ItemGroup* ItemGroup::createVfoDisplayPreset(QObject* parent)
 
 ItemGroup* ItemGroup::createClockPreset(QObject* parent)
 {
+    // Clock preset is a single narrow strip at the top of its target
+    // region (0..0.15 normalized). The previous version installed
+    // both the background and the ClockItem at full container size
+    // (0,0,1,1), which collided with auto-stacking heuristics: every
+    // subsequent item the user added landed on top of the clock
+    // instead of beside it. Now the bg + clock share the same narrow
+    // strip and the auto-stacker treats them as a real stack member.
     auto* group = new ItemGroup(QStringLiteral("Clock"), parent);
     auto* bg = new SolidColourItem(group);
-    bg->setRect(0.0f, 0.0f, 1.0f, 1.0f);
+    bg->setRect(0.0f, 0.0f, 1.0f, 0.15f);
     bg->setColour(QColor(0x0f, 0x0f, 0x1a));
     bg->setZOrder(0);
     group->addItem(bg);
     auto* clock = new ClockItem(group);
-    clock->setRect(0.0f, 0.0f, 1.0f, 1.0f);
+    clock->setRect(0.0f, 0.0f, 1.0f, 0.15f);
     clock->setZOrder(1);
     group->addItem(clock);
     return group;

--- a/src/gui/meters/MeterItem.cpp
+++ b/src/gui/meters/MeterItem.cpp
@@ -597,11 +597,27 @@ void NeedleItem::setValue(double v)
 {
     MeterItem::setValue(v);
 
-    const float dbm = static_cast<float>(v);
+    const float val = static_cast<float>(v);
 
     // Exponential smoothing (from AetherSDR SMOOTH_ALPHA = 0.3)
-    m_smoothedDbm += kSmoothAlpha * (dbm - m_smoothedDbm);
-    m_smoothedDbm = std::clamp(m_smoothedDbm, kS0Dbm, kMaxDbm);
+    m_smoothedDbm += kSmoothAlpha * (val - m_smoothedDbm);
+
+    // Clamp to the appropriate value range. Calibrated needles
+    // (ANANMM Volts/Amps/Power/SWR/Compression/ALC) use the
+    // calibration map's key range — they're in native units (volts,
+    // amps, watts, etc.), NOT dBm. Clamping a 13V reading to the
+    // [-127, -13] dBm range mangles it to -13, then
+    // calibratedPosition() looks up -13 in a {10, 12.5, 15} map and
+    // returns the first calibration point — the symptom was every
+    // calibrated needle drawing as a near-horizontal line at the
+    // offset row.
+    if (m_scaleCalibration.isEmpty()) {
+        m_smoothedDbm = std::clamp(m_smoothedDbm, kS0Dbm, kMaxDbm);
+    } else {
+        const float minKey = m_scaleCalibration.firstKey();
+        const float maxKey = m_scaleCalibration.lastKey();
+        m_smoothedDbm = std::clamp(m_smoothedDbm, minKey, maxKey);
+    }
 
     // Peak tracking (from AetherSDR Medium preset: 500ms hold, 10 dB/sec decay)
     if (m_smoothedDbm > m_peakDbm) {

--- a/src/gui/meters/MeterItem.h
+++ b/src/gui/meters/MeterItem.h
@@ -447,6 +447,16 @@ public:
 
     void setValue(double v) override;
 
+    // Smoothed value as currently held by the needle. Named
+    // m_smoothedDbm historically because the needle started life as a
+    // dBm-only S-meter; for calibrated needles (ANANMM Volts/Amps/
+    // Power/SWR/Compression/ALC) it holds the value in the calibration
+    // map's native units (volts, amps, watts, etc.) — see setValue()
+    // for the per-mode clamp logic. Exposed so tests can assert the
+    // post-smoothing value without round-tripping through paint
+    // geometry.
+    float smoothedValue() const { return m_smoothedDbm; }
+
     // Multi-layer: participates in all 4 pipeline layers
     bool participatesIn(Layer layer) const override;
     Layer renderLayer() const override { return Layer::Geometry; }

--- a/tests/tst_container_persistence.cpp
+++ b/tests/tst_container_persistence.cpp
@@ -146,6 +146,74 @@ private slots:
             QCOMPARE(meter->items().size(), 3);
         }
     }
+
+    // ContainerManager must announce every MeterWidget it manages so
+    // MainWindow can wire them into MeterPoller. Previously, only the
+    // initial m_meterWidget on the panel container was registered;
+    // user-created containers' meters were orphaned and never received
+    // setValue() calls — bars sat at frac=0 (visually invisible) and
+    // needles never moved. Symptom: "BarMeter not drawing".
+    void createdContainerMeterAnnouncedForPolling()
+    {
+        QWidget dockParent;
+        QSplitter splitter;
+        ContainerManager mgr(&dockParent, &splitter);
+
+        QList<MeterWidget*> announced;
+        QObject::connect(&mgr, &ContainerManager::meterReadyForPolling,
+                         [&announced](MeterWidget* m) {
+            announced.append(m);
+        });
+
+        ContainerWidget* c = mgr.createContainer(1, DockMode::Floating);
+        QVERIFY(c);
+        auto* meter = new MeterWidget();
+        c->setContent(meter);
+
+        QCOMPARE(announced.size(), 1);
+        QCOMPARE(announced.first(), meter);
+    }
+
+    // After restoreState, every container that ContainerManager
+    // materialized a MeterWidget for must also be announced. The
+    // restored meter is a fresh instance, not the one the test
+    // populated in phase 1, so we just assert that exactly one signal
+    // fired with a non-null pointer matching the container's content.
+    void restoredContainerMeterAnnouncedForPolling()
+    {
+        QWidget dockParent;
+        QSplitter splitter;
+        QString savedId;
+
+        {
+            ContainerManager mgr(&dockParent, &splitter);
+            ContainerWidget* c = mgr.createContainer(1, DockMode::Floating);
+            savedId = c->id();
+            auto* meter = new MeterWidget();
+            c->setContent(meter);
+            meter->addItem(new BarItem());
+            mgr.saveState();
+        }
+
+        {
+            ContainerManager mgr2(&dockParent, &splitter);
+
+            QList<MeterWidget*> announced;
+            QObject::connect(&mgr2, &ContainerManager::meterReadyForPolling,
+                             [&announced](MeterWidget* m) {
+                announced.append(m);
+            });
+
+            mgr2.restoreState();
+
+            QCOMPARE(announced.size(), 1);
+            QVERIFY(announced.first() != nullptr);
+
+            ContainerWidget* c = mgr2.container(savedId);
+            QVERIFY(c);
+            QCOMPARE(announced.first(), qobject_cast<MeterWidget*>(c->content()));
+        }
+    }
 };
 
 QTEST_MAIN(TstContainerPersistence)

--- a/tests/tst_container_persistence.cpp
+++ b/tests/tst_container_persistence.cpp
@@ -16,6 +16,7 @@
 
 #include "core/AppSettings.h"
 #include "gui/containers/ContainerManager.h"
+#include "gui/containers/ContainerSettingsDialog.h"
 #include "gui/containers/ContainerWidget.h"
 #include "gui/meters/MeterItem.h"
 #include "gui/meters/MeterWidget.h"
@@ -213,6 +214,102 @@ private slots:
             QVERIFY(c);
             QCOMPARE(announced.first(), qobject_cast<MeterWidget*>(c->content()));
         }
+    }
+
+    // NeedleItem::setValue historically clamped to the AetherSDR
+    // S-meter dBm range [-127, -13]. ANANMM's calibrated needles
+    // (Volts 10-15, Amps 0-20, Power 0-150W, SWR 1-10, Compression
+    // 0-30 dB, ALC 0-30 dB) all use NATIVE units in their calibration
+    // maps. The dBm clamp destroyed the value before
+    // calibratedPosition() ran, collapsing every calibrated needle
+    // to the first/last calibration point. Visually: needles drew as
+    // a near-horizontal line at the offset row regardless of value.
+    //
+    // RED: with the old clamp, smoothedValue() will sit at -13.0 (or
+    // similar) after pushing 13.0 because it's outside [-127, -13].
+    // GREEN: clamp uses calibration map's key range when the map is
+    // populated.
+    void calibratedNeedleNotClampedToDbmRange()
+    {
+        NeedleItem needle;
+
+        // Volts-style calibration: keys 10..15 V, all positions in
+        // the same y row (matches the ANANMM voltmeter layout).
+        QMap<float, QPointF> cal;
+        cal.insert(10.0f, QPointF(0.559, 0.756));
+        cal.insert(12.5f, QPointF(0.605, 0.772));
+        cal.insert(15.0f, QPointF(0.665, 0.784));
+        needle.setScaleCalibration(cal);
+
+        // Push a realistic Volts reading enough times for the
+        // exponential smoothing (alpha 0.3) to converge from the
+        // default kS0Dbm.
+        for (int i = 0; i < 40; ++i) {
+            needle.setValue(13.0);
+        }
+
+        // Must be inside the calibration range, NOT clamped to the
+        // dBm range (-127..-13) which would leave it at or below -13.
+        const float v = needle.smoothedValue();
+        QVERIFY2(v >= 10.0f,
+                 qPrintable(QStringLiteral(
+                     "calibrated needle smoothedValue %1 below "
+                     "calibration min — dBm clamp not bypassed").arg(v)));
+        QVERIFY2(v <= 15.0f,
+                 qPrintable(QStringLiteral(
+                     "calibrated needle smoothedValue %1 above "
+                     "calibration max").arg(v)));
+    }
+
+    // ContainerSettingsDialog::addNewItem stacks new items vertically
+    // by computing yPos = max(y + height) of existing items, clamped
+    // at 0.9. The ANANMM preset installs 7 needles each at (0,0,1,1)
+    // — full-container background overlays. With the old logic, the
+    // clamp pinned every new item at y=0.9 and they piled up on top
+    // of each other. The fix: items with itemHeight() > 0.7 are
+    // treated as backgrounds and excluded from the stack
+    // calculation.
+    void nextStackYPosIgnoresFullContainerOverlays()
+    {
+        // Case 1: only an ANANMM-style full-container needle present.
+        // Old behaviour returned 0.9 (clamped from 1.0). New
+        // behaviour should return 0.0 — there are no narrow stacked
+        // items, so the next item starts at the top.
+        QVector<MeterItem*> overlaysOnly;
+        auto* fullNeedle = new NeedleItem();
+        fullNeedle->setRect(0.0f, 0.0f, 1.0f, 1.0f);
+        overlaysOnly.append(fullNeedle);
+
+        const float yOverlay =
+            ContainerSettingsDialog::nextStackYPos(overlaysOnly);
+        QVERIFY2(yOverlay < 0.05f,
+                 qPrintable(QStringLiteral(
+                     "yPos %1 still pinned by full-container overlay").arg(yOverlay)));
+
+        // Case 2: full-container background + two real stacked bars.
+        // Should return 0.30 (after the second bar), not 0.9.
+        QVector<MeterItem*> mixed;
+        auto* bg = new NeedleItem();
+        bg->setRect(0.0f, 0.0f, 1.0f, 1.0f);
+        mixed.append(bg);
+
+        auto* bar1 = new BarItem();
+        bar1->setRect(0.0f, 0.0f, 1.0f, 0.15f);
+        mixed.append(bar1);
+
+        auto* bar2 = new BarItem();
+        bar2->setRect(0.0f, 0.15f, 1.0f, 0.15f);
+        mixed.append(bar2);
+
+        const float yMixed =
+            ContainerSettingsDialog::nextStackYPos(mixed);
+        QVERIFY2(qFuzzyCompare(yMixed + 1.0f, 0.30f + 1.0f),
+                 qPrintable(QStringLiteral(
+                     "yPos %1 should follow stacked bars (0.30), not "
+                     "the overlay clamp").arg(yMixed)));
+
+        qDeleteAll(overlaysOnly);
+        qDeleteAll(mixed);
     }
 };
 


### PR DESCRIPTION
## Summary

Six related fixes uncovered while debugging "BarMeter not drawing in
ANANMM container." The orphan-poller bug turned out to be the root,
and chasing it surfaced four downstream issues plus a defensive save
hook. None of these are part of the larger Default Multimeter port
that's tracked in a separate plan — that work is queued for after
this lands.

## Commits

1. **`cb3683d` fix(meters): register every container's MeterWidget with MeterPoller**
   `MainWindow` only ever called `MeterPoller::addTarget(m_meterWidget)`
   for the panel container's initial meter. User-created containers
   (and PR #7's restored containers) had their meters orphaned —
   bars sat at frac=0, needles never moved. New
   `ContainerWidget::contentChanged` signal flows through
   `ContainerManager::meterReadyForPolling` into `MeterPoller`. Auto-
   unregister via `QObject::destroyed` hookup so swapped content
   doesn't leave dangling pointers.

2. **`951ea63` fix(editor): clarify built-in vs MMIO binding controls**
   Two-line label/tooltip change. The MeterBinding combo and the
   "Variable…" MMIO picker button sat side-by-side in
   `BaseItemEditor` with no visual distinction; users assumed the
   button was the only binding selector. Combo now has a tooltip
   naming what it covers; button text changes to "MMIO Variable…"
   so its scope is visible without hovering.

3. **`7c6b6a6` fix(meters): calibrated needle clamp + ANANMM-aware item stacking**
   Two bugs in one commit:
   - `NeedleItem::setValue` clamped m_smoothedDbm to the dBm range
     [-127, -13] unconditionally. ANANMM's Volts/Amps/Power/SWR/
     Compression/ALC needles use NATIVE units in their calibration
     maps. Pushing 13.0 V to a Volts needle was clamped to -13,
     calibratedPosition(-13) returned the first volts cal point at
     y=0.756 (≈ pivot y=0.736), and the needle drew as a near-
     horizontal line. Fix: when calibration is non-empty, clamp to
     the calibration map's first/last key range.
   - `ContainerSettingsDialog::addNewItem` stacked new items via
     yPos = max(y+h) of existing items, clamped to 0.9. ANANMM's
     7 needles + image background are all at (0,0,1,1), so every
     newly-added item piled at y=0.9 stacked on top of each other.
     Fix: extracted static `nextStackYPos(items)` helper that
     ignores items with `itemHeight() > 0.7` (background-style).

4. **`f228bc3` fix(dialog): offset Load Preset items by stack position**
   `loadPresetByName` cloned preset items at their factory-hardcoded
   coordinates, bypassing `nextStackYPos`. Loading the Clock preset
   into a container that already had a bar landed both at y=0.
   Compute `nextStackYPos` BEFORE the clone loop, offset every cloned
   preset item's y by the result. Preset internal spacing preserved.

5. **`ad77794` fix(meters): shrink Clock preset to a narrow top strip**
   `createClockPreset` installed both its background and ClockItem
   at full container size (0,0,1,1). The auto-stacking heuristic
   then classified the clock as background-style and any subsequent
   narrow item piled at y=0 on top of it. The clock preset itself
   was malformed. Fix: both items use a (0, 0, 1, 0.15) rect.

6. **`2237fb8` fix(mainwindow): persist container state on aboutToQuit too**
   `MainWindow::closeEvent` only fires on window-close events (⌘Q,
   close button). It does NOT fire on signal-based shutdown
   (SIGTERM, force-quit, debugger detach). Hit during automated
   screenshot/relaunch loops on this branch where pkill killed the
   test instance before saveState ran, losing the floating container
   the user had built mid-session. Connect
   `QCoreApplication::aboutToQuit` to a small handler that calls
   `ContainerManager::saveState` + `AppSettings::save`. Idempotent
   with the closeEvent path.

## Test plan

Automated (`tst_container_persistence`, 8 cases including the 4 new
ones added by this branch):
- [x] User-created container shape (bare MeterWidget) round-trip
- [x] Wrapped container shape (MeterWidget inside QWidget host)
- [x] `meterReadyForPolling` signal fires on createContainer + setContent
- [x] `meterReadyForPolling` fires after restoreState materializes a meter
- [x] `calibratedNeedleNotClampedToDbmRange` — Volts-style needle pushed 13.0 holds in [10, 15], not clamped to dBm range
- [x] `nextStackYPosIgnoresFullContainerOverlays` — full-container overlay alone returns 0.0 (not 0.9 clamp); overlay + 2 stacked bars returns 0.30
- [x] All pre-existing PR #7 tests still pass (8 total)

Manual:
- [x] Live build verified: floating ANANMM container's calibrated needles (S-meter on Container #0) animate at meaningful angles with radio connected at -73 dBm — visible orange/red ticks replace the prior horizontal collapse
- [x] Container persistence across ⌘Q + relaunch (verified with AppSettings file inspection: 2 containers persisted, 6 items keys present)
- [ ] (Deferred) Bar meter row layout — addressed in the follow-up Default Multimeter port

## Build

\`\`\`bash
cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build -j\$(nproc)
# Tests:
cmake -B build-tests -G Ninja -DNEREUS_BUILD_TESTS=ON
cmake --build build-tests --target tst_container_persistence
./build-tests/tests/tst_container_persistence
\`\`\`

JJ Boyd ~KG4VCF

🤖 Co-Authored with Claude Code