### PR TITLE
fix(p1): encode VFO frequency as raw Hz — Phase 3G-11

### DIFF
--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -508,6 +508,11 @@ Shipped as three sequential PRs off `main`. Strict dependency: PR1 helpers feed 
 
 **Non-goals:** RX2/TX display surface, Spectrum Overlay flyout refactors, skin system, Thetis default-value adoption beyond the seven PR2 recipes. Source-first protocol per CLAUDE.md governs everything else; 3G-8's §10 divergence exception is **not** extended.
 
+### Phase 3G-11: P1 Field-Report Fixes
+**Goal:** Close out the bugs surfaced by alpha testers running Protocol 1 hardware after 3I shipped. Grouped under one phase so each fix doesn't have to claim its own number. Each bullet below lands from its own session / branch.
+
+- **P1 RX/TX VFO frequency encoding** — `P1RadioConnection::composeCcBankRxFreq` / `composeCcBankTxFreq` were pre-converting Hz to an NCO phase word (`freqHz * 2^32 / 122.88e6`). P1 firmware expects raw Hz; Thetis `NetworkIO.cs:215-223` only calls `Freq2PhaseWord` on the P2 (`ETH`) branch, and the native `networkproto1.c:476-494` splats `prn->{tx,rx}[0].frequency` directly into C1..C4 with no conversion. Symptom reproduced in alpha tester pcap4 (2026-04-15, ANAN-10E): 319 consecutive `C0=0x04` frames pinned at phase word `0x080D5555`, aliased waterfall, VFO did not track dial. Fix aligns with pre-existing `tst_p1_wire_format` assertions that had silently drifted unvalidated. Branch `fix/p1-freq-encoding`, confirmed working against live ANAN-10E 2026-04-15.
+
 ### Phase 3I: Radio Connector & Radio-Model Port ✅ COMPLETE
 **Goal:** Full Protocol 1 support across every ANAN/Hermes-family board (Hermes Lite 2, ANAN-10/10E/100/100B/100D/200D, Metis) with feature parity at the wire-format and Hardware-setup-UI level for all supported radios. A P1 radio should behave identically to how ANAN-G2 on P2 behaves today.
 

--- a/src/core/P1RadioConnection.cpp
+++ b/src/core/P1RadioConnection.cpp
@@ -132,16 +132,28 @@ void P1RadioConnection::composeCcBank0(quint8 out[5], int sampleRate, bool mox,
 // ---------------------------------------------------------------------------
 // composeCcBankRxFreq
 //
-// Source: networkproto1.c:653-663 — case 2 (RX1/DDC0 frequency)
+// Source: networkproto1.c:484-494 — case 2 (RX1/DDC0 frequency)
 //   rxIndex 0 → C0 |= 4 (address 0x02)
 //   rxIndex 1 → C0 |= 6 (address 0x03)  [case 3]
 //   rxIndex 2 → C0 |= 8 (address 0x04)  [case 5]
-//   C1..C4 = frequency bytes big-endian
+//   C1..C4 = (prn->rx[id].frequency >> {24,16,8,0}) & 0xff — raw Hz, big-endian
 //
-// Note: Thetis actually uses a phase-word (Freq2PhaseWord) for Ethernet P1,
-// but the NetworkIO.cs:222 path for P1-USB sends raw Hz. For NereusSDR Task 7
-// scope we store raw Hz exactly as the case 2 source shows; phase-word
-// conversion is a TODO for the send-path wiring in Task 9.
+// P1 (Protocol 1 / ENC "USB") sends **raw Hz** on the wire — NOT a phase
+// word. Thetis NetworkIO.cs:215-223 VFOfreq() selects the encoding based on
+// CurrentRadioProtocol:
+//
+//     if (CurrentRadioProtocol == RadioProtocol.USB)   // USB == P1
+//         SetVFOfreq(id, f_freq, tx);                   // raw Hz
+//     else SetVFOfreq(id, Freq2PhaseWord(f_freq), tx);  // phase word (P2)
+//
+// The RadioProtocol.USB enum value maps to Protocol 1 (see cmaster.cs:520
+// "case RadioProtocol.USB: //p1"). The native side (networkproto1.c:491-494)
+// then splats prn->rx[0].frequency directly into C1..C4 with no conversion.
+//
+// Previous revisions of this helper pre-converted to a phase word and the
+// on-wire bytes were interpreted by Hermes firmware as raw Hz far above
+// Nyquist, which produced an aliased waterfall and a non-tracking VFO on
+// ANAN-10E (pcap4 from alpha tester, 2026-04-15).
 // ---------------------------------------------------------------------------
 void P1RadioConnection::composeCcBankRxFreq(quint8 out[5], int rxIndex, quint64 freqHz) noexcept
 {
@@ -156,44 +168,36 @@ void P1RadioConnection::composeCcBankRxFreq(quint8 out[5], int rxIndex, quint64 
     quint8 addrBits = (rxIndex >= 0 && rxIndex < 7) ? kRxC0Address[rxIndex] : 4;
     out[0] = addrBits;  // MOX=0; address is already left-shifted in the table
 
-    // Ethernet P1 radios (ANAN-10/10E/100/100D, Orion, Angelia) tune via an
-    // NCO phase word, NOT raw Hz. Thetis NetworkIO.cs:220-223 branches on
-    // CurrentRadioProtocol: USB -> raw Hz, else -> Freq2PhaseWord. The
-    // converted value is stored in prn->rx[id].frequency (netInterface.c:517)
-    // and networkproto1.c case 2 (:491-494) writes those bytes directly into
-    // C1..C4.
-    //
-    //   Freq2PhaseWord(freq) = (2^32 * freq) / 122880000   (NetworkIO.cs:249-253)
-    //
-    // 122.88 MHz is the only phase-word divisor in Thetis source (searched:
-    // that constant appears only at NetworkIO.cs:251 and one commented-out
-    // duplicate). HL2 uses the same ChannelMaster source path and therefore
-    // the same divisor.
-    quint32 pw32 = static_cast<quint32>((freqHz << 32) / 122880000ull);
-    out[1] = static_cast<quint8>((pw32 >> 24) & 0xFF);
-    out[2] = static_cast<quint8>((pw32 >> 16) & 0xFF);
-    out[3] = static_cast<quint8>((pw32 >>  8) & 0xFF);
-    out[4] = static_cast<quint8>( pw32        & 0xFF);
+    // Raw Hz, big-endian — see header comment for Thetis source citations.
+    // Thetis stores freq as int32 in prn->rx[0].frequency; clamp to 32 bits
+    // here so anything above ~4.29 GHz (impossible for HF) truncates cleanly.
+    const quint32 hz = static_cast<quint32>(freqHz);
+    out[1] = static_cast<quint8>((hz >> 24) & 0xFF);
+    out[2] = static_cast<quint8>((hz >> 16) & 0xFF);
+    out[3] = static_cast<quint8>((hz >>  8) & 0xFF);
+    out[4] = static_cast<quint8>( hz        & 0xFF);
 }
 
 // ---------------------------------------------------------------------------
 // composeCcBankTxFreq
 //
-// Source: networkproto1.c:645-651 — case 1 (TX VFO frequency)
+// Source: networkproto1.c:476-482 — case 1 (TX VFO frequency)
 //   C0 |= 2 → address 0x01
-//   C1..C4 = frequency bytes big-endian
+//   C1..C4 = (prn->tx[0].frequency >> {24,16,8,0}) & 0xff — raw Hz, big-endian
+//
+// Same raw-Hz encoding as composeCcBankRxFreq — see that function's header
+// comment for the NetworkIO.cs:215-223 branching rule.
 // ---------------------------------------------------------------------------
 void P1RadioConnection::composeCcBankTxFreq(quint8 out[5], quint64 freqHz) noexcept
 {
     // Source: networkproto1.c:477 — C0 |= 2  (case 1 = TX VFO)
     out[0] = 0x02;  // address 0x01, MOX=0
 
-    // Same phase-word conversion as RX freq — Ethernet P1 NCO tuning word.
-    quint32 pw32 = static_cast<quint32>((freqHz << 32) / 122880000ull);
-    out[1] = static_cast<quint8>((pw32 >> 24) & 0xFF);
-    out[2] = static_cast<quint8>((pw32 >> 16) & 0xFF);
-    out[3] = static_cast<quint8>((pw32 >>  8) & 0xFF);
-    out[4] = static_cast<quint8>( pw32        & 0xFF);
+    const quint32 hz = static_cast<quint32>(freqHz);
+    out[1] = static_cast<quint8>((hz >> 24) & 0xFF);
+    out[2] = static_cast<quint8>((hz >> 16) & 0xFF);
+    out[3] = static_cast<quint8>((hz >>  8) & 0xFF);
+    out[4] = static_cast<quint8>( hz        & 0xFF);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Restores VFO tuning on Protocol 1 hardware. `P1RadioConnection::composeCcBankRxFreq` and `composeCcBankTxFreq` were pre-converting Hz to an NCO phase word; P1 firmware expects raw Hz.
- First entry in new **Phase 3G-11 (P1 Field-Report Fixes)** bucket. Other in-flight P1 alpha-tester fixes will land as additional bullets under the same phase.

## Root cause

Tracked down from alpha tester pcap4 (2026-04-15, ANAN-10E). 319 consecutive `C0=0x04` Metis frames over 20 seconds all pinned at phase word `0x080D5555`, producing an aliased waterfall and a VFO that would not track the dial.

Thetis `NetworkIO.cs:215-223 VFOfreq()` selects the encoding on `CurrentRadioProtocol`:

```csharp
if (CurrentRadioProtocol == RadioProtocol.USB)     // USB == P1  (cmaster.cs:520)
    SetVFOfreq(id, f_freq, tx);                    // raw Hz
else SetVFOfreq(id, Freq2PhaseWord(f_freq), tx);   // phase word (P2)
```

The native `networkproto1.c:476-494` then splats `prn->{tx,rx}[0].frequency` directly into C1..C4 big-endian with no conversion. NereusSDR was running `Freq2PhaseWord` unconditionally; the in-file comment misread the Thetis `else` branch as the common path.

## Fix

- `composeCcBankRxFreq` / `composeCcBankTxFreq`: splat `freqHz` big-endian into C1..C4 as raw Hz, cast to `quint32`.
- Header comments rewritten to cite `NetworkIO.cs:215-223` and `networkproto1.c:476-494` correctly and record the pcap4 root cause.
- `docs/MASTER-PLAN.md`: new Phase 3G-11 bucket.

## Test plan

- [x] `tst_p1_wire_format` — **29 passed, 0 failed**. The `rxFrequencyEncodedBigEndian32` / `txFrequencyEncodedBigEndian32` cases already asserted raw Hz; the implementation had silently drifted past them. Fix realigns code with the pre-existing assertions.
- [x] Full NereusSDR.exe build succeeds on mingw1310_64 + Qt 6.11.0.
- [x] Local smoke test on ANAN-G2 (Saturn / P2) — connect, stream, clean shutdown (exercises unrelated P2 path; sanity only).
- [x] **Verified working on tester's live ANAN-10E (Protocol 1) 2026-04-15** — VFO now tracks the dial.
- [ ] CI `tst_p1_wire_format` green.

## Follow-ups (out of scope)

- `NEREUS_BUILD_TESTS` suite does not appear to be wired into `ci.yml` — `tst_p1_wire_format` had correct assertions but the implementation drifted undetected. Worth a separate task to ensure opt-in tests actually run on PR.
- Possible separate RX1 signal-chain staleness: in the same pcap, RX1 bytes were byte-identical across all 319 frames while TX varied. May still be an issue post-fix; waiting on follow-up pcap to confirm. Would belong under 3G-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)