### PR TITLE
docs(alpha-test): expand alpha-tester guide to full OpenHPSDR family

### DIFF
--- a/docs/debugging/alpha-tester-hl2-smoke-test.md
+++ b/docs/debugging/alpha-tester-hl2-smoke-test.md
@@ -1,16 +1,30 @@
-# NereusSDR Alpha Test — Hermes Lite 2
+# NereusSDR Alpha Test — OpenHPSDR Radios (P1 & P2)
 
 **Hi, and thank you.** You're helping test an **alpha-stage** SDR console. This doc walks you through what to try, what "success" looks like, and — just as important — what does **not** work yet so you don't waste time filing bugs for features we know are missing.
 
 **What this build is:**
 - A ground-up C++/Qt6 port of [Thetis](https://github.com/ramdor/Thetis) (the Apache Labs / OpenHPSDR console), architecturally modelled on [AetherSDR](https://github.com/ten9876/AetherSDR).
-- This particular test build is **Phase 3I** — the work that brought Protocol 1 radios (HL2, ANAN-10/100/10E/100B/100D/200D, Metis) into the app alongside the Protocol 2 radios (ANAN-G2 Saturn, ANAN-7000/8000) that already worked.
-- The **goal of your test** is simple: can NereusSDR discover your HL2, connect, and let you listen to a live SSB signal with a working spectrum and waterfall?
+- Supports the **full OpenHPSDR family** over **both Protocol 1 (P1)** and **Protocol 2 (P2)**. That includes the Apache Labs ANAN line (100/100B/100D/10/10E/200D/7000/8000/G2-Saturn), Hermes / Hermes Lite 2, Metis, Angelia, Orion, Orion MkII, and any other board that speaks the OpenHPSDR discovery + frame protocols.
+- The **goal of your test** is simple: can NereusSDR discover your radio, connect, and let you listen to a live SSB signal with a working spectrum and waterfall?
 
 **What this build is NOT:**
 - Ready for transmit. **Do not key up.** The TX pipeline is intentionally cold — commands go on the wire but there is no SSB modulator yet.
 - Feature-complete. Dozens of controls you see in the UI are placeholder — more on that below.
-- Signed. On macOS you'll need to right-click → Open the first time. On Windows you'll see a SmartScreen warning you'll need to click through.
+- Signed on macOS or Windows. First launch on macOS needs right-click → Open. First launch on Windows triggers a SmartScreen warning you'll need to click through.
+
+---
+
+## Supported radios
+
+| Family | Protocol | State |
+|---|---|---|
+| ANAN-G2 / Saturn | P2 | Primary dev target — fully tested |
+| ANAN-7000DLE / 8000DLE | P2 | Should work (same P2 code path as G2) |
+| ANAN-200D / 100D / 100B / 100 / 10 / 10E | P1 | Works — per-board capability gating |
+| Hermes / Hermes Lite 2 | P1 | Works — HL2 has its own I/O Board tab |
+| Metis / Angelia / Orion / Orion MkII | P1 | Works — same P1 discovery + frame parser |
+
+If your radio implements stock OpenHPSDR P1 or P2 protocol, the app will try to talk to it. Capability differences (ADC count, max receivers, preamp ranges, attenuator step size, sample rates, PureSignal / Diversity / XVTR presence) are driven by a per-board registry — if your board shows up under a wrong name or wrong capabilities, that's a bug we want to hear about.
 
 ---
 
@@ -30,13 +44,14 @@ Before you dive in, here's the honest state of the overall application so you ha
 | 3G-1..7 | Dockable/floatable container system, GPU-rendered meter engine with 31 item types, container settings dialog, MMIO external-data subsystem | Working |
 | 3G-8 | RX1 Display parity — every control on the Setup → Display pages wired to the renderer (47 controls) | Working |
 | 3H | Thetis-inspired skin system | **Not started** |
-| 3I | **THIS PHASE** — Protocol 1 support for the full ANAN/Hermes family, including HL2 | Working — that's what you're testing |
+| 3I | **Protocol 1 support** for the full ANAN/Hermes family including HL2 (discovery, connection, capability gating, Hardware page, saved radios, auto-reconnect) | Working |
 | 3J | TCI protocol server (for N1MM+, Log4OM etc.) | Not started |
 | 3K | CAT / rigctld bridge | Not started |
-| 3L | HL2 IoBoardHl2 I2C-over-ep2 encoding (currently inside a closed DLL) | Not started |
+| 3L | HL2-specific I2C-over-ep2 encoding (currently inside a closed DLL) | Not started |
 | 3M | TX pipeline — SSB, CW, full processing chain, PureSignal PA linearization | **Not started** |
+| 3N | **Release pipeline + /release skill + GPG-signed alpha binaries** | Working — this is how you got the build |
 
-The short version: **single-receiver RX works end-to-end on any supported ANAN/Hermes radio. Everything beyond that is either scaffolded, cold-wired, or not started.**
+The short version: **single-receiver RX works end-to-end on any supported OpenHPSDR radio, P1 or P2. Everything beyond that is either scaffolded, cold-wired, or not started.**
 
 ### Touring the app
 
@@ -54,7 +69,7 @@ When you launch NereusSDR, you'll see a main window **modelled after [AetherSDR]
 
 **Meter widgets**
 - A **GPU-rendered meter engine** powers everything meter-shaped. ~31 item types in the engine: bars, needles, arc-style S-meters, dials, text overlays, rotators, clocks, magic-eye tubes, image atoms, LEDs, history graphs, multi-meter displays, data out, and interactive button grids.
-- **What actually updates with real data on your HL2:** the signal S-meter (arc needle), the noise-floor / RF power bars bound to the live RX1 channel, the clocks, and the basic button grids (band, mode, filter, antenna, tuning step).
+- **What actually updates with real data** (any supported radio): the signal S-meter (arc needle), the noise-floor / RF power bars bound to the live RX1 channel, the clocks, and the basic button grids (band, mode, filter, antenna, tuning step).
 - **What doesn't update:** most TX-side meters (forward/reverse power, SWR, ALC, compression, mic gain), PureSignal feedback indicators, PA-related gauges, the magic eye, data out. They render their backgrounds and needles-at-zero correctly but there's no source pushing data into them. That's because the underlying pipelines (TX, PureSignal, PA control) are later phases.
 
 **Container settings**
@@ -66,14 +81,14 @@ When you launch NereusSDR, you'll see a main window **modelled after [AetherSDR]
   - **Display → Spectrum Defaults** (17 controls: averaging, peak hold, trace fill/width/colour, gradient, cal offset, FPS overlay, etc.)
   - **Display → Waterfall Defaults** (17 controls: AGC, reverse scroll, opacity, update rate, overlays, timestamp, low/mid/high colours)
   - **Display → Grid & Scales** (13 controls, including per-band Max/Min storage across all 14 bands — 160 m through 6 m + GEN + WWV + XVTR)
-  - **Hardware Config** (new in Phase 3I — what you'll be testing) with 9 capability-gated sub-tabs
+  - **Hardware Config** — 9 capability-gated sub-tabs. Which tabs you see depends on your radio. On an HL2 most tabs hide because the hardware isn't there; on an ANAN-7000 / 8000 / G2 all 9 tabs are visible.
 - The **other ~40 pages** mostly exist as stub widgets with `NYI` (Not Yet Implemented) tooltips on disabled controls. You can navigate into them, they won't crash, but they won't affect anything.
 
 **Spectrum overlay panel**
 - Hover-reveal overlay button strip on the spectrum widget — 10 buttons with 5 flyout sub-panels (display, filter, noise, spots, tools). Partially wired; auto-closes on outside click.
 
 **Persistence**
-- Dock layout, container contents, floating positions, pin-on-top state, per-band grid values, audio device selection, last-connected radio, per-MAC hardware settings (new in 3I), spectrum/waterfall settings — all persist across app restarts via an XML-based `AppSettings` store.
+- Dock layout, container contents, floating positions, pin-on-top state, per-band grid values, audio device selection, last-connected radio, per-MAC hardware settings, spectrum/waterfall settings — all persist across app restarts via an XML-based `AppSettings` store.
 
 ### What actually works across the whole app right now
 
@@ -91,12 +106,12 @@ Not just the Phase 3I connector — this is the **total** functional surface are
 10. **Filter presets** via the filter button grid
 11. **VFO display** with per-digit mouse-wheel tuning
 12. **Signal S-meter** (arc needle, live from WDSP)
-13. **Attenuator / preamp / sample rate** controls for all supported boards, capability-gated per board
+13. **Attenuator / preamp / sample rate** controls for all supported boards, capability-gated per board (HL2 has its own 0–60 dB range and step granularity; ANAN boards use the stock 0–31 dB / 0–40 dB ranges)
 14. **Saved radio profiles** keyed by MAC — discover once, re-use next launch with auto-reconnect
 15. **Manually-added radios** outside the local subnet via the Add Manually dialog
 16. **Full container system** with drag-to-dock, layout persistence, per-container settings
 17. **31 meter item types** styled and placed, with 38+ presets in the library
-18. **47-page Setup dialog** — Display section fully wired (47 controls), Hardware Config section new in 3I, other pages stubbed
+18. **47-page Setup dialog** — Display section fully wired (47 controls), Hardware Config section with capability-gated tabs, other pages stubbed
 
 **Single-radio, single-receiver, receive-only.** Everything else listed in the "Planned" column of the phase table above is either not started or scaffolded but inert.
 
@@ -109,13 +124,13 @@ Things that work but aren't polished:
 - **~40 of the 47 Setup pages** are disabled-controls-with-NYI-tooltips. They won't crash, they just don't do anything.
 - **Some menu items** in the menu bar are not yet wired. Mostly harmless — you'll see an action and nothing will happen.
 - **Keyboard shortcuts** are partial.
-- **Multi-RX** — the app has the multi-receiver foundation in place but the UI only exposes RX1 for now. RX2 hardware support exists on 2-ADC boards; there's no second-receiver spectrum yet.
+- **Multi-RX** — the app has the multi-receiver foundation in place but the UI only exposes RX1 for now. RX2 hardware support exists on 2-ADC boards (ANAN-7000 / 8000 / G2 / Orion MkII); there's no second-receiver spectrum yet.
 
 ### Performance expectations
 
 On a modern laptop (M-series Mac, recent AMD/Intel desktop, decent mid-range Linux box):
 - **Idle CPU:** ~1–5% after connect
-- **Audio:** no dropouts at 48 / 96 / 192 / 384 kHz
+- **Audio:** no dropouts at 48 / 96 / 192 / 384 kHz where the hardware supports it (HL2 maxes at 384 k; ANAN boards go higher)
 - **Spectrum:** ~30 FPS steady on the GPU path
 - **Memory:** ~250–500 MB resident depending on container layout
 - **First-launch FFTW wisdom caching:** the very first time you run the app it will pop a progress dialog while FFTW plans its optimal FFT routines for your CPU. This takes ~10–60 seconds, once, ever. Subsequent launches skip it.
@@ -126,8 +141,11 @@ On a modern laptop (M-series Mac, recent AMD/Intel desktop, decent mid-range Lin
 
 ### Things you need
 
-- A **Hermes Lite 2** powered up and on the same Ethernet/Wi-Fi LAN as your computer.
-- A recent **firmware** on the HL2 — v70 or newer. The app will refuse to connect to anything older than v70 and tell you why.
+- An **OpenHPSDR-compatible radio** (see "Supported radios" above) powered up and on the same Ethernet/Wi-Fi LAN as your computer.
+- Recent firmware on your radio. Per-family minimums:
+  - **Hermes Lite 2:** v70 or newer. The app refuses older firmware and tells you why.
+  - **ANAN-G2 / Saturn:** recent radioberry / Saturn firmware — the P2 path has been tested against current production firmware.
+  - **Other ANAN / Hermes / Metis / Angelia / Orion:** run whatever firmware you'd use with Thetis. If Thetis connects, NereusSDR should.
 - Speakers or headphones plugged into your computer's audio output (NereusSDR decodes audio on the computer side, not on the radio).
 - A browser and a GitHub account so you can report what you see.
 
@@ -138,14 +156,33 @@ On a modern laptop (M-series Mac, recent AMD/Intel desktop, decent mid-range Lin
 
 ### Get the build
 
-**Option A: pre-built installer (recommended for non-developers)**
-Grab the latest build from <https://github.com/boydsoftprez/NereusSDR/releases> — pick the installer for your OS. **NOTE:** the Phase 3I work is currently on PR #12 (branch `feature/phase3i-radio-connector-port`) and may not be in a tagged release yet. If you don't see a release labeled "Phase 3I" or newer, go with Option B.
+**Option A: pre-built binary (recommended for non-developers)**
+
+Grab the latest release from <https://github.com/boydsoftprez/NereusSDR/releases>. Pick the right file for your OS:
+
+| Platform | File |
+|---|---|
+| Linux x86_64 | `NereusSDR-vX.Y.Z-x86_64.AppImage` |
+| Linux aarch64 (Pi / ARM server) | `NereusSDR-vX.Y.Z-aarch64.AppImage` |
+| macOS Apple Silicon | `NereusSDR-vX.Y.Z-macOS-apple-silicon.dmg` |
+| Windows (installer) | `NereusSDR-vX.Y.Z-Windows-x64-setup.exe` |
+| Windows (portable zip) | `NereusSDR-vX.Y.Z-Windows-x64-portable.zip` |
+
+**Intel Mac:** no pre-built binary yet — GitHub Actions retired the free Intel macOS runner. Build from source (Option B).
+
+Every artifact is detached-GPG-signed (key `KG4VCF`). To verify before running:
+
+```bash
+gpg --keyserver keyserver.ubuntu.com --recv-keys KG4VCF
+gpg --verify SHA256SUMS.txt.asc SHA256SUMS.txt
+sha256sum -c SHA256SUMS.txt
+```
 
 **Option B: build from source**
+
 ```bash
 git clone https://github.com/boydsoftprez/NereusSDR.git
 cd NereusSDR
-git checkout feature/phase3i-radio-connector-port
 cmake -S . -B build-clean -G Ninja
 cmake --build build-clean -j
 ```
@@ -176,45 +213,46 @@ When the app opens you should see:
 
 **If it crashes on launch:** skip to the "Reporting bugs" section at the bottom and send us the crash log.
 
-### 2. Open the Connection Panel and find your HL2
+### 2. Open the Connection Panel and find your radio
 
 Somewhere in the menus (likely **Radio → Connection…** or a connection button in the UI) there's a **ConnectionPanel** — a dialog listing discovered radios.
 
 1. Open it.
 2. Click **Start Discovery**.
-3. Within about 5 seconds your HL2 should appear in the list.
+3. Within about 5 seconds your radio should appear in the list.
 
-**What each column should show for a healthy HL2:**
+**What each column should show for a healthy radio:**
 - **Status dot:** green (online and free)
-- **Name:** "Hermes Lite 2"
-- **Board:** HermesLite
-- **Protocol:** P1
-- **IP:** your HL2's IPv4 address on the LAN
-- **MAC:** your HL2's MAC
-- **Firmware:** 70 or higher (probably 72+)
-- **In-Use:** "free"
+- **Name:** the board name (`Hermes Lite 2`, `ANAN-G2`, `ANAN-7000DLE`, `Hermes`, `Orion`, etc.)
+- **Board:** the detected board type
+- **Protocol:** `P1` for HL2 / Hermes / Metis / older ANAN, `P2` for ANAN-G2 / 7000 / 8000
+- **IP:** your radio's IPv4 address on the LAN
+- **MAC:** your radio's MAC
+- **Firmware:** the firmware version the radio reported
+- **In-Use:** `free` (or `busy` if another client is connected)
 
-**✅ Success bar for step 2:** your HL2 shows up in the list within ~5 seconds with all columns populated.
+**✅ Success bar for step 2:** your radio shows up in the list within ~5 seconds with all columns populated, board type detected correctly, and protocol reported correctly for that board (P1 for Hermes-family, P2 for ANAN-G2/7000/8000).
 
 **Known rough edge:** discovery is not async yet — clicking **Start Discovery** may freeze the GUI for up to 10 seconds while it walks every network interface on your computer. On a Mac with lots of VPN tunnels or Docker bridges this can be noticeable. It should not last longer than ~15 seconds. If the GUI is still frozen after 30 seconds, something is wrong and we'd like to know.
 
-**If your HL2 doesn't appear:**
-- Is the HL2 powered on and the link light solid?
+**If your radio doesn't appear:**
+- Is the radio powered on and the link light solid?
 - Can you ping it from your computer? `ping 192.168.1.something`
 - Are you on the same subnet? (Discovery uses broadcast; it won't cross routers.)
 - Try clicking **Rescan** or **Stop** then **Start Discovery** again.
+- If the radio is on a different subnet or behind a VPN, use **Add Manually…** and type the IP directly.
 
 ### 3. Connect
 
-Double-click your HL2's row (or click it once and click **Connect**).
+Double-click your radio's row (or click it once and click **Connect**).
 
 Within about 2 seconds:
 - The state should flip through Connecting → **Connected**
-- The connection panel should show your HL2 as the active radio
+- The connection panel should show your radio as the active radio
 
 **✅ Success bar for step 3:** state reaches Connected without a crash. If the app crashes within the first second of clicking Connect, please grab the crash report — there's been a history of WDSP init races that we chased down, and a regression there is worth knowing about.
 
-**Known rough edge:** if your HL2 firmware is below v70, the app will refuse to connect and give you a "Firmware too old" error. That's by design. Flash newer firmware and try again.
+**Known rough edge:** HL2 firmware below v70 is refused with a "Firmware too old" error. That's by design. Flash newer firmware and try again. Other boards have no hard-coded minimum — the app just tries to speak the protocol and bails if the board doesn't respond correctly.
 
 ### 4. Listen to a live signal — THE BIG ONE
 
@@ -231,7 +269,7 @@ This is the single most important thing to verify.
 
 > You should **hear live radio** through your computer's speakers. Spectrum should show signal peaks where stations are transmitting. Waterfall should scroll and show vertical signal trails. Moving the VFO should tune to different stations, and you should hear them come in and drop out as you sweep.
 
-**If you can listen to a QSO on 20 m through NereusSDR with a live waterfall and working spectrum, the Phase 3I port is a success.** That's the whole thing we're testing.
+**If you can listen to a QSO on 20 m through NereusSDR with a live waterfall and working spectrum, the alpha is a success.** That's the whole thing we're testing.
 
 **Expected UI behaviors at this stage:**
 - Spectrum updates ~30 times per second
@@ -245,8 +283,8 @@ This is the single most important thing to verify.
 
 While listening to a live signal:
 
-- **Attenuator:** find the attenuator control (probably in one of the applets on the right). Slide it from 0 to 30 dB. Background noise should drop by roughly 30 dB audibly and visibly on the spectrum. HL2 supports 0–60 dB in 1 dB steps (different from the other ANAN radios which are 0–31 dB).
-- **Sample rate:** open **Setup → Hardware Config → Radio Info**, change the sample rate combo from 48k to 192k or 384k. The spectrum span should widen correspondingly. No crash.
+- **Attenuator / preamp:** find the attenuator control (probably in one of the applets on the right). Slide it across its range. Background noise should drop audibly and visibly on the spectrum. The exact range depends on your board (HL2: 0–60 dB in 1 dB steps; Hermes/ANAN-10/100/100B: preamp on/off plus 0–31 dB attenuator; ANAN-100D/200D/7000/8000/G2: 0–31 dB in 1 dB steps with separate preamp bits). If the control's range matches what your board actually supports, capability gating is working.
+- **Sample rate:** open **Setup → Hardware Config → Radio Info**, change the sample rate combo. Available rates depend on the board (HL2: 48/96/192/384 k; ANAN: usually 48/96/192/384 k, some boards go higher on P2). The spectrum span should widen/narrow correspondingly. No crash on rate change.
 - **Mode:** switch LSB ↔ USB. Audio character should change (on SSB the wrong sideband sounds like Donald Duck).
 - **Volume:** the volume control should work.
 - **Disconnect and reconnect:** click Disconnect, wait for the spectrum to go quiet, click Connect again. Audio should resume.
@@ -255,15 +293,28 @@ While listening to a live signal:
 
 ### 6. Hardware Config tabs
 
-Open **Setup → Hardware Config**. You should see a tab strip at the top with 9 tabs, but **most of them will be hidden** because they don't apply to HL2. For an HL2 you should see only:
+Open **Setup → Hardware Config**. You should see a tab strip at the top with **up to 9 tabs**, but **which tabs are visible depends on your radio's capabilities.** This is capability gating — NereusSDR inspects your board's feature bits and hides tabs that don't apply.
 
-- **Radio Info** — read-only labels showing board type, protocol, ADC count, max RX, firmware, MAC, IP, plus a live sample-rate combo and active-RX spinbox
-- **HL2 I/O Board** — GPIO / PTT / CW input / aux output assignments
-- **Bandwidth Monitor** — LAN PHY rate display, throttle threshold, auto-pause toggle
+Reference table:
 
-The tabs for Antenna/ALEX, OC Outputs, XVTR, PureSignal, Diversity, and PA Calibration should all be **hidden** — HL2 doesn't have that hardware.
+| Tab | Radios that show it |
+|---|---|
+| **Radio Info** | All radios |
+| **HL2 I/O Board** | Hermes Lite 2 only |
+| **Bandwidth Monitor** | Hermes Lite 2 only |
+| **Antenna / ALEX** | All boards with ALEX hardware (Hermes / ANAN / Orion / Saturn) |
+| **OC Outputs** | Boards with Open Collector outputs |
+| **XVTR** | Boards supporting transverter offsets |
+| **PureSignal** | 2-ADC boards with feedback path (ANAN-100D / 200D / 7000 / 8000 / G2 / Orion MkII) |
+| **Diversity** | 2-ADC boards supporting diversity reception |
+| **PA Calibration** | Boards with PA power-sensing hardware |
 
-**✅ Success bar for step 6:** Radio Info populates with your actual HL2 info; the other HL2-specific tabs are visible; the non-HL2 tabs are not.
+For example:
+- An **HL2** sees Radio Info + HL2 I/O Board + Bandwidth Monitor (most others hidden).
+- An **ANAN-100** sees Radio Info + Antenna/ALEX + OC Outputs + XVTR + PA Calibration (no PureSignal, no Diversity, no HL2 tabs).
+- An **ANAN-G2 / 7000 / 8000** sees all 9 minus the HL2-specific pair.
+
+**✅ Success bar for step 6:** Radio Info populates with your actual board info (correct board name, ADC count, max RX, firmware, MAC, IP). The tabs you do see match the capability table above for your board. The tabs you don't see are hidden because your board doesn't have that hardware.
 
 ### 7. Quit cleanly
 
@@ -273,7 +324,7 @@ Close the app (red close button, or File → Quit, or ⌘Q on macOS, Alt+F4 on W
 
 ### 8. Relaunch
 
-Open the app again. If you had your HL2 connected when you quit, it should **silently auto-reconnect** within a few seconds without you needing to open ConnectionPanel.
+Open the app again. If you had your radio connected when you quit, it should **silently auto-reconnect** within a few seconds without you needing to open ConnectionPanel.
 
 **✅ Success bar for step 8:** auto-reconnect works, or at worst it silently gives up without popping an error.
 
@@ -281,40 +332,42 @@ Open the app again. If you had your HL2 connected when you quit, it should **sil
 
 ## What is NOT wired up (don't file bugs for these)
 
-This is the list of things you will see in the UI that look like they should work but are intentionally stubbed for this phase. Please **do not file bugs** against these — they're tracked in the Phase 3I design doc §9 and the Phase 3I verification doc. Later phases will light them up.
+This is the list of things you will see in the UI that look like they should work but are intentionally stubbed for this phase. Please **do not file bugs** against these — they're tracked in the Phase 3I / 3L / 3M design docs. Later phases will light them up.
 
 ### Transmit, period
 
-- **No TX audio.** The SSB modulator doesn't exist yet. Keying up (MOX button, PTT input, Tune button) will put command bytes on the wire asking the radio to transmit, but there is no I/Q audio being generated to transmit with. On HL2 specifically you should not see the radio's TX LED come on if you try, because the MOX state machine hasn't been fully wired either. **But don't test this. Alpha = RX only.**
+- **No TX audio.** The SSB modulator doesn't exist yet. Keying up (MOX button, PTT input, Tune button) will put command bytes on the wire asking the radio to transmit, but there is no I/Q audio being generated to transmit with. **Don't test this. Alpha = RX only.**
 - **No CW transmit.** Same reason.
-- **No PureSignal linearization.** The PureSignal tab is hidden for HL2 anyway.
-- **No external PTT input routing** — the HL2 I/O Board tab has combos for PTT pin, CW key pin, and aux outputs, but they just persist the setting. They don't drive real GPIO yet. Phase 3L.
+- **No PureSignal linearization.** Scaffold only; no DSP behind the switch.
+- **No external PTT input routing** — the HL2 I/O Board tab and the ANAN OC Outputs tab have combos for PTT pin, CW key pin, and aux outputs, but they just persist the setting. They don't drive real GPIO yet. Phase 3L / Phase 3M.
 - **No aux output assignments active** — same story. Tab remembers your pick, nothing acts on it yet.
 
 ### Controls that look live but are cold
 
-- **PureSignal enable** (hidden for HL2 but visible for 2-ADC boards) — state persists, no DSP runs.
+- **PureSignal enable** (visible on 2-ADC boards) — state persists, no DSP runs.
+- **Diversity enable** (visible on 2-ADC boards) — state persists, no second-RX fusion runs.
 - **PA Calibration** tables — state persists, no real calibration.
-- **Bandwidth Monitor** live PHY rate — label shows "— Mbps" because no real feed is wired yet. The app does watch for HL2 LAN throttling internally via a sequence-gap heuristic, but the rate display itself is a Phase 3L item.
-- **XVTR transverter editor** (hidden for HL2) — table works, but nothing downstream acts on the entries yet.
-- **OC Outputs mask grid** (hidden for HL2) — persists, doesn't drive relays.
+- **Bandwidth Monitor** live PHY rate (HL2) — label shows `— Mbps` because no real feed is wired yet. The app does watch for HL2 LAN throttling internally via a sequence-gap heuristic, but the rate display itself is a Phase 3L item.
+- **XVTR transverter editor** — table works, but nothing downstream acts on the entries yet.
+- **OC Outputs mask grid** — persists, doesn't drive relays.
 
-### UI features not yet in Phase 3I
+### UI features not yet in this build
 
 - **TCI protocol server** (for N1MM+, Log4OM, etc.) — Phase 3J.
 - **CAT / rigctld** (for logging programs) — Phase 3K.
 - **Up to 4 independent panadapters in configurable layouts** — Phase 3F. You get RX1 only in the spectrum panel for now.
+- **Second receiver (RX2)** — hardware support exists on 2-ADC boards (ANAN-7000/8000/G2/Orion MkII) but there's no UI for it yet.
 - **Skin import from Thetis** — Phase 3H.
-- **Firmware flashing from within the app** — not planned for Phase 3I.
+- **Firmware flashing from within the app** — not planned for this phase.
 - **Multi-radio simultaneous connection** — not planned at all; one radio at a time.
 
 ### Things that might look weird but aren't bugs
 
-- **The atoms / meter items that aren't wired up.** You'll see meter widgets in the UI that don't update or have placeholder values. The meter engine supports ~31 item types (bars, needles, dials, text overlays, rotators, clocks, magic-eye displays, data out, etc.), and many of them are fully styled but not yet bound to real data streams. The ones that DO work for HL2: signal S-meter, spectrum/waterfall, the clock widgets. The ones that don't: most TX meters (power, ALC, compression, SWR), most PA-related meters, magic eye, data out. If a meter isn't moving, assume it's not wired up rather than broken.
+- **The atoms / meter items that aren't wired up.** You'll see meter widgets in the UI that don't update or have placeholder values. The meter engine supports ~31 item types (bars, needles, dials, text overlays, rotators, clocks, magic-eye displays, data out, etc.), and many of them are fully styled but not yet bound to real data streams. The ones that DO work on any supported radio: signal S-meter, spectrum/waterfall, the clock widgets. The ones that don't: most TX meters (power, ALC, compression, SWR), most PA-related meters, magic eye, data out. If a meter isn't moving, assume it's not wired up rather than broken.
 - **Some setup-dialog pages still say "NYI" (Not Yet Implemented)** on their tooltips. Those are the pages that haven't been ported from Thetis yet.
 - **Right-click context menus** are minimal in some places.
 - **Keyboard shortcuts** are partial.
-- **The continuous radio re-discovery** behavior you might expect from some other SDR apps is not present — discovery is one-shot, user-triggered. This was a deliberate fix during Phase 3I smoke testing because the original implementation was blocking the GUI for 15+ seconds every 5 seconds.
+- **The continuous radio re-discovery** behavior you might expect from some other SDR apps is not present — discovery is one-shot, user-triggered. This was a deliberate fix because the original implementation was blocking the GUI for 15+ seconds every 5 seconds.
 
 ---
 
@@ -323,10 +376,12 @@ This is the list of things you will see in the UI that look like they should wor
 Beyond the basic "can I hear signals" test, these are the spicier scenarios we haven't hit often:
 
 1. **Leave the app connected for an hour or two.** Does CPU usage climb over time? Does audio glitch? Does the spectrum stop updating? (We're hunting for memory leaks and slow-drift bugs that only show up after extended runs.)
-2. **Pull the HL2's Ethernet cable** while connected. The app should detect the silence within 2 seconds, transition to an Error state, and try to reconnect up to 3 times at 5-second intervals. Plug the cable back in during that window — it should recover. If you wait longer than ~20 seconds, it should give up and stay in Error until you click Connect again.
-3. **Let your HL2 be somewhere unusual on your network** — behind a VPN, on a different subnet accessible via static route, or on the other end of a LAN bridge. Broadcast discovery won't find it but the manual-add dialog (**Add Manually…** button in ConnectionPanel) lets you type in the IP directly. Worth confirming that works.
+2. **Pull the radio's Ethernet cable** while connected. The app should detect the silence within 2 seconds, transition to an Error state, and try to reconnect up to 3 times at 5-second intervals. Plug the cable back in during that window — it should recover. If you wait longer than ~20 seconds, it should give up and stay in Error until you click Connect again.
+3. **Let your radio be somewhere unusual on your network** — behind a VPN, on a different subnet accessible via static route, or on the other end of a LAN bridge. Broadcast discovery won't find it but the manual-add dialog (**Add Manually…** button in ConnectionPanel) lets you type in the IP directly. Worth confirming that works on your board.
 4. **Change the sample rate while listening** to a signal. Does audio stay connected? Does the spectrum span update correctly?
 5. **Try Add Manually with a wrong IP.** Does the app handle "radio doesn't respond" gracefully, or does it freeze?
+6. **Cold / warm / hot swap radios.** If you have more than one supported board on your network, switch between them: connect to A, disconnect, connect to B. No crash, no stale state bleeding from the first radio.
+7. **Exercise the capability gating.** Open Hardware Config on each board you have and confirm the right tabs appear/hide. If you see a tab that shouldn't be there (e.g. PureSignal on a Hermes-classic), that's a capability-registry bug.
 
 ---
 
@@ -336,27 +391,35 @@ When something goes wrong, the more of these you can include, the faster we can 
 
 ### 1. What you were doing
 
-One line describing what you clicked / typed right before the problem. Example: *"I clicked Connect on the HL2 row and about 0.5 s later the app crashed."*
+One line describing what you clicked / typed right before the problem. Example: *"I clicked Connect on the ANAN-G2 row and about 0.5 s later the app crashed."*
 
 ### 2. Which version
+
+From **Help → About**, or from the terminal:
 
 ```bash
 cd NereusSDR
 git rev-parse HEAD
 ```
 
-Or, if you built from a release, the version string from **Help → About**.
+If you're on a tagged release, give us the tag (e.g. `v0.1.1`).
 
-### 3. The app log
+### 3. Which radio
+
+- Board family (HL2 / Hermes / Metis / Angelia / Orion / Orion MkII / ANAN-10/100/100B/100D/200D/7000/8000 / G2-Saturn / other)
+- Protocol (P1 or P2 — NereusSDR tells you this in the Connection Panel)
+- Firmware version (from Setup → Hardware Config → Radio Info once connected, or your radio's built-in web UI)
+
+### 4. The app log
 
 NereusSDR writes every log line to a file. Find it:
-- **macOS:** `~/Library/Application Support/NereusSDR/nereussdr.log` (or somewhere under `~/Library/Preferences/NereusSDR/`)
+- **macOS:** `~/Library/Application Support/NereusSDR/nereussdr.log` (or under `~/Library/Preferences/NereusSDR/`)
 - **Linux:** `~/.config/NereusSDR/nereussdr.log`
 - **Windows:** `%LOCALAPPDATA%\NereusSDR\nereussdr.log`
 
 The file is rewritten on each launch, so grab it *before* you relaunch the app after a crash.
 
-### 4. Any crash report
+### 5. Any crash report
 
 If the OS popped a crash dialog, there's a full crash log somewhere:
 - **macOS:** `~/Library/Logs/DiagnosticReports/NereusSDR-*.ips` (most recent one)
@@ -365,21 +428,16 @@ If the OS popped a crash dialog, there's a full crash log somewhere:
 
 Attach the whole file to the bug report. It's usually 30–100 KB of text.
 
-### 5. Your HL2 firmware version
-
-You can read it from the **Setup → Hardware Config → Radio Info** tab once you're connected, or look at the HL2's built-in web UI.
-
 ### 6. File the report
 
-- Easy: comment on [PR #12](https://github.com/boydsoftprez/NereusSDR/pull/12) with your findings
-- Or: open a new issue at <https://github.com/boydsoftprez/NereusSDR/issues/new> and tag it `alpha-test` / `hl2` / `phase-3i` as appropriate
+Open a new issue at <https://github.com/boydsoftprez/NereusSDR/issues/new> and tag it `alpha-test` plus your radio family (e.g. `hl2`, `anan-g2`, `anan-100d`, `hermes`, etc.).
 
 **What's useful:**
 - Repro steps
 - What you expected vs what happened
 - Logs + crash reports if available
 - Screenshots for visual bugs
-- Your OS version
+- Your OS version and your radio's board + firmware
 
 **What's not useful (we already know):**
 - "TX doesn't work" — intentional, see above
@@ -393,12 +451,12 @@ You can read it from the **Setup → Hardware Config → Radio Info** tab once y
 If at the end of this test you:
 
 1. Launched the app
-2. Discovered your HL2 in ConnectionPanel
+2. Discovered your radio in ConnectionPanel
 3. Connected to it without a crash
 4. Heard a live SSB QSO with a working spectrum and waterfall
 5. Quit cleanly
 
-…then we've hit our **alpha-test success criterion** for Phase 3I. Everything beyond that is a bonus.
+…then we've hit our **alpha-test success criterion**. Everything beyond that is a bonus.
 
 **Thank you for testing.** We're trying to build a modern, open, cross-platform replacement for Thetis, and we can't do it without people running the code on real hardware and telling us what breaks. If you send us one usable bug report with logs attached, you've already contributed more than most people ever will to an open-source radio project.
 


### PR DESCRIPTION
## Summary
- Expands `docs/debugging/alpha-tester-hl2-smoke-test.md` from HL2-only to cover the full OpenHPSDR P1/P2 family now supported after Phase 3I.
- Adds supported-radios table, pre-built binary downloads + GPG verify, per-family firmware minimums, capability-gating tab reference, and multi-radio procedures.
- Updates the bug-report template to require board + protocol + firmware.

## Test plan
- [ ] Render the doc on GitHub and spot-check the new tables
- [ ] Confirm all download links resolve (macOS Apple Silicon, Linux AppImage aarch64, Windows portable zip)
- [ ] Confirm GPG verification instructions match the current signing key
- [ ] Sanity-check the Hardware Config capability-gating table against the actual UI

JJ Boyd ~KG4VCF
Co-Authored with Claude Code