### PR TITLE
docs: reframe NereusSDR intro as independent client informed by Thetis

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://en.cppreference.com/w/cpp/20)
 [![Qt6](https://img.shields.io/badge/Qt-6-green.svg)](https://www.qt.io/)
 
-NereusSDR is a ground-up port of [Thetis](https://github.com/ramdor/Thetis) (the Apache Labs / OpenHPSDR SDR console) from C# to C++20 and Qt6. It uses [AetherSDR](https://github.com/ten9876/AetherSDR) as the architectural template. The goal is a modern, cross-platform, GPU-accelerated SDR console that preserves the full feature set of Thetis while dramatically improving the UI, multi-panadapter experience, and waterfall fluidity.
+NereusSDR is an independent cross-platform SDR client deeply informed by the workflow, feature set, and operating style of [Thetis](https://github.com/ramdor/Thetis), reimagined with a new GUI, a modernized architecture, and native support for macOS, Linux, and Windows.
 
 ---
 

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-NereusSDR is a ground-up port of Thetis (OpenHPSDR SDR console) from C# to Qt6/C++20, using AetherSDR as the architectural template. We've completed the scaffolding (Phase 0), architectural analysis (Phase 1), and architecture design (Phase 2). Now moving to Phase 3: Implementation.
+NereusSDR is an independent cross-platform SDR client deeply informed by the workflow, feature set, and operating style of Thetis, reimagined with a new GUI, a modernized architecture, and native support for macOS, Linux, and Windows. We've completed the scaffolding (Phase 0), architectural analysis (Phase 1), and architecture design (Phase 2). Now moving to Phase 3: Implementation.
 
 ---
 

--- a/docs/project-brief.md
+++ b/docs/project-brief.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-NereusSDR is a ground-up port of Thetis (the OpenHPSDR / Apache Labs SDR console) from C# to **Qt6 / C++20**, using **AetherSDR** (`https://github.com/ten9876/AetherSDR`) as the architectural template and inspiration. The goal is a modern, cross-platform, GPU-accelerated SDR console that preserves the full feature set of Thetis while dramatically improving the UI, multi-panadapter experience, and waterfall fluidity.
+NereusSDR is an independent cross-platform SDR client deeply informed by the workflow, feature set, and operating style of Thetis, reimagined with a new GUI, a modernized architecture, and native support for macOS, Linux, and Windows.
 
 ## Supported Radio Hardware
 


### PR DESCRIPTION
## Summary
- Rewrite the "what is NereusSDR" tagline in README, project-brief, and MASTER-PLAN to describe the project as an independent cross-platform SDR client informed by Thetis, rather than a ground-up port.
- Drop the AetherSDR architectural-template mention from the public-facing intros (still referenced in CLAUDE.md and architecture docs for internal engineering guidance).
- Internal engineering contracts (CLAUDE.md source-first porting protocol, architecture docs, phase plans, reviews) are intentionally left unchanged.

## Test plan
- [ ] README renders cleanly on GitHub
- [ ] No other user-facing docs still describe the project as a "port"

73 de JJ Boyd ~KG4VCF
Co-Authored with Claude Code