### PR TITLE
fix(p1): prime Hermes DDC, phase-word VFO, nddc=2 bank round-robin + two Windows crashes

### DIFF
--- a/src/core/P1RadioConnection.cpp
+++ b/src/core/P1RadioConnection.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <QtEndian>
 #include <QNetworkDatagram>
+#include <QThread>
 #include <QVariant>
 
 namespace NereusSDR {
@@ -36,7 +37,9 @@ namespace NereusSDR {
 // ---------------------------------------------------------------------------
 void P1RadioConnection::composeEp2Frame(quint8 out[1032], quint32 seq,
                                          int /*ccAddress*/,
-                                         int sampleRate, bool mox) noexcept
+                                         int sampleRate, bool mox,
+                                         quint64 rx1FreqHz,
+                                         int activeRxCount) noexcept
 {
     // Source: networkproto1.c:223-230 — MetisWriteFrame() header + sequence
     out[0] = 0xEF;
@@ -55,14 +58,14 @@ void P1RadioConnection::composeEp2Frame(quint8 out[1032], quint32 seq,
     out[9]  = 0x7F;
     out[10] = 0x7F;
 
-    // C0..C4 for subframe 0 — compose bank 0 (general settings)
-    quint8 cc[5] = {};
-    composeCcBank0(cc, sampleRate, mox);
-    out[11] = cc[0];
-    out[12] = cc[1];
-    out[13] = cc[2];
-    out[14] = cc[3];
-    out[15] = cc[4];
+    // C0..C4 for subframe 0 -- compose bank 0 (general settings)
+    quint8 cc0[5] = {};
+    composeCcBank0(cc0, sampleRate, mox, activeRxCount);
+    out[11] = cc0[0];
+    out[12] = cc0[1];
+    out[13] = cc0[2];
+    out[14] = cc0[3];
+    out[15] = cc0[4];
 
     // Bytes 16..519: TX I/Q + mic data — zeros (RX-only; TX producer added in TX phase)
 
@@ -72,12 +75,18 @@ void P1RadioConnection::composeEp2Frame(quint8 out[1032], quint32 seq,
     out[521] = 0x7F;
     out[522] = 0x7F;
 
-    // C0..C4 for subframe 1 — repeat bank 0 (round-robin comes in later task)
-    out[523] = cc[0];
-    out[524] = cc[1];
-    out[525] = cc[2];
-    out[526] = cc[3];
-    out[527] = cc[4];
+    // C0..C4 for subframe 1 — RX1 frequency bank (address 0x02, Thetis case 2).
+    // Without this, the radio streams ADC data at LO=0 → huge DC spike with no
+    // visible signals. Partial round-robin: bank 0 on subframe 0, RX1 freq on
+    // subframe 1. Remaining banks (TX freq, Alex, atten, OC, RX2+) come with
+    // the full round-robin in the outstanding P1 tasks.
+    quint8 cc1[5] = {};
+    composeCcBankRxFreq(cc1, 0 /* rxIndex */, rx1FreqHz);
+    out[523] = cc1[0];
+    out[524] = cc1[1];
+    out[525] = cc1[2];
+    out[526] = cc1[3];
+    out[527] = cc1[4];
 
     // Bytes 528..1031: TX I/Q + mic data — zeros (RX-only)
 }
@@ -92,13 +101,14 @@ void P1RadioConnection::composeEp2Frame(quint8 out[1032], quint32 seq,
 //   C3 = BPF/atten/preamp flags — zero for stub
 //   C4 = antenna, duplex, NDDCs — zero for stub
 // ---------------------------------------------------------------------------
-void P1RadioConnection::composeCcBank0(quint8 out[5], int sampleRate, bool mox) noexcept
+void P1RadioConnection::composeCcBank0(quint8 out[5], int sampleRate, bool mox,
+                                        int activeRxCount) noexcept
 {
-    // Source: networkproto1.c:615 — C0 = (unsigned char)XmitBit
+    // Source: networkproto1.c:615 -- C0 = (unsigned char)XmitBit
     out[0] = mox ? 0x01 : 0x00;
 
-    // Source: networkproto1.c:620 — C1 = (SampleRateIn2Bits & 3)
-    // 48000→0, 96000→1, 192000→2, 384000→3
+    // Source: networkproto1.c:620 -- C1 = (SampleRateIn2Bits & 3)
+    // 48000->0, 96000->1, 192000->2, 384000->3
     quint8 srBits = 0;
     if      (sampleRate >= 384000) { srBits = 3; }
     else if (sampleRate >= 192000) { srBits = 2; }
@@ -106,11 +116,17 @@ void P1RadioConnection::composeCcBank0(quint8 out[5], int sampleRate, bool mox) 
     else                            { srBits = 0; }
     out[1] = srBits & 0x03;
 
-    // C2..C4: OC outputs, filter bits, antenna — zero for Task 7 scope.
-    // Source: networkproto1.c:621-640 — full encoding in later tasks
+    // C2, C3: OC outputs / filter bits -- zero for Task 7 scope.
     out[2] = 0;
     out[3] = 0;
-    out[4] = 0;
+
+    // C4: number of DDCs to run, encoded as (nddc - 1) << 3
+    // Source: networkproto1.c:470. Thetis sends 0x08 for nddc=2 even on
+    // single-RX setups (diversity pre-allocation). We send the actual
+    // count so 1-RX configurations write 0x00. The Hermes firmware
+    // accepts both.
+    int nddc = (activeRxCount < 1) ? 1 : (activeRxCount > 7 ? 7 : activeRxCount);
+    out[4] = static_cast<quint8>((nddc - 1) << 3);
 }
 
 // ---------------------------------------------------------------------------
@@ -130,21 +146,34 @@ void P1RadioConnection::composeCcBank0(quint8 out[5], int sampleRate, bool mox) 
 void P1RadioConnection::composeCcBankRxFreq(quint8 out[5], int rxIndex, quint64 freqHz) noexcept
 {
     // Address assignments from networkproto1.c:
-    //   rxIndex 0 → case 2: C0 |= 4   (networkproto1.c:654)
-    //   rxIndex 1 → case 3: C0 |= 6   (networkproto1.c:667)
-    //   rxIndex 2 → case 5: C0 |= 8   (networkproto1.c:694)
-    //   rxIndex 3 → case 7: C0 |= 0x0c (networkproto1.c:718)
-    //   rxIndex 4 → case 8: C0 |= 0x0e (networkproto1.c:728)
-    //   rxIndex 5 → case 9: C0 |= 0x10 (networkproto1.c:738)
+    //   rxIndex 0 → case 2: C0 |= 4   (networkproto1.c:485)
+    //   rxIndex 1 → case 3: C0 |= 6   (networkproto1.c:498)
+    //   rxIndex 2 → case 5: C0 |= 8   (networkproto1.c:526)
+    //   rxIndex 3 → case 7: C0 |= 0x0c
+    //   rxIndex 4 → case 8: C0 |= 0x0e
+    //   rxIndex 5 → case 9: C0 |= 0x10
     static const quint8 kRxC0Address[] = { 4, 6, 8, 0x0c, 0x0e, 0x10, 0x12 };
     quint8 addrBits = (rxIndex >= 0 && rxIndex < 7) ? kRxC0Address[rxIndex] : 4;
     out[0] = addrBits;  // MOX=0; address is already left-shifted in the table
 
-    quint32 freq32 = static_cast<quint32>(freqHz & 0xFFFFFFFF);
-    out[1] = static_cast<quint8>((freq32 >> 24) & 0xFF);
-    out[2] = static_cast<quint8>((freq32 >> 16) & 0xFF);
-    out[3] = static_cast<quint8>((freq32 >>  8) & 0xFF);
-    out[4] = static_cast<quint8>( freq32        & 0xFF);
+    // Ethernet P1 radios (ANAN-10/10E/100/100D, Orion, Angelia) tune via an
+    // NCO phase word, NOT raw Hz. Thetis NetworkIO.cs:220-223 branches on
+    // CurrentRadioProtocol: USB -> raw Hz, else -> Freq2PhaseWord. The
+    // converted value is stored in prn->rx[id].frequency (netInterface.c:517)
+    // and networkproto1.c case 2 (:491-494) writes those bytes directly into
+    // C1..C4.
+    //
+    //   Freq2PhaseWord(freq) = (2^32 * freq) / 122880000   (NetworkIO.cs:249-253)
+    //
+    // 122.88 MHz is the only phase-word divisor in Thetis source (searched:
+    // that constant appears only at NetworkIO.cs:251 and one commented-out
+    // duplicate). HL2 uses the same ChannelMaster source path and therefore
+    // the same divisor.
+    quint32 pw32 = static_cast<quint32>((freqHz << 32) / 122880000ull);
+    out[1] = static_cast<quint8>((pw32 >> 24) & 0xFF);
+    out[2] = static_cast<quint8>((pw32 >> 16) & 0xFF);
+    out[3] = static_cast<quint8>((pw32 >>  8) & 0xFF);
+    out[4] = static_cast<quint8>( pw32        & 0xFF);
 }
 
 // ---------------------------------------------------------------------------
@@ -156,14 +185,15 @@ void P1RadioConnection::composeCcBankRxFreq(quint8 out[5], int rxIndex, quint64 
 // ---------------------------------------------------------------------------
 void P1RadioConnection::composeCcBankTxFreq(quint8 out[5], quint64 freqHz) noexcept
 {
-    // Source: networkproto1.c:646 — C0 |= 2
+    // Source: networkproto1.c:477 — C0 |= 2  (case 1 = TX VFO)
     out[0] = 0x02;  // address 0x01, MOX=0
 
-    quint32 freq32 = static_cast<quint32>(freqHz & 0xFFFFFFFF);
-    out[1] = static_cast<quint8>((freq32 >> 24) & 0xFF);
-    out[2] = static_cast<quint8>((freq32 >> 16) & 0xFF);
-    out[3] = static_cast<quint8>((freq32 >>  8) & 0xFF);
-    out[4] = static_cast<quint8>( freq32        & 0xFF);
+    // Same phase-word conversion as RX freq — Ethernet P1 NCO tuning word.
+    quint32 pw32 = static_cast<quint32>((freqHz << 32) / 122880000ull);
+    out[1] = static_cast<quint8>((pw32 >> 24) & 0xFF);
+    out[2] = static_cast<quint8>((pw32 >> 16) & 0xFF);
+    out[3] = static_cast<quint8>((pw32 >>  8) & 0xFF);
+    out[4] = static_cast<quint8>( pw32        & 0xFF);
 }
 
 // ---------------------------------------------------------------------------
@@ -330,11 +360,26 @@ void P1RadioConnection::connectToRadio(const RadioInfo& info)
     m_intentionalDisconnect = false;
     m_epSendSeq = 0;
     m_epRecvSeqExpected = 0;
+    m_ccRoundRobinIdx = 0;
+
+    // Thetis hardcodes nddc=4 for plain Hermes/ANAN10/ANAN100 and nddc=2 for
+    // ANAN10E/100B (HermesII) in console.cs:8378-8454. No current-source P1
+    // path uses nddc=1 for Hermes-class boards. Captured Thetis traffic with
+    // the tester's radio shows nddc=2 on the wire (sub0 C4 = 0x08 bits).
+    // Default m_activeRxCount to 2 for Hermes-class P1 until we have a
+    // model-override setting. parseEp6Frame uses this same value to select
+    // the 14-byte nddc=2 slot layout, so sent and received must agree.
+    if (m_radioInfo.protocol == ProtocolVersion::Protocol1) {
+        m_activeRxCount = 2;
+    }
 
     // Reset reconnect state — fresh connection resets the retry counter.
     // Source: NereusSDR design doc §3.6 — explicit user reconnect clears attempts.
     m_reconnectAttempts = 0;
     m_lastEp6At = QDateTime();
+    m_firstEp6Logged = false;
+    m_parseFailLogged = false;
+    m_firstEmitLogged = false;
 
     // Apply per-board quirks (attenuator clamp, OC zero-force, etc.) now that
     // m_caps is set. Source: specHPSDR.cs per-HPSDRHW branches.
@@ -361,14 +406,28 @@ void P1RadioConnection::connectToRadio(const RadioInfo& info)
                           << "at" << info.address.toString() << "port" << info.port
                           << "from local port" << (m_socket ? m_socket->localPort() : 0);
 
-    // Send initial ep2 command frame so the radio knows our settings
-    // Source: networkproto1.c:597-884 WriteMainLoop context
-    sendCommandFrame();
-
-    // Send metis-start to begin ep6 stream
-    // Source: networkproto1.c:33-68 SendStartToMetis — cmd byte 0x01 = IQ only
+    // Prime the radio with alternating TX-VFO and RX1-VFO ep2 frames BEFORE
+    // metis-start so the DDC initializes with the correct phase words,
+    // sample rate, and nddc. Without priming, the Hermes firmware streams
+    // ADC-idle data (I=DC offset, Q=0) -- confirmed in the tester's pcap
+    // where every sample had Q=0 for 20 seconds.
+    //
+    // Port of Thetis networkproto1.c:35-68 SendStartToMetis + :281
+    // MetisReadThreadMainLoop. Thetis sends up to 16 primed ep2 frames
+    // (5x ForceCandCFrame(1) inside SendStartToMetis + ForceCandCFrame(3)
+    // at the top of MetisReadThreadMainLoop). We collapse that into two
+    // ForceCandCFrame(3) equivalents: 3 TX + 3 RX1 before metis-start, and
+    // 3 TX + 3 RX1 after.
     m_running = true;
+    sendPrimingBurst(3);
+
+    // Send metis-start to begin ep6 stream.
+    // Source: networkproto1.c:33-68 SendStartToMetis -- cmd byte 0x01 = IQ only
     sendMetisStart(false);
+
+    // Second priming burst after start, matching Thetis's ForceCandCFrame(3)
+    // at MetisReadThreadMainLoop:281.
+    sendPrimingBurst(3);
 
     m_watchdogTimer->start();
     setState(ConnectionState::Connected);
@@ -505,6 +564,16 @@ void P1RadioConnection::onReadyRead()
             // Source: NereusSDR design doc §3.6 — successful data resets the retry counter.
             m_lastEp6At = QDateTime::currentDateTimeUtc();
 
+            // Diagnostic: log the first EP6 frame of this session so
+            // remote debugging can tell "connected but no data" apart
+            // from "connected and streaming".
+            if (!m_firstEp6Logged) {
+                m_firstEp6Logged = true;
+                qCInfo(lcConnection) << "P1: first ep6 frame received from"
+                                     << dg.senderAddress().toString()
+                                     << "(1032 bytes)";
+            }
+
             // If we were in a reconnect attempt, the first good frame means recovery.
             // Stop the reconnect timer and transition to Connected.
             if (cs == ConnectionState::Connecting) {
@@ -540,11 +609,18 @@ void P1RadioConnection::onWatchdogTick()
     const ConnectionState cs = state();
 
     // Send periodic command frame (keep-alive) when connected or reconnecting.
-    // Skip ep2 if the HL2 LAN PHY is throttling — resume once throttle clears.
+    // Alternate between TX-VFO bank and RX1-VFO bank on consecutive ticks so
+    // both freq banks get refreshed at ~kWatchdogTickMs cadence. Thetis sends
+    // banks at ~368 fps; we approximate with 25 ms ticks (40 fps) which gives
+    // the radio ~2x per second per bank of freshness -- enough for
+    // single-frequency monitoring.
+    //
+    // Skip ep2 if the HL2 LAN PHY is throttling -- resume once throttle clears.
     // Source: Task 12 hl2CheckBandwidthMonitor throttle flag.
     if (cs == ConnectionState::Connected || cs == ConnectionState::Connecting) {
         if (!m_hl2Throttled) {
-            sendCommandFrame();
+            const bool txBank = (m_ccRoundRobinIdx++ & 1) != 0;
+            sendCommandFrame(txBank);
         }
     }
 
@@ -603,11 +679,15 @@ void P1RadioConnection::onReconnectTimeout()
     // Transition to Connecting for this retry attempt.
     setState(ConnectionState::Connecting);
 
-    // Send stop then start so the radio re-arms its ep6 sender.
-    // Source: networkproto1.c:49-110 SendStopToMetis / SendStartToMetis.
-    // The socket stays bound from the initial connect.
+    // Send stop then prime then start so the radio re-arms its ep6 sender
+    // with the current RX1 frequency latched. Without the primed C&C burst,
+    // the radio comes back up in ADC-idle state (I=DC, Q=0).
+    // Source: networkproto1.c:49-110 SendStopToMetis / SendStartToMetis plus
+    // the ForceCandCFrame bracket pattern from MetisReadThreadMainLoop:281.
     sendMetisStop();
+    sendPrimingBurst(3);
     sendMetisStart(false);
+    sendPrimingBurst(3);
 
     // Re-arm the watchdog so onReadyRead can complete the transition to Connected.
     if (!m_watchdogTimer->isActive()) {
@@ -676,17 +756,84 @@ void P1RadioConnection::sendMetisStop()
 // Builds a 1032-byte ep2 frame via composeEp2Frame and sends it to the radio.
 // Source: networkproto1.c:216-236 MetisWriteFrame + :597-884 WriteMainLoop
 // ---------------------------------------------------------------------------
-void P1RadioConnection::sendCommandFrame()
+void P1RadioConnection::sendCommandFrame(bool sub1TxBank)
 {
     if (!m_socket) { return; }
 
     quint8 frame[1032];
     memset(frame, 0, sizeof(frame));
 
-    composeEp2Frame(frame, m_epSendSeq++, 0 /* ccAddress */, m_sampleRate, m_mox);
+    // ep2 header (magic + seq)
+    frame[0] = 0xEF;
+    frame[1] = 0xFE;
+    frame[2] = 0x01;
+    frame[3] = 0x02;
+    const quint32 seq = m_epSendSeq++;
+    frame[4] = static_cast<quint8>((seq >> 24) & 0xFF);
+    frame[5] = static_cast<quint8>((seq >> 16) & 0xFF);
+    frame[6] = static_cast<quint8>((seq >>  8) & 0xFF);
+    frame[7] = static_cast<quint8>( seq        & 0xFF);
+
+    // Subframe 0: sync + bank 0 (general settings)
+    frame[8]  = 0x7F;
+    frame[9]  = 0x7F;
+    frame[10] = 0x7F;
+    quint8 cc0[5] = {};
+    composeCcBank0(cc0, m_sampleRate, m_mox, m_activeRxCount);
+    frame[11] = cc0[0];
+    frame[12] = cc0[1];
+    frame[13] = cc0[2];
+    frame[14] = cc0[3];
+    frame[15] = cc0[4];
+
+    // Subframe 1: sync + selectable bank (TX freq or RX1 freq).
+    // Match Thetis networkproto1.c:134-139 ForceCandCFrame which sends
+    // alternating TX-VFO (bank 1, C0=0x02) and RX1-VFO (bank 2, C0=0x04)
+    // frames as the C&C priming sequence.
+    frame[520] = 0x7F;
+    frame[521] = 0x7F;
+    frame[522] = 0x7F;
+    quint8 cc1[5] = {};
+    if (sub1TxBank) {
+        composeCcBankTxFreq(cc1, m_txFreqHz);
+    } else {
+        composeCcBankRxFreq(cc1, 0 /* rxIndex */, m_rxFreqHz[0]);
+    }
+    frame[523] = cc1[0];
+    frame[524] = cc1[1];
+    frame[525] = cc1[2];
+    frame[526] = cc1[3];
+    frame[527] = cc1[4];
 
     QByteArray pkt(reinterpret_cast<const char*>(frame), 1032);
     m_socket->writeDatagram(pkt, m_radioInfo.address, m_radioInfo.port);
+}
+
+// ---------------------------------------------------------------------------
+// sendPrimingBurst
+//
+// Port of Thetis networkproto1.c:134-139 ForceCandCFrame(count):
+//   ForceCandCFrames(count, 2, prn->tx[0].frequency);  // TX bank
+//   Sleep(10);
+//   ForceCandCFrames(count, 4, prn->rx[0].frequency);  // RX1 bank
+//   Sleep(10);
+//
+// Thetis calls this with count=1 inside each retry of SendStartToMetis and
+// with count=3 once at the top of MetisReadThreadMainLoop. We call it with
+// count=3 before metis-start and count=3 after, matching the MetisReadThread
+// invocation. The Sleep(10) gap between TX and RX bursts is preserved because
+// some Hermes firmware revisions need a small idle gap between bank changes.
+// ---------------------------------------------------------------------------
+void P1RadioConnection::sendPrimingBurst(int countPerBank)
+{
+    for (int i = 0; i < countPerBank; ++i) {
+        sendCommandFrame(true /* sub1TxBank */);
+    }
+    QThread::msleep(10);
+    for (int i = 0; i < countPerBank; ++i) {
+        sendCommandFrame(false /* sub1TxBank -> RX1 bank */);
+    }
+    QThread::msleep(10);
 }
 
 // ---------------------------------------------------------------------------
@@ -704,6 +851,17 @@ void P1RadioConnection::parseEp6Frame(const QByteArray& pkt)
     const auto* frame = reinterpret_cast<const quint8*>(pkt.constData());
 
     if (!P1RadioConnection::parseEp6Frame(frame, m_activeRxCount, perRx)) {
+        if (!m_parseFailLogged) {
+            m_parseFailLogged = true;
+            qCWarning(lcConnection) << "P1: parseEp6Frame rejected frame;"
+                                    << "activeRxCount=" << m_activeRxCount
+                                    << "magic=" << QString::asprintf("%02X %02X %02X %02X",
+                                                                     frame[0], frame[1], frame[2], frame[3])
+                                    << "sync0=" << QString::asprintf("%02X %02X %02X",
+                                                                     frame[8], frame[9], frame[10])
+                                    << "sync1=" << QString::asprintf("%02X %02X %02X",
+                                                                     frame[520], frame[521], frame[522]);
+        }
         return;
     }
 
@@ -714,6 +872,11 @@ void P1RadioConnection::parseEp6Frame(const QByteArray& pkt)
         if (!perRx[static_cast<size_t>(r)].empty()) {
             QVector<float> samples(perRx[static_cast<size_t>(r)].begin(),
                                    perRx[static_cast<size_t>(r)].end());
+            if (!m_firstEmitLogged) {
+                m_firstEmitLogged = true;
+                qCInfo(lcConnection) << "P1: first iqDataReceived emit; rx=" << r
+                                     << "samples=" << samples.size();
+            }
             emit iqDataReceived(r, samples);
         }
     }

--- a/src/core/P1RadioConnection.h
+++ b/src/core/P1RadioConnection.h
@@ -30,8 +30,11 @@ public:
     // Wire-format compose helpers — static, testable in isolation.
     // Each implementation cites its Thetis source line.
     static void composeEp2Frame(quint8 out[1032], quint32 seq, int ccAddress,
-                                int sampleRate, bool mox) noexcept;
-    static void composeCcBank0(quint8 out[5], int sampleRate, bool mox) noexcept;
+                                int sampleRate, bool mox,
+                                quint64 rx1FreqHz = 0,
+                                int activeRxCount = 1) noexcept;
+    static void composeCcBank0(quint8 out[5], int sampleRate, bool mox,
+                               int activeRxCount = 1) noexcept;
     static void composeCcBankRxFreq(quint8 out[5], int rxIndex, quint64 freqHz) noexcept;
     static void composeCcBankTxFreq(quint8 out[5], quint64 freqHz) noexcept;
     static void composeCcBankAtten(quint8 out[5], int dB) noexcept;
@@ -75,7 +78,16 @@ private:
     // --- Wire format (networkproto1.c) — implemented in Tasks 7 & 8 ---
     void sendMetisStart(bool iqAndMic);
     void sendMetisStop();
-    void sendCommandFrame();
+    // Send one ep2 command frame. `sub1TxBank=true` puts TX VFO (bank 1,
+    // C0=0x02) on subframe 1; false puts RX1 VFO (bank 2, C0=0x04).
+    // The steady-state watchdog and the initial priming burst alternate
+    // between the two, matching Thetis's ForceCandCFrame(N) pattern in
+    // networkproto1.c:134-139.
+    void sendCommandFrame(bool sub1TxBank = false);
+    // Match Thetis ForceCandCFrame(count): send `count` TX-freq ep2 frames
+    // then `count` RX1-freq ep2 frames. Called before and after metis-start
+    // on both the initial connect and watchdog-driven reconnect paths.
+    void sendPrimingBurst(int countPerBank);
     void parseEp6Frame(const QByteArray& pkt);
 
     // --- Command & Control banks (NetworkIO.cs SetC0..SetC4) ---
@@ -124,8 +136,17 @@ private:
     // Timing constants are NereusSDR policy (documented in design doc §3.6),
     // not ported from Thetis.
     QDateTime   m_lastEp6At;                                    // UTC timestamp of last good ep6 frame
+    bool        m_firstEp6Logged{false};                        // diagnostic: log once on first EP6 arrival per session
+    bool        m_parseFailLogged{false};                       // diagnostic: log once if first ep6 parse fails
+    bool        m_firstEmitLogged{false};                       // diagnostic: log once on first iqDataReceived emit
     int         m_reconnectAttempts{0};                         // how many retries so far this cycle
-    static constexpr int kWatchdogTickMs       = 500;           // watchdog polling interval
+    // 25 ms (= 40 fps) is enough to keep the radio's ep2 command pipe fed
+    // without matching Thetis's full ~368 fps audio-drain cadence. Each tick
+    // sends one ep2 command frame, alternating the subframe-1 bank between
+    // TX VFO and RX1 VFO so both frequency banks are refreshed every ~50 ms.
+    // The previous 500 ms interval was a keep-alive tick, not a command
+    // stream, which left the radio's DDC stuck in its pre-primed idle state.
+    static constexpr int kWatchdogTickMs       = 25;            // watchdog + ep2 command cadence
     static constexpr int kWatchdogSilenceMs    = 2000;          // silence → Error threshold
     static constexpr int kReconnectIntervalMs  = 5000;          // delay between retry attempts
     static constexpr int kMaxReconnectAttempts = 3;             // max retries before staying in Error

--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -433,6 +433,7 @@ void RadioDiscovery::onStaleCheck()
     QStringList stale;
 
     for (auto it = m_lastSeen.constBegin(); it != m_lastSeen.constEnd(); ++it) {
+        if (it.key() == m_connectedMac) { continue; }
         if (now - it.value() > kStaleTimeoutMs) {
             stale.append(it.key());
         }

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -119,6 +119,13 @@ public:
 
     QList<RadioInfo> discoveredRadios() const;
 
+    // Mark a MAC as currently-connected so onStaleCheck will not emit
+    // radioLost for it. Once a radio is streaming (P1 ep6 / P2 DDC),
+    // it stops replying to discovery broadcasts, so the stale timer
+    // would otherwise fire ~15s after every healthy connect.
+    void setConnectedMac(const QString& mac) { m_connectedMac = mac; }
+    void clearConnectedMac() { m_connectedMac.clear(); }
+
     // Public static parsers — exposed for unit-testing in Task 5.
     // Both return true on a valid discovery reply and populate 'out'.
     // From Thetis clsRadioDiscovery.cs parseDiscoveryReply() P1/P2 branches.
@@ -154,6 +161,7 @@ private:
     QTimer m_staleTimer;
     QMap<QString, RadioInfo> m_radios;   // keyed by MAC address
     QMap<QString, qint64> m_lastSeen;    // MAC -> timestamp
+    QString m_connectedMac;              // MAC currently in use by a RadioConnection; exempt from stale-removal
 };
 
 } // namespace NereusSDR

--- a/src/core/ReceiverManager.cpp
+++ b/src/core/ReceiverManager.cpp
@@ -181,12 +181,30 @@ void ReceiverManager::feedIqData(int hwReceiverIndex, const QVector<float>& samp
 {
     auto it = m_hwToLogical.constFind(hwReceiverIndex);
     if (it == m_hwToLogical.constEnd()) {
+        if (!m_firstDropLogged) {
+            m_firstDropLogged = true;
+            QStringList mapped;
+            for (auto mi = m_hwToLogical.constBegin(); mi != m_hwToLogical.constEnd(); ++mi) {
+                mapped << QString("hw%1->rx%2").arg(mi.key()).arg(mi.value());
+            }
+            qCWarning(lcReceiver) << "ReceiverManager: first feedIqData dropped;"
+                                  << "hwReceiverIndex=" << hwReceiverIndex
+                                  << "map=" << (mapped.isEmpty() ? QStringLiteral("(empty)") : mapped.join(','));
+        }
         return;
     }
 
     int logicalIndex = it.value();
     auto rxIt = m_receivers.constFind(logicalIndex);
     if (rxIt != m_receivers.constEnd()) {
+        if (!m_firstForwardLogged) {
+            m_firstForwardLogged = true;
+            qCInfo(lcReceiver) << "ReceiverManager: first feedIqData forwarded;"
+                               << "hw=" << hwReceiverIndex
+                               << "logical=" << logicalIndex
+                               << "wdspChannel=" << rxIt->wdspChannel
+                               << "samples=" << samples.size();
+        }
         emit iqDataForReceiver(logicalIndex, samples);
         if (rxIt->wdspChannel >= 0) {
             emit iqDataForChannel(rxIt->wdspChannel, samples);

--- a/src/core/ReceiverManager.h
+++ b/src/core/ReceiverManager.h
@@ -112,6 +112,10 @@ private:
     // Mapping from hardware DDC index to logical receiver index
     QMap<int, int> m_hwToLogical;
 
+    // Diagnostic: one-shot logging of first successful and first dropped feedIqData
+    bool m_firstForwardLogged{false};
+    bool m_firstDropLogged{false};
+
     static const ReceiverConfig kInvalidConfig;
 };
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -262,9 +262,25 @@ void MainWindow::buildUI()
         }
     });
 
-    // Create FFTEngine on a worker thread (spectrum thread from architecture)
+    // Create FFTEngine on a worker thread (spectrum thread from architecture).
+    // Sample rate starts at P2 default (768k); RadioModel::wireSampleRateChanged
+    // updates it to the actual wire rate on each connect (P1=192k, P2=768k).
     m_fftEngine = new FFTEngine(0);  // receiver 0
     m_fftEngine->setSampleRate(768000.0);
+    connect(m_radioModel, &RadioModel::wireSampleRateChanged,
+            this, [this](double rateHz) {
+        if (m_fftEngine) {
+            QMetaObject::invokeMethod(m_fftEngine, [engine = m_fftEngine, rateHz]() {
+                engine->setSampleRate(rateHz);
+            });
+        }
+        if (m_spectrumWidget) {
+            m_spectrumWidget->setSampleRate(rateHz);
+            // Also update the frequency range so the visible span matches.
+            double freq = m_spectrumWidget->centerFrequency();
+            m_spectrumWidget->setFrequencyRange(freq, rateHz);
+        }
+    });
     m_fftEngine->setFftSize(4096);
     m_fftEngine->setOutputFps(30);
 

--- a/src/gui/meters/MeterPoller.h
+++ b/src/gui/meters/MeterPoller.h
@@ -3,6 +3,7 @@
 #include "core/WdspTypes.h"
 
 #include <QObject>
+#include <QPointer>
 #include <QTimer>
 #include <QVector>
 
@@ -77,7 +78,7 @@ private slots:
 
 private:
     QTimer m_timer;
-    RxChannel* m_rxChannel{nullptr};
+    QPointer<RxChannel> m_rxChannel;
     QVector<MeterWidget*> m_targets;
 };
 

--- a/src/gui/widgets/VfoWidget.cpp
+++ b/src/gui/widgets/VfoWidget.cpp
@@ -77,14 +77,7 @@ VfoWidget::VfoWidget(QWidget* parent)
     buildUI();
 }
 
-VfoWidget::~VfoWidget()
-{
-    // Floating buttons are parented to SpectrumWidget, clean them up
-    delete m_closeBtn;
-    delete m_lockBtn;
-    delete m_recBtn;
-    delete m_playBtn;
-}
+VfoWidget::~VfoWidget() = default;
 
 void VfoWidget::buildUI()
 {

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -132,10 +132,17 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     // Configure ReceiverManager with hardware capabilities
     m_receiverManager->setMaxReceivers(info.maxReceivers);
 
-    // Create receiver 0 with DDC mapping for ANAN-G2
-    // From Thetis console.cs:8216 UpdateDDCs: DDC2 is the primary RX for 2-ADC boards
+    // Create receiver 0 with protocol-appropriate DDC mapping.
+    // P2 2-ADC boards (ANAN-G2/Saturn) use DDC2 as primary RX per
+    // Thetis console.cs:8216 UpdateDDCs. P1 radios deliver samples on
+    // hardware receiver index 0, so leave the mapping auto-assigned
+    // (which rebuildHardwareMapping resolves to 0 for the first active
+    // receiver). Hardcoding DDC2 for everything dropped every P1 ep6
+    // packet at ReceiverManager::feedIqData on tester hardware.
     int rxIdx = m_receiverManager->createReceiver();
-    m_receiverManager->setDdcMapping(rxIdx, 2);   // DDC2 for ANAN-G2
+    if (info.protocol == ProtocolVersion::Protocol2) {
+        m_receiverManager->setDdcMapping(rxIdx, 2);   // DDC2 for 2-ADC P2 boards
+    }
     m_receiverManager->setAdcForReceiver(rxIdx, 0); // ADC0
 
     // Create slice 0 and load persisted VFO state from AppSettings
@@ -152,14 +159,25 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     // Initialize WDSP DSP engine (wisdom runs async — channel creation
     // is deferred until initializedChanged fires)
     QString configDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
-    connect(m_wdspEngine, &WdspEngine::initializedChanged, this, [this](bool ok) {
+    // Protocol-dependent DSP rates. Thetis P1 default is 192 kHz on the
+    // wire (setup.cs: SampleRate1 default = 192000); Saturn/ANAN-G2 P2
+    // streams at 768 kHz. in_size follows the Thetis formula
+    // 64 * input_rate / 48000 so fexchange2 sees 48-kHz output chunks.
+    const bool isP1 = (info.protocol == ProtocolVersion::Protocol1);
+    const int wdspInputRate = isP1 ? 192000 : 768000;
+    const int wdspInSize    = isP1 ? 256    : 1024;
+
+    connect(m_wdspEngine, &WdspEngine::initializedChanged, this,
+            [this, wdspInputRate, wdspInSize](bool ok) {
         if (!ok) {
             return;
         }
-        // Create primary RX channel once WDSP is ready
-        // in_size=1024 at 768k (Thetis formula: 64 * 768000/48000 = 1024)
-        // WDSP decimates 768k→48k internally, outputs 64 samples per exchange
-        RxChannel* rxCh = m_wdspEngine->createRxChannel(0, 1024, 4096, 768000, 48000, 48000);
+        // Create primary RX channel once WDSP is ready. in_size follows
+        // Thetis cmaster.c create_rcvr: 64 * input_rate / 48000. WDSP
+        // decimates input_rate -> 48000 internally and outputs 64 samples
+        // per fexchange2 call.
+        RxChannel* rxCh = m_wdspEngine->createRxChannel(0, wdspInSize, 4096,
+                                                         wdspInputRate, 48000, 48000);
         if (rxCh) {
             // Apply slice state to WDSP channel (no longer hardcoded)
             if (m_activeSlice) {
@@ -203,10 +221,40 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     connect(m_connThread, &QThread::started, m_connection, &RadioConnection::init);
     m_connThread->start();
 
-    // Dispatch connect command to worker thread
+    // CRITICAL: push sample rate + VFO frequency to the connection BEFORE
+    // dispatching connectToRadio. The worker thread dequeues invokeMethod
+    // calls in FIFO order, so whatever we queue first runs first. If we
+    // queue connectToRadio before the setters, connectToRadio -> sendCommandFrame
+    // -> composeEp2Frame reads m_rxFreqHz[0]=0 and m_sampleRate=48000 defaults
+    // and sends a primed ep2 frame with phase word 0 to the radio just before
+    // metis-start. Result: radio initializes DDC at freq=0 (bypass/idle state)
+    // and streams ADC-pinned data with Q=0 forever. Verified against Thetis
+    // NetworkIO.cs flow: Thetis always sets SetDDCRate + SetVFOfreq BEFORE
+    // SendStartToMetis, so ForceCandCFrame inside SendStartToMetis reads the
+    // correct freq/rate from globals.
+    const int wireSampleRate = wdspInputRate;
+    QMetaObject::invokeMethod(m_connection, [conn = m_connection, wireSampleRate]() {
+        conn->setSampleRate(wireSampleRate);
+    });
+    if (m_activeSlice) {
+        int hwRx = m_receiverManager->receiverConfig(0).hardwareRx;
+        if (hwRx < 0) { hwRx = 0; }
+        quint64 freqHz = m_activeSlice->frequency();
+        QMetaObject::invokeMethod(m_connection, [conn = m_connection, hwRx, freqHz]() {
+            conn->setReceiverFrequency(hwRx, freqHz);
+        });
+    }
+
+    // Now dispatch connectToRadio -- it will find the correct m_rxFreqHz[0]
+    // and m_sampleRate when sendCommandFrame runs inside it.
     QMetaObject::invokeMethod(m_connection, [conn = m_connection, info]() {
         conn->connectToRadio(info);
     });
+
+    // Tell MainWindow / FFTEngine / SpectrumWidget the wire rate so bin math
+    // matches (P1=192k, P2=768k). Without this the FFT thinks 768k and
+    // compresses the real spectrum by 4x on P1.
+    emit wireSampleRateChanged(static_cast<double>(wireSampleRate));
 
     qCDebug(lcConnection) << "Connecting to" << info.displayName()
                           << "P" << static_cast<int>(info.protocol);
@@ -554,6 +602,9 @@ void RadioModel::onConnectionStateChanged(ConnectionState state)
             AppSettings& s = AppSettings::instance();
             s.setLastConnected(m_lastRadioInfo.macAddress);
             s.save();
+            // Exempt this MAC from discovery stale-removal — once the
+            // radio is streaming it stops replying to broadcasts.
+            m_discovery->setConnectedMac(m_lastRadioInfo.macAddress);
         }
         // Phase 3I — fan out to HardwarePage so its sub-tabs populate with
         // the connected radio's fields (Radio Info labels, sample rate,
@@ -562,12 +613,14 @@ void RadioModel::onConnectionStateChanged(ConnectionState state)
         break;
     case ConnectionState::Disconnected:
         qCDebug(lcConnection) << "Disconnected from" << m_name;
+        m_discovery->clearConnectedMac();
         break;
     case ConnectionState::Connecting:
         qCDebug(lcConnection) << "Connecting to" << m_name << "...";
         break;
     case ConnectionState::Error:
         qCWarning(lcConnection) << "Connection error for" << m_name;
+        m_discovery->clearConnectedMac();
         break;
     }
 }

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -91,6 +91,10 @@ public:
 signals:
     void infoChanged();
     void connectionStateChanged();
+    // Emitted when the on-air sample rate for the current connection is
+    // known. MainWindow reacts by updating FFTEngine + SpectrumWidget so
+    // bin math matches the wire rate (P1=192k, P2=768k).
+    void wireSampleRateChanged(double rateHz);
     // Fires on each transition to Connected with the RadioInfo of the live
     // connection. HardwarePage (Phase 3I) listens to this to repopulate
     // sub-tabs with per-radio fields.


### PR DESCRIPTION
## Summary

Two separate fix tracks that got chained in one branch during an alpha-tester
debugging session. Shipped as a dev deploy zip but not yet fully verified
against the tester's hardware — the P1-tuning half is waiting on a new pcap
from the alpha tester to confirm the wire-level changes produce real I/Q.

**Track A — Windows crash fixes (verified locally on Saturn P2, crash-free)**
- `MeterPoller` held a raw `RxChannel*` that dangled when `WdspEngine::shutdown()` destroyed the owning `unique_ptr`. First 100ms meter-poll tick segfaulted inside `GetRXAMeter` reading `m_channelId` as `0xFEEEFEEE`. → `QPointer<RxChannel>`.
- `VfoWidget::~VfoWidget` raw-deleted four buttons that were parented to `SpectrumWidget`, racing with Qt's `deleteChildren` and double-freeing a dangling pointer on shutdown. → `= default` and let Qt's parent ownership handle it.

**Track B — Hermes ANAN-10E P1 connection (waiting on tester verification)**
- Alpha tester's radio connected via P1, ep6 packets flowed at 380 fps, but every I/Q sample for 20 seconds showed `I ≈ 0x001C00` (ADC DC offset) and `Q = 0x000000`. Thetis on the same PC against the same radio transitions to real varying I/Q within ~100ms of connecting.
- Diagnosis went through four rounds of wrong guesses before we captured Thetis traffic against the tester's radio and compared byte-for-byte with our traffic. Root cause turned out to be **seven interacting bugs**, described in detail in the commit message.

The highlights:

| # | Bug | Fix |
|---|---|---|
| 1 | `RadioModel::connectToRadio` queued `invokeMethod(conn, connectToRadio)` **before** `setSampleRate` and `setReceiverFrequency`. Worker thread dequeued `connectToRadio` first, composed its single primed ep2 with `m_rxFreqHz[0]=0` and `m_sampleRate=48000` defaults, then sent metis-start. Radio saw RX1 freq bank = 0 → DDC tuned to 0 Hz → ADC-idle data for the rest of the session. | Reorder the invokeMethod queue. |
| 2 | `composeCcBankRxFreq` / `composeCcBankTxFreq` sent **raw Hz** in C1..C4. Ethernet P1 requires `Freq2PhaseWord(hz) = hz << 32 / 122_880_000`. | Apply the phase-word conversion. Verified against Thetis `NetworkIO.cs:249-253` and matched pcap bytes `0x080C4444 == pw(3.863 MHz)`. |
| 3 | `composeEp2Frame` put bank 0 on **both** subframes, never sending any RX frequency bank. | Put bank 0 on subframe 0 and a selectable TX/RX1 freq bank on subframe 1. |
| 4 | `composeCcBank0` hardcoded `C4 = 0x00` (no duplex bit, nddc=1). Per `networkproto1.c:468-471`, C4 encodes `((nddc-1)<<3)` and the duplex bit. No Thetis P1 code path uses nddc=1 for any Hermes-class board. Thetis pcap shows `nddc=2` on the wire for this exact radio. | Force `m_activeRxCount = 2` for P1 in `connectToRadio`; `composeCcBank0` now derives C4 from it. `parseEp6Frame` uses the same variable so send/recv slot layouts stay consistent (14-byte slots). |
| 5 | Wire sample rate was never pushed at all. WDSP configured for 768 kHz (Saturn P2 default) but radio defaulted to 48 kHz → WDSP buffer starvation. | Protocol-aware rates: P1=192 kHz (in_size=256), P2=768 kHz (in_size=1024). New `RadioModel::wireSampleRateChanged` signal updates `FFTEngine` and `SpectrumWidget` bin math to match. |
| 6 | `sendCommandFrame` fired once per 500 ms watchdog (2 fps). Thetis sends ~368 fps (its audio-drain loop). The single primed frame was insufficient for the radio to latch DDC settings before metis-start. | `kWatchdogTickMs` 500 → 25 ms (40 fps). Each tick alternates TX / RX1 banks via `m_ccRoundRobinIdx`. Added `sendPrimingBurst(N)` that ports Thetis's `ForceCandCFrame(N)` literally: N TX-freq frames, msleep(10), N RX1-freq frames, msleep(10). Called with `N=3` before and after `metis-start` on both initial-connect and reconnect paths. |
| 7 | `onReconnectTimeout` used the old bare `sendMetisStop → sendMetisStart` sequence. After a watchdog silence trip the radio came back in the same pre-primed idle state. | Reconnect path now brackets `metis-stop/start` with `sendPrimingBurst(3)` on both sides, matching the initial-connect path. |

Also fixed in this branch:

- **DDC2 hardcode:** `RadioModel::connectToRadio` unconditionally called `setDdcMapping(rxIdx, 2)` "for ANAN-G2" regardless of board type. P1 Hermes (which emits at hw index 0) had every ep6 packet silently dropped at `ReceiverManager::feedIqData` due to hw2 → rx0 map lookup failure. Now conditional on `info.protocol == Protocol2`.
- **`RadioDiscovery::onStaleCheck`:** now exempts the currently-connected MAC. Once a radio is streaming it stops replying to broadcasts, so the 15s stale timer fired ~15s into every healthy connect and emitted `radioLost` even though the connection was fine. `RadioModel` calls `setConnectedMac`/`clearConnectedMac` from the connection-state transitions.
- **P1 first-frame diagnostic logging:** one-shot INF logs on first ep6 frame received, first `iqDataReceived` emit, first `ReceiverManager::feedIqData` forward or drop. Makes remote debugging ("connected but no data") possible without another round trip. These are what let us confirm the ReceiverManager hw-map mismatch in the tester's pcap in round 3.
- **VfoWidget destructor:** see Track A above.

## Evidence trail

The P1 fix track was driven by two real captures from the alpha tester:
- `C:\temp\pcap1\p1-capture-20260414-014424.pcapng` — NereusSDR broken, 4.033 MHz. Phase word `0x0866EEEE` on the wire, Q=0 everywhere.
- `C:\temp\pcap2\p1-capture-20260414-014904.pcapng` — Thetis working, 3.863 MHz. Alternating sub1 banks `0x02`/`0x04`, phase word `0x080C4444 = pw(3.863 MHz)`, steady-state frame 40000 shows real signed I/Q.

Key Thetis references read end-to-end during diagnosis:
- `networkproto1.c:35-68` — `SendStartToMetis` retry loop
- `networkproto1.c:106-139` — `ForceCandCFrame` / `ForceCandCFrames`
- `networkproto1.c:273-290` — `MetisReadThreadMainLoop` startup (`ForceCandCFrame(3)`)
- `networkproto1.c:358-373` — ep6 frame parser
- `networkproto1.c:430-499` — ep2 bank composition (cases 0..2)
- `netInterface.c:1211-1255` — `EnableRxs`, `Protocol1DDCConfig`, `SetDDCRate`
- `netInterface.c:502-518` — `SetVFOfreq` stores `Freq2PhaseWord` result
- `NetworkIO.cs:220-253` — `VFOfreq`, `Freq2PhaseWord` ((2^32 * freq) / 122_880_000)
- `console.cs:8378-8454` — per-`HPSDRModel` nddc selection (plain Hermes=4, ANAN-10E=2)
- `clsHardwareSpecific.cs:85-127` — `HPSDRModel → HPSDRHW` mapping
- `clsRadioDiscovery.cs:1203-1211` — `mapP1DeviceType` (boardId → HPSDRHW)

## Adversarial review response

Ran an adversarial review pass on an earlier version of this fix (single-bank
priming, nddc=1, 500 ms watchdog). Review correctly caught:

1. Priming loop sent 5 identical RX1-only frames, never touching the TX bank → didn't match Thetis's `ForceCandCFrame` pattern. **Fixed** by adding `sendCommandFrame(bool sub1TxBank)` and `sendPrimingBurst(N)`.
2. nddc=1 has no corresponding Thetis code path; the radio's firmware likely needs `nddc ≥ 2` to actually run DDCs. **Fixed** by forcing `m_activeRxCount = 2` for P1.
3. Reconnect path still used bare stop/start. **Fixed** by wrapping with primed bursts.
4. 2 fps watchdog can't hold the radio's ep2 command pipe alive. **Fixed** by moving to 25 ms (40 fps) with bank rotation per tick.
5. Unsourced speculation that HL2 needs a different clock divisor. **Removed** — only one `122880000` constant exists anywhere in Thetis source; HL2 uses the same divisor.

Review also flagged that the correct model-level fix for ANAN-10E requires a
separate logical model field distinct from board-type (matching Thetis's
`HPSDRModel` vs `HPSDRHW` split, where the tester's radio is detected by
discovery as `HPSDRHW.Hermes` but Thetis's UI model may override it to
`ANAN-10E`). That refactor is deferred — forcing nddc=2 for all P1 in this
branch is a narrower workaround that gets the tester's specific radio talking.
See "Follow-ups" below.

## Test plan

**Track A (verified locally on Saturn P2):**
- [x] Launched patched build, connected to Saturn, left running past the 100 ms meter-tick window — no MeterPoller segfault.
- [x] Exited normally — no VfoWidget shutdown crash.
- [x] Firewall rule installed, DDC I/Q streaming confirmed on UDP port 1037 in local capture.

**Track B (blocked on tester — this is the next step):**
- [ ] Tester runs refreshed `capture-p1.ps1` against the new deploy zip while connecting with the VFO tuned to a known-active frequency.
- [ ] Inspect the resulting pcap:
    - [ ] Outbound ep2 sub0 C1 = `0x02` (192 kHz)
    - [ ] Outbound ep2 sub0 C4 bits 3-6 = `(nddc-1) << 3` = `0x08` (nddc=2)
    - [ ] Outbound ep2 sub1 C0 alternates `0x02` (TX bank) and `0x04` (RX1 bank) per frame
    - [ ] Outbound ep2 sub1 C1..C4 = Freq2PhaseWord(VFO), **not** raw Hz and **not** zero
    - [ ] Outbound ep2 frame rate ≈ 40 fps (25 ms watchdog)
    - [ ] Incoming ep6 sample values: I **and** Q both vary; neither is stuck at a constant; Q is NOT always zero
- [ ] Tester reports audible audio and visible signals on the waterfall.

**If acceptance checks fail** (most likely next suspect):
- Bank round-robin is still minimal (banks 0, 1, 2 only). Thetis rotates through banks 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 covering preamp, attenuator, filter, OC, CW, EER, BPF2, extra OC. If the radio needs to see one of these before enabling RX output, we'll discover it in round 2.

## Follow-ups (not in this PR)

- **Logical model override (Phase 3I-T2 scope).** Add an optional user-selectable model override so a radio whose discovery reports `boardId=1` can be configured as `ANAN-10E` / `HPSDRHW.HermesII` with its own capability entry. Thetis's flow is `HPSDRModel` (user choice) → `HPSDRHW` (hardware class) → per-hardware config; we currently collapse both into `HPSDRHW` from discovery bytes, which means all Hermes-class boards get identical treatment.
- **Full bank round-robin.** Port Thetis's `out_control_idx` rotation covering banks 0..18 (or the per-board `end_frame` subset from `networkproto1.c:682`). Needed for correct BPF/atten/preamp/OC handling.
- **Watchdog decoupled from ep2 cadence.** Current 25 ms watchdog tick is both "silence detection" and "ep2 send". A cleaner split would let the ep2 cadence track ep6 arrival rate (Thetis's approach — the audio drain loop produces the ep2 stream, tying it to RX rate automatically).
- **HL2 bandwidth monitor integration.** Already checks on every watchdog tick via `hl2CheckBandwidthMonitor()`, but the new 40 fps cadence means 20x more throttle checks than before. Verify no regression on HL2.

## Files touched

```
src/core/P1RadioConnection.cpp    | 267 +++++++++++++++++++++++++++++++++--------
src/core/P1RadioConnection.h      |  29 ++++-
src/core/RadioDiscovery.cpp       |   1 +
src/core/RadioDiscovery.h         |   8 ++
src/core/ReceiverManager.cpp      |  18 +++
src/core/ReceiverManager.h        |   4 +
src/gui/MainWindow.cpp            |  18 ++-
src/models/RadioModel.cpp         |  71 +++++++++--
src/models/RadioModel.h           |   4 +
```

JJ Boyd ~KG4VCF
🤖 Co-Authored with [Claude Code](https://claude.com/claude-code)
