### PR TITLE
Phase 3G-9a: source-first audit + tooltips + slider readouts (PR1 of 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)  # for clangd / IDE integration
 
 # macOS: ensure Homebrew lib/include paths are in the search path
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,7 @@ set(GUI_SOURCES
     src/gui/setup/AudioSetupPages.cpp
     src/gui/setup/DspSetupPages.cpp
     src/gui/setup/DisplaySetupPages.cpp
+    src/gui/setup/SetupHelpers.cpp
     src/gui/setup/TransmitSetupPages.cpp
     src/gui/setup/AppearanceSetupPages.cpp
     src/gui/setup/CatNetworkSetupPages.cpp

--- a/docs/architecture/2026-04-15-phase3g9a-display-audit-plan.md
+++ b/docs/architecture/2026-04-15-phase3g9a-display-audit-plan.md
@@ -1,0 +1,1133 @@
+# Phase 3G-9a — Source-First Audit + Tooltips + Slider Readouts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Take the three 3G-8 display Setup pages from "every control works" to "every control has a source-first citation, a useful tooltip, and — for sliders — a bidirectional numeric spinbox companion."
+
+**Architecture:** Add a small `SetupHelpers` factory (two functions) that returns a prebuilt slider+spinbox pair wired bidirectionally against feedback loops. Refactor `DisplaySetupPages.cpp` to use the factory. Then walk the 47 controls and add per-control Thetis citation comments + tooltips (verbatim where Thetis is substantive, rewritten where weak, new where NereusSDR-original). Zero model or renderer changes.
+
+**Tech Stack:** C++20, Qt6 (QtWidgets, QtTest). No new third-party deps.
+
+**Scope boundary:** RX1 Display only — `SpectrumDefaultsPage`, `WaterfallDefaultsPage`, `GridScalesPage`. RX2 Display, TX Display, Spectrum Overlay flyouts, and meter editors are out of scope per spec §2.
+
+**Parent branch:** `main` (commits `4b0a027`, `8437888`). New branch `feature/display-audit-pr1`.
+
+**Design spec:** `docs/architecture/2026-04-15-display-refactor-design.md` §4.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/gui/setup/SetupHelpers.h` — two factory functions, two POD struct return types
+- `src/gui/setup/SetupHelpers.cpp` — implementations, ~100 LOC
+- `tests/tst_setup_helpers.cpp` — QtTest smoke for the factories (~80 LOC)
+
+**Modify:**
+- `src/gui/setup/DisplaySetupPages.cpp` — 8 slider refactors (4 in Spectrum, 4 in Waterfall) + 47 tooltip/citation blocks
+- `CMakeLists.txt` — register `SetupHelpers.cpp` as part of `GUI_SOURCES`
+- `tests/CMakeLists.txt` — register `tst_setup_helpers`
+
+**Untouched:**
+- `src/gui/setup/DisplaySetupPages.h` — no API change
+- Any `src/models/` or `src/gui/SpectrumWidget*` — zero behavior changes
+
+## Slider Inventory (exact)
+
+After reading `DisplaySetupPages.h`, there are **8 sliders** in scope (not 12 as the spec estimated — `GridScalesPage` uses only spinboxes/combos/swatches). The spec's "~12 sliders" estimate is corrected here:
+
+**SpectrumDefaultsPage (4 sliders):**
+| Member | Range | Suffix | Connects to |
+|---|---|---|---|
+| `m_fpSlider` | 10–60 | ` fps` | `FFTEngine::setOutputFps` |
+| `m_fillAlphaSlider` | 0–100 | `%` | `SpectrumWidget::setFillAlpha(v/100.f)` |
+| `m_lineWidthSlider` | 1–3 | ` px` | `SpectrumWidget::setLineWidth` |
+| `m_dataLineAlphaSlider` | 0–255 | ` (0-255)` | `SpectrumWidget::setFillColor` alpha channel |
+
+**WaterfallDefaultsPage (4 sliders):**
+| Member | Range | Suffix | Connects to |
+|---|---|---|---|
+| `m_highThresholdSlider` | -200 to 0 | ` dBm` | `SpectrumWidget::setWaterfallHighThreshold` |
+| `m_lowThresholdSlider` | -200 to 0 | ` dBm` | `SpectrumWidget::setWaterfallLowThreshold` |
+| `m_updatePeriodSlider` | 10–500 | ` ms` | `SpectrumWidget::setWaterfallUpdatePeriod` |
+| `m_opacitySlider` | 0–100 | `%` | `SpectrumWidget::setWaterfallOpacity` |
+
+**GridScalesPage: 0 sliders** — no refactor needed for this page. Only the tooltip/citation pass touches it.
+
+---
+
+## Tooltip Decision Rule (spec §4.1.2)
+
+For each of the 47 controls:
+
+1. Grep `../Thetis/Project Files/Source/Console/setup.designer.cs` for the Thetis control name from the 3G-8 plan tables (§3.1/§4.1/§5.1).
+2. Find `toolTip1.SetToolTip(this.<controlName>, "<text>");`.
+3. **If Thetis tooltip is substantive** (>10 chars, says something about what the control does): port verbatim.
+   - Add comment: `// Tooltip from Thetis setup.designer.cs:NNNN`
+4. **If Thetis tooltip is empty, missing, or just echoes the label**: write a new one describing what the user will see change.
+   - Add comment: `// Tooltip rewritten — Thetis original: "<original or empty>"`
+5. **If the control is a NereusSDR extension** (S2 FFT Window, S9/S10 Peak Hold, W5 Reverse Scroll, W8/W9 Timestamp): write from scratch, no attribution comment needed.
+
+Citation comment format (above every `connect(...)` block):
+```cpp
+// Thetis: setup.designer.cs:NNNN (controlName) → target
+```
+or for extensions:
+```cpp
+// NereusSDR extension — no Thetis equivalent
+```
+
+---
+
+## Task 1: Branch + SetupHelpers Skeleton
+
+**Files:**
+- Create: `src/gui/setup/SetupHelpers.h`
+- Create: `src/gui/setup/SetupHelpers.cpp` (empty body for now)
+- Modify: `CMakeLists.txt` (register new source file)
+
+- [ ] **Step 1: Create the branch**
+
+Run:
+```bash
+cd ~/NereusSDR
+git checkout main && git pull --ff-only
+git checkout -b feature/display-audit-pr1
+```
+
+Expected: clean switch, no conflicts.
+
+- [ ] **Step 2: Re-read CLAUDE.md and CONTRIBUTING.md**
+
+Per standing preference, start each branch with a fresh read of both files. No code yet — just load them into context.
+
+- [ ] **Step 3: Write `SetupHelpers.h`**
+
+Create `src/gui/setup/SetupHelpers.h`:
+
+```cpp
+#pragma once
+
+// Setup page factory helpers — produce prewired slider+spinbox rows so every
+// numeric control in the Setup dialog has a live readout and supports both
+// mouse and keyboard entry without copy-pasted boilerplate.
+//
+// Bidirectional sync uses QSignalBlocker to prevent signal feedback loops.
+
+#include <QWidget>
+#include <QString>
+
+class QSlider;
+class QSpinBox;
+class QDoubleSpinBox;
+
+namespace NereusSDR {
+
+// Integer slider + QSpinBox pair.
+struct SliderRow {
+    QSlider*  slider;
+    QSpinBox* spin;
+    QWidget*  container;  // HBox with slider + spin, ready to drop into a form layout
+};
+
+// Double slider + QDoubleSpinBox pair. Slider operates in integer units
+// scaled by 10^decimals under the hood.
+struct SliderRowD {
+    QSlider*        slider;
+    QDoubleSpinBox* spin;
+    QWidget*        container;
+};
+
+// Build an int slider+spinbox row. The slider and spinbox are wired
+// bidirectionally via QSignalBlocker so dragging the slider updates the
+// spinbox value without retriggering the slider's valueChanged signal,
+// and typing into the spinbox updates the slider without retriggering
+// the spinbox's valueChanged signal. Consumers connect to slider->valueChanged
+// (one source of truth) to drive model updates.
+//
+// Arguments:
+//   min, max, initial — range and start value
+//   suffix            — unit string appended in the spinbox (" dBm", "%", etc.)
+//   parent            — ownership of the returned container widget
+SliderRow makeSliderRow(int min, int max, int initial,
+                        const QString& suffix = QString(),
+                        QWidget* parent = nullptr);
+
+// Double variant. decimals controls the spinbox's decimal places and the
+// slider's internal integer granularity (step = 10^-decimals in user space).
+SliderRowD makeDoubleSliderRow(double min, double max, double initial,
+                               int decimals,
+                               const QString& suffix = QString(),
+                               QWidget* parent = nullptr);
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 4: Write empty `SetupHelpers.cpp`**
+
+Create `src/gui/setup/SetupHelpers.cpp`:
+
+```cpp
+#include "SetupHelpers.h"
+
+#include <QSlider>
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+#include <QHBoxLayout>
+
+namespace NereusSDR {
+
+// Intentionally empty — filled in by Task 2.
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 5: Register the new file in CMakeLists.txt**
+
+Find the `GUI_SOURCES` list (around line 200–300 in `CMakeLists.txt`, search for `src/gui/setup/DisplaySetupPages.cpp`) and add the new path right below it:
+
+```cmake
+    src/gui/setup/DisplaySetupPages.cpp
+    src/gui/setup/SetupHelpers.cpp
+```
+
+- [ ] **Step 6: Build to verify it compiles**
+
+Run:
+```bash
+cmake --build build --target NereusSDRObjs
+```
+
+Expected: PASS. `SetupHelpers.cpp` compiles as an empty translation unit with no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gui/setup/SetupHelpers.h src/gui/setup/SetupHelpers.cpp CMakeLists.txt
+git commit -S -m "feat(setup): scaffold SetupHelpers.h/.cpp for slider readout factory
+
+Empty skeleton — implementations and tests land in the next commit.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Implement `makeSliderRow` with TDD
+
+**Files:**
+- Create: `tests/tst_setup_helpers.cpp`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `src/gui/setup/SetupHelpers.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tst_setup_helpers.cpp`:
+
+```cpp
+// tst_setup_helpers.cpp
+//
+// Phase 3G-9a — unit smoke for SetupHelpers factory functions. Verifies
+// bidirectional slider↔spinbox sync without signal feedback loops and that
+// returned widgets match the requested range/initial/suffix.
+
+#include <QtTest/QtTest>
+#include <QSlider>
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+#include <QSignalSpy>
+
+#include "gui/setup/SetupHelpers.h"
+
+using namespace NereusSDR;
+
+class TestSetupHelpers : public QObject {
+    Q_OBJECT
+private slots:
+
+    // --- makeSliderRow (int) -------------------------------------------------
+
+    void sliderRow_honorsRangeAndInitial()
+    {
+        SliderRow row = makeSliderRow(10, 60, 30, QStringLiteral(" fps"));
+        QVERIFY(row.slider);
+        QVERIFY(row.spin);
+        QVERIFY(row.container);
+
+        QCOMPARE(row.slider->minimum(), 10);
+        QCOMPARE(row.slider->maximum(), 60);
+        QCOMPARE(row.slider->value(),   30);
+
+        QCOMPARE(row.spin->minimum(), 10);
+        QCOMPARE(row.spin->maximum(), 60);
+        QCOMPARE(row.spin->value(),   30);
+        QCOMPARE(row.spin->suffix(),  QStringLiteral(" fps"));
+
+        delete row.container;
+    }
+
+    void sliderRow_sliderDragUpdatesSpinbox()
+    {
+        SliderRow row = makeSliderRow(0, 100, 50);
+        row.slider->setValue(77);
+        QCOMPARE(row.spin->value(), 77);
+        delete row.container;
+    }
+
+    void sliderRow_spinboxEntryUpdatesSlider()
+    {
+        SliderRow row = makeSliderRow(0, 100, 50);
+        row.spin->setValue(22);
+        QCOMPARE(row.slider->value(), 22);
+        delete row.container;
+    }
+
+    void sliderRow_noFeedbackLoop()
+    {
+        // Dragging the slider must emit slider->valueChanged exactly once,
+        // not bounce back through the spinbox and emit again.
+        SliderRow row = makeSliderRow(0, 100, 50);
+        QSignalSpy spy(row.slider, &QSlider::valueChanged);
+        row.slider->setValue(60);
+        QCOMPARE(spy.count(), 1);
+
+        // And typing into the spinbox must emit spin->valueChanged exactly once.
+        QSignalSpy spinSpy(row.spin, qOverload<int>(&QSpinBox::valueChanged));
+        row.spin->setValue(70);
+        QCOMPARE(spinSpy.count(), 1);
+
+        delete row.container;
+    }
+
+    // --- makeDoubleSliderRow -------------------------------------------------
+
+    void doubleSliderRow_honorsRangeAndDecimals()
+    {
+        SliderRowD row = makeDoubleSliderRow(-30.0, 30.0, 0.0, 1, QStringLiteral(" dBm"));
+        QVERIFY(row.slider);
+        QVERIFY(row.spin);
+
+        QCOMPARE(row.spin->minimum(),  -30.0);
+        QCOMPARE(row.spin->maximum(),   30.0);
+        QCOMPARE(row.spin->value(),      0.0);
+        QCOMPARE(row.spin->decimals(),   1);
+        QCOMPARE(row.spin->suffix(),   QStringLiteral(" dBm"));
+
+        // Slider granularity is 10^decimals = 10 units per unit.
+        QCOMPARE(row.slider->minimum(), -300);
+        QCOMPARE(row.slider->maximum(),  300);
+        QCOMPARE(row.slider->value(),     0);
+
+        delete row.container;
+    }
+
+    void doubleSliderRow_bidirectionalSync()
+    {
+        SliderRowD row = makeDoubleSliderRow(-30.0, 30.0, 0.0, 1);
+        row.spin->setValue(12.5);
+        QCOMPARE(row.slider->value(), 125);
+
+        row.slider->setValue(-75);
+        QCOMPARE(row.spin->value(), -7.5);
+
+        delete row.container;
+    }
+};
+
+QTEST_MAIN(TestSetupHelpers)
+#include "tst_setup_helpers.moc"
+```
+
+- [ ] **Step 2: Register test in `tests/CMakeLists.txt`**
+
+Find the block of `nereus_add_test(...)` calls near the `tst_hardware_page_capability_gating` entry and add:
+
+```cmake
+nereus_add_test(tst_setup_helpers)
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run:
+```bash
+cmake --build build --target tst_setup_helpers 2>&1 | tail -20
+```
+
+Expected: BUILD FAIL with linker errors (unresolved `makeSliderRow` / `makeDoubleSliderRow`). That proves the test reaches the factory symbols.
+
+- [ ] **Step 4: Implement `makeSliderRow`**
+
+Replace the body of `src/gui/setup/SetupHelpers.cpp` with:
+
+```cpp
+#include "SetupHelpers.h"
+
+#include <QSlider>
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+#include <QHBoxLayout>
+#include <QSignalBlocker>
+#include <cmath>
+
+namespace NereusSDR {
+
+SliderRow makeSliderRow(int min, int max, int initial,
+                        const QString& suffix,
+                        QWidget* parent)
+{
+    auto* container = new QWidget(parent);
+    auto* layout    = new QHBoxLayout(container);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(8);
+
+    auto* slider = new QSlider(Qt::Horizontal, container);
+    slider->setRange(min, max);
+    slider->setValue(initial);
+
+    auto* spin = new QSpinBox(container);
+    spin->setRange(min, max);
+    spin->setValue(initial);
+    spin->setSuffix(suffix);
+    spin->setFixedWidth(80);
+    spin->setAlignment(Qt::AlignRight);
+
+    // Bidirectional sync. QSignalBlocker on the opposite widget prevents the
+    // receiver from re-emitting and creating an infinite loop. Consumers of
+    // the row should connect to slider->valueChanged as the single source of
+    // truth for model updates.
+    QObject::connect(slider, &QSlider::valueChanged, spin, [spin](int v) {
+        QSignalBlocker block(spin);
+        spin->setValue(v);
+    });
+    QObject::connect(spin, qOverload<int>(&QSpinBox::valueChanged),
+                     slider, [slider](int v) {
+        QSignalBlocker block(slider);
+        slider->setValue(v);
+    });
+
+    layout->addWidget(slider, /*stretch=*/1);
+    layout->addWidget(spin,   /*stretch=*/0);
+
+    return { slider, spin, container };
+}
+
+SliderRowD makeDoubleSliderRow(double min, double max, double initial,
+                               int decimals,
+                               const QString& suffix,
+                               QWidget* parent)
+{
+    const int scale = static_cast<int>(std::pow(10, decimals));
+
+    auto* container = new QWidget(parent);
+    auto* layout    = new QHBoxLayout(container);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(8);
+
+    auto* slider = new QSlider(Qt::Horizontal, container);
+    slider->setRange(static_cast<int>(min * scale),
+                     static_cast<int>(max * scale));
+    slider->setValue(static_cast<int>(initial * scale));
+
+    auto* spin = new QDoubleSpinBox(container);
+    spin->setDecimals(decimals);
+    spin->setRange(min, max);
+    spin->setValue(initial);
+    spin->setSuffix(suffix);
+    spin->setSingleStep(1.0 / scale);
+    spin->setFixedWidth(90);
+    spin->setAlignment(Qt::AlignRight);
+
+    QObject::connect(slider, &QSlider::valueChanged, spin, [spin, scale](int v) {
+        QSignalBlocker block(spin);
+        spin->setValue(static_cast<double>(v) / scale);
+    });
+    QObject::connect(spin, qOverload<double>(&QDoubleSpinBox::valueChanged),
+                     slider, [slider, scale](double v) {
+        QSignalBlocker block(slider);
+        slider->setValue(static_cast<int>(v * scale));
+    });
+
+    layout->addWidget(slider, 1);
+    layout->addWidget(spin,   0);
+
+    return { slider, spin, container };
+}
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run:
+```bash
+cmake --build build --target tst_setup_helpers && ctest --test-dir build -R tst_setup_helpers --output-on-failure
+```
+
+Expected: all 6 test slots pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gui/setup/SetupHelpers.cpp tests/tst_setup_helpers.cpp tests/CMakeLists.txt
+git commit -S -m "feat(setup): implement SliderRow + SliderRowD factories
+
+Bidirectional slider↔spinbox pair with QSignalBlocker guards against
+feedback loops. Unit-test covers range honor, bidirectional sync, no
+feedback loop, and double-precision scaling via decimals.
+
+Used by DisplaySetupPages in subsequent commits to give every numeric
+Setup control a live readout and keyboard entry path.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Refactor `SpectrumDefaultsPage` Sliders
+
+**Files:**
+- Modify: `src/gui/setup/DisplaySetupPages.cpp` (lines ~145–388, `SpectrumDefaultsPage::buildUI`)
+
+**Goal:** Convert the 4 sliders in `SpectrumDefaultsPage` to use `makeSliderRow`. The refactor pattern is identical for each slider — this task shows the FPS slider in full, then lists the other three with their specific parameters.
+
+- [ ] **Step 1: Add include for SetupHelpers.h**
+
+At the top of `src/gui/setup/DisplaySetupPages.cpp`, add the include right after the `DisplaySetupPages.h` include:
+
+```cpp
+#include "DisplaySetupPages.h"
+#include "SetupHelpers.h"
+#include "gui/ColorSwatchButton.h"
+// ... rest of existing includes
+```
+
+- [ ] **Step 2: Refactor the FPS slider (reference pattern)**
+
+Find this block in `SpectrumDefaultsPage::buildUI()` (around line 194–198):
+
+```cpp
+    m_fpSlider = new QSlider(Qt::Horizontal, renderGroup);
+    m_fpSlider->setRange(10, 60);
+    m_fpSlider->setValue(30);
+    connect(m_fpSlider, &QSlider::valueChanged, this, [this](int v) { pushFps(v); });
+    renderForm->addRow(QStringLiteral("FPS (10–60):"), m_fpSlider);
+```
+
+Replace with:
+
+```cpp
+    {
+        auto row = makeSliderRow(10, 60, 30, QStringLiteral(" fps"), renderGroup);
+        m_fpSlider = row.slider;
+        connect(m_fpSlider, &QSlider::valueChanged, this, [this](int v) { pushFps(v); });
+        renderForm->addRow(QStringLiteral("FPS:"), row.container);
+    }
+```
+
+Note the braces: they scope `row` so its name can be reused in subsequent slider blocks without shadowing complaints. `m_fpSlider` now points at the slider half of the pair — the spinbox is owned by the row container and stays in sync automatically.
+
+- [ ] **Step 3: Refactor `m_fillAlphaSlider` (0–100, "%")**
+
+Find (around line 241–248):
+
+```cpp
+    m_fillAlphaSlider = new QSlider(Qt::Horizontal, renderGroup);
+    m_fillAlphaSlider->setRange(0, 100);
+    m_fillAlphaSlider->setValue(70);
+    connect(m_fillAlphaSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setFillAlpha(v / 100.0f);
+        }
+    });
+    renderForm->addRow(QStringLiteral("Fill Alpha:"), m_fillAlphaSlider);
+```
+
+Replace with:
+
+```cpp
+    {
+        auto row = makeSliderRow(0, 100, 70, QStringLiteral("%"), renderGroup);
+        m_fillAlphaSlider = row.slider;
+        connect(m_fillAlphaSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setFillAlpha(v / 100.0f);
+            }
+        });
+        renderForm->addRow(QStringLiteral("Fill Alpha:"), row.container);
+    }
+```
+
+- [ ] **Step 4: Refactor `m_lineWidthSlider` (1–3, " px")**
+
+Find (around line 251–258):
+
+```cpp
+    m_lineWidthSlider = new QSlider(Qt::Horizontal, renderGroup);
+    m_lineWidthSlider->setRange(1, 3);
+    m_lineWidthSlider->setValue(1);
+    connect(m_lineWidthSlider, &QSlider::valueChanged, this, [this](int v) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setLineWidth(static_cast<float>(v));
+        }
+    });
+    renderForm->addRow(QStringLiteral("Line Width:"), m_lineWidthSlider);
+```
+
+Replace with:
+
+```cpp
+    {
+        auto row = makeSliderRow(1, 3, 1, QStringLiteral(" px"), renderGroup);
+        m_lineWidthSlider = row.slider;
+        connect(m_lineWidthSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setLineWidth(static_cast<float>(v));
+            }
+        });
+        renderForm->addRow(QStringLiteral("Line Width:"), row.container);
+    }
+```
+
+- [ ] **Step 5: Refactor `m_dataLineAlphaSlider` (0–255, no suffix)**
+
+Find (around line 290–300):
+
+```cpp
+    m_dataLineAlphaSlider = new QSlider(Qt::Horizontal, colorGroup);
+    m_dataLineAlphaSlider->setRange(0, 255);
+    m_dataLineAlphaSlider->setValue(230);
+    connect(m_dataLineAlphaSlider, &QSlider::valueChanged, this, [this](int a) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            QColor c = w->fillColor();
+            c.setAlpha(a);
+            w->setFillColor(c);
+        }
+    });
+    colorForm->addRow(QStringLiteral("Line Alpha:"), m_dataLineAlphaSlider);
+```
+
+Replace with:
+
+```cpp
+    {
+        auto row = makeSliderRow(0, 255, 230, QString(), colorGroup);
+        m_dataLineAlphaSlider = row.slider;
+        connect(m_dataLineAlphaSlider, &QSlider::valueChanged, this, [this](int a) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                QColor c = w->fillColor();
+                c.setAlpha(a);
+                w->setFillColor(c);
+            }
+        });
+        colorForm->addRow(QStringLiteral("Line Alpha:"), row.container);
+    }
+```
+
+- [ ] **Step 6: Build, launch, manually verify**
+
+Run:
+```bash
+cmake --build build --target NereusSDR 2>&1 | tail -5
+pkill -x NereusSDR 2>/dev/null; sleep 0.3
+open build/NereusSDR.app
+```
+
+Open Setup → Display → Spectrum Defaults. Verify:
+- Each of the 4 refactored sliders shows a spinbox to its right with the correct suffix.
+- Dragging each slider updates the spinbox.
+- Typing into each spinbox updates the slider.
+- The underlying behavior (FPS changes, fill alpha changes, etc.) still fires — drag each and watch the spectrum react.
+
+- [ ] **Step 7: Run smoke test suite**
+
+Run:
+```bash
+ctest --test-dir build --output-on-failure 2>&1 | tail -15
+```
+
+Expected: all tests pass, including `tst_setup_helpers` and `tst_smoke`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/gui/setup/DisplaySetupPages.cpp
+git commit -S -m "refactor(setup): SpectrumDefaultsPage uses SliderRow helpers
+
+Converts m_fpSlider, m_fillAlphaSlider, m_lineWidthSlider, and
+m_dataLineAlphaSlider to use makeSliderRow(), giving each slider a
+live numeric spinbox readout with unit suffix and keyboard entry path.
+No behavior changes — the backing connects() still drive the same
+FFTEngine / SpectrumWidget setters.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Refactor `WaterfallDefaultsPage` Sliders
+
+**Files:**
+- Modify: `src/gui/setup/DisplaySetupPages.cpp` (`WaterfallDefaultsPage::buildUI`)
+
+**Goal:** Convert the 4 sliders in `WaterfallDefaultsPage` using the same pattern as Task 3.
+
+- [ ] **Step 1: Locate `WaterfallDefaultsPage::buildUI()`**
+
+Search `src/gui/setup/DisplaySetupPages.cpp` for `void WaterfallDefaultsPage::buildUI()`. The 4 sliders are `m_highThresholdSlider`, `m_lowThresholdSlider`, `m_updatePeriodSlider`, `m_opacitySlider`.
+
+- [ ] **Step 2: Refactor `m_highThresholdSlider` (-200 to 0, " dBm", initial -40)**
+
+Find the existing `m_highThresholdSlider = new QSlider(...)` block and replace it with:
+
+```cpp
+    {
+        auto row = makeSliderRow(-200, 0, -40, QStringLiteral(" dBm"), levelsGroup);
+        m_highThresholdSlider = row.slider;
+        connect(m_highThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setWaterfallHighThreshold(static_cast<float>(v));
+            }
+        });
+        levelsForm->addRow(QStringLiteral("High Threshold:"), row.container);
+    }
+```
+
+If the existing block uses a different group/form variable name, substitute. Preserve the existing connect body — copy the lambda from the `connect(m_highThresholdSlider, ...)` line verbatim. Initial value `-40` is NereusSDR's current default; do not change it in this PR (that's PR2's job).
+
+- [ ] **Step 3: Refactor `m_lowThresholdSlider` (-200 to 0, " dBm", initial -130)**
+
+Apply the same pattern. Initial value -130. Suffix " dBm".
+
+```cpp
+    {
+        auto row = makeSliderRow(-200, 0, -130, QStringLiteral(" dBm"), levelsGroup);
+        m_lowThresholdSlider = row.slider;
+        connect(m_lowThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setWaterfallLowThreshold(static_cast<float>(v));
+            }
+        });
+        levelsForm->addRow(QStringLiteral("Low Threshold:"), row.container);
+    }
+```
+
+- [ ] **Step 4: Refactor `m_updatePeriodSlider` (10–500, " ms", initial 50)**
+
+```cpp
+    {
+        auto row = makeSliderRow(10, 500, 50, QStringLiteral(" ms"), displayGroup);
+        m_updatePeriodSlider = row.slider;
+        connect(m_updatePeriodSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setWaterfallUpdatePeriod(v);
+            }
+        });
+        displayForm->addRow(QStringLiteral("Update Period:"), row.container);
+    }
+```
+
+If the existing connect body calls a different SpectrumWidget setter, preserve the original call.
+
+- [ ] **Step 5: Refactor `m_opacitySlider` (0–100, "%", initial 100)**
+
+```cpp
+    {
+        auto row = makeSliderRow(0, 100, 100, QStringLiteral("%"), displayGroup);
+        m_opacitySlider = row.slider;
+        connect(m_opacitySlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setWaterfallOpacity(v / 100.0f);
+            }
+        });
+        displayForm->addRow(QStringLiteral("Opacity:"), row.container);
+    }
+```
+
+Preserve whatever scale conversion the existing connect used (some setters take 0–100, some take 0.0–1.0 — check the existing code and keep it).
+
+- [ ] **Step 6: Build and launch**
+
+```bash
+cmake --build build --target NereusSDR 2>&1 | tail -5
+pkill -x NereusSDR 2>/dev/null; sleep 0.3
+open build/NereusSDR.app
+```
+
+Open Setup → Display → Waterfall Defaults. Drag each of the 4 refactored sliders and confirm (a) the spinbox tracks, (b) typing in the spinbox updates the slider, (c) the waterfall reacts live.
+
+- [ ] **Step 7: Run tests**
+
+```bash
+ctest --test-dir build --output-on-failure 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/gui/setup/DisplaySetupPages.cpp
+git commit -S -m "refactor(setup): WaterfallDefaultsPage uses SliderRow helpers
+
+Converts m_highThresholdSlider, m_lowThresholdSlider,
+m_updatePeriodSlider, and m_opacitySlider to use makeSliderRow().
+Each slider now has a live numeric spinbox with unit suffix.
+No behavior changes.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Source-First Citations + Tooltip Port — SpectrumDefaultsPage
+
+**Files:**
+- Modify: `src/gui/setup/DisplaySetupPages.cpp` (`SpectrumDefaultsPage` section)
+
+**Goal:** Add per-control `// Thetis: setup.designer.cs:NNNN (controlName)` citation comments above every `connect(...)` block in `SpectrumDefaultsPage::buildUI()`, plus a `setToolTip(...)` call for every control following the tooltip decision rule above.
+
+This is a mechanical pass. The workflow is: for each control, grep Thetis for the control name, extract tooltip, classify, write comment + tooltip.
+
+**Reference:** The 3G-8 plan's §3.1/§3.2 already identified the Thetis control name for all 17 `SpectrumDefaultsPage` controls. Use that table as the starting point. Re-verify each line number against current `../Thetis/` state — line numbers may have drifted.
+
+- [ ] **Step 1: Extract Thetis tooltip for `udDisplayFPS`**
+
+Run:
+```bash
+grep -n "udDisplayFPS" "../Thetis/Project Files/Source/Console/setup.designer.cs" | head -5
+grep -n 'SetToolTip(this.udDisplayFPS' "../Thetis/Project Files/Source/Console/setup.designer.cs"
+```
+
+Expected: find the `toolTip1.SetToolTip(this.udDisplayFPS, "...");` line. Copy the string.
+
+Classify it:
+- Substantive (>10 chars, useful) → port verbatim with attribution comment.
+- Empty/echo → rewrite with comment citing original.
+
+- [ ] **Step 2: Annotate FPS slider**
+
+Above the `connect(m_fpSlider, ...)` block from Task 3, add:
+
+```cpp
+    // Thetis: setup.designer.cs:NNNN (udDisplayFPS) → console.DisplayFPS
+    {
+        auto row = makeSliderRow(10, 60, 30, QStringLiteral(" fps"), renderGroup);
+        m_fpSlider = row.slider;
+        m_fpSlider->setToolTip(QStringLiteral(
+            "<EXACT THETIS STRING OR REWRITE>"));
+        // If rewritten: // Tooltip rewritten — Thetis original: "<original>"
+        connect(m_fpSlider, &QSlider::valueChanged, this, [this](int v) { pushFps(v); });
+        renderForm->addRow(QStringLiteral("FPS:"), row.container);
+    }
+```
+
+Replace `NNNN` with the actual line number from step 1. Replace `<EXACT THETIS STRING OR REWRITE>` with the actual tooltip text.
+
+- [ ] **Step 3: Repeat steps 1–2 for every control in `SpectrumDefaultsPage`**
+
+17 controls total. The Thetis names are (from 3G-8 plan §3.1/§3.2):
+
+| Member | Thetis control name | Type |
+|---|---|---|
+| `m_fftSizeCombo` | `tbDisplayFFTSize` | Thetis (TrackBar → we use combo) |
+| `m_windowCombo` | — | **NereusSDR extension** — write new tooltip |
+| `m_fpSlider` | `udDisplayFPS` | Thetis |
+| `m_averagingCombo` | `comboDispPanAveraging` | Thetis |
+| `m_averagingTimeSpin` | `udDisplayAVGTime` | Thetis |
+| `m_decimationSpin` | `udDisplayDecimation` | Thetis |
+| `m_fillToggle` | `chkDisplayPanFill` | Thetis |
+| `m_fillAlphaSlider` | `tbDataFillAlpha` | Thetis |
+| `m_lineWidthSlider` | `udDisplayLineWidth` | Thetis |
+| `m_gradientToggle` | `chkDataLineGradient` | Thetis |
+| `m_dataLineColorBtn` | `clrbtnDataLine` | Thetis |
+| `m_dataLineAlphaSlider` | `tbDataLineAlpha` | Thetis |
+| `m_dataFillColorBtn` | `clrbtnDataFill` | Thetis |
+| `m_calOffsetSpin` | (programmatic only, `Display.RX1DisplayCalOffset`) | Thetis — no designer tooltip; write useful one, cite `display.cs:1372` |
+| `m_peakHoldToggle` | — | **NereusSDR extension** |
+| `m_peakHoldDelaySpin` | — | **NereusSDR extension** |
+| `m_threadPriorityCombo` | `comboDisplayThreadPriority` | Thetis |
+
+For each, run the same grep pattern, extract, classify, paste with the appropriate citation + tooltip comment. Use single `setToolTip(QStringLiteral("..."))` calls on the widget right after it's constructed (or after the row unwraps for sliders).
+
+**Tooltip strings must never span multiple lines in the source** — if a Thetis tooltip has a newline, use `\n` inline. Keep the QStringLiteral on one logical C++ line or use adjacent string concatenation.
+
+- [ ] **Step 4: Build and verify tooltips appear**
+
+```bash
+cmake --build build --target NereusSDR 2>&1 | tail -5
+pkill -x NereusSDR 2>/dev/null; sleep 0.3
+open build/NereusSDR.app
+```
+
+Open Setup → Display → Spectrum Defaults. Hover every control for ~1 second. Confirm each one shows a tooltip that reads sensibly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gui/setup/DisplaySetupPages.cpp
+git commit -S -m "feat(setup): tooltips + Thetis citations for SpectrumDefaultsPage
+
+Every control in SpectrumDefaultsPage now has:
+- A // Thetis: setup.designer.cs:NNNN (controlName) citation comment
+  above its connect(...) block (or 'NereusSDR extension' for
+  project-specific controls).
+- A setToolTip() call, verbatim from Thetis where the upstream is
+  substantive, rewritten where Thetis was empty or echoed the label,
+  and written from scratch for the 3 NereusSDR extensions.
+
+17 controls, no behavior changes.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Source-First Citations + Tooltip Port — WaterfallDefaultsPage
+
+**Files:**
+- Modify: `src/gui/setup/DisplaySetupPages.cpp` (`WaterfallDefaultsPage` section)
+
+**Goal:** Same pass as Task 5, for the 17 controls in `WaterfallDefaultsPage`.
+
+**Reference table** (from 3G-8 plan §4.1/§4.2):
+
+| Member | Thetis control name | Type |
+|---|---|---|
+| `m_highThresholdSlider` | `udDisplayWaterfallHighLevel` | Thetis |
+| `m_lowThresholdSlider` | `udDisplayWaterfallLowLevel` | Thetis |
+| `m_agcToggle` | `chkRX1WaterfallAGC` | Thetis |
+| `m_lowColorBtn` | `clrbtnWaterfallLow` | Thetis |
+| `m_useSpectrumMinMaxToggle` | `chkWaterfallUseRX1SpectrumMinMax` | Thetis |
+| `m_updatePeriodSlider` | `udDisplayWaterfallUpdatePeriod` | Thetis |
+| `m_reverseToggle` | — | **NereusSDR extension** |
+| `m_opacitySlider` | `tbRX1WaterfallOpacity` | Thetis |
+| `m_colorSchemeCombo` | `comboColorPalette` | Thetis |
+| `m_wfAveragingCombo` | `comboDispWFAveraging` | Thetis |
+| `m_showRxFilterToggle` | `chkShowRXFilterOnWaterfall` | Thetis |
+| `m_showTxFilterToggle` | `chkShowTXFilterOnRXWaterfall` | Thetis |
+| `m_showRxZeroLineToggle` | `chkShowRXZeroLineOnWaterfall` | Thetis |
+| `m_showTxZeroLineToggle` | `chkShowTXZeroLineOnWaterfall` | Thetis |
+| `m_timestampPosCombo` | — | **NereusSDR extension** |
+| `m_timestampModeCombo` | — | **NereusSDR extension** |
+
+- [ ] **Step 1: Walk the 17 controls**
+
+For each row in the table: grep Thetis designer for the control name, extract SetToolTip string, classify, paste citation comment + `setToolTip(...)` call in `WaterfallDefaultsPage::buildUI()`. Use the same pattern as Task 5.
+
+- [ ] **Step 2: Build + hover-check every control**
+
+```bash
+cmake --build build --target NereusSDR 2>&1 | tail -5
+pkill -x NereusSDR 2>/dev/null; sleep 0.3
+open build/NereusSDR.app
+```
+
+Setup → Display → Waterfall Defaults. Hover all 17 controls, confirm tooltips appear.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/gui/setup/DisplaySetupPages.cpp
+git commit -S -m "feat(setup): tooltips + Thetis citations for WaterfallDefaultsPage
+
+Same pattern as SpectrumDefaultsPage — 17 controls, each with a source
+citation comment and a tooltip (Thetis-verbatim, rewritten, or new for
+NereusSDR extensions: Reverse Scroll, Timestamp Position, Timestamp Mode).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Source-First Citations + Tooltip Port — GridScalesPage
+
+**Files:**
+- Modify: `src/gui/setup/DisplaySetupPages.cpp` (`GridScalesPage` section)
+
+**Goal:** Last of the three pages. 13 controls, no sliders (all combos/spinboxes/checkboxes/color swatches).
+
+**Reference table** (from 3G-8 plan §5.1/§5.2):
+
+| Member | Thetis control name | Type |
+|---|---|---|
+| `m_gridToggle` | `chkGridControl` | Thetis |
+| `m_dbMaxSpin` | `udDisplayGridMax` | Thetis (per-band) |
+| `m_dbMinSpin` | `udDisplayGridMin` | Thetis (per-band) |
+| `m_dbStepSpin` | `udDisplayGridStep` | Thetis (global) |
+| `m_freqLabelAlignCombo` | `comboDisplayLabelAlign` | Thetis |
+| `m_zeroLineToggle` | `chkShowZeroLine` | Thetis |
+| `m_showFpsToggle` | `chkShowFPS` | Thetis |
+| `m_gridColorBtn` | `clrbtnGrid` | Thetis |
+| `m_gridFineColorBtn` | `clrbtnGridFine` | Thetis |
+| `m_hGridColorBtn` | `clrbtnHGridColor` | Thetis |
+| `m_gridTextColorBtn` | `clrbtnText` | Thetis |
+| `m_zeroLineColorBtn` | `clrbtnZeroLine` | Thetis |
+| `m_bandEdgeColorBtn` | `clrbtnBandEdge` | Thetis |
+
+All 13 are Thetis-sourced; no extensions. Note the per-band dB Max / dB Min slots — the tooltip should mention "edits the current band's grid slot; see band indicator above."
+
+- [ ] **Step 1: Walk the 13 controls**
+
+Same workflow as Tasks 5–6. grep → extract → classify → paste.
+
+- [ ] **Step 2: Build + hover-check**
+
+```bash
+cmake --build build --target NereusSDR 2>&1 | tail -5
+pkill -x NereusSDR 2>/dev/null; sleep 0.3
+open build/NereusSDR.app
+```
+
+Setup → Display → Grid & Scales. Hover all 13 controls.
+
+- [ ] **Step 3: Full test suite**
+
+```bash
+ctest --test-dir build --output-on-failure 2>&1 | tail -15
+```
+
+Expected: all green, including `tst_setup_helpers` and `tst_smoke`.
+
+- [ ] **Step 4: Tooltip coverage audit**
+
+```bash
+grep -c "setToolTip" src/gui/setup/DisplaySetupPages.cpp
+```
+
+Expected: at least 47 (one per control). Can be more if any control uses multiple tooltips (e.g., on label + widget).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gui/setup/DisplaySetupPages.cpp
+git commit -S -m "feat(setup): tooltips + Thetis citations for GridScalesPage
+
+Final page — 13 controls, all Thetis-sourced (no extensions). Per-band
+dB Max / dB Min tooltips note that they edit the currently-active band
+slot. Brings PR1 tooltip coverage to 47/47.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Final Verification + PR Draft
+
+**Files:** none modified. This task validates the branch end-to-end.
+
+- [ ] **Step 1: Clean rebuild from scratch**
+
+```bash
+cmake --build build --target clean
+cmake --build build 2>&1 | tail -10
+```
+
+Expected: build green, no warnings on the touched files.
+
+- [ ] **Step 2: Full test suite**
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Launch + manual sweep**
+
+```bash
+pkill -x NereusSDR 2>/dev/null; sleep 0.3
+open build/NereusSDR.app
+```
+
+Open Setup → Display. For each of the three pages:
+- Every slider has a spinbox readout with a unit suffix.
+- Drag slider → spinbox tracks. Type in spinbox → slider tracks.
+- Hover every control → tooltip appears, reads sensibly, no `<EXACT THETIS STRING OR REWRITE>` placeholders.
+- Every connect target still fires (spectrum/waterfall react live to every change).
+
+- [ ] **Step 4: Diff review**
+
+```bash
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+```
+
+Expected: ~7 commits, `DisplaySetupPages.cpp` delta around ~600 lines (mostly additive tooltip/citation blocks), new `SetupHelpers.{h,cpp}` ~200 lines, new `tst_setup_helpers.cpp` ~100 lines.
+
+Visually skim the diff for: missing braces, leftover placeholder strings, tooltip typos, accidental behavior changes (any `connect(...)` lambda bodies should be unchanged from pre-refactor).
+
+- [ ] **Step 5: Draft the PR description**
+
+Write to a scratch file (don't post yet — per standing preference, user reviews all public GitHub posts):
+
+```markdown
+# Phase 3G-9a — Source-First Audit + Tooltips + Slider Readouts
+
+First of three PRs under Phase 3G-9 (Display Refactor). Design spec:
+`docs/architecture/2026-04-15-display-refactor-design.md` §4.
+
+## What
+
+- Added `SetupHelpers.h/.cpp` with `makeSliderRow` / `makeDoubleSliderRow`
+  factories. Each returns a bidirectionally-synced slider+spinbox pair with
+  unit suffix, guarded against signal feedback loops via QSignalBlocker.
+- Refactored all 8 sliders in `SpectrumDefaultsPage` and `WaterfallDefaultsPage`
+  to use the helpers. Every numeric Setup control now has a live spinbox readout
+  and a keyboard entry path.
+- Added `setToolTip(...)` calls for all 47 controls across the three Setup pages
+  (Spectrum 17, Waterfall 17, Grid & Scales 13). Tooltip text is verbatim from
+  Thetis `setup.designer.cs` where the upstream string is substantive, rewritten
+  (with the original recorded in an adjacent comment) where Thetis was weak, and
+  written from scratch for the 6 NereusSDR-original extensions.
+- Added `// Thetis: setup.designer.cs:NNNN (controlName)` source-first citation
+  comments above every `connect(...)` block — the source-first protocol is now
+  self-documenting in the code.
+
+## Why
+
+Phase 3G-8 shipped working wire-up for 47 controls. This PR closes the polish
+gap: missing tooltips (10/47 → 47/47), missing source citations (0/47 → 47/47),
+and slider-only controls that forced mouse-only input with no numeric readout.
+
+## Testing
+
+- New `tst_setup_helpers` QtTest smoke: 6 assertions covering range honor,
+  bidirectional sync, no feedback loops, double-precision scaling.
+- Existing tests stay green.
+- Manual: hovered every control across all three pages, dragged every slider
+  and typed into every spinbox to verify bidirectional sync.
+
+## Scope
+
+Explicitly out of scope: RX2 Display, TX Display, Spectrum Overlay flyouts,
+meter editors. These deferred per spec §2.
+
+## Next
+
+PR2 (3G-9b) — smooth defaults + Clarity Blue palette + tuning doc.
+PR3 (3G-9c) — Clarity adaptive display tuning (research-doc gated).
+```
+
+- [ ] **Step 6: Push the branch and open the PR**
+
+```bash
+git push -u origin feature/display-audit-pr1
+```
+
+Then per standing preference, show the PR description draft in the terminal and wait for user approval before running `gh pr create`.
+
+---
+
+## Commit Shape Recap
+
+Expected final commit log on `feature/display-audit-pr1`:
+
+1. `feat(setup): scaffold SetupHelpers.h/.cpp for slider readout factory` (Task 1)
+2. `feat(setup): implement SliderRow + SliderRowD factories` (Task 2)
+3. `refactor(setup): SpectrumDefaultsPage uses SliderRow helpers` (Task 3)
+4. `refactor(setup): WaterfallDefaultsPage uses SliderRow helpers` (Task 4)
+5. `feat(setup): tooltips + Thetis citations for SpectrumDefaultsPage` (Task 5)
+6. `feat(setup): tooltips + Thetis citations for WaterfallDefaultsPage` (Task 6)
+7. `feat(setup): tooltips + Thetis citations for GridScalesPage` (Task 7)
+
+7 GPG-signed commits, no `--no-verify`, no `--amend`. Task 8 is verification only and produces no commit.

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -451,25 +451,27 @@ void WaterfallDefaultsPage::buildUI()
     auto* levForm  = new QFormLayout(levGroup);
     levForm->setSpacing(6);
 
-    m_highThresholdSlider = new QSlider(Qt::Horizontal, levGroup);
-    m_highThresholdSlider->setRange(-200, 0);
-    m_highThresholdSlider->setValue(-40);
-    connect(m_highThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
-        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
-            w->setWfHighThreshold(static_cast<float>(v));
-        }
-    });
-    levForm->addRow(QStringLiteral("High Threshold:"), m_highThresholdSlider);
+    {
+        auto row = makeSliderRow(-200, 0, -40, QStringLiteral(" dBm"), levGroup);
+        m_highThresholdSlider = row.slider;
+        connect(m_highThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setWfHighThreshold(static_cast<float>(v));
+            }
+        });
+        levForm->addRow(QStringLiteral("High Threshold:"), row.container);
+    }
 
-    m_lowThresholdSlider = new QSlider(Qt::Horizontal, levGroup);
-    m_lowThresholdSlider->setRange(-200, 0);
-    m_lowThresholdSlider->setValue(-130);
-    connect(m_lowThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
-        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
-            w->setWfLowThreshold(static_cast<float>(v));
-        }
-    });
-    levForm->addRow(QStringLiteral("Low Threshold:"), m_lowThresholdSlider);
+    {
+        auto row = makeSliderRow(-200, 0, -130, QStringLiteral(" dBm"), levGroup);
+        m_lowThresholdSlider = row.slider;
+        connect(m_lowThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setWfLowThreshold(static_cast<float>(v));
+            }
+        });
+        levForm->addRow(QStringLiteral("Low Threshold:"), row.container);
+    }
 
     m_agcToggle = new QCheckBox(QStringLiteral("AGC"), levGroup);
     connect(m_agcToggle, &QCheckBox::toggled, this, [this](bool on) {
@@ -504,15 +506,16 @@ void WaterfallDefaultsPage::buildUI()
     auto* dispForm  = new QFormLayout(dispGroup);
     dispForm->setSpacing(6);
 
-    m_updatePeriodSlider = new QSlider(Qt::Horizontal, dispGroup);
-    m_updatePeriodSlider->setRange(10, 500);
-    m_updatePeriodSlider->setValue(50);
-    connect(m_updatePeriodSlider, &QSlider::valueChanged, this, [this](int v) {
-        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
-            w->setWfUpdatePeriodMs(v);
-        }
-    });
-    dispForm->addRow(QStringLiteral("Update Period (ms):"), m_updatePeriodSlider);
+    {
+        auto row = makeSliderRow(10, 500, 50, QStringLiteral(" ms"), dispGroup);
+        m_updatePeriodSlider = row.slider;
+        connect(m_updatePeriodSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setWfUpdatePeriodMs(v);
+            }
+        });
+        dispForm->addRow(QStringLiteral("Update Period:"), row.container);
+    }
 
     m_reverseToggle = new QCheckBox(QStringLiteral("Reverse scroll"), dispGroup);
     connect(m_reverseToggle, &QCheckBox::toggled, this, [this](bool on) {
@@ -522,15 +525,16 @@ void WaterfallDefaultsPage::buildUI()
     });
     dispForm->addRow(QString(), m_reverseToggle);
 
-    m_opacitySlider = new QSlider(Qt::Horizontal, dispGroup);
-    m_opacitySlider->setRange(0, 100);
-    m_opacitySlider->setValue(100);
-    connect(m_opacitySlider, &QSlider::valueChanged, this, [this](int v) {
-        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
-            w->setWfOpacity(v);
-        }
-    });
-    dispForm->addRow(QStringLiteral("Opacity:"), m_opacitySlider);
+    {
+        auto row = makeSliderRow(0, 100, 100, QStringLiteral("%"), dispGroup);
+        m_opacitySlider = row.slider;
+        connect(m_opacitySlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setWfOpacity(v);
+            }
+        });
+        dispForm->addRow(QStringLiteral("Opacity:"), row.container);
+    }
 
     m_colorSchemeCombo = new QComboBox(dispGroup);
     m_colorSchemeCombo->addItems({

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -503,6 +503,9 @@ void WaterfallDefaultsPage::buildUI()
     {
         auto row = makeSliderRow(-200, 0, -40, QStringLiteral(" dBm"), levGroup);
         m_highThresholdSlider = row.slider;
+        // Thetis: setup.designer.cs:34259 (udDisplayWaterfallHighLevel)
+        m_highThresholdSlider->setToolTip(QStringLiteral("Waterfall High Signal - Show High Color above this value (gradient in between)."));
+        row.spin->setToolTip(QStringLiteral("Waterfall High Signal - Show High Color above this value (gradient in between)."));
         connect(m_highThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
             if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
                 w->setWfHighThreshold(static_cast<float>(v));
@@ -514,6 +517,9 @@ void WaterfallDefaultsPage::buildUI()
     {
         auto row = makeSliderRow(-200, 0, -130, QStringLiteral(" dBm"), levGroup);
         m_lowThresholdSlider = row.slider;
+        // Thetis: setup.designer.cs:34219 (udDisplayWaterfallLowLevel)
+        m_lowThresholdSlider->setToolTip(QStringLiteral("Waterfall Low Signal - Show Low Color below this value (gradient in between)."));
+        row.spin->setToolTip(QStringLiteral("Waterfall Low Signal - Show Low Color below this value (gradient in between)."));
         connect(m_lowThresholdSlider, &QSlider::valueChanged, this, [this](int v) {
             if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
                 w->setWfLowThreshold(static_cast<float>(v));
@@ -523,6 +529,8 @@ void WaterfallDefaultsPage::buildUI()
     }
 
     m_agcToggle = new QCheckBox(QStringLiteral("AGC"), levGroup);
+    // Thetis: setup.designer.cs:34069 (chkRX1WaterfallAGC)
+    m_agcToggle->setToolTip(QStringLiteral("Automatically calculates Low Level Threshold for Waterfall."));
     connect(m_agcToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setWfAgcEnabled(on);
@@ -531,6 +539,8 @@ void WaterfallDefaultsPage::buildUI()
     levForm->addRow(QString(), m_agcToggle);
 
     m_useSpectrumMinMaxToggle = new QCheckBox(QStringLiteral("Use spectrum min/max"), levGroup);
+    // Thetis: setup.designer.cs:34054 (chkWaterfallUseRX1SpectrumMinMax)
+    m_useSpectrumMinMaxToggle->setToolTip(QStringLiteral("Spectrum Grid min/max used for low and high level"));
     connect(m_useSpectrumMinMaxToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setWfUseSpectrumMinMax(on);
@@ -539,6 +549,8 @@ void WaterfallDefaultsPage::buildUI()
     levForm->addRow(QString(), m_useSpectrumMinMaxToggle);
 
     m_lowColorBtn = new ColorSwatchButton(QColor(Qt::black), levGroup);
+    // Thetis: setup.designer.cs:34176 (clrbtnWaterfallLow)
+    m_lowColorBtn->setToolTip(QStringLiteral("The Color to use when the signal level is at or below the low level set above."));
     // Waterfall "low" colour is conceptually the 0.0 stop of the gradient —
     // exposed here for plan §4.2 W10 parity. SpectrumWidget currently uses
     // gradient tables from wfSchemeStops() so the user's custom value is
@@ -558,6 +570,9 @@ void WaterfallDefaultsPage::buildUI()
     {
         auto row = makeSliderRow(10, 500, 50, QStringLiteral(" ms"), dispGroup);
         m_updatePeriodSlider = row.slider;
+        // Thetis: setup.designer.cs:34145 (udDisplayWaterfallUpdatePeriod)
+        m_updatePeriodSlider->setToolTip(QStringLiteral("How often to update (scroll another pixel line) on the waterfall display. Note that this is tamed by the FPS setting."));
+        row.spin->setToolTip(QStringLiteral("How often to update (scroll another pixel line) on the waterfall display. Note that this is tamed by the FPS setting."));
         connect(m_updatePeriodSlider, &QSlider::valueChanged, this, [this](int v) {
             if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
                 w->setWfUpdatePeriodMs(v);
@@ -567,6 +582,8 @@ void WaterfallDefaultsPage::buildUI()
     }
 
     m_reverseToggle = new QCheckBox(QStringLiteral("Reverse scroll"), dispGroup);
+    // NereusSDR extension — no Thetis equivalent
+    m_reverseToggle->setToolTip(QStringLiteral("Waterfall normally scrolls top to bottom (newest at top). When checked, scrolls bottom to top (newest at bottom)."));
     connect(m_reverseToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setWfReverseScroll(on);
@@ -577,6 +594,10 @@ void WaterfallDefaultsPage::buildUI()
     {
         auto row = makeSliderRow(0, 100, 100, QStringLiteral("%"), dispGroup);
         m_opacitySlider = row.slider;
+        // Thetis: setup.designer.cs:2056 (tbRX1WaterfallOpacity) — rewritten
+        // Thetis original: (none)
+        m_opacitySlider->setToolTip(QStringLiteral("Waterfall opacity (0 = fully transparent, 100 = fully opaque). Blends the waterfall over the spectrum background."));
+        row.spin->setToolTip(QStringLiteral("Waterfall opacity (0 = fully transparent, 100 = fully opaque). Blends the waterfall over the spectrum background."));
         connect(m_opacitySlider, &QSlider::valueChanged, this, [this](int v) {
             if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
                 w->setWfOpacity(v);
@@ -592,6 +613,9 @@ void WaterfallDefaultsPage::buildUI()
         QStringLiteral("LinLog"),    QStringLiteral("LinRad"),
         QStringLiteral("Custom")
     });
+    // Thetis: setup.designer.cs:34110 (comboColorPalette) — rewritten
+    // Thetis original: "Sets the color scheme"
+    m_colorSchemeCombo->setToolTip(QStringLiteral("Waterfall colour palette. Each scheme maps signal level to a different colour gradient from low (dark) to high (bright)."));
     connect(m_colorSchemeCombo, qOverload<int>(&QComboBox::currentIndexChanged),
             this, [this](int i) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
@@ -606,6 +630,9 @@ void WaterfallDefaultsPage::buildUI()
         QStringLiteral("None"), QStringLiteral("Weighted"),
         QStringLiteral("Logarithmic"), QStringLiteral("Time Window")
     });
+    // Thetis: setup.designer.cs:2083 (comboDispWFAveraging) — rewritten
+    // Thetis original: (none)
+    m_wfAveragingCombo->setToolTip(QStringLiteral("Waterfall averaging mode. Weighted and Time Window smooth rapid signal changes; None shows raw FFT output per row."));
     connect(m_wfAveragingCombo, qOverload<int>(&QComboBox::currentIndexChanged),
             this, [this](int i) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
@@ -622,6 +649,9 @@ void WaterfallDefaultsPage::buildUI()
     ovForm->setSpacing(6);
 
     m_showRxFilterToggle = new QCheckBox(QStringLiteral("Show RX filter on waterfall"), ovGroup);
+    // Thetis: setup.designer.cs:3189 (chkShowRXFilterOnWaterfall) — rewritten
+    // Thetis original: (none)
+    m_showRxFilterToggle->setToolTip(QStringLiteral("Overlay the current RX passband filter boundaries on the waterfall display."));
     connect(m_showRxFilterToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setShowRxFilterOnWaterfall(on);
@@ -630,6 +660,9 @@ void WaterfallDefaultsPage::buildUI()
     ovForm->addRow(QString(), m_showRxFilterToggle);
 
     m_showTxFilterToggle = new QCheckBox(QStringLiteral("Show TX filter on RX waterfall"), ovGroup);
+    // Thetis: setup.designer.cs:3187 (chkShowTXFilterOnRXWaterfall) — rewritten
+    // Thetis original: (none)
+    m_showTxFilterToggle->setToolTip(QStringLiteral("Overlay the TX passband filter boundaries on the RX waterfall display."));
     connect(m_showTxFilterToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setShowTxFilterOnRxWaterfall(on);
@@ -638,6 +671,9 @@ void WaterfallDefaultsPage::buildUI()
     ovForm->addRow(QString(), m_showTxFilterToggle);
 
     m_showRxZeroLineToggle = new QCheckBox(QStringLiteral("Show RX zero line on waterfall"), ovGroup);
+    // Thetis: setup.designer.cs:3188 (chkShowRXZeroLineOnWaterfall) — rewritten
+    // Thetis original: (none)
+    m_showRxZeroLineToggle->setToolTip(QStringLiteral("Draw a line on the waterfall at the RX centre frequency (zero-beat reference)."));
     connect(m_showRxZeroLineToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setShowRxZeroLineOnWaterfall(on);
@@ -646,6 +682,9 @@ void WaterfallDefaultsPage::buildUI()
     ovForm->addRow(QString(), m_showRxZeroLineToggle);
 
     m_showTxZeroLineToggle = new QCheckBox(QStringLiteral("Show TX zero line on waterfall"), ovGroup);
+    // Thetis: setup.designer.cs:3242 (chkShowTXZeroLineOnWaterfall) — rewritten
+    // Thetis original: (none)
+    m_showTxZeroLineToggle->setToolTip(QStringLiteral("Draw a line on the waterfall at the TX centre frequency (zero-beat reference)."));
     connect(m_showTxZeroLineToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setShowTxZeroLineOnWaterfall(on);
@@ -663,6 +702,8 @@ void WaterfallDefaultsPage::buildUI()
     m_timestampPosCombo = new QComboBox(timeGroup);
     m_timestampPosCombo->addItems({QStringLiteral("None"), QStringLiteral("Left"),
                                    QStringLiteral("Right")});
+    // NereusSDR extension — no Thetis equivalent
+    m_timestampPosCombo->setToolTip(QStringLiteral("Position of the time stamp drawn on each waterfall row. None disables timestamps; Left and Right place them at the respective edge."));
     connect(m_timestampPosCombo, qOverload<int>(&QComboBox::currentIndexChanged),
             this, [this](int i) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
@@ -675,6 +716,8 @@ void WaterfallDefaultsPage::buildUI()
 
     m_timestampModeCombo = new QComboBox(timeGroup);
     m_timestampModeCombo->addItems({QStringLiteral("UTC"), QStringLiteral("Local")});
+    // NereusSDR extension — no Thetis equivalent
+    m_timestampModeCombo->setToolTip(QStringLiteral("Time zone used for waterfall timestamps. UTC uses Coordinated Universal Time; Local uses the system clock time zone."));
     connect(m_timestampModeCombo, qOverload<int>(&QComboBox::currentIndexChanged),
             this, [this](int i) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -803,6 +803,8 @@ void GridScalesPage::buildUI()
 
     m_gridToggle = new QCheckBox(QStringLiteral("Show grid"), gridGroup);
     m_gridToggle->setChecked(true);
+    // Thetis: setup.designer.cs:52824 (chkGridControl)
+    m_gridToggle->setToolTip(QStringLiteral("Display the Major Grid on the Panadapter including the frequency numbers"));
     connect(m_gridToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setGridEnabled(on);
@@ -818,6 +820,9 @@ void GridScalesPage::buildUI()
     m_dbMaxSpin->setRange(-200, 0);
     m_dbMaxSpin->setValue(-40);
     m_dbMaxSpin->setSuffix(QStringLiteral(" dB"));
+    // Thetis: setup.designer.cs:34745 (udDisplayGridMax) — rewritten
+    // Thetis original: "Signal level at top of display in dB."
+    m_dbMaxSpin->setToolTip(QStringLiteral("Signal level at the top of the display in dB. Edits the current band's grid slot — see the band indicator above."));
     connect(m_dbMaxSpin, qOverload<int>(&QSpinBox::valueChanged),
             this, [this](int v) {
         if (auto* pan = firstPan(model())) {
@@ -830,6 +835,9 @@ void GridScalesPage::buildUI()
     m_dbMinSpin->setRange(-200, 0);
     m_dbMinSpin->setValue(-140);
     m_dbMinSpin->setSuffix(QStringLiteral(" dB"));
+    // Thetis: setup.designer.cs:34714 (udDisplayGridMin) — rewritten
+    // Thetis original: "Signal Level at bottom of display in dB."
+    m_dbMinSpin->setToolTip(QStringLiteral("Signal level at the bottom of the display in dB. Edits the current band's grid slot — see the band indicator above."));
     connect(m_dbMinSpin, qOverload<int>(&QSpinBox::valueChanged),
             this, [this](int v) {
         if (auto* pan = firstPan(model())) {
@@ -842,7 +850,9 @@ void GridScalesPage::buildUI()
     m_dbStepSpin->setRange(1, 40);
     m_dbStepSpin->setValue(10);
     m_dbStepSpin->setSuffix(QStringLiteral(" dB"));
-    m_dbStepSpin->setToolTip(QStringLiteral("Global grid step — Thetis stores this as a single value (not per-band)."));
+    // Thetis: setup.designer.cs:34683 (udDisplayGridStep) — rewritten
+    // Thetis original: "Horizontal Grid Step Size in dB."
+    m_dbStepSpin->setToolTip(QStringLiteral("Horizontal grid step size in dB. Sets the spacing between dB grid lines across all bands (global, not per-band)."));
     connect(m_dbStepSpin, qOverload<int>(&QSpinBox::valueChanged),
             this, [this](int v) {
         if (auto* pan = firstPan(model())) {
@@ -873,6 +883,9 @@ void GridScalesPage::buildUI()
         QStringLiteral("Off")
     });
     m_freqLabelAlignCombo->setCurrentIndex(1);
+    // Thetis: setup.designer.cs:34649 (comboDisplayLabelAlign) — rewritten
+    // Thetis original: "Sets the alignement of the grid callouts on the display."
+    m_freqLabelAlignCombo->setToolTip(QStringLiteral("Sets the alignment of the frequency labels on the grid callouts on the display."));
     connect(m_freqLabelAlignCombo, qOverload<int>(&QComboBox::currentIndexChanged),
             this, [this](int i) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
@@ -882,6 +895,9 @@ void GridScalesPage::buildUI()
     lblForm->addRow(QStringLiteral("Freq Label Align:"), m_freqLabelAlignCombo);
 
     m_zeroLineToggle = new QCheckBox(QStringLiteral("Show zero line"), lblGroup);
+    // Thetis: setup.designer.cs:3221 (chkShowZeroLine) — rewritten
+    // Thetis original: (none)
+    m_zeroLineToggle->setToolTip(QStringLiteral("Show a horizontal line at 0 dBm on the panadapter grid."));
     connect(m_zeroLineToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setShowZeroLine(on);
@@ -890,6 +906,8 @@ void GridScalesPage::buildUI()
     lblForm->addRow(QString(), m_zeroLineToggle);
 
     m_showFpsToggle = new QCheckBox(QStringLiteral("Show FPS overlay"), lblGroup);
+    // Thetis: setup.designer.cs:33177 (chkShowFPS)
+    m_showFpsToggle->setToolTip(QStringLiteral("Show FPS reading in top left of spectrum area"));
     connect(m_showFpsToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setShowFps(on);
@@ -917,21 +935,39 @@ void GridScalesPage::buildUI()
     };
 
     m_gridColorBtn     = makeBtn(colGroup, QColor(255, 255, 255, 40), &SpectrumWidget::setGridColor);
+    // Thetis: setup.designer.cs:3202 (clrbtnGrid) — rewritten
+    // Thetis original: (none)
+    m_gridColorBtn->setToolTip(QStringLiteral("Colour of the major vertical grid lines on the panadapter."));
     colForm->addRow(QStringLiteral("Grid Color:"), m_gridColorBtn);
 
     m_gridFineColorBtn = makeBtn(colGroup, QColor(255, 255, 255, 20), &SpectrumWidget::setGridFineColor);
+    // Thetis: setup.designer.cs:3198 (clrbtnGridFine) — rewritten
+    // Thetis original: (none)
+    m_gridFineColorBtn->setToolTip(QStringLiteral("Colour of the minor (fine) grid lines between major grid lines on the panadapter."));
     colForm->addRow(QStringLiteral("Grid Fine Color:"), m_gridFineColorBtn);
 
     m_hGridColorBtn    = makeBtn(colGroup, QColor(255, 255, 255, 40), &SpectrumWidget::setHGridColor);
+    // Thetis: setup.designer.cs:3193 (clrbtnHGridColor) — rewritten
+    // Thetis original: (none)
+    m_hGridColorBtn->setToolTip(QStringLiteral("Colour of the horizontal dB grid lines on the panadapter."));
     colForm->addRow(QStringLiteral("H-Grid Color:"), m_hGridColorBtn);
 
     m_gridTextColorBtn = makeBtn(colGroup, QColor(255, 255, 0), &SpectrumWidget::setGridTextColor);
+    // Thetis: setup.designer.cs:3206 (clrbtnText) — rewritten
+    // Thetis original: (none)
+    m_gridTextColorBtn->setToolTip(QStringLiteral("Colour of the frequency and dB labels drawn on the panadapter grid."));
     colForm->addRow(QStringLiteral("Text Color:"), m_gridTextColorBtn);
 
     m_zeroLineColorBtn = makeBtn(colGroup, QColor(255, 0, 0), &SpectrumWidget::setZeroLineColor);
+    // Thetis: setup.designer.cs:3204 (clrbtnZeroLine) — rewritten
+    // Thetis original: (none)
+    m_zeroLineColorBtn->setToolTip(QStringLiteral("Colour of the zero line (0 dBm marker) drawn on the panadapter when Show zero line is checked."));
     colForm->addRow(QStringLiteral("Zero Line Color:"), m_zeroLineColorBtn);
 
     m_bandEdgeColorBtn = makeBtn(colGroup, QColor(255, 0, 0), &SpectrumWidget::setBandEdgeColor);
+    // Thetis: setup.designer.cs:3232 (clrbtnBandEdge) — rewritten
+    // Thetis original: (none)
+    m_bandEdgeColorBtn->setToolTip(QStringLiteral("Colour of the band edge markers drawn at the amateur band boundaries on the panadapter."));
     colForm->addRow(QStringLiteral("Band Edge Color:"), m_bandEdgeColorBtn);
 
     contentLayout()->addWidget(colGroup);

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -210,7 +210,7 @@ void SpectrumDefaultsPage::buildUI()
     m_averagingCombo = new QComboBox(renderGroup);
     m_averagingCombo->addItems({QStringLiteral("None"), QStringLiteral("Weighted"),
                                 QStringLiteral("Logarithmic"), QStringLiteral("Time Window")});
-    // Thetis: setup.designer.cs (comboDispPanAveraging) — no upstream tooltip; rewritten
+    // Thetis: setup.designer.cs:34835 (comboDispPanAveraging) — no upstream tooltip; rewritten
     // Thetis original: (none)
     m_averagingCombo->setToolTip(QStringLiteral("Panadapter spectrum averaging mode. Weighted and Time Window smooth the display; None shows raw FFT output."));
     connect(m_averagingCombo, qOverload<int>(&QComboBox::currentIndexChanged),
@@ -226,8 +226,11 @@ void SpectrumDefaultsPage::buildUI()
     m_averagingTimeSpin->setSingleStep(10);
     m_averagingTimeSpin->setSuffix(QStringLiteral(" ms"));
     m_averagingTimeSpin->setValue(100);
-    // Thetis: setup.designer.cs:34902 (udDisplayAVGTime)
-    m_averagingTimeSpin->setToolTip(QStringLiteral("When averaging, use this number of buffers to calculate the average."));
+    // Thetis: setup.designer.cs:34902 (udDisplayAVGTime) — rewritten
+    // Thetis original: "When averaging, use this number of buffers to calculate the average."
+    // Rewritten because NereusSDR expresses this as a millisecond window that's
+    // converted to a smoothing alpha, not a discrete buffer count.
+    m_averagingTimeSpin->setToolTip(QStringLiteral("Duration of the averaging window in milliseconds. Longer = heavier smoothing, slower response to signal changes."));
     connect(m_averagingTimeSpin, qOverload<int>(&QSpinBox::valueChanged),
             this, [this](int ms) {
         // Translate ms to an alpha between 0.05 (slow) and 0.95 (fast).
@@ -287,8 +290,9 @@ void SpectrumDefaultsPage::buildUI()
     }
 
     m_gradientToggle = new QCheckBox(QStringLiteral("Trace gradient"), renderGroup);
-    // Thetis: setup.designer.cs:53918 (chkDataLineGradient)
-    m_gradientToggle->setToolTip(QStringLiteral("The data line is also uses the gradient if checked"));
+    // Thetis: setup.designer.cs:53918 (chkDataLineGradient) — rewritten (grammar fix)
+    // Thetis original: "The data line is also uses the gradient if checked"
+    m_gradientToggle->setToolTip(QStringLiteral("When checked, the spectrum trace line renders with the gradient colour applied."));
     connect(m_gradientToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setGradientEnabled(on);

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -160,6 +160,9 @@ void SpectrumDefaultsPage::buildUI()
                               QStringLiteral("4096"), QStringLiteral("8192"),
                               QStringLiteral("16384")});
     m_fftSizeCombo->setCurrentText(QStringLiteral("4096"));
+    // Thetis: setup.designer.cs:35043 (tbDisplayFFTSize) — no upstream tooltip; rewritten
+    // Thetis original: (none)
+    m_fftSizeCombo->setToolTip(QStringLiteral("FFT size used for spectrum analysis. Larger = finer frequency resolution at higher CPU cost."));
     connect(m_fftSizeCombo, &QComboBox::currentTextChanged,
             this, [this](const QString& txt) {
         if (model() && model()->fftEngine()) {
@@ -171,6 +174,8 @@ void SpectrumDefaultsPage::buildUI()
     m_windowCombo = new QComboBox(fftGroup);
     m_windowCombo->addItems({QStringLiteral("Blackman-Harris"), QStringLiteral("Hann"),
                              QStringLiteral("Hamming"),         QStringLiteral("Flat-Top")});
+    // NereusSDR extension — no Thetis equivalent (Thetis hardcodes Blackman-Harris 4-term)
+    m_windowCombo->setToolTip(QStringLiteral("FFT window function. Blackman-Harris offers best sidelobe rejection; Flat-Top is best for amplitude accuracy."));
     connect(m_windowCombo, qOverload<int>(&QComboBox::currentIndexChanged),
             this, [this](int i) {
         if (!model() || !model()->fftEngine()) { return; }
@@ -195,6 +200,9 @@ void SpectrumDefaultsPage::buildUI()
     {
         auto row = makeSliderRow(10, 60, 30, QStringLiteral(" fps"), renderGroup);
         m_fpSlider = row.slider;
+        // Thetis: setup.designer.cs:33856 (udDisplayFPS) — Thetis original: "Frames Per Second (approximate)" (placeholder); rewritten
+        m_fpSlider->setToolTip(QStringLiteral("Spectrum/waterfall redraw rate. Higher = smoother animation at cost of CPU."));
+        row.spin->setToolTip(QStringLiteral("Spectrum/waterfall redraw rate. Higher = smoother animation at cost of CPU."));
         connect(m_fpSlider, &QSlider::valueChanged, this, [this](int v) { pushFps(v); });
         renderForm->addRow(QStringLiteral("FPS:"), row.container);
     }
@@ -202,6 +210,9 @@ void SpectrumDefaultsPage::buildUI()
     m_averagingCombo = new QComboBox(renderGroup);
     m_averagingCombo->addItems({QStringLiteral("None"), QStringLiteral("Weighted"),
                                 QStringLiteral("Logarithmic"), QStringLiteral("Time Window")});
+    // Thetis: setup.designer.cs (comboDispPanAveraging) — no upstream tooltip; rewritten
+    // Thetis original: (none)
+    m_averagingCombo->setToolTip(QStringLiteral("Panadapter spectrum averaging mode. Weighted and Time Window smooth the display; None shows raw FFT output."));
     connect(m_averagingCombo, qOverload<int>(&QComboBox::currentIndexChanged),
             this, [this](int i) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
@@ -215,6 +226,8 @@ void SpectrumDefaultsPage::buildUI()
     m_averagingTimeSpin->setSingleStep(10);
     m_averagingTimeSpin->setSuffix(QStringLiteral(" ms"));
     m_averagingTimeSpin->setValue(100);
+    // Thetis: setup.designer.cs:34902 (udDisplayAVGTime)
+    m_averagingTimeSpin->setToolTip(QStringLiteral("When averaging, use this number of buffers to calculate the average."));
     connect(m_averagingTimeSpin, qOverload<int>(&QSpinBox::valueChanged),
             this, [this](int ms) {
         // Translate ms to an alpha between 0.05 (slow) and 0.95 (fast).
@@ -228,11 +241,14 @@ void SpectrumDefaultsPage::buildUI()
     m_decimationSpin = new QSpinBox(renderGroup);
     m_decimationSpin->setRange(1, 32);
     m_decimationSpin->setValue(1);
-    m_decimationSpin->setToolTip(QStringLiteral("Spectrum decimation factor (Thetis udDisplayDecimation parity)"));
+    // Thetis: setup.designer.cs:33732 (udDisplayDecimation)
+    m_decimationSpin->setToolTip(QStringLiteral("Display decimation. Higher the number, the lower the resolution."));
     // Scaffolded only — FFTEngine decimation hook deferred to a future phase.
     renderForm->addRow(QStringLiteral("Decimation:"), m_decimationSpin);
 
     m_fillToggle = new QCheckBox(QStringLiteral("Fill under trace"), renderGroup);
+    // Thetis: setup.designer.cs:33749 (chkDisplayPanFill)
+    m_fillToggle->setToolTip(QStringLiteral("Check to fill the panadapter display line below the data."));
     connect(m_fillToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setPanFillEnabled(on);
@@ -243,6 +259,10 @@ void SpectrumDefaultsPage::buildUI()
     {
         auto row = makeSliderRow(0, 100, 70, QStringLiteral("%"), renderGroup);
         m_fillAlphaSlider = row.slider;
+        // Thetis: setup.designer.cs:3215 (tbDataFillAlpha) — no upstream tooltip; rewritten
+        // Thetis original: (none)
+        m_fillAlphaSlider->setToolTip(QStringLiteral("Opacity of the fill area under the spectrum trace (0 = transparent, 100 = opaque)."));
+        row.spin->setToolTip(QStringLiteral("Opacity of the fill area under the spectrum trace (0 = transparent, 100 = opaque)."));
         connect(m_fillAlphaSlider, &QSlider::valueChanged, this, [this](int v) {
             if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
                 w->setFillAlpha(v / 100.0f);
@@ -254,6 +274,10 @@ void SpectrumDefaultsPage::buildUI()
     {
         auto row = makeSliderRow(1, 3, 1, QStringLiteral(" px"), renderGroup);
         m_lineWidthSlider = row.slider;
+        // Thetis: setup.designer.cs:3228 (udDisplayLineWidth) — no upstream tooltip; rewritten
+        // Thetis original: (none)
+        m_lineWidthSlider->setToolTip(QStringLiteral("Spectrum trace line width in pixels (1–3 px)."));
+        row.spin->setToolTip(QStringLiteral("Spectrum trace line width in pixels (1–3 px)."));
         connect(m_lineWidthSlider, &QSlider::valueChanged, this, [this](int v) {
             if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
                 w->setLineWidth(static_cast<float>(v));
@@ -263,6 +287,8 @@ void SpectrumDefaultsPage::buildUI()
     }
 
     m_gradientToggle = new QCheckBox(QStringLiteral("Trace gradient"), renderGroup);
+    // Thetis: setup.designer.cs:53918 (chkDataLineGradient)
+    m_gradientToggle->setToolTip(QStringLiteral("The data line is also uses the gradient if checked"));
     connect(m_gradientToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setGradientEnabled(on);
@@ -279,6 +305,9 @@ void SpectrumDefaultsPage::buildUI()
 
     const QColor initLine = sw ? sw->fillColor() : QColor(0x00, 0xe5, 0xff);
     m_dataLineColorBtn = new ColorSwatchButton(initLine, colorGroup);
+    // Thetis: setup.designer.cs:3234 (clrbtnDataLine) — no upstream tooltip; rewritten
+    // Thetis original: (none)
+    m_dataLineColorBtn->setToolTip(QStringLiteral("Click to choose the spectrum trace line colour."));
     connect(m_dataLineColorBtn, &ColorSwatchButton::colorChanged,
             this, [this](const QColor& c) {
         // SpectrumWidget currently uses one colour for both line and fill.
@@ -294,6 +323,10 @@ void SpectrumDefaultsPage::buildUI()
     {
         auto row = makeSliderRow(0, 255, 230, QString(), colorGroup);
         m_dataLineAlphaSlider = row.slider;
+        // Thetis: setup.designer.cs:3214 (tbDataLineAlpha) — no upstream tooltip; rewritten
+        // Thetis original: (none)
+        m_dataLineAlphaSlider->setToolTip(QStringLiteral("Opacity of the spectrum trace line (0 = invisible, 255 = fully opaque)."));
+        row.spin->setToolTip(QStringLiteral("Opacity of the spectrum trace line (0 = invisible, 255 = fully opaque)."));
         connect(m_dataLineAlphaSlider, &QSlider::valueChanged, this, [this](int a) {
             if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
                 QColor c = w->fillColor();
@@ -305,6 +338,9 @@ void SpectrumDefaultsPage::buildUI()
     }
 
     m_dataFillColorBtn = new ColorSwatchButton(initLine, colorGroup);
+    // Thetis: setup.designer.cs:3217 (clrbtnDataFill) — no upstream tooltip; rewritten
+    // Thetis original: (none)
+    m_dataFillColorBtn->setToolTip(QStringLiteral("Click to choose the spectrum fill area colour (applied under the trace when Fill is enabled)."));
     connect(m_dataFillColorBtn, &ColorSwatchButton::colorChanged,
             this, [this](const QColor& c) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
@@ -325,6 +361,9 @@ void SpectrumDefaultsPage::buildUI()
     m_calOffsetSpin->setSingleStep(0.5);
     m_calOffsetSpin->setSuffix(QStringLiteral(" dBm"));
     m_calOffsetSpin->setValue(0.0);
+    // Thetis: display.cs:1372 (Display.RX1DisplayCalOffset) — programmatic only, no designer tooltip; rewritten
+    // Thetis original: (none — set programmatically via Display.RX1DisplayCalOffset)
+    m_calOffsetSpin->setToolTip(QStringLiteral("dBm calibration offset applied to all displayed signal levels. Use to match a calibrated reference."));
     connect(m_calOffsetSpin, qOverload<double>(&QDoubleSpinBox::valueChanged),
             this, [this](double v) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
@@ -334,6 +373,8 @@ void SpectrumDefaultsPage::buildUI()
     calForm->addRow(QStringLiteral("Cal Offset:"), m_calOffsetSpin);
 
     m_peakHoldToggle = new QCheckBox(QStringLiteral("Peak hold"), calGroup);
+    // NereusSDR extension — no Thetis equivalent
+    m_peakHoldToggle->setToolTip(QStringLiteral("When enabled, the highest signal level seen at each frequency bin is held on the display."));
     connect(m_peakHoldToggle, &QCheckBox::toggled, this, [this](bool on) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
             w->setPeakHoldEnabled(on);
@@ -346,6 +387,8 @@ void SpectrumDefaultsPage::buildUI()
     m_peakHoldDelaySpin->setSingleStep(100);
     m_peakHoldDelaySpin->setSuffix(QStringLiteral(" ms"));
     m_peakHoldDelaySpin->setValue(2000);
+    // NereusSDR extension — no Thetis equivalent
+    m_peakHoldDelaySpin->setToolTip(QStringLiteral("Time in milliseconds before a held peak begins to decay back toward the live trace."));
     connect(m_peakHoldDelaySpin, qOverload<int>(&QSpinBox::valueChanged),
             this, [this](int v) {
         if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
@@ -368,6 +411,8 @@ void SpectrumDefaultsPage::buildUI()
         QStringLiteral("Highest")
     });
     m_threadPriorityCombo->setCurrentIndex(3);  // Above Normal (Thetis default)
+    // Thetis: setup.designer.cs:33165 (comboDisplayThreadPriority)
+    m_threadPriorityCombo->setToolTip(QStringLiteral("Set the priority of the display thread"));
     connect(m_threadPriorityCombo, qOverload<int>(&QComboBox::currentIndexChanged),
             this, [this](int i) {
         // Map Thetis 5-item ThreadPriority → QThread::Priority per §13 Q3.

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -1,4 +1,5 @@
 #include "DisplaySetupPages.h"
+#include "SetupHelpers.h"
 #include "gui/ColorSwatchButton.h"
 #include "gui/SpectrumWidget.h"
 #include "gui/StyleConstants.h"
@@ -191,11 +192,12 @@ void SpectrumDefaultsPage::buildUI()
     auto* renderForm  = new QFormLayout(renderGroup);
     renderForm->setSpacing(6);
 
-    m_fpSlider = new QSlider(Qt::Horizontal, renderGroup);
-    m_fpSlider->setRange(10, 60);
-    m_fpSlider->setValue(30);
-    connect(m_fpSlider, &QSlider::valueChanged, this, [this](int v) { pushFps(v); });
-    renderForm->addRow(QStringLiteral("FPS (10–60):"), m_fpSlider);
+    {
+        auto row = makeSliderRow(10, 60, 30, QStringLiteral(" fps"), renderGroup);
+        m_fpSlider = row.slider;
+        connect(m_fpSlider, &QSlider::valueChanged, this, [this](int v) { pushFps(v); });
+        renderForm->addRow(QStringLiteral("FPS:"), row.container);
+    }
 
     m_averagingCombo = new QComboBox(renderGroup);
     m_averagingCombo->addItems({QStringLiteral("None"), QStringLiteral("Weighted"),
@@ -238,25 +240,27 @@ void SpectrumDefaultsPage::buildUI()
     });
     renderForm->addRow(QString(), m_fillToggle);
 
-    m_fillAlphaSlider = new QSlider(Qt::Horizontal, renderGroup);
-    m_fillAlphaSlider->setRange(0, 100);
-    m_fillAlphaSlider->setValue(70);
-    connect(m_fillAlphaSlider, &QSlider::valueChanged, this, [this](int v) {
-        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
-            w->setFillAlpha(v / 100.0f);
-        }
-    });
-    renderForm->addRow(QStringLiteral("Fill Alpha:"), m_fillAlphaSlider);
+    {
+        auto row = makeSliderRow(0, 100, 70, QStringLiteral("%"), renderGroup);
+        m_fillAlphaSlider = row.slider;
+        connect(m_fillAlphaSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setFillAlpha(v / 100.0f);
+            }
+        });
+        renderForm->addRow(QStringLiteral("Fill Alpha:"), row.container);
+    }
 
-    m_lineWidthSlider = new QSlider(Qt::Horizontal, renderGroup);
-    m_lineWidthSlider->setRange(1, 3);
-    m_lineWidthSlider->setValue(1);
-    connect(m_lineWidthSlider, &QSlider::valueChanged, this, [this](int v) {
-        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
-            w->setLineWidth(static_cast<float>(v));
-        }
-    });
-    renderForm->addRow(QStringLiteral("Line Width:"), m_lineWidthSlider);
+    {
+        auto row = makeSliderRow(1, 3, 1, QStringLiteral(" px"), renderGroup);
+        m_lineWidthSlider = row.slider;
+        connect(m_lineWidthSlider, &QSlider::valueChanged, this, [this](int v) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                w->setLineWidth(static_cast<float>(v));
+            }
+        });
+        renderForm->addRow(QStringLiteral("Line Width:"), row.container);
+    }
 
     m_gradientToggle = new QCheckBox(QStringLiteral("Trace gradient"), renderGroup);
     connect(m_gradientToggle, &QCheckBox::toggled, this, [this](bool on) {
@@ -287,17 +291,18 @@ void SpectrumDefaultsPage::buildUI()
     });
     colorForm->addRow(QStringLiteral("Data Line Color:"), m_dataLineColorBtn);
 
-    m_dataLineAlphaSlider = new QSlider(Qt::Horizontal, colorGroup);
-    m_dataLineAlphaSlider->setRange(0, 255);
-    m_dataLineAlphaSlider->setValue(230);
-    connect(m_dataLineAlphaSlider, &QSlider::valueChanged, this, [this](int a) {
-        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
-            QColor c = w->fillColor();
-            c.setAlpha(a);
-            w->setFillColor(c);
-        }
-    });
-    colorForm->addRow(QStringLiteral("Line Alpha:"), m_dataLineAlphaSlider);
+    {
+        auto row = makeSliderRow(0, 255, 230, QString(), colorGroup);
+        m_dataLineAlphaSlider = row.slider;
+        connect(m_dataLineAlphaSlider, &QSlider::valueChanged, this, [this](int a) {
+            if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+                QColor c = w->fillColor();
+                c.setAlpha(a);
+                w->setFillColor(c);
+            }
+        });
+        colorForm->addRow(QStringLiteral("Line Alpha:"), row.container);
+    }
 
     m_dataFillColorBtn = new ColorSwatchButton(initLine, colorGroup);
     connect(m_dataFillColorBtn, &ColorSwatchButton::colorChanged,

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -571,8 +571,8 @@ void WaterfallDefaultsPage::buildUI()
         auto row = makeSliderRow(10, 500, 50, QStringLiteral(" ms"), dispGroup);
         m_updatePeriodSlider = row.slider;
         // Thetis: setup.designer.cs:34145 (udDisplayWaterfallUpdatePeriod)
-        m_updatePeriodSlider->setToolTip(QStringLiteral("How often to update (scroll another pixel line) on the waterfall display. Note that this is tamed by the FPS setting."));
-        row.spin->setToolTip(QStringLiteral("How often to update (scroll another pixel line) on the waterfall display. Note that this is tamed by the FPS setting."));
+        m_updatePeriodSlider->setToolTip(QStringLiteral("How often to update (scroll another pixel line) on the waterfall display.  Note that this is tamed by the FPS setting."));
+        row.spin->setToolTip(QStringLiteral("How often to update (scroll another pixel line) on the waterfall display.  Note that this is tamed by the FPS setting."));
         connect(m_updatePeriodSlider, &QSlider::valueChanged, this, [this](int v) {
             if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
                 w->setWfUpdatePeriodMs(v);

--- a/src/gui/setup/SetupHelpers.cpp
+++ b/src/gui/setup/SetupHelpers.cpp
@@ -1,12 +1,96 @@
 #include "SetupHelpers.h"
 
+#include <cmath>
+
+#include <QHBoxLayout>
+#include <QDoubleSpinBox>
+#include <QSignalBlocker>
 #include <QSlider>
 #include <QSpinBox>
-#include <QDoubleSpinBox>
-#include <QHBoxLayout>
+#include <QWidget>
 
 namespace NereusSDR {
 
-// Intentionally empty — filled in by Task 2.
+SliderRow makeSliderRow(int min, int max, int initial,
+                        const QString& suffix,
+                        QWidget* parent)
+{
+    auto* container = new QWidget(parent);
+    auto* layout    = new QHBoxLayout(container);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(8);
+
+    auto* slider = new QSlider(Qt::Horizontal, container);
+    slider->setRange(min, max);
+    slider->setValue(initial);
+
+    auto* spin = new QSpinBox(container);
+    spin->setRange(min, max);
+    spin->setValue(initial);
+    spin->setSuffix(suffix);
+    spin->setFixedWidth(80);
+    spin->setAlignment(Qt::AlignRight);
+
+    // Bidirectional sync. QSignalBlocker on the opposite widget prevents the
+    // receiver from re-emitting and creating an infinite loop. Consumers of
+    // the row should connect to slider->valueChanged as the single source of
+    // truth for model updates.
+    QObject::connect(slider, &QSlider::valueChanged, spin, [spin](int v) {
+        QSignalBlocker block(spin);
+        spin->setValue(v);
+    });
+    QObject::connect(spin, qOverload<int>(&QSpinBox::valueChanged),
+                     slider, [slider](int v) {
+        QSignalBlocker block(slider);
+        slider->setValue(v);
+    });
+
+    layout->addWidget(slider, /*stretch=*/1);
+    layout->addWidget(spin,   /*stretch=*/0);
+
+    return { slider, spin, container };
+}
+
+SliderRowD makeDoubleSliderRow(double min, double max, double initial,
+                               int decimals,
+                               const QString& suffix,
+                               QWidget* parent)
+{
+    const int scale = static_cast<int>(std::pow(10, decimals));
+
+    auto* container = new QWidget(parent);
+    auto* layout    = new QHBoxLayout(container);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(8);
+
+    auto* slider = new QSlider(Qt::Horizontal, container);
+    slider->setRange(static_cast<int>(min * scale),
+                     static_cast<int>(max * scale));
+    slider->setValue(static_cast<int>(initial * scale));
+
+    auto* spin = new QDoubleSpinBox(container);
+    spin->setDecimals(decimals);
+    spin->setRange(min, max);
+    spin->setValue(initial);
+    spin->setSuffix(suffix);
+    spin->setSingleStep(1.0 / scale);
+    spin->setFixedWidth(90);
+    spin->setAlignment(Qt::AlignRight);
+
+    QObject::connect(slider, &QSlider::valueChanged, spin, [spin, scale](int v) {
+        QSignalBlocker block(spin);
+        spin->setValue(static_cast<double>(v) / scale);
+    });
+    QObject::connect(spin, qOverload<double>(&QDoubleSpinBox::valueChanged),
+                     slider, [slider, scale](double v) {
+        QSignalBlocker block(slider);
+        slider->setValue(static_cast<int>(v * scale));
+    });
+
+    layout->addWidget(slider, 1);
+    layout->addWidget(spin,   0);
+
+    return { slider, spin, container };
+}
 
 } // namespace NereusSDR

--- a/src/gui/setup/SetupHelpers.cpp
+++ b/src/gui/setup/SetupHelpers.cpp
@@ -1,0 +1,12 @@
+#include "SetupHelpers.h"
+
+#include <QSlider>
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+#include <QHBoxLayout>
+
+namespace NereusSDR {
+
+// Intentionally empty — filled in by Task 2.
+
+} // namespace NereusSDR

--- a/src/gui/setup/SetupHelpers.cpp
+++ b/src/gui/setup/SetupHelpers.cpp
@@ -11,6 +11,15 @@
 
 namespace NereusSDR {
 
+// Spinbox widths tuned to fit the widest expected value + suffix without
+// clipping. Int spinboxes handle up to "-200 dBm" in ~80px; double spinboxes
+// reserve an extra 10px for the decimal point and fractional digit.
+// Spinboxes inherit the dark-theme stylesheet from the parent Setup page
+// (see applyDarkStyle() in DisplaySetupPages.cpp) via Qt QSS inheritance,
+// so no per-widget styling is needed in the factory.
+static constexpr int kSetupSpinWidth  = 80;
+static constexpr int kSetupSpinWidthD = 90;
+
 SliderRow makeSliderRow(int min, int max, int initial,
                         const QString& suffix,
                         QWidget* parent)
@@ -28,7 +37,7 @@ SliderRow makeSliderRow(int min, int max, int initial,
     spin->setRange(min, max);
     spin->setValue(initial);
     spin->setSuffix(suffix);
-    spin->setFixedWidth(80);
+    spin->setFixedWidth(kSetupSpinWidth);
     spin->setAlignment(Qt::AlignRight);
 
     // Bidirectional sync. QSignalBlocker on the opposite widget prevents the
@@ -74,7 +83,7 @@ SliderRowD makeDoubleSliderRow(double min, double max, double initial,
     spin->setValue(initial);
     spin->setSuffix(suffix);
     spin->setSingleStep(1.0 / scale);
-    spin->setFixedWidth(90);
+    spin->setFixedWidth(kSetupSpinWidthD);
     spin->setAlignment(Qt::AlignRight);
 
     QObject::connect(slider, &QSlider::valueChanged, spin, [spin, scale](int v) {

--- a/src/gui/setup/SetupHelpers.h
+++ b/src/gui/setup/SetupHelpers.h
@@ -17,17 +17,17 @@ namespace NereusSDR {
 
 // Integer slider + QSpinBox pair.
 struct SliderRow {
-    QSlider*  slider;
-    QSpinBox* spin;
-    QWidget*  container;  // HBox with slider + spin, ready to drop into a form layout
+    QSlider*  slider    = nullptr;
+    QSpinBox* spin      = nullptr;
+    QWidget*  container = nullptr;  // HBox with slider + spin, ready to drop into a form layout
 };
 
 // Double slider + QDoubleSpinBox pair. Slider operates in integer units
 // scaled by 10^decimals under the hood.
 struct SliderRowD {
-    QSlider*        slider;
-    QDoubleSpinBox* spin;
-    QWidget*        container;
+    QSlider*        slider    = nullptr;
+    QDoubleSpinBox* spin      = nullptr;
+    QWidget*        container = nullptr;  // HBox with slider + spin, ready to drop into a form layout
 };
 
 // Build an int slider+spinbox row. The slider and spinbox are wired

--- a/src/gui/setup/SetupHelpers.h
+++ b/src/gui/setup/SetupHelpers.h
@@ -6,9 +6,9 @@
 //
 // Bidirectional sync uses QSignalBlocker to prevent signal feedback loops.
 
-#include <QWidget>
 #include <QString>
 
+class QWidget;
 class QSlider;
 class QSpinBox;
 class QDoubleSpinBox;

--- a/src/gui/setup/SetupHelpers.h
+++ b/src/gui/setup/SetupHelpers.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// Setup page factory helpers — produce prewired slider+spinbox rows so every
+// numeric control in the Setup dialog has a live readout and supports both
+// mouse and keyboard entry without copy-pasted boilerplate.
+//
+// Bidirectional sync uses QSignalBlocker to prevent signal feedback loops.
+
+#include <QWidget>
+#include <QString>
+
+class QSlider;
+class QSpinBox;
+class QDoubleSpinBox;
+
+namespace NereusSDR {
+
+// Integer slider + QSpinBox pair.
+struct SliderRow {
+    QSlider*  slider;
+    QSpinBox* spin;
+    QWidget*  container;  // HBox with slider + spin, ready to drop into a form layout
+};
+
+// Double slider + QDoubleSpinBox pair. Slider operates in integer units
+// scaled by 10^decimals under the hood.
+struct SliderRowD {
+    QSlider*        slider;
+    QDoubleSpinBox* spin;
+    QWidget*        container;
+};
+
+// Build an int slider+spinbox row. The slider and spinbox are wired
+// bidirectionally via QSignalBlocker so dragging the slider updates the
+// spinbox value without retriggering the slider's valueChanged signal,
+// and typing into the spinbox updates the slider without retriggering
+// the spinbox's valueChanged signal. Consumers connect to slider->valueChanged
+// (one source of truth) to drive model updates.
+//
+// Arguments:
+//   min, max, initial — range and start value
+//   suffix            — unit string appended in the spinbox (" dBm", "%", etc.)
+//   parent            — ownership of the returned container widget
+SliderRow makeSliderRow(int min, int max, int initial,
+                        const QString& suffix = QString(),
+                        QWidget* parent = nullptr);
+
+// Double variant. decimals controls the spinbox's decimal places and the
+// slider's internal integer granularity (step = 10^-decimals in user space).
+SliderRowD makeDoubleSliderRow(double min, double max, double initial,
+                               int decimals,
+                               const QString& suffix = QString(),
+                               QWidget* parent = nullptr);
+
+} // namespace NereusSDR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ function(nereus_add_test name)
 endfunction()
 
 # ── Pre-existing tests from main (smoke + 3G-9 meter suite) ────────────────
+nereus_add_test(tst_setup_helpers)
 nereus_add_test(tst_smoke)
 nereus_add_test(tst_container_persistence)
 nereus_add_test(tst_meter_item_bar)

--- a/tests/tst_setup_helpers.cpp
+++ b/tests/tst_setup_helpers.cpp
@@ -1,0 +1,111 @@
+// tst_setup_helpers.cpp
+//
+// Phase 3G-9a — unit smoke for SetupHelpers factory functions. Verifies
+// bidirectional slider↔spinbox sync without signal feedback loops and that
+// returned widgets match the requested range/initial/suffix.
+
+#include <QtTest/QtTest>
+#include <QSlider>
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+#include <QSignalSpy>
+
+#include "gui/setup/SetupHelpers.h"
+
+using namespace NereusSDR;
+
+class TestSetupHelpers : public QObject {
+    Q_OBJECT
+private slots:
+
+    // --- makeSliderRow (int) -------------------------------------------------
+
+    void sliderRow_honorsRangeAndInitial()
+    {
+        SliderRow row = makeSliderRow(10, 60, 30, QStringLiteral(" fps"));
+        QVERIFY(row.slider);
+        QVERIFY(row.spin);
+        QVERIFY(row.container);
+
+        QCOMPARE(row.slider->minimum(), 10);
+        QCOMPARE(row.slider->maximum(), 60);
+        QCOMPARE(row.slider->value(),   30);
+
+        QCOMPARE(row.spin->minimum(), 10);
+        QCOMPARE(row.spin->maximum(), 60);
+        QCOMPARE(row.spin->value(),   30);
+        QCOMPARE(row.spin->suffix(),  QStringLiteral(" fps"));
+
+        delete row.container;
+    }
+
+    void sliderRow_sliderDragUpdatesSpinbox()
+    {
+        SliderRow row = makeSliderRow(0, 100, 50);
+        row.slider->setValue(77);
+        QCOMPARE(row.spin->value(), 77);
+        delete row.container;
+    }
+
+    void sliderRow_spinboxEntryUpdatesSlider()
+    {
+        SliderRow row = makeSliderRow(0, 100, 50);
+        row.spin->setValue(22);
+        QCOMPARE(row.slider->value(), 22);
+        delete row.container;
+    }
+
+    void sliderRow_noFeedbackLoop()
+    {
+        // Dragging the slider must emit slider->valueChanged exactly once,
+        // not bounce back through the spinbox and emit again.
+        SliderRow row = makeSliderRow(0, 100, 50);
+        QSignalSpy spy(row.slider, &QSlider::valueChanged);
+        row.slider->setValue(60);
+        QCOMPARE(spy.count(), 1);
+
+        // And typing into the spinbox must emit spin->valueChanged exactly once.
+        QSignalSpy spinSpy(row.spin, qOverload<int>(&QSpinBox::valueChanged));
+        row.spin->setValue(70);
+        QCOMPARE(spinSpy.count(), 1);
+
+        delete row.container;
+    }
+
+    // --- makeDoubleSliderRow -------------------------------------------------
+
+    void doubleSliderRow_honorsRangeAndDecimals()
+    {
+        SliderRowD row = makeDoubleSliderRow(-30.0, 30.0, 0.0, 1, QStringLiteral(" dBm"));
+        QVERIFY(row.slider);
+        QVERIFY(row.spin);
+
+        QCOMPARE(row.spin->minimum(),  -30.0);
+        QCOMPARE(row.spin->maximum(),   30.0);
+        QCOMPARE(row.spin->value(),      0.0);
+        QCOMPARE(row.spin->decimals(),   1);
+        QCOMPARE(row.spin->suffix(),   QStringLiteral(" dBm"));
+
+        // Slider granularity is 10^decimals = 10 units per unit.
+        QCOMPARE(row.slider->minimum(), -300);
+        QCOMPARE(row.slider->maximum(),  300);
+        QCOMPARE(row.slider->value(),     0);
+
+        delete row.container;
+    }
+
+    void doubleSliderRow_bidirectionalSync()
+    {
+        SliderRowD row = makeDoubleSliderRow(-30.0, 30.0, 0.0, 1);
+        row.spin->setValue(12.5);
+        QCOMPARE(row.slider->value(), 125);
+
+        row.slider->setValue(-75);
+        QCOMPARE(row.spin->value(), -7.5);
+
+        delete row.container;
+    }
+};
+
+QTEST_MAIN(TestSetupHelpers)
+#include "tst_setup_helpers.moc"


### PR DESCRIPTION
# Phase 3G-9a — Source-First Audit + Tooltips + Slider Readouts

First of three PRs under Phase 3G-9 (Display Refactor). Closes the polish gap left by 3G-8: every Display control now has a Thetis source citation, a tooltip, and — for sliders — a bidirectional numeric spinbox companion.

**Design spec:** `docs/architecture/2026-04-15-display-refactor-design.md` §4
**Implementation plan:** `docs/architecture/2026-04-15-phase3g9a-display-audit-plan.md`

## What

### New `SetupHelpers` factory (Tasks 1–2)

`src/gui/setup/SetupHelpers.{h,cpp}` exposes two factory functions:

```cpp
SliderRow  makeSliderRow(int min, int max, int initial,
                         const QString& suffix = {}, QWidget* parent = nullptr);
SliderRowD makeDoubleSliderRow(double min, double max, double initial,
                               int decimals, const QString& suffix = {},
                               QWidget* parent = nullptr);
```

Each returns a `{slider, spin, container}` POD. The slider and spinbox are wired bidirectionally via `QSignalBlocker` guards against feedback loops. Consumers connect to `slider->valueChanged` as the single source of truth for model updates. Spinbox carries the unit suffix (` fps`, ` dBm`, `%`, ` ms`, ` px`). Spinboxes inherit the dark-theme stylesheet from the parent Setup page via Qt QSS cascade — no per-widget styling needed.

### Slider refactor (Tasks 3–4)

All 8 numeric sliders across `SpectrumDefaultsPage` and `WaterfallDefaultsPage` converted to use `makeSliderRow()`:

**Spectrum:** `m_fpSlider`, `m_fillAlphaSlider`, `m_lineWidthSlider`, `m_dataLineAlphaSlider`
**Waterfall:** `m_highThresholdSlider`, `m_lowThresholdSlider`, `m_updatePeriodSlider`, `m_opacitySlider`

Lambda bodies preserved byte-for-byte. `loadFromRenderer()` continues to work unchanged because each `m_xSlider` member still points at the slider half of the row.

### Tooltips + Thetis citations (Tasks 5–7)

Every control on all three pages (`SpectrumDefaultsPage`, `WaterfallDefaultsPage`, `GridScalesPage`) now has:

- A `// Thetis: setup.designer.cs:NNNN (controlName)` source-first citation comment, *or* `// NereusSDR extension — no Thetis equivalent` for the 6 extensions (FFT Window, Peak Hold + Delay, Reverse Scroll, Timestamp Position, Timestamp Mode).
- A `setToolTip(...)` call. **Verbatim** from Thetis where the upstream is substantive, **rewritten** where Thetis was empty / placeholder / label echo / grammar broken / unit mismatch (with the original recorded inline as `// Thetis original: "..."`), or **written from scratch** for the 6 extensions.
- For sliders, the tooltip is set on **both** the `QSlider` and its `QSpinBox` companion so hovering either half of the row shows the same text.

**Coverage:** 47 controls, 47 tooltips, 47 citation blocks. `setToolTip` count in `DisplaySetupPages.cpp`: **10 → 62** (sliders contribute 2 each).

## Why

Phase 3G-8 shipped working wire-up for every Display control. This PR closes the polish gap that audit found:
- Most controls had no tooltip (10/47)
- No source-first citations meant readers had to grep Thetis themselves to verify any given control
- Sliders were mouse-only with no value readout — keyboard users couldn't enter exact values, and you couldn't tell at a glance what the current setting was

## Testing

- New `tst_setup_helpers` (6 QtTest slots): range/initial/suffix honor, bidirectional slider→spinbox, bidirectional spinbox→slider, no-feedback-loop (QSignalSpy verifies exactly one emit per setValue), double-precision scaling via 10^decimals, double bidirectional sync. **6/6 green.**
- Full test suite: **16/18 green.** The 2 failures (`tst_p1_wire_format`, `tst_p1_loopback_connection`) are **pre-existing on `main`** and unrelated to PR1 — verified by checking out `main` and rerunning. PR1 touches zero P1 code.
- Manual smoke across all three Display setup pages: every slider drag updates its spinbox, every spinbox entry updates its slider, every control hover shows a sensible tooltip, every connect target still fires (FPS visibly changes spectrum frame rate, fill alpha visibly changes opacity, threshold sliders visibly retune the waterfall, etc.).

## Scope

**In:** `SpectrumDefaultsPage`, `WaterfallDefaultsPage`, `GridScalesPage`. 47 controls.
**Out (deferred to later phases):** RX2 Display, TX Display, Spectrum Overlay flyouts, meter editors. Spec §2.

## Next

- **PR2 (3G-9b)** — smooth defaults + Clarity Blue waterfall palette + tuning rationale doc.
- **PR3 (3G-9c)** — `Clarity` adaptive display tuning, gated by a research doc.

## Commit sequence

11 GPG-signed commits:

| Commit | Subject |
|---|---|
| `f71ec1e` | feat(setup): scaffold SetupHelpers.h/.cpp for slider readout factory |
| `3778670` | fix(setup): SetupHelpers.h forward-declares QWidget; enable compile_commands.json |
| `0c0805a` | feat(setup): implement SliderRow + SliderRowD factories with TDD |
| `6103292` | refactor(setup): name spinbox widths as constants; document style inheritance |
| `d392027` | refactor(setup): SpectrumDefaultsPage uses SliderRow helpers |
| `7e124c5` | refactor(setup): WaterfallDefaultsPage uses SliderRow helpers |
| `b624f0b` | feat(setup): tooltips + Thetis citations for SpectrumDefaultsPage |
| `3250389` | fix(setup): Task 5 tooltip review findings |
| `535925e` | feat(setup): tooltips + Thetis citations for WaterfallDefaultsPage |
| `bee6559` | fix(setup): restore double-space in updatePeriod verbatim tooltip |
| `125027d` | feat(setup): tooltips + Thetis citations for GridScalesPage |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

JJ Boyd ~KG4VCF
Co-Authored with Claude Code
