### PR TITLE
fix(release): stage libfftw3f-3.dll into Windows deploy folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,6 +396,17 @@ jobs:
           if (Test-Path "third_party\fftw3\bin\libfftw3-3.dll") {
             copy third_party\fftw3\bin\libfftw3-3.dll deploy\
           }
+          # libfftw3f-3.dll (single-precision) is the one FFTEngine actually
+          # imports — committed in-tree at third_party/fftw3/bin/. windeployqt
+          # only resolves Qt DLLs, so this non-Qt dependency must be staged
+          # by hand or the .exe fails to start on clean installs with
+          # "libfftw3f-3.dll was not found" (shipped broken in v0.1.2).
+          if (Test-Path "third_party\fftw3\bin\libfftw3f-3.dll") {
+            copy third_party\fftw3\bin\libfftw3f-3.dll deploy\
+          } else {
+            Write-Error "libfftw3f-3.dll missing from third_party\fftw3\bin\ — Windows artifact would ship broken"
+            exit 1
+          }
 
       - name: Create portable ZIP
         shell: pwsh


### PR DESCRIPTION
## Summary

- v0.1.2 Windows installer and portable ZIP both shipped broken: NereusSDR.exe fails to launch on clean installs with `The code execution cannot proceed because libfftw3f-3.dll was not found`.
- Root cause: `Deploy Qt` step in `release.yml` only copied `libfftw3-3.dll` (double precision) into `deploy\`. FFTEngine actually imports the **single-precision** `libfftw3f-3.dll` — committed in-tree at `third_party/fftw3/bin/`, found fine at build time, but never staged into the artifact. `windeployqt` doesn't resolve non-Qt DLLs.
- Fix: copy `libfftw3f-3.dll` into `deploy\` alongside the existing double-precision copy. NSIS installer (`installer.nsi:56` — `File /r deploy\`) and the portable ZIP (`Compress-Archive deploy\*`) both pick it up automatically.
- Fail-loud guard: if the DLL ever vanishes from the repo, the Windows build aborts at `Deploy Qt` instead of silently shipping broken again. Same spirit as the `NEREUS_GPU_SPECTRUM` fail-loud from 9f05dac.

## Workaround for users on v0.1.2

Download [`libfftw3f-3.dll` from the repo](https://github.com/boydsoftprez/NereusSDR/raw/main/third_party/fftw3/bin/libfftw3f-3.dll) and drop it next to `NereusSDR.exe`:

- **NSIS installer:** `C:\Program Files\NereusSDR\libfftw3f-3.dll` (requires admin)
- **Portable ZIP:** extraction folder, alongside `NereusSDR.exe`

Or, elevated PowerShell one-liner:

```powershell
Invoke-WebRequest `
  -Uri "https://github.com/boydsoftprez/NereusSDR/raw/main/third_party/fftw3/bin/libfftw3f-3.dll" `
  -OutFile "C:\Program Files\NereusSDR\libfftw3f-3.dll"
```

## Test plan

- [ ] PR CI passes on all three OSes (ci.yml)
- [ ] After merge: `/release patch` cuts v0.1.3
- [ ] Verify release.yml Windows job logs show `libfftw3f-3.dll` copied in the `Deploy Qt` step
- [ ] Download v0.1.3 NSIS installer on a clean Windows VM with no dev FFTW — install, launch, confirm no system error
- [ ] Verify v0.1.3 portable ZIP contains `libfftw3f-3.dll` next to `NereusSDR.exe`

73 de JJ Boyd ~KG4VCF
Co-Authored with Claude Code
