### PR TITLE
fix(release): unbreak Linux AppImage builds after GPU-spectrum fail-loud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           pip3 install aqtinstall
           aqt install-qt linux desktop 6.7.3 linux_gcc_64 \
-            -m qtmultimedia \
+            -m qtmultimedia qtshadertools \
             --outputdir ${{ github.workspace }}/Qt
           echo "Qt6_DIR=${{ github.workspace }}/Qt/6.7.3/gcc_64/lib/cmake/Qt6" >> $GITHUB_ENV
           echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/6.7.3/gcc_64" >> $GITHUB_ENV
@@ -158,6 +158,10 @@ jobs:
           CMAKE_EXTRA=""
           if [ "${{ matrix.use_aqt }}" = "true" ]; then
             CMAKE_EXTRA="-DCMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/6.7.3/gcc_64"
+          else
+            # Ubuntu 24.04 ARM ships Qt 6.4.2; QRhiWidget requires 6.7+.
+            # Mirror ci.yml linux-gcc: CPU-only spectrum on this runner.
+            CMAKE_EXTRA="-DNEREUS_GPU_SPECTRUM=OFF"
           fi
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
## Summary
- v0.1.2 release run (24377162661) failed both Linux jobs at the Configure step because commit 9f05dac now hard-errors when `NEREUS_GPU_SPECTRUM` is requested but cannot satisfy its preconditions, and `release.yml`'s Linux lanes were never brought in line with `ci.yml`.
- **x86_64 (aqtinstall Qt 6.7.3):** add `qtshadertools` to the `-m` modules list. The "Qt6 private modules missing: ShaderTools" error came from aqtinstall not pulling `qtshadertools` by default; `ci.yml` already lists it for its Linux lane.
- **aarch64 (Ubuntu 24.04 ARM, system Qt 6.4.2):** pass `-DNEREUS_GPU_SPECTRUM=OFF`. System Qt is older than 6.7 (QRhiWidget requires 6.7+), which is exactly the condition `ci.yml`'s linux-gcc lane already handles the same way. aarch64 AppImage will ship with the CPU spectrum fallback until we install Qt 6.7 via aqtinstall on ARM or bump the runner.

macOS and Windows lanes were unaffected in the failed v0.1.2 run; only Linux needs patching.

## Test plan
- [ ] CI green on `fix/release-linux-gpu-spectrum`
- [ ] After merge, delete failed tag `v0.1.2` and re-run `/release patch 0.1.2`
- [ ] Verify all 5 platform artifacts upload and `sign-and-publish` job completes
- [ ] Draft GitHub Release for v0.1.2 shows 7 expected artifacts (2× AppImage + DMG + Windows ZIP + NSIS + SHA256SUMS + sig)

73 de JJ Boyd ~KG4VCF
Co-Authored with Claude Code