### PR TITLE
Phase 3G-9c: Clarity adaptive waterfall tuning (PR3 of 3)

### DIFF
--- a/docs/architecture/waterfall-tuning.md
+++ b/docs/architecture/waterfall-tuning.md
@@ -154,15 +154,22 @@ Tuning the palette against a band dominated by narrow carriers (CW, digital, unm
 
 **Recommended test content:** 80m SSB at night, 40m SSB evenings, 20m SSB daytime.
 
-## Open questions for PR3 (Clarity adaptive)
+## Clarity adaptive tuning (PR3 — Phase 3G-9c, resolved)
 
-PR3 builds an adaptive auto-tune system (`Clarity`) on top of these static defaults. Open questions at the time of this doc:
+PR3 shipped `ClarityController` as an **add-on** to the existing Waterfall AGC, not a replacement. Both coexist:
 
-- Does Waterfall AGC (§6 here) get superseded by Clarity's noise-floor estimator? Likely yes — Clarity's percentile-based estimator is more robust than running min/max AGC (which pumps badly on strong carriers), and having both produces conflicting behaviour.
-- Should the static defaults in §5 be replaced by adaptive initial values? Probably keep them as the fallback when Clarity is off.
-- The AGC margin (12 dB here) should probably be user-configurable in PR3 — or replaced entirely by Clarity's deadband mechanism.
+- **Waterfall AGC on, Clarity off** — legacy running-min/max one-pole follower with 12 dB margin (PR2 behavior, unchanged).
+- **Clarity on** — percentile-based noise-floor estimator (30th percentile, EWMA τ=3s, ±2 dB deadband) drives Waterfall Low/High thresholds. Legacy AGC yields via `m_clarityActive` flag in `pushWaterfallRow()`.
+- **Clarity paused** (TX, manual slider drag) — legacy AGC resumes if its checkbox is on.
+- **Both off** — thresholds are purely user-set (manual mode).
 
-See `docs/architecture/2026-04-15-display-refactor-design.md` §6 for the PR3 design.
+Resolved open questions from the PR2 draft:
+
+1. **Does Clarity supersede Waterfall AGC?** No — they coexist. Clarity takes priority when active; AGC runs when Clarity is off or paused. User chooses their preferred mode.
+2. **Should PR2 static defaults be replaced by adaptive initial values?** No — the smooth-defaults profile stays as the fallback when Clarity is off. Clarity sits on top.
+3. **AGC margin (12 dB) user-configurable?** Not in PR3 — the margin stays at 12 dB for the legacy AGC path. Clarity uses its own threshold margins (-5 / +55 dB around the smoothed floor, 60 dB total range) with a 30 dB minimum-gap clamp for empty bands.
+
+See `docs/architecture/2026-04-15-display-refactor-design.md` §6 for the full PR3 design.
 
 ## Related follow-ups flagged during PR2 tuning
 

--- a/src/core/ClarityController.cpp
+++ b/src/core/ClarityController.cpp
@@ -14,12 +14,27 @@ ClarityController::ClarityController(QObject* parent)
 
 void ClarityController::setEnabled(bool on)
 {
+    if (m_enabled == on) { return; }
     m_enabled = on;
+    if (on) {
+        // P1 fix: reset deadband state so the next frame unconditionally
+        // emits — otherwise an off→on cycle on a stable band leaves
+        // m_clarityActive false because the deadband suppresses re-emission.
+        m_hasEmitted  = false;
+        m_hasSmoothed = false;
+    }
 }
 
 void ClarityController::setTransmitting(bool tx)
 {
+    if (m_transmitting == tx) { return; }
     m_transmitting = tx;
+    // P2 fix: emit pausedChanged so MainWindow can clear m_clarityActive
+    // on TX and let legacy AGC resume. Without this, setTransmitting
+    // silently suppresses feedBins but nothing tells SpectrumWidget.
+    if (m_enabled) {
+        emit pausedChanged(tx);
+    }
 }
 
 void ClarityController::notifyManualOverride()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -323,12 +323,14 @@ void MainWindow::buildUI()
     m_clarityController = new ClarityController(this);
     m_radioModel->setClarityController(m_clarityController);
 
-    // Restore enabled state from AppSettings
+    // Restore enabled state from AppSettings + sync the clarityActive
+    // flag on SpectrumWidget so legacy AGC knows to stand down.
     {
         auto& s = AppSettings::instance();
         bool clarityOn = s.value(QStringLiteral("ClarityEnabled"), QStringLiteral("False"))
                             .toString() == QStringLiteral("True");
         m_clarityController->setEnabled(clarityOn);
+        m_spectrumWidget->setClarityActive(clarityOn);
     }
 
     // Feed FFT bins to Clarity (auto-queued: spectrum thread → main)
@@ -341,11 +343,20 @@ void MainWindow::buildUI()
     connect(&m_radioModel->transmitModel(), &TransmitModel::moxChanged,
             m_clarityController, &ClarityController::setTransmitting);
 
-    // Clarity → SpectrumWidget threshold update
+    // Clarity → SpectrumWidget threshold update + clarityActive flag
     connect(m_clarityController, &ClarityController::waterfallThresholdsChanged,
             m_spectrumWidget, [this](float low, float high) {
+        m_spectrumWidget->setClarityActive(true);
         m_spectrumWidget->setWfLowThreshold(low);
         m_spectrumWidget->setWfHighThreshold(high);
+    });
+
+    // When Clarity pauses or is disabled, let legacy AGC resume.
+    connect(m_clarityController, &ClarityController::pausedChanged,
+            m_spectrumWidget, [this](bool paused) {
+        if (paused) {
+            m_spectrumWidget->setClarityActive(false);
+        }
     });
 
     // Wire: zoom changes → adjust FFT size for appropriate bin resolution

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -359,6 +359,22 @@ void MainWindow::buildUI()
         }
     });
 
+    // Clarity ↔ overlay panel: badge + Re-tune button (wired after
+    // m_overlayPanel creation in buildUI, which runs before this point).
+    if (m_overlayPanel) {
+        connect(m_clarityController, &ClarityController::waterfallThresholdsChanged,
+                m_overlayPanel, [this](float, float) {
+            m_overlayPanel->setClarityStatus(/*active=*/true, /*paused=*/false);
+        });
+        connect(m_clarityController, &ClarityController::pausedChanged,
+                m_overlayPanel, [this](bool paused) {
+            bool enabled = m_clarityController->isEnabled();
+            m_overlayPanel->setClarityStatus(enabled, paused);
+        });
+        connect(m_overlayPanel, &SpectrumOverlayPanel::clarityRetuneRequested,
+                m_clarityController, &ClarityController::retuneNow);
+    }
+
     // Wire: zoom changes → adjust FFT size for appropriate bin resolution
     // Target: ~500-1000 bins across the visible bandwidth for good detail
     connect(m_spectrumWidget, &SpectrumWidget::bandwidthChangeRequested,

--- a/src/gui/SpectrumOverlayPanel.cpp
+++ b/src/gui/SpectrumOverlayPanel.cpp
@@ -907,7 +907,7 @@ void SpectrumOverlayPanel::buildDisplayFlyout()
         m_clarityBadge->setFixedSize(18, 18);
         m_clarityBadge->setAlignment(Qt::AlignCenter);
         m_clarityBadge->setToolTip("Clarity status: green = active, amber = paused");
-        m_clarityBadge->hide();  // hidden until Clarity is enabled
+        m_clarityBadge->hide();
         grid->addWidget(m_clarityBadge, row, 1);
 
         m_clarityRetuneBtn = new QPushButton("Re-tune");

--- a/src/gui/SpectrumOverlayPanel.cpp
+++ b/src/gui/SpectrumOverlayPanel.cpp
@@ -897,6 +897,33 @@ void SpectrumOverlayPanel::buildDisplayFlyout()
         ++row;
     }
 
+    // Phase 3G-9c: Clarity adaptive tuning — status badge + Re-tune button
+    {
+        auto* lbl = new QLabel("Clarity:");
+        lbl->setStyleSheet(labelStyle);
+        grid->addWidget(lbl, row, 0);
+
+        m_clarityBadge = new QLabel("C");
+        m_clarityBadge->setFixedSize(18, 18);
+        m_clarityBadge->setAlignment(Qt::AlignCenter);
+        m_clarityBadge->setToolTip("Clarity status: green = active, amber = paused");
+        m_clarityBadge->hide();  // hidden until Clarity is enabled
+        grid->addWidget(m_clarityBadge, row, 1);
+
+        m_clarityRetuneBtn = new QPushButton("Re-tune");
+        m_clarityRetuneBtn->setFixedSize(52, 18);
+        m_clarityRetuneBtn->setStyleSheet(
+            "QPushButton { background: #1a3050; color: #c8d8e8; border: 1px solid #304050;"
+            "  border-radius: 2px; font-size: 10px; padding: 0; }"
+            "QPushButton:hover { background: #254060; }"
+            "QPushButton:pressed { background: #0d2040; }");
+        m_clarityRetuneBtn->setToolTip("Force Clarity to re-estimate the noise floor now");
+        grid->addWidget(m_clarityRetuneBtn, row, 2, 1, 2, Qt::AlignRight);
+        connect(m_clarityRetuneBtn, &QPushButton::clicked,
+                this, &SpectrumOverlayPanel::clarityRetuneRequested);
+        ++row;
+    }
+
     // Separator
     {
         auto* sep = new QFrame;
@@ -1088,6 +1115,25 @@ void SpectrumOverlayPanel::repositionZoomButtons()
     y = std::max(kMargin, y);
     m_zoomStrip->move(x, y);
     m_zoomStrip->raise();
+}
+
+// ── Clarity status badge (Phase 3G-9c) ───────────────────────────────────────
+
+void SpectrumOverlayPanel::setClarityStatus(bool active, bool paused)
+{
+    if (!m_clarityBadge) { return; }
+    if (!active && !paused) {
+        m_clarityBadge->hide();
+        return;
+    }
+    const QString color = paused
+        ? QStringLiteral("#d4a017")   // amber
+        : QStringLiteral("#22b14c");  // green
+    m_clarityBadge->setStyleSheet(
+        QStringLiteral("QLabel { background: %1; color: #0f0f1a; "
+                        "border-radius: 9px; font-size: 11px; "
+                        "font-weight: bold; }").arg(color));
+    m_clarityBadge->show();
 }
 
 } // namespace NereusSDR

--- a/src/gui/SpectrumOverlayPanel.h
+++ b/src/gui/SpectrumOverlayPanel.h
@@ -52,6 +52,9 @@ signals:
     // Collapse
     void collapsed(bool isCollapsed);
 
+    // Clarity adaptive tuning (Phase 3G-9c)
+    void clarityRetuneRequested();
+
     // NYI placeholders
     void addRxClicked();
     void addTnfClicked();
@@ -66,6 +69,10 @@ public:
     // Reposition zoom buttons to bottom-left of parent spectrum widget.
     // Must be called after parent resize.
     void repositionZoomButtons();
+
+    // Phase 3G-9c: update the Clarity status badge.
+    // active=true → green "C", paused=true → amber "C", both false → hidden.
+    void setClarityStatus(bool active, bool paused);
 
 private:
     // Layout
@@ -140,6 +147,10 @@ private:
     QSlider*     m_noiseFloorSlider{nullptr};
     QLabel*      m_noiseFloorLabel{nullptr};
     QPushButton* m_weightedAvgBtn{nullptr};
+
+    // ── Clarity badge + Re-tune (Phase 3G-9c) ────────────────────────────
+    QLabel*      m_clarityBadge{nullptr};
+    QPushButton* m_clarityRetuneBtn{nullptr};
 
     // ── DAX flyout ───────────────────────────────────────────────────────
     QWidget*   m_daxFlyout{nullptr};

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -279,7 +279,8 @@ void SpectrumWidget::loadSettings()
     }
 
     // Phase 3G-8 commit 4: waterfall renderer state.
-    // m_wfAgcEnabled removed in Phase 3G-9c — Clarity supersedes.
+    m_wfAgcEnabled = s.value(settingsKey(QStringLiteral("DisplayWfAgc"), m_panIndex),
+                             QStringLiteral("False")).toString() == QStringLiteral("True");
     m_wfReverseScroll = s.value(settingsKey(QStringLiteral("DisplayWfReverseScroll"), m_panIndex),
                                 QStringLiteral("False")).toString() == QStringLiteral("True");
     m_wfOpacity          = readInt(QStringLiteral("DisplayWfOpacity"), 100);
@@ -371,7 +372,8 @@ void SpectrumWidget::saveSettings()
               m_gradientEnabled ? QStringLiteral("True") : QStringLiteral("False"));
 
     // Phase 3G-8 commit 4: waterfall renderer state.
-    // DisplayWfAgc persistence removed in Phase 3G-9c — Clarity supersedes.
+    s.setValue(settingsKey(QStringLiteral("DisplayWfAgc"), m_panIndex),
+              m_wfAgcEnabled ? QStringLiteral("True") : QStringLiteral("False"));
     s.setValue(settingsKey(QStringLiteral("DisplayWfReverseScroll"), m_panIndex),
               m_wfReverseScroll ? QStringLiteral("True") : QStringLiteral("False"));
     writeInt(QStringLiteral("DisplayWfOpacity"), m_wfOpacity);
@@ -641,6 +643,20 @@ void SpectrumWidget::setWfLowThreshold(float dbm)
     m_wfLowThreshold = dbm;
     scheduleSettingsSave();
     update();
+}
+
+void SpectrumWidget::setWfAgcEnabled(bool on)
+{
+    if (m_wfAgcEnabled == on) { return; }
+    m_wfAgcEnabled = on;
+    m_wfAgcPrimed = false;
+    scheduleSettingsSave();
+    update();
+}
+
+void SpectrumWidget::setClarityActive(bool on)
+{
+    m_clarityActive = on;
 }
 
 void SpectrumWidget::setWfReverseScroll(bool on)
@@ -1443,10 +1459,32 @@ void SpectrumWidget::pushWaterfallRow(const QVector<float>& bins)
         src = &wfLocal;
     }
 
-    // Phase 3G-9c: legacy running-min/max AGC removed — ClarityController
-    // now drives m_wfLowThreshold / m_wfHighThreshold via its
-    // waterfallThresholdsChanged signal wired in MainWindow.
-    if (m_wfUseSpectrumMinMax) {
+    // AGC: track a slow envelope of visible-range min/max and bias the
+    // effective thresholds toward it. Simple one-pole follower.
+    // Phase 3G-9c: skipped when Clarity is actively driving thresholds —
+    // both can be enabled but Clarity takes priority when active.
+    if (m_wfAgcEnabled && !m_clarityActive) {
+        float mn = (*src)[firstBin];
+        float mx = mn;
+        for (int i = firstBin + 1; i <= lastBin; ++i) {
+            const float v = (*src)[i];
+            if (v < mn) { mn = v; }
+            if (v > mx) { mx = v; }
+        }
+        if (!m_wfAgcPrimed) {
+            m_wfAgcRunMin = mn;
+            m_wfAgcRunMax = mx;
+            m_wfAgcPrimed = true;
+        } else {
+            constexpr float kAgcAlpha = 0.05f;
+            m_wfAgcRunMin = kAgcAlpha * mn + (1.0f - kAgcAlpha) * m_wfAgcRunMin;
+            m_wfAgcRunMax = kAgcAlpha * mx + (1.0f - kAgcAlpha) * m_wfAgcRunMax;
+        }
+        // Phase 3G-9b: 12 dB margin for palette breathing room.
+        const float margin = 12.0f;
+        m_wfLowThreshold  = m_wfAgcRunMin - margin;
+        m_wfHighThreshold = m_wfAgcRunMax + margin;
+    } else if (m_wfUseSpectrumMinMax) {
         // Borrow spectrum grid thresholds.
         m_wfHighThreshold = m_refLevel;
         m_wfLowThreshold  = m_refLevel - m_dynamicRange;

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -174,6 +174,10 @@ public:
     float wfHighThreshold() const { return m_wfHighThreshold; }
     void setWfLowThreshold(float dbm);
     float wfLowThreshold() const { return m_wfLowThreshold; }
+    void setWfAgcEnabled(bool on);
+    bool wfAgcEnabled() const { return m_wfAgcEnabled; }
+    void setClarityActive(bool on);
+    bool clarityActive() const { return m_clarityActive; }
     void setWfReverseScroll(bool on);
     bool wfReverseScroll() const { return m_wfReverseScroll; }
     void setWfOpacity(int percent);          // 0..100
@@ -391,6 +395,8 @@ private:
 
     // ---- Phase 3G-8 commit 4: waterfall renderer state ----
 
+    bool  m_wfAgcEnabled{false};
+    bool  m_clarityActive{false};     // Phase 3G-9c: suppresses legacy AGC when Clarity drives thresholds
     bool  m_wfReverseScroll{false};
     int   m_wfOpacity{100};           // 0..100
     int   m_wfUpdatePeriodMs{50};     // NereusSDR default per §10 divergence
@@ -405,6 +411,11 @@ private:
     bool  m_showTxFilterOnRxWaterfall{false};
     bool  m_showRxZeroLineOnWaterfall{false};
     bool  m_showTxZeroLineOnWaterfall{false};
+
+    // AGC rolling envelope (tracked across waterfall rows).
+    float m_wfAgcRunMin{0.0f};
+    float m_wfAgcRunMax{0.0f};
+    bool  m_wfAgcPrimed{false};
 
     // Rate-limit waterfall pushes per m_wfUpdatePeriodMs.
     qint64 m_wfLastPushMs{0};

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -206,6 +206,12 @@ void SpectrumDefaultsPage::buildUI()
                     QStringLiteral("ClarityEnabled"),
                     on ? QStringLiteral("True") : QStringLiteral("False"));
             }
+            // Sync the clarityActive flag so legacy AGC knows whether
+            // to stand down. Off = AGC free to run, On = AGC yields
+            // once Clarity emits its first threshold update.
+            if (auto* sw2 = model() ? model()->spectrumWidget() : nullptr) {
+                if (!on) { sw2->setClarityActive(false); }
+            }
         });
     }
     contentLayout()->addWidget(clarityToggle);
@@ -521,6 +527,7 @@ void WaterfallDefaultsPage::loadFromRenderer()
     if (!sw) { return; }
     QSignalBlocker b1(m_highThresholdSlider);
     QSignalBlocker b2(m_lowThresholdSlider);
+    QSignalBlocker b3(m_agcToggle);
     QSignalBlocker b4(m_useSpectrumMinMaxToggle);
     QSignalBlocker b5(m_updatePeriodSlider);
     QSignalBlocker b6(m_reverseToggle);
@@ -536,6 +543,7 @@ void WaterfallDefaultsPage::loadFromRenderer()
 
     m_highThresholdSlider->setValue(static_cast<int>(sw->wfHighThreshold()));
     m_lowThresholdSlider->setValue(static_cast<int>(sw->wfLowThreshold()));
+    m_agcToggle->setChecked(sw->wfAgcEnabled());
     m_useSpectrumMinMaxToggle->setChecked(sw->wfUseSpectrumMinMax());
     m_updatePeriodSlider->setValue(sw->wfUpdatePeriodMs());
     m_reverseToggle->setChecked(sw->wfReverseScroll());
@@ -589,15 +597,15 @@ void WaterfallDefaultsPage::buildUI()
         levForm->addRow(QStringLiteral("Low Threshold:"), row.container);
     }
 
-    // Phase 3G-9c: legacy Waterfall AGC checkbox replaced by inert label.
-    // ClarityController supersedes the running-min/max AGC — its
-    // percentile-based estimator is more robust against strong carriers.
-    // Thetis origin: setup.designer.cs:34069 (chkRX1WaterfallAGC).
-    m_agcDeprecationLabel = new QLabel(
-        QStringLiteral("AGC — superseded by Clarity (see Spectrum Defaults)"),
-        levGroup);
-    m_agcDeprecationLabel->setEnabled(false);
-    levForm->addRow(QString(), m_agcDeprecationLabel);
+    m_agcToggle = new QCheckBox(QStringLiteral("AGC"), levGroup);
+    // Thetis: setup.designer.cs:34069 (chkRX1WaterfallAGC)
+    m_agcToggle->setToolTip(QStringLiteral("Automatically calculates Low Level Threshold for Waterfall."));
+    connect(m_agcToggle, &QCheckBox::toggled, this, [this](bool on) {
+        if (auto* w = model() ? model()->spectrumWidget() : nullptr) {
+            w->setWfAgcEnabled(on);
+        }
+    });
+    levForm->addRow(QString(), m_agcToggle);
 
     m_useSpectrumMinMaxToggle = new QCheckBox(QStringLiteral("Use spectrum min/max"), levGroup);
     // Thetis: setup.designer.cs:34054 (chkWaterfallUseRX1SpectrumMinMax)

--- a/src/gui/setup/DisplaySetupPages.h
+++ b/src/gui/setup/DisplaySetupPages.h
@@ -73,7 +73,7 @@ private:
     // Section: Levels
     QSlider*           m_highThresholdSlider{nullptr};
     QSlider*           m_lowThresholdSlider{nullptr};
-    QLabel*            m_agcDeprecationLabel{nullptr};
+    QCheckBox*         m_agcToggle{nullptr};
     ColorSwatchButton* m_lowColorBtn{nullptr};                // W10
     QCheckBox*         m_useSpectrumMinMaxToggle{nullptr};    // W15
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -621,9 +621,7 @@ void RadioModel::applyClaritySmoothDefaults()
     sw->setPanFillEnabled(false);
 
     // 6. Waterfall AGC — tracks band conditions automatically. With AGC on,
-    //    Phase 3G-9c: Waterfall AGC is superseded by ClarityController.
-    //    The setWfAgcEnabled call was removed here. Clarity is enabled via
-    //    the master toggle in Setup → Display → Spectrum Defaults.
+    sw->setWfAgcEnabled(true);
 
     // 7. Waterfall update period — 30 ms for smooth scroll motion.
     sw->setWfUpdatePeriodMs(30);


### PR DESCRIPTION
## Summary

- Adds **Clarity**, an adaptive waterfall tuning system that keeps Low/High thresholds centered on the actual noise floor using a 30th-percentile estimator with 3-second EWMA smoothing and ±2 dB deadband gating
- Clarity is an **add-on** alongside the existing Waterfall AGC — both coexist, user chooses their preferred mode; Clarity takes priority when active, legacy AGC resumes when Clarity is off or paused
- Independent waterfall averaging time slider (decoupled from spectrum trace smoothing)
- 25 TDD unit tests (8 estimator + 17 controller) covering all gate combinations, edge cases, and EWMA smoothing behavior

### Commits

| # | Commit | Scope |
|---|--------|-------|
| 1 | `NoiseFloorEstimator` | Pure-math percentile estimator via `std::nth_element`, 8 tests |
| 2 | `ClarityController` | Stateful QObject: 2 Hz cadence, EWMA τ=3s, ±2 dB deadband, TX pause, manual override, 30 dB min-gap clamp, 17 tests |
| 3 | Per-band memory | `BandGridSettings.clarityFloor` + `snapToFloor()` for band-switch snap |
| 4 | Pipeline wiring | FFT→Clarity→SpectrumWidget thresholds, MOX pause, master toggle on Spectrum Defaults page |
| 5 | Parity fix | Restored legacy Waterfall AGC alongside Clarity via `m_clarityActive` coexistence flag |
| 6 | Overlay panel | "C" status badge (green/amber) + "Re-tune" button in display flyout |
| 7 | Doc update | Closed out waterfall-tuning.md open questions |
| 8 | Review fixes | P1: off→on deadband reset, P2: TX pause emits pausedChanged |
| 9 | WF avg time | Independent waterfall averaging time slider+spinbox (decoupled from spectrum) |

### Coexistence model

- AGC on + Clarity off → legacy 12 dB margin running-min/max (PR2 behavior)
- Clarity on → percentile + EWMA drives thresholds; AGC yields via `m_clarityActive`
- Clarity paused (TX/override) → AGC resumes if enabled
- Both off → manual thresholds

## Test plan

- [ ] Build green on macOS
- [ ] 25 Clarity unit tests pass
- [ ] Full test suite passes (pre-existing `tst_p1_loopback_connection` failure excluded)
- [ ] Setup pages render: Clarity toggle on Spectrum Defaults, AGC checkbox on Waterfall Defaults, WF Avg Time slider
- [ ] Enable Clarity with radio connected: waterfall tightens around noise floor within ~5s
- [ ] Toggle Clarity off: thresholds freeze, AGC resumes if checked
- [ ] Re-tune button in Display flyout forces immediate re-estimate
- [ ] Badge shows green (active) / amber (paused during TX)
- [ ] WF Avg Time slider adjusts waterfall smoothing independently of spectrum trace

JJ Boyd ~KG4VCF
Co-Authored with Claude Code