### PR TITLE
fix(ci): ship real NereusSDR icon in AppImage instead of placeholder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,11 +204,24 @@ jobs:
           Categories=HamRadio;Audio;
           Comment=Cross-platform OpenHPSDR SDR Console
           DESKTOP
-          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
-          convert -size 256x256 xc:"#0f0f1a" -fill "#00b4d8" -gravity center \
-            -pointsize 48 -annotate +0+0 "NSDR" \
-            AppDir/usr/share/icons/hicolor/256x256/apps/nereussdr.png 2>/dev/null || \
-          touch AppDir/usr/share/icons/hicolor/256x256/apps/nereussdr.png
+          # Install the real NereusSDR icon at standard hicolor sizes.
+          # Uses the pre-rendered PNGs from resources/icons/NereusSDR.iconset/
+          # so there is no image-processing dependency on the runner (the
+          # previous implementation called `convert` and fell back to `touch`,
+          # which either produced a placeholder "NSDR" text bitmap or a
+          # zero-byte file — neither is a usable icon). linuxdeploy creates
+          # the top-level .DirIcon symlink automatically based on the
+          # .desktop file's `Icon=nereussdr` field, so file managers will
+          # thumbnail the AppImage correctly.
+          for size in 16 32 64 128 256 512; do
+            mkdir -p AppDir/usr/share/icons/hicolor/${size}x${size}/apps
+          done
+          cp resources/icons/NereusSDR.iconset/icon_16x16.png     AppDir/usr/share/icons/hicolor/16x16/apps/nereussdr.png
+          cp resources/icons/NereusSDR.iconset/icon_32x32.png     AppDir/usr/share/icons/hicolor/32x32/apps/nereussdr.png
+          cp resources/icons/NereusSDR.iconset/icon_32x32@2x.png  AppDir/usr/share/icons/hicolor/64x64/apps/nereussdr.png
+          cp resources/icons/NereusSDR.iconset/icon_128x128.png   AppDir/usr/share/icons/hicolor/128x128/apps/nereussdr.png
+          cp resources/icons/NereusSDR.iconset/icon_256x256.png   AppDir/usr/share/icons/hicolor/256x256/apps/nereussdr.png
+          cp resources/icons/NereusSDR.iconset/icon_512x512.png   AppDir/usr/share/icons/hicolor/512x512/apps/nereussdr.png
 
           ./linuxdeploy-${{ matrix.arch }}.AppImage \
             --appdir AppDir \


### PR DESCRIPTION
## Summary

The AppImage build step in `.github/workflows/release.yml` was generating a **placeholder icon** at build time — calling ImageMagick `convert` to draw a 256×256 dark-blue square with "NSDR" text on it, with a `touch` fallback that creates a zero-byte file on runners without ImageMagick. Neither output is a usable icon, and the v0.1.1 release shipped the "NSDR" text bitmap as its visible icon.

The real icon has been in the repo all along at `resources/icons/NereusSDR.png` (1024×1024), with pre-rendered PNGs at every standard size in `resources/icons/NereusSDR.iconset/`. This PR replaces the placeholder-generation block with straight `cp` commands that install the pre-rendered icons at every standard hicolor size:

- `16×16`, `32×32`, `64×64`, `128×128`, `256×256`, `512×512` — each going into `AppDir/usr/share/icons/hicolor/<size>/apps/nereussdr.png`

linuxdeploy's existing `--desktop-file` handling continues to create the top-level `.DirIcon` symlink chain automatically, so AppImage thumbnailers and file managers render the correct icon on the AppImage file itself.

## Why

- **Zero image-processing dependency on the runner.** The old `convert` call silently failed on any runner without ImageMagick, and the `touch` fallback was worse than nothing.
- **Crisp at every UI context** — app launcher (48/64), file manager thumbnail (256), dock (128/256), taskbar (16/32), HiDPI scale-up (512).
- **No new files.** All six pre-rendered PNGs already live in `resources/icons/NereusSDR.iconset/` (they were added for the macOS `.icns` generation step).
- **~150 KB added to the AppImage**, the total size of the six bundled PNGs.
- **No changes to the `.desktop` file** — `Icon=nereussdr` still matches the installed filename without extension.
- **No changes to the linuxdeploy invocation.**

## Test plan

- [x] Verified current v0.1.1 AppImage's symlink chain: `.DirIcon → nereussdr.png → usr/share/icons/hicolor/256x256/apps/nereussdr.png`. The structure is already correct — only the underlying file was a placeholder. After this patch, that file will be the real icon.
- [x] Verified all six source PNGs exist in `resources/icons/NereusSDR.iconset/` at the expected dimensions (checked via `file` on each).
- [ ] CI release.yml dry-run — will happen when this PR triggers the workflow.
- [ ] Post-merge: cut a test release and download the resulting AppImage; verify the icon thumbnails correctly in Files / Nautilus and in GNOME Activities after a double-click.

## Notes

- `one issue per PR` — this PR is scoped to the icon fix only. I noticed unrelated working-tree modifications in `src/gui/SpectrumWidget.cpp` and `src/gui/meters/MeterWidget.cpp` (adding explicit Vulkan-backend selection for Linux) while working on this; those are intentionally **not** included here and should go in a separate PR if you want them landed.
- Unrelated: PR #17 (`fix/wdsp-linux-port-bfo-deadlock`) fixes the Linux audio deadlock and is awaiting review; this PR is independent of it and can land in either order.

—
JJ Boyd ~KG4VCF
Co-Authored with Claude Code