### PR TITLE
fix(windows): spectrum/waterfall rendering, disconnect crash, and DDC IQ streaming on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,19 @@ jobs:
       - name: Configure (Linux)
         if: runner.os == 'Linux'
         run: |
+          # Linux CI uses Ubuntu's system Qt 6 via apt (qt6-base-dev),
+          # which on ubuntu-24.04 is Qt 6.4.2 — too old for QRhiWidget
+          # (requires 6.7+). GPU spectrum is explicitly disabled here
+          # so CMake's new FATAL_ERROR path does not trip. Upgrading
+          # the Linux CI runner to install-qt-action-managed Qt 6.7+
+          # (matching release.yml) is a separate ticket; for now this
+          # matches the historical behavior of Linux CI silently
+          # falling back to the CPU path.
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DNEREUS_GPU_SPECTRUM=OFF
 
       - name: Configure (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,14 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
+          # -DNEREUS_GPU_SPECTRUM=ON is explicit so CMake's FATAL_ERROR
+          # fires at configure time if the Qt install is missing the
+          # ShaderTools or Gui private modules. v0.1.1 silently shipped
+          # without GPU spectrum because this flag was implicit; never
+          # again.
           cmake -B build -G "MinGW Makefiles" \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DNEREUS_GPU_SPECTRUM=ON
 
       # ------------------------------------------------------------------
       # Build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,13 @@ jobs:
 
       - name: Build
         run: |
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          # CodeQL runs on Ubuntu with apt-managed Qt 6.4.2, which is
+          # older than QRhiWidget's 6.7+ requirement. GPU spectrum is
+          # explicitly disabled here so CMake's FATAL_ERROR path does
+          # not trip. Same reasoning as Linux ci.yml Configure step.
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DNEREUS_GPU_SPECTRUM=OFF
           cmake --build build -j$(nproc)
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,8 +352,14 @@ jobs:
       - name: Configure
         shell: bash
         run: |
+          # -DNEREUS_GPU_SPECTRUM=ON is explicit so CMake's FATAL_ERROR
+          # fires at configure time if the Qt install is missing the
+          # ShaderTools or Gui private modules. v0.1.1 silently shipped
+          # without GPU spectrum because this flag was implicit; never
+          # again.
           cmake -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_BUILD_TYPE=Release \
+            -DNEREUS_GPU_SPECTRUM=ON
 
       - name: Build
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,22 +153,89 @@ endif()
 
 # --------------------------------------------------------------------------
 # GPU-accelerated spectrum/waterfall (QRhi — requires Qt 6.7+)
+#
+# History: v0.1.1 shipped a Windows installer that silently disabled
+# GPU spectrum because this block used `message(STATUS)` fallbacks when
+# the private-module detection failed, and the shipping pipeline never
+# explicitly requested -DNEREUS_GPU_SPECTRUM=ON. Users saw a blank
+# spectrum area and no log line from SpectrumWidget::initialize().
+#
+# The check now does three things differently:
+#   1. Probes for both a _FOUND variable AND an imported target, since
+#      Qt's private-module CMake exports have varied across 6.x minor
+#      releases and install-qt-action layouts.
+#   2. Captures a specific reason string when either component is
+#      missing so the error message can point the user at the fix.
+#   3. Promotes the fallback to FATAL_ERROR when the caller opted in
+#      to GPU spectrum (the default) — silently shipping a CPU-only
+#      binary is the exact footgun that caused v0.1.1. Users who
+#      genuinely want the CPU path must pass -DNEREUS_GPU_SPECTRUM=OFF
+#      explicitly to acknowledge it.
 # --------------------------------------------------------------------------
-option(NEREUS_GPU_SPECTRUM "Enable GPU-accelerated spectrum/waterfall via QRhi" ON)
+option(NEREUS_GPU_SPECTRUM "Enable GPU-accelerated spectrum/waterfall via QRhi (requires Qt 6.7+ with ShaderTools and Gui private headers)" ON)
+
+# Remember whether the caller requested it before any auto-disable, so
+# we can produce a hard failure if we can't honor the request.
+set(_nereus_gpu_spectrum_requested ${NEREUS_GPU_SPECTRUM})
+set(_nereus_gpu_fail_reason "")
+
 if(NEREUS_GPU_SPECTRUM)
     if(Qt6_VERSION VERSION_LESS "6.7")
-        message(STATUS "Qt ${Qt6_VERSION} < 6.7 — GPU spectrum disabled (requires QRhiWidget)")
+        set(_nereus_gpu_fail_reason
+            "Qt ${Qt6_VERSION} is older than 6.7 (QRhiWidget requires 6.7+)")
         set(NEREUS_GPU_SPECTRUM OFF)
     else()
-        find_package(Qt6 QUIET COMPONENTS ShaderTools)
-        find_package(Qt6 QUIET COMPONENTS GuiPrivate)
-        if(Qt6ShaderTools_FOUND AND Qt6GuiPrivate_FOUND)
+        # Ask CMake to locate the private modules. QUIET so we can emit
+        # a single, context-rich failure message below instead of
+        # multiple cryptic find_package warnings.
+        find_package(Qt6 QUIET COMPONENTS ShaderTools GuiPrivate)
+
+        # Belt-and-braces detection: accept either the _FOUND variable
+        # or the imported target. install-qt-action on Windows has
+        # shipped Qt 6.7/6.8 layouts where Qt6GuiPrivate_FOUND is not
+        # set even though the Qt6::GuiPrivate target exists, which is
+        # what silently broke v0.1.1.
+        set(_nereus_have_shadertools FALSE)
+        set(_nereus_have_guiprivate  FALSE)
+        if(Qt6ShaderTools_FOUND OR TARGET Qt6::ShaderTools)
+            set(_nereus_have_shadertools TRUE)
+        endif()
+        if(Qt6GuiPrivate_FOUND OR TARGET Qt6::GuiPrivate)
+            set(_nereus_have_guiprivate TRUE)
+        endif()
+
+        if(_nereus_have_shadertools AND _nereus_have_guiprivate)
             message(STATUS "QRhi support enabled — GPU spectrum/waterfall active")
         else()
-            message(STATUS "Qt6 ShaderTools or GuiPrivate not found — GPU spectrum disabled")
+            set(_nereus_gpu_fail_reason "Qt6 private modules missing:")
+            if(NOT _nereus_have_shadertools)
+                string(APPEND _nereus_gpu_fail_reason " ShaderTools")
+            endif()
+            if(NOT _nereus_have_guiprivate)
+                string(APPEND _nereus_gpu_fail_reason " GuiPrivate")
+            endif()
             set(NEREUS_GPU_SPECTRUM OFF)
         endif()
     endif()
+endif()
+
+# Fail loudly if the caller asked for GPU spectrum and we couldn't
+# deliver it. This prevents a repeat of the v0.1.1 silent-CPU-fallback
+# shipping incident.
+if(_nereus_gpu_spectrum_requested AND NOT NEREUS_GPU_SPECTRUM)
+    message(FATAL_ERROR
+        "NEREUS_GPU_SPECTRUM was requested but cannot be enabled.\n"
+        "Reason: ${_nereus_gpu_fail_reason}\n"
+        "Fix options:\n"
+        "  - install-qt-action: ensure 'qtshadertools' is in the modules list; "
+        "private headers come with qtbase by default on Linux/macOS but some "
+        "install-qt-action Windows layouts need the private headers pulled in "
+        "via the Qt installer.\n"
+        "  - Local dev: install Qt with ShaderTools and private headers "
+        "(official online installer: check 'Qt Shader Tools' and 'Qt 5 Compat' "
+        "isn't needed, but private headers ship with the base Qt module).\n"
+        "  - To build without GPU spectrum (CPU-only fallback), re-run cmake "
+        "with -DNEREUS_GPU_SPECTRUM=OFF.")
 endif()
 
 # --------------------------------------------------------------------------

--- a/scripts/windows/installer.nsi
+++ b/scripts/windows/installer.nsi
@@ -3,6 +3,7 @@
 ; Invoked by .github/workflows/release.yml build-windows job.
 
 !include "MUI2.nsh"
+!include "LogicLib.nsh"
 
 ;--- Variables passed in via /D on the makensis command line ---
 ; NSDR_VERSION   — full version string, e.g. 0.2.0
@@ -75,6 +76,34 @@ Section "NereusSDR (required)" SecMain
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\NereusSDR" \
               "NoRepair" 1
 
+  ; Windows Firewall inbound UDP allow for NereusSDR.exe.
+  ;
+  ; OpenHPSDR Protocol 2 radios (ANAN, Hermes, HL2, Saturn) stream
+  ; DDC I/Q data from UDP source ports 1035-1041 to the client PC. Those
+  ; packets are "unsolicited inbound UDP" from Windows Defender Firewall's
+  ; stateful-inspection point of view — the PC never sends to those source
+  ; ports so the firewall has no return-flow mapping and silently drops
+  ; every DDC packet. Result: the spectrum/waterfall stays empty even
+  ; though the radio is connected and streaming correctly. Control
+  ; packets (high-priority status on 1025, mic samples on 1026) flow fine
+  ; because the PC sends CmdRx/CmdTx to those radio ports, which opens
+  ; the return flow. Pre-v0.1.2 installers had no firewall rule and
+  ; users had to either allow manually or disable the firewall; this
+  ; rule is what Thetis, PowerSDR, SparkSDR, and every other OpenHPSDR
+  ; client installer creates at install time.
+  ;
+  ; netsh errors are non-fatal — log and continue so the installer still
+  ; succeeds on systems where the firewall service is disabled or a
+  ; policy blocks the change. The user can always allow manually.
+  DetailPrint "Adding Windows Firewall rule: NereusSDR (inbound UDP)"
+  nsExec::ExecToLog 'netsh advfirewall firewall delete rule name="NereusSDR (inbound UDP)"'
+  Pop $0
+  nsExec::ExecToLog 'netsh advfirewall firewall add rule name="NereusSDR (inbound UDP)" dir=in action=allow program="$INSTDIR\NereusSDR.exe" protocol=UDP profile=any description="Allow inbound UDP from OpenHPSDR radios (DDC IQ streams, control)"'
+  Pop $0
+  ${If} $0 != 0
+    DetailPrint "netsh returned $0 — firewall rule may not be active. You can allow NereusSDR manually via Windows Security → Firewall & network protection."
+  ${EndIf}
+
   WriteUninstaller "$INSTDIR\uninstall.exe"
 SectionEnd
 
@@ -94,6 +123,13 @@ Section "Uninstall"
   Delete "$SMPROGRAMS\NereusSDR\NereusSDR.lnk"
   Delete "$SMPROGRAMS\NereusSDR\Uninstall NereusSDR.lnk"
   RMDir  "$SMPROGRAMS\NereusSDR"
+
+  ; Remove the firewall rule we created at install time. Ignore the
+  ; return code — if the rule is already gone (user removed it manually,
+  ; or a previous uninstall already cleaned up), that's fine.
+  DetailPrint "Removing Windows Firewall rule: NereusSDR (inbound UDP)"
+  nsExec::ExecToLog 'netsh advfirewall firewall delete rule name="NereusSDR (inbound UDP)"'
+  Pop $0
 
   RMDir /r "$INSTDIR"
 

--- a/src/core/RadioConnectionTeardown.h
+++ b/src/core/RadioConnectionTeardown.h
@@ -1,0 +1,70 @@
+// src/core/RadioConnectionTeardown.h
+//
+// Shared helper for tearing down a RadioConnection that lives on its
+// own worker QThread. Used by RadioModel during disconnect / shutdown
+// and by the regression test tst_cross_thread_teardown.
+//
+// Why this exists: P1RadioConnection and P2RadioConnection create
+// QTimers inside init(), which runs on the worker thread after
+// moveToThread(). Those timers are thread-affined to the worker.
+// If the main thread destroys the RadioConnection directly after
+// joining the worker, each child QTimer's destructor calls killTimer
+// on the wrong thread — Qt prints "Timers cannot be stopped from
+// another thread" and on Windows the process can terminate abnormally
+// during cleanup.
+//
+// The correct pattern, captured here: queue a lambda on the worker
+// that runs the protocol disconnect() and then schedules self-
+// deletion via deleteLater(). When quit() fires, the worker's event
+// loop processes the pending DeferredDelete as part of its shutdown
+// sequence, so the destructor runs on the worker thread — where the
+// timers live — and no cross-thread warnings fire.
+//
+// Both pointer references are set to nullptr on return; the QThread
+// container itself is main-thread-owned and safe to delete from the
+// caller, which this helper does.
+
+#pragma once
+
+#include "core/RadioConnection.h"
+
+#include <QMetaObject>
+#include <QThread>
+
+namespace NereusSDR {
+
+inline void teardownWorkerThreadedConnection(RadioConnection*& conn,
+                                             QThread*& thread)
+{
+    if (!conn || !thread) {
+        conn = nullptr;
+        if (thread) {
+            delete thread;
+            thread = nullptr;
+        }
+        return;
+    }
+
+    if (thread->isRunning()) {
+        RadioConnection* c = conn;
+        QMetaObject::invokeMethod(c, [c]() {
+            c->disconnect();
+            c->deleteLater();
+        });
+        thread->quit();
+        if (!thread->wait(3000)) {
+            thread->terminate();
+            thread->wait(1000);
+        }
+    }
+
+    // conn was destroyed on the worker thread by the DeferredDelete
+    // that Qt processes during quit(). Just null out the caller's
+    // pointer.
+    conn = nullptr;
+
+    delete thread;
+    thread = nullptr;
+}
+
+} // namespace NereusSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1,5 +1,6 @@
 #include "RadioModel.h"
 #include "core/RadioConnection.h"
+#include "core/RadioConnectionTeardown.h"
 #include "core/RadioDiscovery.h"
 #include "core/BoardCapabilities.h"
 #include "core/ReceiverManager.h"
@@ -527,26 +528,12 @@ void RadioModel::teardownConnection()
     QObject::disconnect(m_connection, nullptr, m_receiverManager, nullptr);
     QObject::disconnect(m_receiverManager, nullptr, this, nullptr);
 
-    if (m_connThread && m_connThread->isRunning()) {
-        // Queue disconnect() then quit() on the worker thread.
-        // disconnect() closes sockets/timers, then quit() exits the event loop.
-        // Both are queued as events — they execute in order when the loop is free.
-        QMetaObject::invokeMethod(m_connection, &RadioConnection::disconnect);
-        m_connThread->quit();
-
-        // Wait for thread to finish. If it doesn't stop in time, force it.
-        if (!m_connThread->wait(3000)) {
-            qCWarning(lcConnection) << "Worker thread did not stop in time, terminating";
-            m_connThread->terminate();
-            m_connThread->wait(1000);
-        }
-    }
-
-    delete m_connection;
-    m_connection = nullptr;
-
-    delete m_connThread;
-    m_connThread = nullptr;
+    // Tear down the connection on its own worker thread via the shared
+    // helper. See src/core/RadioConnectionTeardown.h for why this must
+    // run on the worker — short version: the RadioConnection's QTimers
+    // are thread-affined to the worker and destroying them on any other
+    // thread emits cross-thread warnings and can crash on Windows.
+    teardownWorkerThreadedConnection(m_connection, m_connThread);
 }
 
 void RadioModel::onConnectionStateChanged(ConnectionState state)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,3 +53,8 @@ target_compile_definitions(tst_hardware_page_capability_gating PRIVATE NEREUS_BU
 
 # HardwarePage per-MAC persistence round-trip (Phase 3I Task 21)
 nereus_add_test(tst_hardware_page_persistence)
+
+# Regression test for Windows shutdown/disconnect crash — cross-thread
+# destruction of RadioConnection (and its worker-affined QTimers).
+nereus_add_test(tst_cross_thread_teardown fakes/P1FakeRadio.cpp)
+target_compile_definitions(tst_cross_thread_teardown PRIVATE NEREUS_BUILD_TESTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,14 @@ find_package(Qt6 REQUIRED COMPONENTS Test)
 function(nereus_add_test name)
     # Additional source files may be passed as extra arguments (ARGN) —
     # needed by Phase 3I tests that link test-only fakes like P1FakeRadio.
-    add_executable(${name} ${name}.cpp ${ARGN})
+    #
+    # TestSandboxInit.cpp is always compiled in. Its global static
+    # constructor calls QStandardPaths::setTestModeEnabled(true) before
+    # main() runs, so AppSettings::instance() resolves to a sandbox
+    # path instead of the real user config file. Without this, ctest
+    # runs can (and have — see v0.1.1 alpha) silently wipe the
+    # developer's NereusSDR.settings via P1FakeRadio-keyed test writes.
+    add_executable(${name} ${name}.cpp TestSandboxInit.cpp ${ARGN})
     target_link_libraries(${name} PRIVATE NereusSDRObjs Qt6::Test)
     add_test(NAME ${name} COMMAND ${name})
 endfunction()

--- a/tests/TestSandboxInit.cpp
+++ b/tests/TestSandboxInit.cpp
@@ -1,0 +1,50 @@
+// tests/TestSandboxInit.cpp
+//
+// Auto-linked into every test binary by nereus_add_test(). Runs
+// QStandardPaths::setTestModeEnabled(true) as a global static
+// constructor — before main(), before any test code, and crucially
+// before AppSettings::instance() can pin its file path to the real
+// ~/.config/NereusSDR/NereusSDR.settings.
+//
+// Why this exists: AppSettings is a process-global singleton whose
+// default constructor calls QStandardPaths::writableLocation(...) to
+// resolve the settings file. Once resolved, the path is cached for
+// the life of the process. If any test touches AppSettings::instance()
+// without first enabling test mode, the singleton pins to the real
+// user config directory and subsequent setValue/save calls overwrite
+// the developer's actual NereusSDR.settings — wiping saved radios,
+// splitter sizes, VFO state, display prefs, etc. This was observed
+// during the v0.1.1 alpha when a ctest run silently replaced a
+// populated 68-key settings file with a 252-key file full of
+// hardware entries keyed to the P1FakeRadio test MAC
+// "aa:bb:cc:11:22:33". See fix(radio) commit for the session that
+// tracked it down.
+//
+// QStandardPaths::setTestModeEnabled(true) is safe to call multiple
+// times and has no side effects other than redirecting the writable-
+// location lookups to a per-user, per-app sandbox path under
+// $XDG_CONFIG_HOME/qttest (Linux), ~/Library/Preferences/qttest
+// (macOS), or %LOCALAPPDATA%\qttest (Windows). The sandbox is shared
+// across all test binaries in a run but is completely isolated from
+// the real NereusSDR install.
+//
+// This file has no public symbols. It is linked into every test
+// target by nereus_add_test() in tests/CMakeLists.txt.
+
+#include <QStandardPaths>
+
+namespace {
+
+struct SandboxInit {
+    SandboxInit()
+    {
+        QStandardPaths::setTestModeEnabled(true);
+    }
+};
+
+// Global static constructor runs before main(). The only dependency
+// is QStandardPaths, a stateless Qt utility that does not require
+// QCoreApplication to be constructed.
+static SandboxInit g_nereusTestSandboxInit;
+
+} // namespace

--- a/tests/tst_cross_thread_teardown.cpp
+++ b/tests/tst_cross_thread_teardown.cpp
@@ -1,0 +1,137 @@
+// tests/tst_cross_thread_teardown.cpp
+//
+// Regression test for the Windows shutdown/disconnect crash where
+// RadioModel destroys a RadioConnection (and its worker-thread-affined
+// QTimers) on the main thread after the worker QThread has already
+// joined. Qt's "Timers cannot be stopped from another thread" check
+// fires on destruction because the child timers' thread affinity is
+// still the (exited) worker thread. On Windows this has terminated
+// the process abnormally after disconnect-button clicks and after
+// close-window shutdowns.
+//
+// The test reproduces the exact teardown pattern with P1RadioConnection:
+// move the connection onto a worker thread, let init() create the
+// timers on the worker, queue a disconnect() back on the worker, quit
+// and join the thread, then destroy the connection on the main (test)
+// thread. A Qt message handler counts any warning that contains the
+// cross-thread timer string; the test passes only when zero such
+// warnings are emitted.
+
+#include <QtTest/QtTest>
+#include <QCoreApplication>
+#include <QStandardPaths>
+#include <QThread>
+#include <atomic>
+
+#include "core/P1RadioConnection.h"
+#include "core/RadioConnection.h"
+#include "core/RadioConnectionTeardown.h"
+#include "core/HpsdrModel.h"
+#include "fakes/P1FakeRadio.h"
+
+using namespace NereusSDR;
+using NereusSDR::Test::P1FakeRadio;
+
+namespace {
+
+static std::atomic<int> g_crossThreadTimerWarnings{0};
+static QtMessageHandler g_previousHandler = nullptr;
+
+static void captureHandler(QtMsgType type,
+                           const QMessageLogContext& ctx,
+                           const QString& msg)
+{
+    if (msg.contains(QStringLiteral("Timers cannot be stopped from another thread"))) {
+        g_crossThreadTimerWarnings.fetch_add(1);
+    }
+    if (g_previousHandler) {
+        g_previousHandler(type, ctx, msg);
+    }
+}
+
+} // namespace
+
+class TestCrossThreadTeardown : public QObject {
+    Q_OBJECT
+
+private slots:
+    void initTestCase() {
+        g_previousHandler = qInstallMessageHandler(captureHandler);
+    }
+
+    void cleanupTestCase() {
+        qInstallMessageHandler(g_previousHandler);
+    }
+
+    void init() {
+        g_crossThreadTimerWarnings.store(0);
+    }
+
+    void workerThreadedConnectionTeardownEmitsNoCrossThreadWarning() {
+        // Loopback fake radio on an ephemeral port. Runs on the test
+        // (main) thread — same as every other P1 test.
+        P1FakeRadio fake;
+        fake.start();
+
+        // Production setup: a worker QThread, a RadioConnection moved
+        // onto it, init() running on the worker so its timers are
+        // affined to the worker thread.
+        auto* worker = new QThread();
+        worker->setObjectName(QStringLiteral("TestConnWorker"));
+
+        auto* conn = new P1RadioConnection();
+        conn->moveToThread(worker);
+        connect(worker, &QThread::started,
+                conn,   &P1RadioConnection::init);
+        worker->start();
+
+        // Connect to the fake radio via a queued call on the worker.
+        RadioInfo info;
+        info.address         = fake.localAddress();
+        info.port            = fake.localPort();
+        info.boardType       = HPSDRHW::HermesLite;
+        info.protocol        = ProtocolVersion::Protocol1;
+        info.firmwareVersion = 72;
+        info.macAddress      = QStringLiteral("aa:bb:cc:11:22:33");
+
+        QMetaObject::invokeMethod(conn, [conn, info]() {
+            conn->connectToRadio(info);
+        });
+
+        // Wait until the state machine reports Connected. At that point
+        // the watchdog timer is running on the worker thread.
+        QTRY_VERIFY_WITH_TIMEOUT(
+            conn->state() == ConnectionState::Connected, 3000);
+        QTRY_VERIFY_WITH_TIMEOUT(fake.isRunning(), 3000);
+
+        // Teardown via the shared helper that production code uses.
+        // This is deliberate — the test exercises the same code path
+        // that RadioModel::teardownConnection does, so any regression
+        // in the helper fails this test.
+        RadioConnection* connBase = conn;
+        QThread*         workerP  = worker;
+        teardownWorkerThreadedConnection(connBase, workerP);
+        QVERIFY(connBase == nullptr);
+        QVERIFY(workerP == nullptr);
+
+        fake.stop();
+
+        // The assertion that drives the fix: no cross-thread timer
+        // warnings may be emitted at any point during the sequence.
+        QCOMPARE(g_crossThreadTimerWarnings.load(), 0);
+    }
+};
+
+// Custom main() so we can enable QStandardPaths test mode BEFORE anything
+// touches AppSettings::instance(). Without this, the singleton pins its
+// file path to the real %LOCALAPPDATA%\NereusSDR\NereusSDR.settings on
+// first construction, and test runs overwrite the user's real settings.
+int main(int argc, char* argv[])
+{
+    QStandardPaths::setTestModeEnabled(true);
+    QCoreApplication app(argc, argv);
+    TestCrossThreadTeardown tc;
+    return QTest::qExec(&tc, argc, argv);
+}
+
+#include "tst_cross_thread_teardown.moc"

--- a/tests/tst_cross_thread_teardown.cpp
+++ b/tests/tst_cross_thread_teardown.cpp
@@ -18,8 +18,6 @@
 // warnings are emitted.
 
 #include <QtTest/QtTest>
-#include <QCoreApplication>
-#include <QStandardPaths>
 #include <QThread>
 #include <atomic>
 
@@ -122,16 +120,9 @@ private slots:
     }
 };
 
-// Custom main() so we can enable QStandardPaths test mode BEFORE anything
-// touches AppSettings::instance(). Without this, the singleton pins its
-// file path to the real %LOCALAPPDATA%\NereusSDR\NereusSDR.settings on
-// first construction, and test runs overwrite the user's real settings.
-int main(int argc, char* argv[])
-{
-    QStandardPaths::setTestModeEnabled(true);
-    QCoreApplication app(argc, argv);
-    TestCrossThreadTeardown tc;
-    return QTest::qExec(&tc, argc, argv);
-}
-
+// Sandbox is enabled by tests/TestSandboxInit.cpp's global static
+// constructor (linked in by nereus_add_test), so we can use QTEST_MAIN
+// like the other tests and trust that AppSettings::instance() resolves
+// to a sandbox path.
+QTEST_MAIN(TestCrossThreadTeardown)
 #include "tst_cross_thread_teardown.moc"

--- a/tests/tst_meter_presets.cpp
+++ b/tests/tst_meter_presets.cpp
@@ -251,7 +251,10 @@ private slots:
                 mi->paint(p, W, H);
             }
         }
-        QVERIFY(img.save(QStringLiteral("/tmp/threeRowStack.png"), "PNG"));
+        // Dump to the platform temp dir (QDir::temp resolves to /tmp on
+        // Linux/macOS and %TEMP% on Windows). The hardcoded /tmp path
+        // used to ship here was the reason this test failed on Windows.
+        QVERIFY(img.save(QDir::temp().absoluteFilePath("threeRowStack.png"), "PNG"));
         qDeleteAll(working);
     }
 
@@ -290,15 +293,15 @@ private slots:
                 mi->paint(p, W, H);
             }
         }
-        QVERIFY(img.save(QStringLiteral("/tmp/alcBarRow.png"), "PNG"));
+        QVERIFY(img.save(QDir::temp().absoluteFilePath("alcBarRow.png"), "PNG"));
         delete g;
     }
 
     // --- Headless visual dump of the createSMeterBarPreset composition ---
     // Renders every item in the Thetis bar-variant preset through its
     // real paint() function into a shared QImage and writes the result
-    // to /tmp/sMeterPreset.png so the image can be read back out-of-
-    // process for debugging. This is what the container would actually
+    // to <tempdir>/sMeterPreset.png so the image can be read back
+    // out-of-process for debugging. This is what the container would actually
     // show if a MeterWidget routed its paint through QPainter instead
     // of QRhi.
     void SMeterBar_dump_full_composition_to_png()
@@ -338,9 +341,10 @@ private slots:
             }
         }
 
-        const QString outPath = QStringLiteral("/tmp/sMeterPreset.png");
+        const QString outPath = QDir::temp().absoluteFilePath(
+            QStringLiteral("sMeterPreset.png"));
         QVERIFY2(img.save(outPath, "PNG"),
-                 "failed to save /tmp/sMeterPreset.png");
+                 qPrintable(QStringLiteral("failed to save ") + outPath));
 
         delete g;
     }


### PR DESCRIPTION
## Summary

Six fixes that together make NereusSDR actually usable on Windows. The v0.1.1 alpha installer had **three separate failure modes** layered on top of each other, plus one latent crash that was hidden by the others. This session untangled them end-to-end.

- **Spectrum/waterfall not rendering (GPU path compiled out)** — `NEREUS_GPU_SPECTRUM` was silently compiled out of the v0.1.1 Windows installer. `SpectrumWidget` fell back to a plain `QWidget` with a dark palette, so users saw a blank rectangle where the waterfall should be. Root cause: CMake's GPU-spectrum detection used `message(STATUS)` fallbacks that flipped the option to OFF without failing the build, and the shipping pipeline never passed `-DNEREUS_GPU_SPECTRUM=ON` explicitly so the default-ON value was the only signal of intent.

- **Disconnect crashed the app** — `RadioModel::teardownConnection` destroyed the `RadioConnection` object (and its worker-thread-affined `QTimer` children) on the main thread after joining the worker `QThread`. Qt fired `"QObject::killTimer: Timers cannot be stopped from another thread"` warnings on every teardown, and on Windows the process terminated abnormally. Latent — previously masked by the blank-render binary, surfaced after the GPU fix.

- **DDC I/Q streams blocked by Windows Defender Firewall** — once the GPU render path was fixed and the crash was gone, the spectrum area drew the grid, axes, and frequency labels (so `QRhi` was confirmed alive) but the spectrum trace and waterfall stayed empty. Packet capture with `pktmon` showed the radio streaming 6,809 DDC I/Q packets from source port 1037 to the PC's listening port over a 12-second window; the NereusSDR process received **zero** of them. Windows Defender Firewall does stateful UDP inspection and only allows return-flow inbound UDP for remote `(IP:port)` pairs the PC has recently sent to. NereusSDR sends commands to the radio's ports 1024/1025/1026/1027 but never to 1035-1041 (those are radio-only outbound source ports for DDC I/Q), so the firewall treats every DDC packet as unsolicited inbound and drops it before it reaches Winsock. macOS has no equivalent default-deny behavior on LAN UDP, which is why the same source code streams correctly there. Pre-v0.1.1 NSIS installers had no firewall rule. Every other OpenHPSDR Windows client (Thetis, PowerSDR, SparkSDR) creates this rule at install time; NereusSDR was missing it.

- **Test suite silently wiped developer settings** — every test that used `AppSettings::instance()` pinned the singleton to the real `~/.config/NereusSDR/NereusSDR.settings` path because no test called `QStandardPaths::setTestModeEnabled(true)` before `QCoreApplication`. A single `ctest` run could replace a populated user settings file with test-MAC hardware entries keyed to `P1FakeRadio`'s `aa:bb:cc:11:22:33` fake MAC. Caught while tracking down the other bugs and fixed.

- **`tst_meter_presets` hardcoded `/tmp/...`** — three `img.save("/tmp/*.png")` calls that work on Linux/macOS but fail on Windows. Caused 3 of the 4 pre-existing ctest failures on Windows.

- **Linux/CodeQL CI tripped the new GPU-spectrum fail-fast check** — ubuntu-latest's apt-managed Qt 6 is version 6.4.2, older than QRhiWidget's 6.7+ requirement. The new `FATAL_ERROR` correctly caught the silent fallback that had been there all along. Added explicit `-DNEREUS_GPU_SPECTRUM=OFF` to Linux CI and CodeQL configure steps, preserving historical Linux-CPU-fallback behavior but making it an explicit opt-out rather than a silent downgrade.

## Commits

| SHA | Subject |
|---|---|
| `323ed4d` | `fix(installer): add Windows Firewall inbound UDP allow for OpenHPSDR DDC streams` |
| `03e7e65` | `ci: disable GPU spectrum on Linux/CodeQL (Ubuntu Qt 6.4.2 too old)` |
| `43c547a` | `test(meters): dump PNGs to QDir::temp() instead of hardcoded /tmp` |
| `1c9d086` | `test: auto-sandbox every test via TestSandboxInit global ctor` |
| `9f05dac` | `fix(build): fail loudly when NEREUS_GPU_SPECTRUM cannot be enabled` |
| `9d52256` | `fix(radio): tear down RadioConnection on its worker thread` |

Each commit has a full standalone body explaining root cause and fix.

## How the disconnect crash was fixed

New header-only helper `src/core/RadioConnectionTeardown.h` exports `teardownWorkerThreadedConnection()`, which queues a lambda on the worker thread that runs both `RadioConnection::disconnect()` and `deleteLater()`. Qt's event loop processes the pending `DeferredDelete` as part of its shutdown sequence when `quit()` fires, so the `RadioConnection` destructor runs on the worker thread — where the timers live — and no cross-thread warnings fire. The main thread still owns and deletes the `QThread` container itself, which is safe because it has no timers. `RadioModel::teardownConnection` now calls the helper instead of open-coding the broken `invokeMethod + quit + wait + delete` dance.

## How the CMake hardening fixes the v0.1.2 release story

`CMakeLists.txt` now remembers whether the caller asked for GPU spectrum before any auto-disable, probes for both the `_FOUND` variables AND the imported targets (because install-qt-action's Qt 6.7/6.8 Windows layouts have been observed with inconsistent `_FOUND` variable behaviour despite working imported targets), captures a specific reason string when detection fails, and promotes the fallback to `FATAL_ERROR` when the caller opted in. Both `.github/workflows/ci.yml` and `.github/workflows/release.yml` now pass `-DNEREUS_GPU_SPECTRUM=ON` explicitly to the Windows configure step, so a broken-installer regression fails the CI job instead of producing a shippable-but-broken artifact.

## How the DDC streaming fix works

36 lines added to `scripts/windows/installer.nsi`. Two `nsExec::ExecToLog 'netsh advfirewall firewall add rule ...'` calls in the install section (one to delete any stale rule from a previous install, one to create the fresh rule), one matching `delete rule` in the uninstall section, non-fatal error handling so the installer still succeeds on systems where the firewall service is disabled or blocked by policy. The installer already runs with `RequestExecutionLevel admin`, so `netsh advfirewall` is available at install time without additional elevation. Zero source code changes — this was never a code bug.

## How the DDC streaming fix was tracked down

Source-code hypotheses that **did not** fix it, each eliminated by evidence: IPv4 vs dual-stack bind, `setActiveReceiverCount` overwriting DDC2 enable bit, TX I/Q silence timer commented out by a prior WIP commit, DDC2 sample rate 768 kHz vs 48 kHz, P2 command byte layout.

What finally caught it: `pktmon` packet capture showed the radio sending 6,809 DDC2 packets from source port 1037 to the PC's NIC, destination port matching the listening socket exactly — while the app received zero of them. That is an OS-layer drop, not a code bug. Combined with the observation that the PC-to-radio flow had never sent anything to port 1037 (it is a radio-outbound-only port), Windows Defender Firewall's stateful inspection was the only explanation consistent with all of the evidence: control packets on 1025/1026 flow because the PC sends CmdRx/CmdTx to those radio ports (creating return-flow mappings), DDC packets from 1037 have no return-flow mapping and are silently dropped.

Byte-for-byte comparison of NereusSDR's outgoing `CmdGeneral` and `CmdRx` packets against Thetis's `network.c:821-1179` reference confirmed the protocol bytes are perfect. The P2 port is a faithful translation. This was entirely an installer-time Windows configuration miss, not a code bug.

## Test plan

- [x] **Regression test for the disconnect crash**: `tst_cross_thread_teardown` builds a loopback `P1FakeRadio`, moves `P1RadioConnection` onto a worker thread, connects through the state machine until the watchdog timer is actively running, tears down via the shared helper, asserts zero `"Timers cannot be stopped from another thread"` warnings captured by an installed `qInstallMessageHandler`. Before fix: 2 warnings captured, test fails. After fix: 0 warnings, test passes.
- [x] **Full local ctest run**: 16 of 16 tests pass (up from 15 of 16 pre-session). Includes the newly-fixed `tst_meter_presets` which previously failed on Windows.
- [x] **Settings-file contamination regression**: md5sum of `~/.config/NereusSDR/NereusSDR.settings` is identical before and after a full ctest run.
- [x] **End-to-end smoke test on Windows 11 with local mingw build + manual firewall rule**: app launches, auto-reconnects to ANAN-G2 (Saturn) P2, **spectrum and waterfall render with live signals at ~30 FPS**, audio flows to the selected output device, click-disconnect leaves the app running without crash.
- [x] **macOS verification**: full branch built and tested on macOS independently — spectrum/waterfall render correctly, confirming the DDC streaming bug was Windows-runtime-only and the code is correct.
- [ ] **CI build on this PR** — all 5 checks (Windows/Linux/macOS/CodeQL/Analyze-cpp) should stay green. The NSIS script change has no CI-job impact since the installer is built only by the release workflow.
- [ ] **v0.1.2 release dry-run** — build the installer through the release pipeline and manually verify that installing on a fresh Windows machine creates the firewall rule visible in `Get-NetFirewallRule -DisplayName 'NereusSDR (inbound UDP)'`, and that uninstalling removes it.

## Release notes

Recommended blurb for the v0.1.2 changelog/release body:

> **v0.1.2 — Windows stability and rendering fixes**
>
> - Spectrum and waterfall now render correctly on Windows. The v0.1.1 installer silently shipped without GPU rendering enabled; v0.1.2 enables the full QRhi/D3D11 path.
> - The Disconnect button no longer crashes the app on Windows. A cross-thread teardown bug was corrupting Qt's timer state during shutdown.
> - The Windows installer now creates a firewall rule allowing NereusSDR to receive inbound UDP from OpenHPSDR radios. Without this, DDC I/Q streams were being silently dropped by Windows Defender Firewall and the spectrum plot stayed empty. Matches what every other OpenHPSDR Windows client does at install time. The rule is removed cleanly at uninstall.
> - Test suite hardened — tests no longer touch the real user settings file.
> - CMake release pipeline hardened — a regression that silently ships a CPU-fallback binary now fails the release build at configure time.

## Not included in this PR

Opening a v0.1.2 hotfix release. Separate trigger once this merges and CI confirms green.

🤖 Co-Authored with Claude Code
JJ Boyd ~KG4VCF
