### PR TITLE
Phase 3I-RP: Radio model selector + P1 C&C completion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ endif()
 set(CORE_SOURCES
     src/core/AppSettings.cpp
     src/core/BoardCapabilities.cpp
+    src/core/HardwareProfile.cpp
     src/core/LogCategories.cpp
     src/core/SupportBundle.cpp
     src/core/RadioDiscovery.cpp

--- a/docs/superpowers/plans/2026-04-16-radio-model-selector-p1-cc.md
+++ b/docs/superpowers/plans/2026-04-16-radio-model-selector-p1-cc.md
@@ -1,0 +1,1388 @@
+# Phase 3I-RP: Radio Model Selector + P1 C&C Completion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix RedPitaya (and all non-standard Hermes devices) by adding a per-MAC radio model selector and completing the P1 C&C 17-bank round-robin.
+
+**Architecture:** Two-layer approach. Layer 1: HardwareProfile struct computed from user-selected HPSDRModel, ported from Thetis clsHardwareSpecific.cs. Layer 2: P1 C&C full 17-bank round-robin ported from Thetis networkproto1.c WriteMainLoop. ConnectionPanel gets a detail panel with model dropdown, persisted per-MAC in AppSettings.
+
+**Tech Stack:** C++20, Qt6, AppSettings XML persistence
+
+**Design Spec:** `docs/superpowers/specs/2026-04-16-radio-model-selector-p1-cc-design.md`
+
+**Thetis Source (READ before implementing):**
+- `../Thetis/Project Files/Source/Console/clsHardwareSpecific.cs` (model overrides)
+- `../Thetis/Project Files/Source/ChannelMaster/networkproto1.c` (WriteMainLoop cases 0-17)
+- `../Thetis/Project Files/Source/Console/HPSDR/NetworkIO.cs:160-176` (board validation)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/core/HardwareProfile.h` | Create | HardwareProfile struct, `profileForModel()` factory, `compatibleModels()` |
+| `src/core/HardwareProfile.cpp` | Create | Implementation of factory + compatibility list |
+| `src/core/P1RadioConnection.h` | Modify | New state members, composeCcBank signatures |
+| `src/core/P1RadioConnection.cpp` | Modify | Full 17-bank round-robin, reconnect log fix |
+| `src/core/P2RadioConnection.cpp` | Modify | Use HardwareProfile for caps lookup |
+| `src/core/RadioDiscovery.h` | Modify | Add `modelOverride` field to RadioInfo |
+| `src/core/AppSettings.h` | Modify | `modelOverride` read/write helpers |
+| `src/core/AppSettings.cpp` | Modify | Persist/restore modelOverride per-MAC |
+| `src/gui/ConnectionPanel.h` | Modify | Detail panel widgets, model dropdown |
+| `src/gui/ConnectionPanel.cpp` | Modify | Detail panel build + wiring |
+| `src/gui/MainWindow.cpp` | Modify | Wire "Radio Setup..." menu item |
+| `src/models/RadioModel.h` | Modify | Store HardwareProfile |
+| `src/models/RadioModel.cpp` | Modify | Compute profile at connect, pass to connection |
+| `src/gui/setup/HardwarePage.cpp` | Modify | Use profile.effectiveBoard for tab visibility |
+| `CMakeLists.txt` | Modify | Add HardwareProfile.cpp to CORE_SOURCES |
+
+---
+
+### Task 1: HardwareProfile struct and factory
+
+**Files:**
+- Create: `src/core/HardwareProfile.h`
+- Create: `src/core/HardwareProfile.cpp`
+- Modify: `CMakeLists.txt:244-258`
+
+This is the foundation. Port of Thetis `clsHardwareSpecific.cs:85-184`.
+
+- [ ] **Step 1: Read Thetis source**
+
+Read `../Thetis/Project Files/Source/Console/clsHardwareSpecific.cs` lines 85-184 and `NetworkIO.cs` lines 160-176 to confirm the override values for each model.
+
+- [ ] **Step 2: Create HardwareProfile.h**
+
+```cpp
+// src/core/HardwareProfile.h
+//
+// Model-driven hardware configuration overrides.
+// Port of Thetis clsHardwareSpecific.cs:85-184.
+//
+// The discovery board byte identifies the chip family (6 values), but 16+
+// distinct radio models share those bytes. This struct resolves the ambiguity
+// by letting the user select their actual model, then computing the correct
+// hardware parameters.
+
+#pragma once
+
+#include "HpsdrModel.h"
+#include "BoardCapabilities.h"
+
+#include <QList>
+
+namespace NereusSDR {
+
+struct HardwareProfile {
+    HPSDRModel               model{HPSDRModel::HERMES};
+    HPSDRHW                  effectiveBoard{HPSDRHW::Hermes};
+    const BoardCapabilities* caps{nullptr};
+    int                      adcCount{1};         // 1 or 2
+    bool                     mkiiBpf{false};       // MKII bandpass filter enable
+    int                      adcSupplyVoltage{33}; // 33 or 50
+    bool                     lrAudioSwap{true};    // L/R audio channel swap
+};
+
+// Compute a HardwareProfile for the given model.
+// Source: Thetis clsHardwareSpecific.cs:85-184
+HardwareProfile profileForModel(HPSDRModel model);
+
+// Return the default (auto-guessed) HPSDRModel for a discovered board byte.
+// Picks the first model whose boardForModel() matches the board type.
+HPSDRModel defaultModelForBoard(HPSDRHW board);
+
+// Return the list of HPSDRModel values compatible with a discovered board byte.
+// Used to populate the model dropdown in ConnectionPanel.
+// Source: Thetis NetworkIO.cs:160-176 board_is_expected_for_model validation.
+QList<HPSDRModel> compatibleModels(HPSDRHW board);
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 3: Create HardwareProfile.cpp**
+
+```cpp
+// src/core/HardwareProfile.cpp
+//
+// Porting from Thetis clsHardwareSpecific.cs:85-184 — Model setter switch.
+// Each case maps an HPSDRModel to its hardware overrides.
+
+#include "HardwareProfile.h"
+
+namespace NereusSDR {
+
+HardwareProfile profileForModel(HPSDRModel model)
+{
+    HardwareProfile p;
+    p.model = model;
+
+    // Source: clsHardwareSpecific.cs:85-184
+    switch (model) {
+    case HPSDRModel::HERMES:
+        p.adcCount = 1; p.mkiiBpf = false; p.adcSupplyVoltage = 33;
+        p.lrAudioSwap = true;  p.effectiveBoard = HPSDRHW::Hermes;
+        break;
+    case HPSDRModel::ANAN10:
+        p.adcCount = 1; p.mkiiBpf = false; p.adcSupplyVoltage = 33;
+        p.lrAudioSwap = true;  p.effectiveBoard = HPSDRHW::Hermes;
+        break;
+    case HPSDRModel::ANAN10E:
+        p.adcCount = 1; p.mkiiBpf = false; p.adcSupplyVoltage = 33;
+        p.lrAudioSwap = true;  p.effectiveBoard = HPSDRHW::HermesII;
+        break;
+    case HPSDRModel::ANAN100:
+        p.adcCount = 1; p.mkiiBpf = false; p.adcSupplyVoltage = 33;
+        p.lrAudioSwap = true;  p.effectiveBoard = HPSDRHW::Hermes;
+        break;
+    case HPSDRModel::ANAN100B:
+        p.adcCount = 1; p.mkiiBpf = false; p.adcSupplyVoltage = 33;
+        p.lrAudioSwap = true;  p.effectiveBoard = HPSDRHW::HermesII;
+        break;
+    case HPSDRModel::ANAN100D:
+        p.adcCount = 2; p.mkiiBpf = false; p.adcSupplyVoltage = 33;
+        p.lrAudioSwap = false; p.effectiveBoard = HPSDRHW::Angelia;
+        break;
+    case HPSDRModel::ANAN200D:
+        p.adcCount = 2; p.mkiiBpf = false; p.adcSupplyVoltage = 50;
+        p.lrAudioSwap = false; p.effectiveBoard = HPSDRHW::Orion;
+        break;
+    case HPSDRModel::ORIONMKII:
+        p.adcCount = 2; p.mkiiBpf = true;  p.adcSupplyVoltage = 50;
+        p.lrAudioSwap = false; p.effectiveBoard = HPSDRHW::OrionMKII;
+        break;
+    case HPSDRModel::ANAN7000D:
+        p.adcCount = 2; p.mkiiBpf = true;  p.adcSupplyVoltage = 50;
+        p.lrAudioSwap = false; p.effectiveBoard = HPSDRHW::OrionMKII;
+        break;
+    case HPSDRModel::ANAN8000D:
+        p.adcCount = 2; p.mkiiBpf = true;  p.adcSupplyVoltage = 50;
+        p.lrAudioSwap = false; p.effectiveBoard = HPSDRHW::OrionMKII;
+        break;
+    case HPSDRModel::ANAN_G2:
+        p.adcCount = 2; p.mkiiBpf = true;  p.adcSupplyVoltage = 50;
+        p.lrAudioSwap = false; p.effectiveBoard = HPSDRHW::Saturn;
+        break;
+    case HPSDRModel::ANAN_G2_1K:
+        p.adcCount = 2; p.mkiiBpf = true;  p.adcSupplyVoltage = 50;
+        p.lrAudioSwap = false; p.effectiveBoard = HPSDRHW::Saturn;
+        break;
+    case HPSDRModel::ANVELINAPRO3:
+        p.adcCount = 2; p.mkiiBpf = true;  p.adcSupplyVoltage = 50;
+        p.lrAudioSwap = false; p.effectiveBoard = HPSDRHW::OrionMKII;
+        break;
+    case HPSDRModel::HERMESLITE:
+        p.adcCount = 1; p.mkiiBpf = false; p.adcSupplyVoltage = 33;
+        p.lrAudioSwap = true;  p.effectiveBoard = HPSDRHW::HermesLite;
+        break;
+    // From clsHardwareSpecific.cs:178-183 — DH1KLM RedPitaya contribution
+    case HPSDRModel::REDPITAYA:
+        p.adcCount = 2; p.mkiiBpf = false; p.adcSupplyVoltage = 50;
+        p.lrAudioSwap = false; p.effectiveBoard = HPSDRHW::OrionMKII;
+        break;
+    default:
+        p.adcCount = 1; p.mkiiBpf = false; p.adcSupplyVoltage = 33;
+        p.lrAudioSwap = true;  p.effectiveBoard = HPSDRHW::Hermes;
+        break;
+    }
+
+    p.caps = &BoardCapsTable::forBoard(p.effectiveBoard);
+    return p;
+}
+
+HPSDRModel defaultModelForBoard(HPSDRHW board)
+{
+    // Walk the enum and return the first model whose boardForModel() matches.
+    for (int i = static_cast<int>(HPSDRModel::FIRST) + 1;
+         i < static_cast<int>(HPSDRModel::LAST); ++i) {
+        auto m = static_cast<HPSDRModel>(i);
+        if (boardForModel(m) == board) {
+            return m;
+        }
+    }
+    return HPSDRModel::HERMES;
+}
+
+QList<HPSDRModel> compatibleModels(HPSDRHW board)
+{
+    QList<HPSDRModel> result;
+
+    // Source: Thetis NetworkIO.cs:160-176 board_is_expected_for_model
+    // RedPitaya can report as Hermes OR OrionMKII.
+    // ANAN-10/10E/100/100B can report as Hermes OR HermesII.
+    for (int i = static_cast<int>(HPSDRModel::FIRST) + 1;
+         i < static_cast<int>(HPSDRModel::LAST); ++i) {
+        auto m = static_cast<HPSDRModel>(i);
+        bool compatible = false;
+
+        // Primary match: boardForModel maps to this board byte
+        if (boardForModel(m) == board) {
+            compatible = true;
+        }
+
+        // Special cases from NetworkIO.cs:164-171
+        if (m == HPSDRModel::REDPITAYA) {
+            // RedPitaya can report as Hermes or OrionMKII
+            compatible = (board == HPSDRHW::Hermes || board == HPSDRHW::OrionMKII);
+        }
+        if (m == HPSDRModel::ANAN10 || m == HPSDRModel::ANAN100) {
+            // These Hermes-based radios can also appear as HermesII
+            if (board == HPSDRHW::Hermes || board == HPSDRHW::HermesII) {
+                compatible = true;
+            }
+        }
+        if (m == HPSDRModel::ANAN10E || m == HPSDRModel::ANAN100B) {
+            if (board == HPSDRHW::Hermes || board == HPSDRHW::HermesII) {
+                compatible = true;
+            }
+        }
+
+        if (compatible) {
+            result.append(m);
+        }
+    }
+    return result;
+}
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 4: Add to CMakeLists.txt**
+
+Add `src/core/HardwareProfile.cpp` to the `CORE_SOURCES` list after `BoardCapabilities.cpp`:
+
+```
+    src/core/BoardCapabilities.cpp
+    src/core/HardwareProfile.cpp
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -5`
+Expected: BUILD SUCCESS, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/HardwareProfile.h src/core/HardwareProfile.cpp CMakeLists.txt
+git commit -m "feat(core): add HardwareProfile model-driven configuration
+
+Port of Thetis clsHardwareSpecific.cs:85-184. Maps HPSDRModel enum
+to hardware overrides (ADC count, BPF, supply voltage, audio swap,
+effective board identity). Includes compatibleModels() for populating
+the ConnectionPanel model dropdown.
+
+Part of Phase 3I-RP (Issue #38).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: AppSettings modelOverride persistence + RadioInfo field
+
+**Files:**
+- Modify: `src/core/RadioDiscovery.h:21-52`
+- Modify: `src/core/AppSettings.h:100-124`
+- Modify: `src/core/AppSettings.cpp:238-260`
+
+- [ ] **Step 1: Add modelOverride to RadioInfo**
+
+In `src/core/RadioDiscovery.h`, add a field to the RadioInfo struct after the `maxSampleRate` field (line 41):
+
+```cpp
+    // Model override — set by user in ConnectionPanel, persisted per-MAC.
+    // When set to a value other than FIRST, overrides the auto-detected model.
+    HPSDRModel modelOverride{HPSDRModel::FIRST}; // FIRST = no override (auto-detect)
+```
+
+- [ ] **Step 2: Add modelOverride to AppSettings saveRadio/savedRadio**
+
+In `src/core/AppSettings.cpp`, inside `saveRadio()` (after the `lastSeen` insert at line 259), add:
+
+```cpp
+    // Model override (Phase 3I-RP). FIRST = no override.
+    if (info.modelOverride != HPSDRModel::FIRST) {
+        m_settings.insert(prefix + QStringLiteral("modelOverride"),
+                          QString::number(static_cast<int>(info.modelOverride)));
+    }
+```
+
+In `savedRadio()` (after the `lastSeen` parse at line 343), add:
+
+```cpp
+    // Model override (Phase 3I-RP)
+    const QString moStr = m_settings.value(prefix + QStringLiteral("modelOverride"),
+                                            QStringLiteral("-1"));
+    int moInt = moStr.toInt();
+    if (moInt > static_cast<int>(HPSDRModel::FIRST) &&
+        moInt < static_cast<int>(HPSDRModel::LAST)) {
+        sr.info.modelOverride = static_cast<HPSDRModel>(moInt);
+    }
+```
+
+- [ ] **Step 3: Add convenience helpers to AppSettings.h**
+
+In `src/core/AppSettings.h`, after `setDiscoveryProfile()` (line 123), add:
+
+```cpp
+    // Model override for a specific radio MAC (Phase 3I-RP).
+    HPSDRModel modelOverride(const QString& macKey) const;
+    void setModelOverride(const QString& macKey, HPSDRModel model);
+```
+
+In `src/core/AppSettings.cpp`, add the implementations:
+
+```cpp
+HPSDRModel AppSettings::modelOverride(const QString& macKey) const
+{
+    const QString prefix = radioKeyPrefix(macKey);
+    const QString val = m_settings.value(prefix + QStringLiteral("modelOverride"),
+                                          QStringLiteral("-1"));
+    int v = val.toInt();
+    if (v > static_cast<int>(HPSDRModel::FIRST) &&
+        v < static_cast<int>(HPSDRModel::LAST)) {
+        return static_cast<HPSDRModel>(v);
+    }
+    return HPSDRModel::FIRST; // no override
+}
+
+void AppSettings::setModelOverride(const QString& macKey, HPSDRModel model)
+{
+    const QString prefix = radioKeyPrefix(macKey);
+    m_settings.insert(prefix + QStringLiteral("modelOverride"),
+                      QString::number(static_cast<int>(model)));
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -5`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/RadioDiscovery.h src/core/AppSettings.h src/core/AppSettings.cpp
+git commit -m "feat(core): add modelOverride to RadioInfo and AppSettings
+
+Per-MAC model override persistence for Phase 3I-RP. RadioInfo gets a
+modelOverride field (FIRST = auto-detect). AppSettings saves/restores
+it alongside existing per-radio fields.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: RadioModel — compute and pass HardwareProfile
+
+**Files:**
+- Modify: `src/models/RadioModel.h`
+- Modify: `src/models/RadioModel.cpp:117-240`
+
+- [ ] **Step 1: Add profile storage to RadioModel.h**
+
+Add include and member. After the existing `#include` block, add:
+
+```cpp
+#include "core/HardwareProfile.h"
+```
+
+Add a member variable in the private section:
+
+```cpp
+    HardwareProfile m_hardwareProfile;
+```
+
+Add a public accessor:
+
+```cpp
+    const HardwareProfile& hardwareProfile() const { return m_hardwareProfile; }
+```
+
+- [ ] **Step 2: Compute profile in connectToRadio()**
+
+In `src/models/RadioModel.cpp`, at the top of `connectToRadio()` after `m_lastRadioInfo = info;` (line 124), add:
+
+```cpp
+    // Compute HardwareProfile from model override (Phase 3I-RP).
+    // If the user set a model override via ConnectionPanel, use it.
+    // Otherwise auto-detect from the discovered board byte.
+    HPSDRModel selectedModel = info.modelOverride;
+    if (selectedModel == HPSDRModel::FIRST) {
+        selectedModel = defaultModelForBoard(info.boardType);
+    }
+    m_hardwareProfile = profileForModel(selectedModel);
+
+    qCDebug(lcConnection) << "HardwareProfile: model=" << displayName(m_hardwareProfile.model)
+                          << "effectiveBoard=" << static_cast<int>(m_hardwareProfile.effectiveBoard)
+                          << "adcCount=" << m_hardwareProfile.adcCount;
+```
+
+Change line 128 from:
+
+```cpp
+    m_model = QString::fromLatin1(BoardCapsTable::forBoard(info.boardType).displayName);
+```
+
+to:
+
+```cpp
+    m_model = QString::fromLatin1(m_hardwareProfile.caps->displayName);
+```
+
+- [ ] **Step 3: Pass profile to connection via RadioConnection interface**
+
+In `src/core/RadioConnection.h`, add a virtual setter (or store on RadioInfo). The simplest approach: since RadioInfo already carries modelOverride, the connection can compute the profile itself. But to keep the profile computation centralized, add a setter to RadioConnection:
+
+In `RadioConnection.h`, add to the public section:
+
+```cpp
+    void setHardwareProfile(const HardwareProfile& profile) { m_hardwareProfile = profile; }
+    const HardwareProfile& hardwareProfile() const { return m_hardwareProfile; }
+protected:
+    HardwareProfile m_hardwareProfile;
+```
+
+In `RadioModel::connectToRadio()`, after creating the connection (after line 208), add:
+
+```cpp
+    m_connection->setHardwareProfile(m_hardwareProfile);
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -5`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/RadioModel.h src/models/RadioModel.cpp src/core/RadioConnection.h
+git commit -m "feat(model): compute HardwareProfile at connect time
+
+RadioModel computes the profile from the user's model override (or
+auto-detects from board byte) and passes it to RadioConnection. The
+profile drives capability lookups, display name, and will drive the
+P1 C&C round-robin values.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: P1RadioConnection — use HardwareProfile + fix bank 0
+
+**Files:**
+- Modify: `src/core/P1RadioConnection.h:127-181`
+- Modify: `src/core/P1RadioConnection.cpp:104-130, 605-810`
+
+This task fixes the immediate bank 0 issue (dither/random/preamp all zeros) and adds the new state members. The full 17-bank round-robin comes in Task 5.
+
+- [ ] **Step 1: Add state members to P1RadioConnection.h**
+
+Replace the existing state block (lines 158-166) with the expanded set:
+
+```cpp
+    int     m_sampleRate{48000};
+    int     m_activeRxCount{1};
+    quint64 m_rxFreqHz[7]{};
+    quint64 m_txFreqHz{0};
+    bool    m_mox{false};
+    int     m_antennaIdx{0};
+
+    // Per-ADC state — initialized from HardwareProfile at connect time
+    bool    m_dither[3]{true, true, true};
+    bool    m_random[3]{true, true, true};
+    bool    m_rxPreamp[3]{};
+    int     m_stepAttn[3]{};      // per-ADC step attenuator (0-31)
+    int     m_txStepAttn{0};
+
+    // Alex filter state — computed from frequency
+    quint8  m_alexHpfBits{0};     // Bank 10 C3: HPF select bits
+    quint8  m_alexLpfBits{0};     // Bank 10 C4: LPF select bits
+
+    // Hardware config
+    int     m_txDrive{0};
+    bool    m_paEnabled{false};
+    bool    m_duplex{true};        // Always on for NereusSDR
+    bool    m_diversity{false};
+    quint8  m_ocOutput{0};         // OC output mask
+    quint16 m_adcCtrl{0};          // ADC-to-DDC assignment bits (P1_adc_cntrl)
+
+    // Reconnect log guard
+    bool    m_reconnectedLogged{false};
+```
+
+- [ ] **Step 2: Initialize state from HardwareProfile in connectToRadio()**
+
+In `P1RadioConnection::connectToRadio()`, after `m_caps = &BoardCapsTable::forBoard(info.boardType);` (line 359), replace with:
+
+```cpp
+    // Use HardwareProfile for caps (Phase 3I-RP)
+    m_caps = m_hardwareProfile.caps;
+
+    // Initialize per-ADC state from profile
+    for (int i = 0; i < 3; ++i) {
+        m_dither[i] = true;   // From Thetis pcap: dither enabled on all ADCs
+        m_random[i] = true;   // From Thetis pcap: random enabled on all ADCs
+        m_rxPreamp[i] = false;
+        m_stepAttn[i] = 0;
+    }
+    m_paEnabled = m_hardwareProfile.caps->hasPaProfile;
+    m_duplex = true;
+    m_reconnectedLogged = false;
+```
+
+- [ ] **Step 3: Fix composeCcBank0 to populate C3 and C4**
+
+Replace the current `composeCcBank0` (lines 104-130) with:
+
+```cpp
+// Source: networkproto1.c:450-471 — WriteMainLoop case 0 (general settings)
+void P1RadioConnection::composeCcBank0(quint8 out[5], int sampleRate, bool mox,
+                                        int activeRxCount) noexcept
+{
+    // C0 = XmitBit (networkproto1.c:446)
+    out[0] = mox ? 0x01 : 0x00;
+
+    // C1 = SampleRateIn2Bits (networkproto1.c:451)
+    quint8 srBits = 0;
+    if      (sampleRate >= 384000) { srBits = 3; }
+    else if (sampleRate >= 192000) { srBits = 2; }
+    else if (sampleRate >= 96000)  { srBits = 1; }
+    else                            { srBits = 0; }
+    out[1] = srBits & 0x03;
+
+    // C2 = OC outputs (networkproto1.c:452) — zero for now
+    out[2] = 0;
+
+    // C3 = preamp/dither/random/input (networkproto1.c:453-461)
+    // Populated from instance state in the non-static path.
+    // Static version keeps zeros for backward compat with existing tests.
+    out[3] = 0;
+
+    // C4 = antenna, duplex, NDDCs, diversity (networkproto1.c:463-471)
+    int nddc = (activeRxCount < 1) ? 1 : (activeRxCount > 7 ? 7 : activeRxCount);
+    out[4] = static_cast<quint8>((nddc - 1) << 3);
+    out[4] |= 0x04; // duplex bit (networkproto1.c:469)
+}
+```
+
+- [ ] **Step 4: Add instance-level composeCcBank0Full()**
+
+Add a new non-static method that uses instance state for C2/C3/C4:
+
+```cpp
+// Instance-level bank 0 compose — uses HardwareProfile + runtime state.
+// Source: networkproto1.c:450-471
+void P1RadioConnection::composeCcBank0Full(quint8 out[5]) const
+{
+    out[0] = m_mox ? 0x01 : 0x00;
+
+    quint8 srBits = 0;
+    if      (m_sampleRate >= 384000) { srBits = 3; }
+    else if (m_sampleRate >= 192000) { srBits = 2; }
+    else if (m_sampleRate >= 96000)  { srBits = 1; }
+    out[1] = srBits & 0x03;
+
+    // C2: OC outputs (networkproto1.c:452)
+    out[2] = (m_ocOutput << 1) & 0xFE;
+
+    // C3: dither, random, preamp, attenuator, RX input (networkproto1.c:453-461)
+    out[3] = (m_rxPreamp[0] ? 0x04 : 0)
+           | (m_dither[0]   ? 0x08 : 0)
+           | (m_random[0]   ? 0x10 : 0);
+    // RX input select bits [6:5] — default to Rx_1_In (0b00100000)
+    out[3] |= 0x20;
+
+    // C4: antenna, duplex, NDDCs, diversity (networkproto1.c:463-471)
+    out[4] = static_cast<quint8>(m_antennaIdx & 0x03);
+    out[4] |= 0x04; // duplex (networkproto1.c:469)
+    int nddc = (m_activeRxCount < 1) ? 1 : (m_activeRxCount > 7 ? 7 : m_activeRxCount);
+    out[4] |= static_cast<quint8>((nddc - 1) << 3);
+    out[4] |= (m_diversity ? 0x80 : 0);
+}
+```
+
+Declare in the header:
+
+```cpp
+    void composeCcBank0Full(quint8 out[5]) const;
+```
+
+- [ ] **Step 5: Update sendCommandFrame to use composeCcBank0Full**
+
+In `sendCommandFrame()` (line 781), replace the subframe 0 composition:
+
+```cpp
+    // Subframe 0: bank 0 (general settings) — use instance state
+    frame[8]  = 0x7F;
+    frame[9]  = 0x7F;
+    frame[10] = 0x7F;
+    quint8 cc0[5] = {};
+    composeCcBank0Full(cc0);
+    frame[11] = cc0[0];
+    frame[12] = cc0[1];
+    frame[13] = cc0[2];
+    frame[14] = cc0[3];
+    frame[15] = cc0[4];
+```
+
+- [ ] **Step 6: Fix reconnect log spam**
+
+In the ep6 receive handler (find the "Reconnected" log line), add the guard:
+
+```cpp
+    if (!m_reconnectedLogged) {
+        qCDebug(lcConnection) << "P1: Reconnected — ep6 stream restored";
+        m_reconnectedLogged = true;
+    }
+```
+
+Clear the flag in the error/disconnect transitions:
+
+In `onWatchdogTick()` where it sets `ConnectionState::Error`, add:
+```cpp
+    m_reconnectedLogged = false;
+```
+
+In `disconnect()`, add:
+```cpp
+    m_reconnectedLogged = false;
+```
+
+- [ ] **Step 7: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -5`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/core/P1RadioConnection.h src/core/P1RadioConnection.cpp
+git commit -m "feat(p1): use HardwareProfile in P1, fix bank 0 C3/C4
+
+Bank 0 now sends dither, random, preamp, duplex, and antenna bits
+instead of zeros. New composeCcBank0Full() reads from instance state
+initialized from HardwareProfile. Fixes reconnect log spam (30-80
+duplicate lines per cycle → 1 line).
+
+Part of Phase 3I-RP (Issue #38).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: P1 C&C full 17-bank round-robin
+
+**Files:**
+- Modify: `src/core/P1RadioConnection.h`
+- Modify: `src/core/P1RadioConnection.cpp`
+
+This is the big port. Each bank is a case in the round-robin, ported from Thetis `networkproto1.c` WriteMainLoop cases 0-17.
+
+- [ ] **Step 1: Read Thetis source**
+
+Read `../Thetis/Project Files/Source/ChannelMaster/networkproto1.c` lines 419-697 (WriteMainLoop). Confirm all 17 bank layouts byte-for-byte.
+
+- [ ] **Step 2: Add composeCcBankN dispatcher**
+
+Add a new method to P1RadioConnection:
+
+```cpp
+// Compose C&C bytes for bank `bankIdx` (0-17).
+// Dispatcher for the full round-robin, ported from Thetis
+// networkproto1.c WriteMainLoop cases 0-17.
+void P1RadioConnection::composeCcForBank(int bankIdx, quint8 out[5]) const
+{
+    memset(out, 0, 5);
+    quint8 C0 = m_mox ? 0x01 : 0x00;
+
+    switch (bankIdx) {
+    case 0: // General settings (networkproto1.c:450-471)
+        composeCcBank0Full(out);
+        return;
+
+    case 1: // TX VFO (networkproto1.c:476-482)
+        composeCcBankTxFreq(out, m_txFreqHz);
+        return;
+
+    case 2: // RX1 VFO DDC0 (networkproto1.c:484-494)
+        composeCcBankRxFreq(out, 0, m_rxFreqHz[0]);
+        return;
+
+    case 3: { // RX2 VFO DDC1 (networkproto1.c:497-511)
+        out[0] = C0 | 0x06;
+        quint64 freq = m_rxFreqHz[1]; // RX2 freq
+        out[1] = (freq >> 24) & 0xFF;
+        out[2] = (freq >> 16) & 0xFF;
+        out[3] = (freq >>  8) & 0xFF;
+        out[4] =  freq        & 0xFF;
+        return;
+    }
+
+    case 4: // ADC assignments + TX ATT (networkproto1.c:517-523)
+        out[0] = C0 | 0x1C;
+        out[1] = m_adcCtrl & 0xFF;
+        out[2] = (m_adcCtrl >> 8) & 0x3F;
+        out[3] = m_txStepAttn & 0x1F;
+        out[4] = 0;
+        return;
+
+    case 5: case 6: case 7: case 8: case 9: {
+        // RX3-RX7 VFO (networkproto1.c:525-575)
+        // C0 address: case5=0x08, 6=0x0A, 7=0x0C, 8=0x0E, 9=0x10
+        static constexpr quint8 kAddr[] = {0x08, 0x0A, 0x0C, 0x0E, 0x10};
+        out[0] = C0 | kAddr[bankIdx - 5];
+        // Most unused DDCs get TX freq (networkproto1.c:541,551)
+        quint64 freq = m_txFreqHz;
+        out[1] = (freq >> 24) & 0xFF;
+        out[2] = (freq >> 16) & 0xFF;
+        out[3] = (freq >>  8) & 0xFF;
+        out[4] =  freq        & 0xFF;
+        return;
+    }
+
+    case 10: // TX drive, mic, Alex HPF/LPF, PA (networkproto1.c:578-591)
+        out[0] = C0 | 0x12;
+        out[1] = m_txDrive & 0xFF;
+        out[2] = 0x40; // line_in=0, mic_boost=0, apollo defaults (networkproto1.c:582)
+        out[3] = m_alexHpfBits | (m_paEnabled ? 0x80 : 0);
+        out[4] = m_alexLpfBits;
+        return;
+
+    case 11: // Preamp control (networkproto1.c:593-601)
+        out[0] = C0 | 0x14;
+        out[1] = (m_rxPreamp[0] ? 0x01 : 0)
+               | (m_rxPreamp[1] ? 0x02 : 0)
+               | (m_rxPreamp[2] ? 0x04 : 0)
+               | (m_rxPreamp[0] ? 0x08 : 0); // bit 3 = rx0 preamp again (Thetis quirk)
+        out[2] = 0; // line_in_gain + puresignal
+        out[3] = 0; // user digital outputs
+        out[4] = (m_stepAttn[0] & 0x1F) | 0x20; // ADC0 step ATT + enable bit
+        return;
+
+    case 12: { // Step ATT ADC1/2, CW keyer (networkproto1.c:604-628)
+        out[0] = C0 | 0x16;
+        // RedPitaya-specific: don't force 31dB on ADC1 during TX
+        // Source: networkproto1.c:606-616 (DH1KLM fix)
+        if (m_mox && m_hardwareProfile.model != HPSDRModel::REDPITAYA) {
+            out[1] = 0x1F; // force 31dB during TX (Thetis default)
+        } else if (m_hardwareProfile.model == HPSDRModel::REDPITAYA) {
+            out[1] = m_stepAttn[1] & 0x1F;
+        } else {
+            out[1] = m_stepAttn[1] & 0xFF;
+        }
+        out[1] |= 0x20; // enable bit
+        out[2] = (m_stepAttn[2] & 0x1F) | 0x20; // ADC2 step ATT + enable
+        out[3] = 0; // CW keyer defaults (speed + mode)
+        out[4] = 0; // CW weight + strict spacing
+        return;
+    }
+
+    case 13: // CW enable (networkproto1.c:633-639)
+        out[0] = C0 | 0x1E;
+        out[1] = 0; // cw_enable
+        out[2] = 0; // sidetone_level
+        out[3] = 0; // rf_delay
+        out[4] = 0;
+        return;
+
+    case 14: // CW hang/sidetone (networkproto1.c:641-646)
+        out[0] = C0 | 0x20;
+        out[1] = 0; out[2] = 0; out[3] = 0; out[4] = 0;
+        return;
+
+    case 15: // EER PWM (networkproto1.c:649-654)
+        out[0] = C0 | 0x22;
+        out[1] = 0; out[2] = 0; out[3] = 0; out[4] = 0;
+        return;
+
+    case 16: // BPF2 (networkproto1.c:657-665)
+        out[0] = C0 | 0x24;
+        out[1] = 0; out[2] = 0; out[3] = 0; out[4] = 0;
+        return;
+
+    case 17: // AnvelinaPro3 extra OC (networkproto1.c:668-673)
+        out[0] = C0 | 0x26;
+        out[1] = 0; out[2] = 0; out[3] = 0; out[4] = 0;
+        return;
+
+    default:
+        return;
+    }
+}
+```
+
+Declare in header:
+
+```cpp
+    void composeCcForBank(int bankIdx, quint8 out[5]) const;
+```
+
+- [ ] **Step 3: Refactor sendCommandFrame to use round-robin**
+
+Replace `sendCommandFrame(bool sub1TxBank)` with a new version that cycles through all banks:
+
+```cpp
+void P1RadioConnection::sendCommandFrame()
+{
+    if (!m_socket) { return; }
+
+    // Determine how many banks this model cycles through
+    // AnvelinaPro3 gets bank 17; all others stop at 16.
+    const int maxBank = (m_hardwareProfile.model == HPSDRModel::ANVELINAPRO3) ? 17 : 16;
+
+    quint8 frame[1032];
+    memset(frame, 0, sizeof(frame));
+
+    // EP2 header
+    frame[0] = 0xEF; frame[1] = 0xFE; frame[2] = 0x01; frame[3] = 0x02;
+    const quint32 seq = m_epSendSeq++;
+    frame[4] = (seq >> 24) & 0xFF;
+    frame[5] = (seq >> 16) & 0xFF;
+    frame[6] = (seq >>  8) & 0xFF;
+    frame[7] =  seq        & 0xFF;
+
+    // Subframe 0: current bank
+    frame[8] = 0x7F; frame[9] = 0x7F; frame[10] = 0x7F;
+    quint8 cc0[5] = {};
+    composeCcForBank(m_ccRoundRobinIdx, cc0);
+    frame[11] = cc0[0]; frame[12] = cc0[1]; frame[13] = cc0[2];
+    frame[14] = cc0[3]; frame[15] = cc0[4];
+
+    // Advance to next bank
+    m_ccRoundRobinIdx++;
+    if (m_ccRoundRobinIdx > maxBank) { m_ccRoundRobinIdx = 0; }
+
+    // Subframe 1: next bank
+    frame[520] = 0x7F; frame[521] = 0x7F; frame[522] = 0x7F;
+    quint8 cc1[5] = {};
+    composeCcForBank(m_ccRoundRobinIdx, cc1);
+    frame[523] = cc1[0]; frame[524] = cc1[1]; frame[525] = cc1[2];
+    frame[526] = cc1[3]; frame[527] = cc1[4];
+
+    // Advance again
+    m_ccRoundRobinIdx++;
+    if (m_ccRoundRobinIdx > maxBank) { m_ccRoundRobinIdx = 0; }
+
+    QByteArray pkt(reinterpret_cast<const char*>(frame), 1032);
+    m_socket->writeDatagram(pkt, m_radioInfo.address, m_radioInfo.port);
+}
+```
+
+- [ ] **Step 4: Update onWatchdogTick to call parameterless sendCommandFrame**
+
+In `onWatchdogTick()`, replace:
+
+```cpp
+        if (!m_hl2Throttled) {
+            const bool txBank = (m_ccRoundRobinIdx++ & 1) != 0;
+            sendCommandFrame(txBank);
+        }
+```
+
+with:
+
+```cpp
+        if (!m_hl2Throttled) {
+            sendCommandFrame();
+        }
+```
+
+- [ ] **Step 5: Update sendPrimingBurst**
+
+Replace calls to `sendCommandFrame(true/false)` in `sendPrimingBurst` with the parameterless version. The round-robin naturally covers all banks, and the priming burst sends multiple packets which cycle through the first few banks:
+
+```cpp
+void P1RadioConnection::sendPrimingBurst(int countPerBank)
+{
+    // Send enough packets to cover at least the general settings + frequency banks.
+    // Each call advances the round-robin by 2 banks.
+    for (int i = 0; i < countPerBank; ++i) {
+        sendCommandFrame();
+    }
+    QThread::msleep(10);
+    for (int i = 0; i < countPerBank; ++i) {
+        sendCommandFrame();
+    }
+    QThread::msleep(10);
+}
+```
+
+- [ ] **Step 6: Update header — remove old sendCommandFrame(bool) signature**
+
+Change the declaration from:
+
+```cpp
+    void sendCommandFrame(bool sub1TxBank);
+```
+
+to:
+
+```cpp
+    void sendCommandFrame();
+```
+
+Remove the old `composeEp2Frame` static method declaration if no longer used by tests (check first — if tests use it, keep it).
+
+- [ ] **Step 7: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -5`
+Expected: BUILD SUCCESS. Fix any compile errors from signature changes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/core/P1RadioConnection.h src/core/P1RadioConnection.cpp
+git commit -m "feat(p1): complete 17-bank C&C round-robin
+
+Port of Thetis networkproto1.c WriteMainLoop cases 0-17. Each 25ms
+tick now sends 2 consecutive banks from the full 17-bank cycle
+(~225ms per full rotation). Includes bank 4 (ADC assignments),
+bank 10 (Alex filters, PA enable), bank 11 (preamp, step ATT),
+bank 12 (RedPitaya-specific ATT handling), banks 13-16 (CW, EER,
+BPF2 defaults).
+
+Fixes Issue #38: RedPitaya stream drops every ~9 seconds due to
+incomplete C&C causing firmware watchdog timeout.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: P2RadioConnection — use HardwareProfile
+
+**Files:**
+- Modify: `src/core/P2RadioConnection.cpp:128, 141`
+
+- [ ] **Step 1: Replace caps lookup**
+
+In `P2RadioConnection::connectToRadio()`, replace line 128:
+
+```cpp
+    m_caps = &BoardCapsTable::forBoard(info.boardType);
+```
+
+with:
+
+```cpp
+    // Use HardwareProfile for capability lookup (Phase 3I-RP).
+    // This ensures a RedPitaya (board byte Hermes) connecting via P2
+    // gets OrionMKII capabilities when the user sets the model override.
+    m_caps = m_hardwareProfile.caps;
+```
+
+Also replace line 141 (`m_numAdc = m_caps->adcCount;`) with:
+
+```cpp
+    m_numAdc = m_hardwareProfile.adcCount;
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -5`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/P2RadioConnection.cpp
+git commit -m "feat(p2): use HardwareProfile for caps and ADC count
+
+P2RadioConnection now reads capabilities and ADC count from the
+HardwareProfile instead of raw board byte lookup. Fixes RedPitaya
+P2 firmware getting Hermes (1-ADC) capabilities instead of
+OrionMKII (2-ADC).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: ConnectionPanel detail panel with model dropdown
+
+**Files:**
+- Modify: `src/gui/ConnectionPanel.h`
+- Modify: `src/gui/ConnectionPanel.cpp`
+
+- [ ] **Step 1: Add detail panel widgets to header**
+
+In `ConnectionPanel.h`, add includes:
+
+```cpp
+#include "core/HardwareProfile.h"
+#include <QComboBox>
+#include <QGroupBox>
+```
+
+Add new widget members after the existing ones:
+
+```cpp
+    // Detail panel (Phase 3I-RP)
+    QGroupBox*   m_detailGroup{nullptr};
+    QLabel*      m_detailBoardLabel{nullptr};
+    QLabel*      m_detailProtoLabel{nullptr};
+    QLabel*      m_detailFwLabel{nullptr};
+    QLabel*      m_detailIpLabel{nullptr};
+    QLabel*      m_detailMacLabel{nullptr};
+    QComboBox*   m_modelCombo{nullptr};
+    QLabel*      m_modelHintLabel{nullptr};
+```
+
+Add new slots:
+
+```cpp
+    void onModelComboChanged(int index);
+    void updateDetailPanel();
+```
+
+- [ ] **Step 2: Build the detail panel in buildUI()**
+
+In `ConnectionPanel::buildUI()`, after the radio table group box is added to `mainLayout` (after line 196), add the detail panel:
+
+```cpp
+    // --- Selected Radio detail panel (Phase 3I-RP) ---
+    m_detailGroup = new QGroupBox(QStringLiteral("Selected Radio"), this);
+    m_detailGroup->setVisible(false); // hidden until a row is selected
+    auto* detailLayout = new QVBoxLayout(m_detailGroup);
+    detailLayout->setSpacing(4);
+
+    // Info row 1: Board + Protocol + Firmware
+    auto* infoRow1 = new QHBoxLayout();
+    m_detailBoardLabel = new QLabel(m_detailGroup);
+    m_detailProtoLabel = new QLabel(m_detailGroup);
+    m_detailFwLabel    = new QLabel(m_detailGroup);
+    for (auto* lbl : {m_detailBoardLabel, m_detailProtoLabel, m_detailFwLabel}) {
+        lbl->setStyleSheet(QStringLiteral("QLabel { color: #8090a0; font-size: 12px; }"));
+    }
+    infoRow1->addWidget(m_detailBoardLabel);
+    infoRow1->addWidget(m_detailProtoLabel);
+    infoRow1->addWidget(m_detailFwLabel);
+    infoRow1->addStretch();
+    detailLayout->addLayout(infoRow1);
+
+    // Info row 2: IP + MAC
+    auto* infoRow2 = new QHBoxLayout();
+    m_detailIpLabel  = new QLabel(m_detailGroup);
+    m_detailMacLabel = new QLabel(m_detailGroup);
+    for (auto* lbl : {m_detailIpLabel, m_detailMacLabel}) {
+        lbl->setStyleSheet(QStringLiteral("QLabel { color: #8090a0; font-size: 12px; }"));
+    }
+    infoRow2->addWidget(m_detailIpLabel);
+    infoRow2->addWidget(m_detailMacLabel);
+    infoRow2->addStretch();
+    detailLayout->addLayout(infoRow2);
+
+    // Model selector row
+    auto* modelRow = new QHBoxLayout();
+    auto* modelLabel = new QLabel(QStringLiteral("Radio Model:"), m_detailGroup);
+    modelLabel->setStyleSheet(QStringLiteral("QLabel { color: #c8d8e8; font-weight: bold; }"));
+    m_modelCombo = new QComboBox(m_detailGroup);
+    m_modelCombo->setMinimumWidth(200);
+    m_modelCombo->setStyleSheet(QStringLiteral(
+        "QComboBox { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050;"
+        "  border-radius: 3px; padding: 4px 8px; }"
+        "QComboBox::drop-down { border: none; }"
+        "QComboBox QAbstractItemView { background: #12202e; color: #c8d8e8;"
+        "  selection-background-color: #005578; }"));
+    connect(m_modelCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &ConnectionPanel::onModelComboChanged);
+    modelRow->addWidget(modelLabel);
+    modelRow->addWidget(m_modelCombo);
+    modelRow->addStretch();
+    detailLayout->addLayout(modelRow);
+
+    // Hint label
+    m_modelHintLabel = new QLabel(m_detailGroup);
+    m_modelHintLabel->setStyleSheet(QStringLiteral(
+        "QLabel { color: #b08020; font-size: 11px; font-style: italic; }"));
+    m_modelHintLabel->setVisible(false);
+    detailLayout->addWidget(m_modelHintLabel);
+
+    mainLayout->addWidget(m_detailGroup);
+```
+
+- [ ] **Step 3: Implement updateDetailPanel()**
+
+```cpp
+void ConnectionPanel::updateDetailPanel()
+{
+    RadioInfo info = selectedRadio();
+    if (info.macAddress.isEmpty()) {
+        m_detailGroup->setVisible(false);
+        return;
+    }
+
+    m_detailGroup->setVisible(true);
+
+    // Board name from raw discovery byte
+    QString boardName = QString::fromLatin1(
+        BoardCapsTable::forBoard(info.boardType).displayName);
+    m_detailBoardLabel->setText(QStringLiteral("Board: %1 (0x%2)")
+        .arg(boardName)
+        .arg(static_cast<int>(info.boardType), 2, 16, QLatin1Char('0')));
+    m_detailProtoLabel->setText(QStringLiteral("Protocol: P%1")
+        .arg(info.protocol == ProtocolVersion::Protocol2 ? 2 : 1));
+    m_detailFwLabel->setText(QStringLiteral("Firmware: %1")
+        .arg(info.firmwareVersion));
+    m_detailIpLabel->setText(QStringLiteral("IP: %1").arg(info.address.toString()));
+    m_detailMacLabel->setText(QStringLiteral("MAC: %1").arg(info.macAddress));
+
+    // Populate model combo with compatible models
+    m_modelCombo->blockSignals(true);
+    m_modelCombo->clear();
+    QList<HPSDRModel> models = compatibleModels(info.boardType);
+    HPSDRModel defaultModel = defaultModelForBoard(info.boardType);
+
+    // Check for persisted override
+    HPSDRModel persisted = AppSettings::instance().modelOverride(info.macAddress);
+    HPSDRModel selected = (persisted != HPSDRModel::FIRST) ? persisted : defaultModel;
+
+    int selectIdx = 0;
+    for (int i = 0; i < models.size(); ++i) {
+        m_modelCombo->addItem(
+            QString::fromLatin1(displayName(models[i])),
+            static_cast<int>(models[i]));
+        if (models[i] == selected) {
+            selectIdx = i;
+        }
+    }
+    m_modelCombo->setCurrentIndex(selectIdx);
+    m_modelCombo->blockSignals(false);
+
+    // Show hint if override differs from auto-detect
+    if (selected != defaultModel) {
+        m_modelHintLabel->setText(QStringLiteral("Board reports \"%1\" -- model override applied")
+            .arg(boardName));
+        m_modelHintLabel->setVisible(true);
+    } else {
+        m_modelHintLabel->setVisible(false);
+    }
+}
+```
+
+- [ ] **Step 4: Implement onModelComboChanged()**
+
+```cpp
+void ConnectionPanel::onModelComboChanged(int index)
+{
+    if (index < 0) { return; }
+    RadioInfo info = selectedRadio();
+    if (info.macAddress.isEmpty()) { return; }
+
+    int modelInt = m_modelCombo->itemData(index).toInt();
+    auto model = static_cast<HPSDRModel>(modelInt);
+
+    AppSettings::instance().setModelOverride(info.macAddress, model);
+    AppSettings::instance().save();
+
+    // Update hint
+    HPSDRModel defaultModel = defaultModelForBoard(info.boardType);
+    QString boardName = QString::fromLatin1(
+        BoardCapsTable::forBoard(info.boardType).displayName);
+    if (model != defaultModel) {
+        m_modelHintLabel->setText(QStringLiteral("Board reports \"%1\" -- model override applied")
+            .arg(boardName));
+        m_modelHintLabel->setVisible(true);
+    } else {
+        m_modelHintLabel->setVisible(false);
+    }
+
+    setStatusText(QStringLiteral("Model set to %1 for %2")
+        .arg(QString::fromLatin1(displayName(model)), info.macAddress));
+}
+```
+
+- [ ] **Step 5: Wire updateDetailPanel to selection changes**
+
+In `onRadioSelectionChanged()` (line 676), add:
+
+```cpp
+    updateDetailPanel();
+```
+
+- [ ] **Step 6: Pass modelOverride in onConnectClicked()**
+
+In `onConnectClicked()`, after `RadioInfo info = selectedRadio();` (line 585), add:
+
+```cpp
+    // Apply model override from dropdown (Phase 3I-RP)
+    if (m_modelCombo && m_modelCombo->currentIndex() >= 0) {
+        int modelInt = m_modelCombo->itemData(m_modelCombo->currentIndex()).toInt();
+        info.modelOverride = static_cast<HPSDRModel>(modelInt);
+    }
+```
+
+- [ ] **Step 7: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -5`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/gui/ConnectionPanel.h src/gui/ConnectionPanel.cpp
+git commit -m "feat(gui): add radio model selector to ConnectionPanel
+
+Detail panel appears below the discovered radios table when a row is
+selected. Shows board info, protocol, firmware, IP, MAC, and a Radio
+Model dropdown populated with compatible models for the discovered
+board byte. Selection persisted per-MAC in AppSettings. Includes
+hint label when override differs from auto-detection.
+
+Part of Phase 3I-RP (Issue #38).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Wire "Radio Setup..." menu item + HardwarePage integration
+
+**Files:**
+- Modify: `src/gui/MainWindow.cpp:631-635`
+- Modify: `src/gui/setup/HardwarePage.cpp:141-156`
+
+- [ ] **Step 1: Wire Radio Setup menu item**
+
+In `MainWindow.cpp`, replace the disabled "Radio Setup..." action (lines 631-635):
+
+```cpp
+    {
+        QAction* radioSetupAction = radioMenu->addAction(QStringLiteral("&Radio Setup..."));
+        radioSetupAction->setEnabled(false);
+        radioSetupAction->setToolTip(QStringLiteral("NYI — Phase X"));
+    }
+```
+
+with:
+
+```cpp
+    radioMenu->addAction(QStringLiteral("&Radio Setup..."), this, [this]() {
+        if (!m_radioModel->isConnected()) {
+            showConnectionPanel();
+            return;
+        }
+        // Open ConnectionPanel focused on current radio
+        showConnectionPanel();
+    });
+```
+
+- [ ] **Step 2: Update HardwarePage to use profile for tab visibility**
+
+In `HardwarePage::onCurrentRadioChanged()` (line 141), replace:
+
+```cpp
+    const BoardCapabilities& caps = BoardCapsTable::forBoard(info.boardType);
+```
+
+with:
+
+```cpp
+    // Use HardwareProfile for capability lookup (Phase 3I-RP).
+    // This ensures model overrides (e.g. RedPitaya → OrionMKII) affect
+    // which tabs are visible.
+    const BoardCapabilities& caps = *m_model->hardwareProfile().caps;
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -5`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/gui/MainWindow.cpp src/gui/setup/HardwarePage.cpp
+git commit -m "feat(gui): wire Radio Setup menu + profile-driven HardwarePage
+
+Radio Setup menu item now opens ConnectionPanel (was disabled NYI).
+HardwarePage uses RadioModel::hardwareProfile() for tab visibility
+instead of raw board byte lookup, so model overrides correctly gate
+which hardware tabs are shown.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Auto-reconnect with model override
+
+**Files:**
+- Modify: `src/models/RadioModel.cpp` (tryAutoReconnect path)
+
+- [ ] **Step 1: Load modelOverride during auto-reconnect**
+
+Find the auto-reconnect path in RadioModel (where it reads from `AppSettings::lastConnected()` and calls `connectToRadio`). Before the `connectToRadio()` call, load the model override:
+
+```cpp
+    // Load persisted model override for auto-reconnect (Phase 3I-RP)
+    HPSDRModel mo = AppSettings::instance().modelOverride(info.macAddress);
+    if (mo != HPSDRModel::FIRST) {
+        info.modelOverride = mo;
+    }
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -5`
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/models/RadioModel.cpp
+git commit -m "feat(model): load model override on auto-reconnect
+
+When auto-reconnecting to a saved radio at startup, the persisted
+model override is loaded from AppSettings and applied to RadioInfo
+before connecting. Ensures RedPitaya users don't have to re-select
+their model every launch.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Build, smoke test, and final commit
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Full clean build**
+
+```bash
+cd /c/Users/boyds/NereusSDR
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build -j$(nproc)
+```
+
+Expected: BUILD SUCCESS with no warnings related to new code.
+
+- [ ] **Step 2: Run the application**
+
+```bash
+./build/NereusSDR
+```
+
+Verify:
+1. App launches without crash
+2. Open Radio > Discover (Ctrl+K)
+3. If a radio is discovered, click it — detail panel appears with model dropdown
+4. Model dropdown shows compatible models for the discovered board byte
+5. Close and reopen — model persists
+
+- [ ] **Step 3: Verify no regressions with existing radio**
+
+If an ANAN-G2 or HL2 is available:
+1. Connect — confirm normal I/Q reception
+2. Check Setup > Hardware Config — tabs should match the radio's capabilities
+3. Waterfall should display normally, no stream drops
+
+- [ ] **Step 4: Final commit if any fixups needed**
+
+Only if small fixes were needed during smoke testing.

--- a/docs/superpowers/specs/2026-04-16-radio-model-selector-p1-cc-design.md
+++ b/docs/superpowers/specs/2026-04-16-radio-model-selector-p1-cc-design.md
@@ -1,0 +1,378 @@
+# Phase 3I-RP: Radio Model Selector + P1 C&C Completion
+
+**Date:** 2026-04-16
+**Status:** Approved
+**Triggered by:** GitHub Issue #38 (RedPitaya user gets noise + periodic stream drops)
+
+---
+
+## Problem Statement
+
+NereusSDR has two related defects that together make RedPitaya (and potentially
+other non-standard Hermes-identifying devices) unusable:
+
+### A) No model override
+
+Discovery returns a board byte (e.g. 0x01 = Hermes), but that byte does not
+distinguish between a real Hermes, an ANAN-10, an ANAN-100, or a RedPitaya.
+The HPSDR ecosystem has only 6 board bytes for 16+ distinct radio models.
+Thetis solves this with a manual model selector (`comboRadioModel` in Setup).
+NereusSDR has none -- it takes the board byte at face value, which leads to
+wrong ADC count, wrong capabilities, and wrong filter/attenuator configuration.
+
+Thetis `clsHardwareSpecific.cs:178-183` shows the RedPitaya overrides:
+- `SetRxADC(2)` -- 2 ADCs, not 1
+- `SetMKIIBPF(0)` -- disable MKII BPF for OpenHPSDR compatibility
+- `SetADCSupply(0, 50)` -- 50V supply
+- `LRAudioSwap(0)` -- no audio swap
+- `Hardware = HPSDRHW.OrionMKII` -- force OrionMKII capability profile
+
+### B) Incomplete P1 C&C round-robin
+
+Thetis cycles through 17 C&C banks at ~381 fps via the audio-driven EP2 path
+(`networkproto1.c` WriteMainLoop cases 0-17). NereusSDR sends only 3 banks
+(general settings, TX freq, RX1 freq) at 40 fps (25ms timer). The remaining
+14 banks -- including dither/random, preamp, Alex filters, PA enable,
+attenuator, CW keyer, and ADC assignments -- are never sent.
+
+Specific issues in the current `composeCcBank0()`:
+- C3 = 0x00: dither OFF, random OFF, preamp OFF, no attenuator bits
+- C4: antenna bits zero, duplex not set, diversity not set
+- Banks 4-16: never composed, never sent
+
+### Confirmed by support bundle (Issue #38)
+
+Patrick's RedPitaya (Pavel Demin firmware) connects as **P1 Hermes** (not P2):
+
+```
+"protocol": 1
+"model": "Hermes (ANAN-10/100)"
+```
+
+Log pattern shows a repeating cycle:
+1. Connect, receive I/Q for ~7 seconds
+2. Watchdog triggers: "ep6 silent for 2020 ms"
+3. Transition to Error state, 5-second reconnect timer
+4. Reconnect succeeds, I/Q resumes for ~7 seconds
+5. Repeat
+
+Additionally, "Reconnected -- ep6 stream restored" log line spams 30-80 times
+per reconnect cycle (fires per queued ep6 frame instead of once).
+
+---
+
+## Architecture: Two Layers
+
+### Layer 1: HardwareProfile -- Model-driven configuration
+
+A new struct that takes an `HPSDRModel` and produces the complete set of
+hardware overrides. Ported from Thetis `clsHardwareSpecific.cs`.
+
+```cpp
+struct HardwareProfile {
+    HPSDRModel           model;
+    HPSDRHW              effectiveBoard;   // overridden board identity
+    const BoardCapabilities* caps;         // looked up from effectiveBoard
+    int                  adcCount;         // 1 or 2
+    bool                 mkiiBpf;          // MKII bandpass filter enable
+    int                  adcSupplyVoltage; // 33 or 50
+    bool                 lrAudioSwap;      // L/R audio channel swap
+};
+```
+
+Source mapping from `clsHardwareSpecific.cs:85-184`:
+
+| HPSDRModel | adcCount | mkiiBpf | adcSupply | audioSwap | effectiveBoard |
+|------------|----------|---------|-----------|-----------|----------------|
+| HERMES | 1 | off | 33 | yes | Hermes |
+| ANAN10 | 1 | off | 33 | yes | Hermes |
+| ANAN10E | 1 | off | 33 | yes | HermesII |
+| ANAN100 | 1 | off | 33 | yes | Hermes |
+| ANAN100B | 1 | off | 33 | yes | HermesII |
+| ANAN100D | 2 | off | 33 | no | Angelia |
+| ANAN200D | 2 | off | 50 | no | Orion |
+| ORIONMKII | 2 | on | 50 | no | OrionMKII |
+| ANAN7000D | 2 | on | 50 | no | OrionMKII |
+| ANAN8000D | 2 | on | 50 | no | OrionMKII |
+| ANAN_G2 | 2 | on | 50 | no | Saturn |
+| ANAN_G2_1K | 2 | on | 50 | no | Saturn |
+| ANVELINAPRO3 | 2 | on | 50 | no | OrionMKII |
+| HERMESLITE | 1 | off | 33 | yes | HermesLite |
+| REDPITAYA | 2 | off | 50 | no | OrionMKII |
+
+The profile is computed once at connect time and stored on RadioModel. Both
+P1RadioConnection and P2RadioConnection read from it instead of doing raw
+`BoardCapsTable::forBoard(info.boardType)` lookups.
+
+### Layer 2: P1 C&C full round-robin
+
+Complete `sendCommandFrame()` to cycle through all 17 Thetis C&C banks.
+Values for each bank come from HardwareProfile + runtime state.
+
+Current state (3 banks only):
+- Subframe 0: always bank 0 (general settings, C3/C4 = 0x00)
+- Subframe 1: alternates TX freq (bank 1) / RX1 freq (bank 2)
+
+New design: both subframes advance through the full 17-bank cycle. Each 25ms
+tick sends 2 consecutive banks. Full cycle in 9 ticks (~225ms).
+
+### How the layers connect
+
+```
+User picks "Red Pitaya" in ConnectionPanel
+  -> persisted as radios/<MAC>/modelOverride = 15
+  -> on Connect: HardwareProfile computed from HPSDRModel::REDPITAYA
+  -> P1RadioConnection reads profile.adcCount, .dither, etc.
+  -> composeCcBank0()  uses profile for dither/random/preamp (C3), antenna/duplex/NDDCs (C4)
+  -> composeCcBank4()  uses profile for ADC assignments
+  -> composeCcBank10() uses profile for Alex filters, PA enable
+  -> composeCcBank12() uses profile for RedPitaya-specific attenuation
+```
+
+---
+
+## UI: ConnectionPanel Detail Panel
+
+### Layout
+
+When a row is selected in the discovered radios table, a detail panel appears
+below the table and above the button strip:
+
+```
++-- Discovered Radios -------------------------------------------------------+
+| *  Name       Board    Proto  IP             MAC        In-Use             |
+| * Hermes     Hermes    P1    192.168.1.175  AA:BB:..   free               |
++----------------------------------------------------------------------------+
+
++-- Selected Radio -----------------------------------------------------------+
+|  Board: Hermes (0x01)    Protocol: P1    Firmware: 32                      |
+|  IP: 192.168.1.175       MAC: AA:BB:CC:DD:EE:F1                            |
+|                                                                             |
+|  Radio Model: [Red Pitaya       v]                                          |
+|               Board reports "Hermes" -- model override applied              |
++-----------------------------------------------------------------------------+
+
+[Start Discovery] [Stop Discovery]   [Add Manually] [Forget]
+                                     [Connect] [Disconnect] [Close]
+```
+
+### Behavior
+
+- Panel hidden when no row selected. Appears on row click.
+- "Radio Model" dropdown populated with models compatible with the discovered
+  board byte + protocol. For a P1 Hermes, the list: Hermes, ANAN-10, ANAN-100,
+  Red Pitaya, Hermes Lite 2. Compatibility determined by: (a) `boardForModel(m)`
+  matches the discovered board byte, OR (b) the model is in a special-case
+  list for that board byte. From `NetworkIO.cs:164-171`:
+  - Hermes (0x01): HERMES, ANAN10, ANAN100, REDPITAYA, HERMESLITE
+  - HermesII (0x02): ANAN10E, ANAN100B, REDPITAYA
+  - OrionMKII (0x05): ORIONMKII, ANAN7000D, ANAN8000D, ANVELINAPRO3, REDPITAYA
+  - Other board bytes: only the models whose boardForModel() matches.
+- Default: auto-guess from board byte. If per-MAC override exists in
+  AppSettings, use that instead.
+- Dropdown change saves immediately to `radios/<MAC>/modelOverride`.
+- Hint line only shown when selected model differs from auto-detection.
+- Double-click on table row still connects immediately using persisted model.
+
+### "Radio Setup..." menu item
+
+The existing disabled `Radio > Radio Setup...` menu item is wired up to open
+a small dialog showing the same detail panel for the currently-connected radio.
+Allows model change post-connect. Reconnect required for changes to take effect
+(dialog states this).
+
+---
+
+## Persistence
+
+### Per-MAC storage
+
+One new key added to the existing per-MAC radio storage:
+
+```
+radios/<MAC>/modelOverride = "15"   (HPSDRModel int value as string)
+```
+
+All other profile values are derived from the model enum at connect time.
+Not stored.
+
+### Auto-guess when no override exists
+
+When `modelOverride` is absent for a MAC, the system picks the first
+`HPSDRModel` whose `boardForModel()` matches the discovered `HPSDRHW` board
+byte. For most radios this is correct. For ambiguous cases (Hermes byte with
+multiple possible models), the user sets it once and it sticks.
+
+### Multi-radio support
+
+The existing per-MAC settings infrastructure (`AppSettings::setHardwareValue`,
+`hardwareValues`) already provides per-radio profiles. The model override
+integrates naturally -- each radio's MAC gets its own model, and the
+HardwareProfile computed from that model drives capability lookups,
+HardwarePage tab visibility, and C&C configuration for that specific radio.
+
+---
+
+## P1 C&C Round-Robin: Complete Bank Specification
+
+All 17 banks ported from Thetis `networkproto1.c` WriteMainLoop cases 0-17.
+
+### Bank 0 (C0=0x00): General settings
+Source: `networkproto1.c:450-471`
+
+| Byte | Content | Current NereusSDR | Fix |
+|------|---------|-------------------|-----|
+| C0 | XmitBit (MOX) | Correct | -- |
+| C1 | SampleRateIn2Bits & 3 | Correct | -- |
+| C2 | OC output mask, EER bit | 0x00 | Populate from m_ocOutput |
+| C3 | 10dB ATT, 20dB ATT, preamp, dither, random, RX input select | 0x00 | Populate from HardwareProfile + state |
+| C4 | Antenna, duplex, NDDCs, diversity | Only NDDCs set | Add duplex=1, antenna bits, diversity |
+
+### Bank 1 (C0=0x02): TX VFO frequency
+Source: `networkproto1.c:476-482`. Already implemented correctly.
+
+### Bank 2 (C0=0x04): RX1 VFO (DDC0) frequency
+Source: `networkproto1.c:484-494`. Already implemented correctly.
+
+### Bank 3 (C0=0x06): RX2 VFO (DDC1) frequency
+Source: `networkproto1.c:497-511`. New. Sends RX2 freq (or TX freq for
+PureSignal, or RX1 freq for Orion DDC config).
+
+### Bank 4 (C0=0x1C): ADC assignments + TX step attenuator
+Source: `networkproto1.c:517-523`. New.
+- C1 = `P1_adc_cntrl & 0xFF` (ADC-to-DDC mapping low byte)
+- C2 = `(P1_adc_cntrl >> 8) & 0x3F` (ADC-to-DDC mapping high bits)
+- C3 = `adc[0].tx_step_attn & 0x1F` (TX step attenuator)
+
+### Banks 5-9 (C0=0x08..0x10): RX3-RX7 VFO frequencies
+Source: `networkproto1.c:525-575`. New. Most set to TX freq or RX1 freq
+depending on DDC configuration.
+
+### Bank 10 (C0=0x12): TX drive, mic, Alex HPF/LPF, PA enable
+Source: `networkproto1.c:578-591`. New. Critical for reception:
+- C1 = TX drive level
+- C2 = mic boost/line-in, Apollo filter bits
+- C3 = Alex HPF select (13MHz, 20MHz, 9.5MHz, 6.5MHz, 1.5MHz, bypass, 6M preamp) + PA enable bit 7
+- C4 = Alex LPF select (30/20, 60/40, 80, 160, 6, 12/10, 17/15)
+
+Alex HPF/LPF values computed from current RX frequency using the Thetis
+frequency-to-filter lookup (already partially ported for P2 in
+`P2RadioConnection`).
+
+### Bank 11 (C0=0x14): Preamp control, mic settings, step ATT
+Source: `networkproto1.c:593-601`. New.
+- C1 = per-RX preamp bits, mic TRS/bias/PTT
+- C2 = line-in gain, PureSignal run flag
+- C3 = user digital outputs
+- C4 = ADC0 step attenuator | 0x20 (enable bit)
+
+### Bank 12 (C0=0x16): Step ATT ADC1/2, CW keyer
+Source: `networkproto1.c:604-628`. New. **Contains RedPitaya-specific logic:**
+```
+if (XmitBit && model != REDPITAYA)
+    C1 = 0x1F;  // force 31dB on ADC1 during TX
+else if (model == REDPITAYA)
+    C1 = adc[1].rx_step_attn & 0x1F;  // use actual value
+else
+    C1 = adc[1].rx_step_attn;
+```
+
+### Banks 13-14 (C0=0x1E, 0x20): CW settings
+Source: `networkproto1.c:633-646`. New. CW enable, sidetone, RF delay, hang
+delay, sidetone frequency.
+
+### Bank 15 (C0=0x22): EER PWM
+Source: `networkproto1.c:649-654`. New. EER PWM min/max.
+
+### Bank 16 (C0=0x24): BPF2 filters
+Source: `networkproto1.c:657-665`. New. Second BPF filter bank, XVTR enable.
+
+### Bank 17 (C0=0x26): AnvelinaPro3 extra OC pins
+Source: `networkproto1.c:668-673`. New. Only sent when model is AnvelinaPro3.
+Skipped for all other models (cycle is 0..16 instead of 0..17).
+
+---
+
+## Runtime State Members
+
+New members on P1RadioConnection, set via setters, read by composeCcBank
+functions:
+
+| Member | Type | Source | Default |
+|--------|------|--------|---------|
+| `m_profile` | `HardwareProfile` | Computed at connect | From model |
+| `m_preamp[3]` | `bool` | SliceModel / setup | From profile |
+| `m_stepAttn[3]` | `int` | SliceModel / setup | 0 |
+| `m_dither[3]` | `bool` | HardwareProfile | true (from profile) |
+| `m_random[3]` | `bool` | HardwareProfile | true (from profile) |
+| `m_txDrive` | `int` | TxApplet / setup | 0 |
+| `m_paEnabled` | `bool` | HardwareProfile | From profile |
+| `m_ocOutput` | `quint8` | Setup OC tab | 0 |
+| `m_duplex` | `bool` | Always on | true |
+| `m_diversity` | `bool` | Setup | false |
+| `m_alexHpf` | `quint8` | Computed from freq | 0 |
+| `m_alexLpf` | `quint8` | Computed from freq | 0 |
+| `m_cwConfig` | `CwConfig` | CW applet / setup | Defaults |
+| `m_micConfig` | `MicConfig` | Setup | Defaults |
+| `m_adcCtrl` | `quint16` | HardwareProfile + DDC config | From profile |
+
+---
+
+## Bug Fixes Included
+
+### Reconnect log spam
+
+In the ep6 receive path, add `m_reconnectedLogged` guard:
+- Set to `true` on first "Reconnected" log after a reconnect
+- Cleared on disconnect or error transition
+- Prevents 30-80 duplicate log lines per reconnect cycle
+
+### P2 connection: board capability override
+
+`P2RadioConnection::connectToRadio()` currently does
+`m_caps = &BoardCapsTable::forBoard(info.boardType)`. Change to read from
+HardwareProfile: `m_caps = profile.caps`. This ensures a RedPitaya connecting
+via P2 (possible with different firmware) gets OrionMKII capabilities.
+
+---
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `src/core/HardwareProfile.h` (new) | HardwareProfile struct + factory function |
+| `src/core/HardwareProfile.cpp` (new) | `profileForModel()` -- port of clsHardwareSpecific.cs |
+| `src/core/P1RadioConnection.h` | New runtime state members, composeCcBank declarations |
+| `src/core/P1RadioConnection.cpp` | Full 17-bank round-robin, reconnect log spam fix |
+| `src/core/P2RadioConnection.cpp` | Use HardwareProfile for caps lookup |
+| `src/core/RadioDiscovery.h` | Add `HPSDRModel modelOverride` field to RadioInfo |
+| `src/core/AppSettings.cpp/h` | Read/write `modelOverride` per-MAC |
+| `src/gui/ConnectionPanel.h/cpp` | Detail panel with model dropdown |
+| `src/gui/MainWindow.cpp` | Wire "Radio Setup..." menu item |
+| `src/models/RadioModel.h/cpp` | Store HardwareProfile, pass to connections |
+| `src/gui/setup/HardwarePage.cpp` | Use profile.effectiveBoard for tab visibility |
+
+---
+
+## Out of Scope
+
+- TX I/Q streaming (Phase 3I-TX)
+- PureSignal DDC feedback routing (Phase 3I-PS)
+- HL2 I/O Board I2C commands (Phase 3L)
+- Full Alex filter auto-compute for all bands (partial: only the lookup table,
+  not the full Thetis `console.cs:6830-7234` filter state machine)
+- CW keyer UI wiring (banks 13-14 will send defaults; CW applet wiring is
+  future work)
+
+---
+
+## Verification
+
+1. Connect to an ANAN-G2 (Saturn/P2) -- confirm no regression, same behavior
+2. Connect to a Hermes Lite 2 (P1) -- confirm full C&C cycle, no stream drops
+3. With a RedPitaya pcap from Patrick: compare NereusSDR's EP2 output against
+   Thetis's EP2 output byte-for-byte for banks 0, 10, 11, 12
+4. Model selector: set a radio to "Red Pitaya", close app, reopen -- confirm
+   override persists and is applied on auto-reconnect
+5. Multi-radio: save two radios with different models, switch between them,
+   confirm each gets its own profile

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -257,6 +257,12 @@ void AppSettings::saveRadio(const RadioInfo& info, bool pinToMac, bool autoConne
     m_settings.insert(prefix + QStringLiteral("autoConnect"),     autoConnect ? QStringLiteral("True") : QStringLiteral("False"));
     m_settings.insert(prefix + QStringLiteral("lastSeen"),
                       QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
+
+    // Model override (Phase 3I-RP). FIRST = no override.
+    if (info.modelOverride != HPSDRModel::FIRST) {
+        m_settings.insert(prefix + QStringLiteral("modelOverride"),
+                          QString::number(static_cast<int>(info.modelOverride)));
+    }
 }
 
 void AppSettings::forgetRadio(const QString& macKey)
@@ -345,6 +351,15 @@ std::optional<SavedRadio> AppSettings::savedRadio(const QString& macKey) const
         sr.lastSeen = QDateTime::fromString(lastSeenStr, Qt::ISODate);
     }
 
+    // Model override (Phase 3I-RP)
+    const QString moStr = m_settings.value(prefix + QStringLiteral("modelOverride"),
+                                            QStringLiteral("-1"));
+    int moInt = moStr.toInt();
+    if (moInt > static_cast<int>(HPSDRModel::FIRST) &&
+        moInt < static_cast<int>(HPSDRModel::LAST)) {
+        sr.info.modelOverride = static_cast<HPSDRModel>(moInt);
+    }
+
     return sr;
 }
 
@@ -419,6 +434,30 @@ void AppSettings::clearHardwareValues(const QString& mac)
             m_settings.remove(k);
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Model override (Phase 3I-RP)
+// ---------------------------------------------------------------------------
+
+HPSDRModel AppSettings::modelOverride(const QString& macKey) const
+{
+    const QString prefix = radioKeyPrefix(macKey);
+    const QString val = m_settings.value(prefix + QStringLiteral("modelOverride"),
+                                          QStringLiteral("-1"));
+    int v = val.toInt();
+    if (v > static_cast<int>(HPSDRModel::FIRST) &&
+        v < static_cast<int>(HPSDRModel::LAST)) {
+        return static_cast<HPSDRModel>(v);
+    }
+    return HPSDRModel::FIRST;
+}
+
+void AppSettings::setModelOverride(const QString& macKey, HPSDRModel model)
+{
+    const QString prefix = radioKeyPrefix(macKey);
+    m_settings.insert(prefix + QStringLiteral("modelOverride"),
+                      QString::number(static_cast<int>(model)));
 }
 
 } // namespace NereusSDR

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -122,6 +122,10 @@ public:
     DiscoveryProfile discoveryProfile() const;
     void             setDiscoveryProfile(DiscoveryProfile p);
 
+    // Model override for a specific radio MAC (Phase 3I-RP).
+    HPSDRModel modelOverride(const QString& macKey) const;
+    void setModelOverride(const QString& macKey, HPSDRModel model);
+
     // -------------------------------------------------------------------------
     // Per-slice-per-band DSP state (Phase 3G-10 Stage 2 — S2.P).
     //

--- a/src/core/HardwareProfile.cpp
+++ b/src/core/HardwareProfile.cpp
@@ -1,0 +1,196 @@
+// src/core/HardwareProfile.cpp
+//
+// Source: mi0bot/Thetis clsHardwareSpecific.cs:85-184, NetworkIO.cs:164-171
+
+#include "HardwareProfile.h"
+
+namespace NereusSDR {
+
+// From Thetis clsHardwareSpecific.cs:85-184
+HardwareProfile profileForModel(HPSDRModel model)
+{
+    HardwareProfile p;
+    p.model = model;
+
+    switch (model) {
+        case HPSDRModel::HERMES:
+            p.effectiveBoard    = HPSDRHW::Hermes;
+            p.adcCount          = 1;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 33;
+            p.lrAudioSwap       = true;
+            break;
+        case HPSDRModel::ANAN10:
+            p.effectiveBoard    = HPSDRHW::Hermes;
+            p.adcCount          = 1;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 33;
+            p.lrAudioSwap       = true;
+            break;
+        case HPSDRModel::ANAN10E:
+            p.effectiveBoard    = HPSDRHW::HermesII;
+            p.adcCount          = 1;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 33;
+            p.lrAudioSwap       = true;
+            break;
+        case HPSDRModel::ANAN100:
+            p.effectiveBoard    = HPSDRHW::Hermes;
+            p.adcCount          = 1;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 33;
+            p.lrAudioSwap       = true;
+            break;
+        case HPSDRModel::ANAN100B:
+            p.effectiveBoard    = HPSDRHW::HermesII;
+            p.adcCount          = 1;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 33;
+            p.lrAudioSwap       = true;
+            break;
+        case HPSDRModel::ANAN100D:
+            p.effectiveBoard    = HPSDRHW::Angelia;
+            p.adcCount          = 2;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 33;
+            p.lrAudioSwap       = false;
+            break;
+        case HPSDRModel::ANAN200D:
+            p.effectiveBoard    = HPSDRHW::Orion;
+            p.adcCount          = 2;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 50;
+            p.lrAudioSwap       = false;
+            break;
+        case HPSDRModel::ORIONMKII:
+            p.effectiveBoard    = HPSDRHW::OrionMKII;
+            p.adcCount          = 2;
+            p.mkiiBpf           = true;
+            p.adcSupplyVoltage  = 50;
+            p.lrAudioSwap       = false;
+            break;
+        case HPSDRModel::ANAN7000D:
+            p.effectiveBoard    = HPSDRHW::OrionMKII;
+            p.adcCount          = 2;
+            p.mkiiBpf           = true;
+            p.adcSupplyVoltage  = 50;
+            p.lrAudioSwap       = false;
+            break;
+        case HPSDRModel::ANAN8000D:
+            p.effectiveBoard    = HPSDRHW::OrionMKII;
+            p.adcCount          = 2;
+            p.mkiiBpf           = true;
+            p.adcSupplyVoltage  = 50;
+            p.lrAudioSwap       = false;
+            break;
+        case HPSDRModel::ANAN_G2:
+            p.effectiveBoard    = HPSDRHW::Saturn;
+            p.adcCount          = 2;
+            p.mkiiBpf           = true;
+            p.adcSupplyVoltage  = 50;
+            p.lrAudioSwap       = false;
+            break;
+        case HPSDRModel::ANAN_G2_1K:
+            p.effectiveBoard    = HPSDRHW::Saturn;
+            p.adcCount          = 2;
+            p.mkiiBpf           = true;
+            p.adcSupplyVoltage  = 50;
+            p.lrAudioSwap       = false;
+            break;
+        case HPSDRModel::ANVELINAPRO3:
+            p.effectiveBoard    = HPSDRHW::OrionMKII;
+            p.adcCount          = 2;
+            p.mkiiBpf           = true;
+            p.adcSupplyVoltage  = 50;
+            p.lrAudioSwap       = false;
+            break;
+        case HPSDRModel::HERMESLITE:
+            p.effectiveBoard    = HPSDRHW::HermesLite;
+            p.adcCount          = 1;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 33;
+            p.lrAudioSwap       = true;
+            break;
+        case HPSDRModel::REDPITAYA:
+            p.effectiveBoard    = HPSDRHW::OrionMKII;
+            p.adcCount          = 2;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 50;
+            p.lrAudioSwap       = false;
+            break;
+        case HPSDRModel::HPSDR:
+            p.effectiveBoard    = HPSDRHW::Atlas;
+            p.adcCount          = 1;
+            p.mkiiBpf           = false;
+            p.adcSupplyVoltage  = 33;
+            p.lrAudioSwap       = true;
+            break;
+        case HPSDRModel::FIRST:
+        case HPSDRModel::LAST:
+            break;
+    }
+
+    p.caps = &BoardCapsTable::forBoard(p.effectiveBoard);
+    return p;
+}
+
+HPSDRModel defaultModelForBoard(HPSDRHW board)
+{
+    // Walk HPSDRModel enum, return first match.
+    for (int i = static_cast<int>(HPSDRModel::FIRST) + 1;
+         i < static_cast<int>(HPSDRModel::LAST); ++i) {
+        auto m = static_cast<HPSDRModel>(i);
+        if (boardForModel(m) == board) {
+            return m;
+        }
+    }
+    return HPSDRModel::HERMES;
+}
+
+// From Thetis NetworkIO.cs:164-171
+QList<HPSDRModel> compatibleModels(HPSDRHW board)
+{
+    QList<HPSDRModel> result;
+
+    for (int i = static_cast<int>(HPSDRModel::FIRST) + 1;
+         i < static_cast<int>(HPSDRModel::LAST); ++i) {
+        auto m = static_cast<HPSDRModel>(i);
+
+        // Primary match: model's native board matches discovered board.
+        if (boardForModel(m) == board) {
+            result.append(m);
+            continue;
+        }
+
+        // Special cross-board compatibility cases.
+        // From Thetis NetworkIO.cs:164-171
+        switch (m) {
+            case HPSDRModel::REDPITAYA:
+                // RedPitaya is compatible with Hermes (0x01) or OrionMKII (0x05)
+                if (board == HPSDRHW::Hermes || board == HPSDRHW::OrionMKII) {
+                    result.append(m);
+                }
+                break;
+            case HPSDRModel::ANAN10:
+            case HPSDRModel::ANAN100:
+                // ANAN-10/100 are compatible with Hermes or HermesII
+                if (board == HPSDRHW::Hermes || board == HPSDRHW::HermesII) {
+                    result.append(m);
+                }
+                break;
+            case HPSDRModel::ANAN10E:
+            case HPSDRModel::ANAN100B:
+                // ANAN-10E/100B are compatible with Hermes or HermesII
+                if (board == HPSDRHW::Hermes || board == HPSDRHW::HermesII) {
+                    result.append(m);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    return result;
+}
+
+} // namespace NereusSDR

--- a/src/core/HardwareProfile.h
+++ b/src/core/HardwareProfile.h
@@ -1,0 +1,37 @@
+// src/core/HardwareProfile.h
+//
+// Maps an HPSDRModel enum to hardware overrides (ADC count, BPF style,
+// supply voltage, audio swap, effective board identity).
+//
+// Source: mi0bot/Thetis clsHardwareSpecific.cs:85-184
+
+#pragma once
+
+#include "HpsdrModel.h"
+#include "BoardCapabilities.h"
+#include <QList>
+
+namespace NereusSDR {
+
+struct HardwareProfile {
+    HPSDRModel               model{HPSDRModel::HERMES};
+    HPSDRHW                  effectiveBoard{HPSDRHW::Hermes};
+    const BoardCapabilities* caps{nullptr};
+    int                      adcCount{1};
+    bool                     mkiiBpf{false};
+    int                      adcSupplyVoltage{33};
+    bool                     lrAudioSwap{true};
+};
+
+// Compute a HardwareProfile for the given model.
+// From Thetis clsHardwareSpecific.cs:85-184
+HardwareProfile profileForModel(HPSDRModel model);
+
+// Return the default (auto-guessed) HPSDRModel for a discovered board byte.
+HPSDRModel defaultModelForBoard(HPSDRHW board);
+
+// Return the list of HPSDRModel values compatible with a discovered board byte.
+// From Thetis NetworkIO.cs:164-171
+QList<HPSDRModel> compatibleModels(HPSDRHW board);
+
+} // namespace NereusSDR

--- a/src/core/P1RadioConnection.cpp
+++ b/src/core/P1RadioConnection.cpp
@@ -641,8 +641,7 @@ void P1RadioConnection::onWatchdogTick()
     // Source: Task 12 hl2CheckBandwidthMonitor throttle flag.
     if (cs == ConnectionState::Connected || cs == ConnectionState::Connecting) {
         if (!m_hl2Throttled) {
-            const bool txBank = (m_ccRoundRobinIdx++ & 1) != 0;
-            sendCommandFrame(txBank);
+            sendCommandFrame();
         }
     }
 
@@ -776,54 +775,46 @@ void P1RadioConnection::sendMetisStop()
 // ---------------------------------------------------------------------------
 // sendCommandFrame
 //
-// Builds a 1032-byte ep2 frame via composeEp2Frame and sends it to the radio.
+// Builds a 1032-byte ep2 frame with two C&C subframes drawn from the full
+// 17-bank round-robin sequence. Each call advances m_ccRoundRobinIdx by 2.
 // Source: networkproto1.c:216-236 MetisWriteFrame + :597-884 WriteMainLoop
 // ---------------------------------------------------------------------------
-void P1RadioConnection::sendCommandFrame(bool sub1TxBank)
+void P1RadioConnection::sendCommandFrame()
 {
     if (!m_socket) { return; }
+
+    const int maxBank = (m_hardwareProfile.model == HPSDRModel::ANVELINAPRO3) ? 17 : 16;
 
     quint8 frame[1032];
     memset(frame, 0, sizeof(frame));
 
-    // ep2 header (magic + seq)
-    frame[0] = 0xEF;
-    frame[1] = 0xFE;
-    frame[2] = 0x01;
-    frame[3] = 0x02;
+    // EP2 header (networkproto1.c:223-230)
+    frame[0] = 0xEF; frame[1] = 0xFE; frame[2] = 0x01; frame[3] = 0x02;
     const quint32 seq = m_epSendSeq++;
     frame[4] = static_cast<quint8>((seq >> 24) & 0xFF);
     frame[5] = static_cast<quint8>((seq >> 16) & 0xFF);
     frame[6] = static_cast<quint8>((seq >>  8) & 0xFF);
     frame[7] = static_cast<quint8>( seq        & 0xFF);
 
-    // Subframe 0: bank 0 (general settings) — use instance state
-    frame[8]  = 0x7F;
-    frame[9]  = 0x7F;
-    frame[10] = 0x7F;
+    // Subframe 0: current bank
+    frame[8] = 0x7F; frame[9] = 0x7F; frame[10] = 0x7F;
     quint8 cc0[5] = {};
-    composeCcBank0Full(cc0);
+    composeCcForBank(m_ccRoundRobinIdx, cc0);
     frame[11] = cc0[0]; frame[12] = cc0[1]; frame[13] = cc0[2];
     frame[14] = cc0[3]; frame[15] = cc0[4];
 
-    // Subframe 1: sync + selectable bank (TX freq or RX1 freq).
-    // Match Thetis networkproto1.c:134-139 ForceCandCFrame which sends
-    // alternating TX-VFO (bank 1, C0=0x02) and RX1-VFO (bank 2, C0=0x04)
-    // frames as the C&C priming sequence.
-    frame[520] = 0x7F;
-    frame[521] = 0x7F;
-    frame[522] = 0x7F;
+    m_ccRoundRobinIdx++;
+    if (m_ccRoundRobinIdx > maxBank) { m_ccRoundRobinIdx = 0; }
+
+    // Subframe 1: next bank
+    frame[520] = 0x7F; frame[521] = 0x7F; frame[522] = 0x7F;
     quint8 cc1[5] = {};
-    if (sub1TxBank) {
-        composeCcBankTxFreq(cc1, m_txFreqHz);
-    } else {
-        composeCcBankRxFreq(cc1, 0 /* rxIndex */, m_rxFreqHz[0]);
-    }
-    frame[523] = cc1[0];
-    frame[524] = cc1[1];
-    frame[525] = cc1[2];
-    frame[526] = cc1[3];
-    frame[527] = cc1[4];
+    composeCcForBank(m_ccRoundRobinIdx, cc1);
+    frame[523] = cc1[0]; frame[524] = cc1[1]; frame[525] = cc1[2];
+    frame[526] = cc1[3]; frame[527] = cc1[4];
+
+    m_ccRoundRobinIdx++;
+    if (m_ccRoundRobinIdx > maxBank) { m_ccRoundRobinIdx = 0; }
 
     QByteArray pkt(reinterpret_cast<const char*>(frame), 1032);
     m_socket->writeDatagram(pkt, m_radioInfo.address, m_radioInfo.port);
@@ -847,11 +838,11 @@ void P1RadioConnection::sendCommandFrame(bool sub1TxBank)
 void P1RadioConnection::sendPrimingBurst(int countPerBank)
 {
     for (int i = 0; i < countPerBank; ++i) {
-        sendCommandFrame(true /* sub1TxBank */);
+        sendCommandFrame();
     }
     QThread::msleep(10);
     for (int i = 0; i < countPerBank; ++i) {
-        sendCommandFrame(false /* sub1TxBank -> RX1 bank */);
+        sendCommandFrame();
     }
     QThread::msleep(10);
 }
@@ -907,6 +898,121 @@ void P1RadioConnection::parseEp6Frame(const QByteArray& pkt)
             }
             emit iqDataReceived(r, samples);
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// composeCcForBank — dispatcher for all 18 C&C banks (0-17)
+//
+// Ported from Thetis networkproto1.c WriteMainLoop cases 0-17.
+// Each bank sets C0 address bits and C1-C4 payload per the OpenHPSDR
+// Protocol 1 specification.
+// ---------------------------------------------------------------------------
+void P1RadioConnection::composeCcForBank(int bankIdx, quint8 out[5]) const
+{
+    memset(out, 0, 5);
+    const quint8 C0base = m_mox ? 0x01 : 0x00;
+
+    switch (bankIdx) {
+    case 0: // General settings (networkproto1.c:450-471)
+        composeCcBank0Full(out);
+        return;
+
+    case 1: // TX VFO (networkproto1.c:476-482)
+        composeCcBankTxFreq(out, m_txFreqHz);
+        return;
+
+    case 2: // RX1 VFO DDC0 (networkproto1.c:484-494)
+        composeCcBankRxFreq(out, 0, m_rxFreqHz[0]);
+        return;
+
+    case 3: { // RX2 VFO DDC1 (networkproto1.c:497-511)
+        // RX2 frequency uses the same phase-word encoding as RX1.
+        composeCcBankRxFreq(out, 1, m_rxFreqHz[1]);
+        return;
+    }
+
+    case 4: // ADC assignments + TX ATT (networkproto1.c:517-523)
+        out[0] = C0base | 0x1C;
+        out[1] = static_cast<quint8>(m_adcCtrl & 0xFF);
+        out[2] = static_cast<quint8>((m_adcCtrl >> 8) & 0x3F);
+        out[3] = static_cast<quint8>(m_txStepAttn & 0x1F);
+        out[4] = 0;
+        return;
+
+    case 5: case 6: case 7: case 8: case 9: {
+        // RX3-RX7 VFOs (networkproto1.c:525-575)
+        // Unused DDCs get TX freq as a safe default.
+        int rxIdx = bankIdx - 3; // bank 5 → rxIdx 2, bank 9 → rxIdx 6
+        composeCcBankRxFreq(out, rxIdx, m_txFreqHz);
+        return;
+    }
+
+    case 10: // TX drive, mic, Alex HPF/LPF, PA (networkproto1.c:578-591)
+        out[0] = C0base | 0x12;
+        out[1] = static_cast<quint8>(m_txDrive & 0xFF);
+        out[2] = 0x40; // line_in=0, mic_boost=0 defaults
+        out[3] = m_alexHpfBits | (m_paEnabled ? 0x80 : 0);
+        out[4] = m_alexLpfBits;
+        return;
+
+    case 11: // Preamp control (networkproto1.c:593-601)
+        out[0] = C0base | 0x14;
+        out[1] = static_cast<quint8>(
+                   (m_rxPreamp[0] ? 0x01 : 0)
+                 | (m_rxPreamp[1] ? 0x02 : 0)
+                 | (m_rxPreamp[2] ? 0x04 : 0)
+                 | (m_rxPreamp[0] ? 0x08 : 0)); // bit3 = rx0 again (Thetis quirk)
+        out[2] = 0; // line_in_gain + puresignal
+        out[3] = 0; // user digital outputs
+        out[4] = static_cast<quint8>((m_stepAttn[0] & 0x1F) | 0x20); // ADC0 step ATT + enable
+        return;
+
+    case 12: { // Step ATT ADC1/2, CW keyer (networkproto1.c:604-628)
+        out[0] = C0base | 0x16;
+        // RedPitaya-specific: don't force 31dB on ADC1 during TX
+        // From networkproto1.c:606-616 (DH1KLM fix)
+        if (m_mox && m_hardwareProfile.model != HPSDRModel::REDPITAYA) {
+            out[1] = 0x1F;
+        } else if (m_hardwareProfile.model == HPSDRModel::REDPITAYA) {
+            out[1] = static_cast<quint8>(m_stepAttn[1] & 0x1F);
+        } else {
+            out[1] = static_cast<quint8>(m_stepAttn[1] & 0xFF);
+        }
+        out[1] |= 0x20; // enable bit
+        out[2] = static_cast<quint8>((m_stepAttn[2] & 0x1F) | 0x20);
+        out[3] = 0; // CW keyer defaults
+        out[4] = 0;
+        return;
+    }
+
+    case 13: // CW enable (networkproto1.c:633-639)
+        out[0] = C0base | 0x1E;
+        out[1] = 0; out[2] = 0; out[3] = 0; out[4] = 0;
+        return;
+
+    case 14: // CW hang/sidetone (networkproto1.c:641-646)
+        out[0] = C0base | 0x20;
+        out[1] = 0; out[2] = 0; out[3] = 0; out[4] = 0;
+        return;
+
+    case 15: // EER PWM (networkproto1.c:649-654)
+        out[0] = C0base | 0x22;
+        out[1] = 0; out[2] = 0; out[3] = 0; out[4] = 0;
+        return;
+
+    case 16: // BPF2 (networkproto1.c:657-665)
+        out[0] = C0base | 0x24;
+        out[1] = 0; out[2] = 0; out[3] = 0; out[4] = 0;
+        return;
+
+    case 17: // AnvelinaPro3 extra OC (networkproto1.c:668-673)
+        out[0] = C0base | 0x26;
+        out[1] = 0; out[2] = 0; out[3] = 0; out[4] = 0;
+        return;
+
+    default:
+        return;
     }
 }
 

--- a/src/core/P1RadioConnection.cpp
+++ b/src/core/P1RadioConnection.cpp
@@ -360,7 +360,21 @@ void P1RadioConnection::connectToRadio(const RadioInfo& info)
     }
 
     m_radioInfo = info;
-    m_caps = &BoardCapsTable::forBoard(info.boardType);
+    // Use HardwareProfile for caps (Phase 3I-RP)
+    m_caps = m_hardwareProfile.caps;
+
+    // Initialize per-ADC state from profile
+    for (int i = 0; i < 3; ++i) {
+        m_dither[i] = true;
+        m_random[i] = true;
+        m_rxPreamp[i] = false;
+        m_stepAttn[i] = 0;
+    }
+    m_txStepAttn = 0;
+    m_paEnabled = m_hardwareProfile.caps->hasPaProfile;
+    m_duplex = true;
+    m_reconnectedLogged = false;
+
     m_intentionalDisconnect = false;
     m_epSendSeq = 0;
     m_epRecvSeqExpected = 0;
@@ -460,6 +474,7 @@ void P1RadioConnection::disconnect()
     // Source: NereusSDR design doc §3.6 — user reconnect resets the cycle.
     m_reconnectAttempts = 0;
     m_lastEp6At = QDateTime();
+    m_reconnectedLogged = false;
 
     if (m_running && m_socket && !m_radioInfo.address.isNull()) {
         m_running = false;
@@ -496,9 +511,9 @@ void P1RadioConnection::setAttenuator(int dB)
     } else if (m_caps && !m_caps->attenuator.present) {
         dB = 0;
     }
-    m_atten = dB;
+    m_stepAttn[0] = dB;
 }
-void P1RadioConnection::setPreamp(bool enabled)              { m_preamp = enabled; }
+void P1RadioConnection::setPreamp(bool enabled)              { m_rxPreamp[0] = enabled; }
 void P1RadioConnection::setTxDrive(int /*level*/)            { /* stub — Task 7 */ }
 void P1RadioConnection::setMox(bool enabled)                 { m_mox = enabled; }
 void P1RadioConnection::setAntenna(int antennaIndex)         { m_antennaIdx = antennaIndex; }
@@ -523,10 +538,10 @@ void P1RadioConnection::applyBoardQuirks()
     // Clamp attenuator to board range.
     // Source: specHPSDR.cs — per-HPSDRHW min/max dB ranges enforced at setup.
     if (m_caps->attenuator.present) {
-        if (m_atten > m_caps->attenuator.maxDb) { m_atten = m_caps->attenuator.maxDb; }
-        if (m_atten < m_caps->attenuator.minDb) { m_atten = m_caps->attenuator.minDb; }
+        if (m_stepAttn[0] > m_caps->attenuator.maxDb) { m_stepAttn[0] = m_caps->attenuator.maxDb; }
+        if (m_stepAttn[0] < m_caps->attenuator.minDb) { m_stepAttn[0] = m_caps->attenuator.minDb; }
     } else {
-        m_atten = 0;
+        m_stepAttn[0] = 0;
     }
 }
 
@@ -585,7 +600,10 @@ void P1RadioConnection::onReadyRead()
                 if (m_reconnectTimer) { m_reconnectTimer->stop(); }
                 if (!m_watchdogTimer->isActive()) { m_watchdogTimer->start(); }
                 setState(ConnectionState::Connected);
-                qCDebug(lcConnection) << "P1: Reconnected — ep6 stream restored";
+                if (!m_reconnectedLogged) {
+                    qCDebug(lcConnection) << "P1: Reconnected — ep6 stream restored";
+                    m_reconnectedLogged = true;
+                }
             }
 
             parseEp6Frame(data);
@@ -647,6 +665,7 @@ void P1RadioConnection::onWatchdogTick()
                                 << "ms (state=" << static_cast<int>(cs)
                                 << "); transitioning to Error and scheduling reconnect";
         m_watchdogTimer->stop();
+        m_reconnectedLogged = false;
         setState(ConnectionState::Error);
         emit errorOccurred(RadioConnectionError::NoDataTimeout,
                            QStringLiteral("Radio stopped responding"));
@@ -778,17 +797,14 @@ void P1RadioConnection::sendCommandFrame(bool sub1TxBank)
     frame[6] = static_cast<quint8>((seq >>  8) & 0xFF);
     frame[7] = static_cast<quint8>( seq        & 0xFF);
 
-    // Subframe 0: sync + bank 0 (general settings)
+    // Subframe 0: bank 0 (general settings) — use instance state
     frame[8]  = 0x7F;
     frame[9]  = 0x7F;
     frame[10] = 0x7F;
     quint8 cc0[5] = {};
-    composeCcBank0(cc0, m_sampleRate, m_mox, m_activeRxCount);
-    frame[11] = cc0[0];
-    frame[12] = cc0[1];
-    frame[13] = cc0[2];
-    frame[14] = cc0[3];
-    frame[15] = cc0[4];
+    composeCcBank0Full(cc0);
+    frame[11] = cc0[0]; frame[12] = cc0[1]; frame[13] = cc0[2];
+    frame[14] = cc0[3]; frame[15] = cc0[4];
 
     // Subframe 1: sync + selectable bank (TX freq or RX1 freq).
     // Match Thetis networkproto1.c:134-139 ForceCandCFrame which sends
@@ -892,6 +908,41 @@ void P1RadioConnection::parseEp6Frame(const QByteArray& pkt)
             emit iqDataReceived(r, samples);
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// composeCcBank0Full — instance-level bank 0 using actual state
+//
+// Source: Thetis networkproto1.c:450-471 (WriteMainLoop case 0)
+// ---------------------------------------------------------------------------
+void P1RadioConnection::composeCcBank0Full(quint8 out[5]) const
+{
+    // C0: MOX bit (networkproto1.c:446)
+    out[0] = m_mox ? 0x01 : 0x00;
+
+    // C1: sample rate (networkproto1.c:451)
+    quint8 srBits = 0;
+    if      (m_sampleRate >= 384000) { srBits = 3; }
+    else if (m_sampleRate >= 192000) { srBits = 2; }
+    else if (m_sampleRate >= 96000)  { srBits = 1; }
+    out[1] = srBits & 0x03;
+
+    // C2: OC outputs (networkproto1.c:452)
+    out[2] = (m_ocOutput << 1) & 0xFE;
+
+    // C3: preamp, dither, random, RX input (networkproto1.c:453-461)
+    out[3] = (m_rxPreamp[0] ? 0x04 : 0)
+           | (m_dither[0]   ? 0x08 : 0)
+           | (m_random[0]   ? 0x10 : 0);
+    // RX input select: default Rx_1_In (networkproto1.c:458)
+    out[3] |= 0x20;
+
+    // C4: antenna, duplex, NDDCs, diversity (networkproto1.c:463-471)
+    out[4] = static_cast<quint8>(m_antennaIdx & 0x03);
+    out[4] |= 0x04; // duplex bit
+    int nddc = (m_activeRxCount < 1) ? 1 : (m_activeRxCount > 7 ? 7 : m_activeRxCount);
+    out[4] |= static_cast<quint8>((nddc - 1) << 3);
+    out[4] |= (m_diversity ? 0x80 : 0);
 }
 
 void P1RadioConnection::composeCcBank0(quint8*) { /* full implementation in Task 7 static helpers */ }

--- a/src/core/P1RadioConnection.h
+++ b/src/core/P1RadioConnection.h
@@ -80,16 +80,17 @@ private:
     // --- Wire format (networkproto1.c) — implemented in Tasks 7 & 8 ---
     void sendMetisStart(bool iqAndMic);
     void sendMetisStop();
-    // Send one ep2 command frame. `sub1TxBank=true` puts TX VFO (bank 1,
-    // C0=0x02) on subframe 1; false puts RX1 VFO (bank 2, C0=0x04).
-    // The steady-state watchdog and the initial priming burst alternate
-    // between the two, matching Thetis's ForceCandCFrame(N) pattern in
-    // networkproto1.c:134-139.
-    void sendCommandFrame(bool sub1TxBank = false);
-    // Match Thetis ForceCandCFrame(count): send `count` TX-freq ep2 frames
-    // then `count` RX1-freq ep2 frames. Called before and after metis-start
-    // on both the initial connect and watchdog-driven reconnect paths.
+    // Send one ep2 command frame with two C&C subframes drawn from the
+    // round-robin bank sequence (0-17). Each call advances m_ccRoundRobinIdx
+    // by 2 (one per subframe). Source: networkproto1.c:597-884 WriteMainLoop.
+    void sendCommandFrame();
+    // Send `countPerBank` ep2 command frames in two bursts with a 10ms gap.
+    // Replaces the old ForceCandCFrame pattern — now simply drives the
+    // round-robin forward, ensuring all banks get primed.
     void sendPrimingBurst(int countPerBank);
+    // Compose 5 C&C bytes for any bank index 0-17.
+    // Dispatcher ported from Thetis networkproto1.c WriteMainLoop cases 0-17.
+    void composeCcForBank(int bankIdx, quint8 out[5]) const;
     void parseEp6Frame(const QByteArray& pkt);
 
     // --- Command & Control banks (NetworkIO.cs SetC0..SetC4) ---
@@ -145,10 +146,9 @@ private:
     int         m_reconnectAttempts{0};                         // how many retries so far this cycle
     // 25 ms (= 40 fps) is enough to keep the radio's ep2 command pipe fed
     // without matching Thetis's full ~368 fps audio-drain cadence. Each tick
-    // sends one ep2 command frame, alternating the subframe-1 bank between
-    // TX VFO and RX1 VFO so both frequency banks are refreshed every ~50 ms.
-    // The previous 500 ms interval was a keep-alive tick, not a command
-    // stream, which left the radio's DDC stuck in its pre-primed idle state.
+    // sends one ep2 command frame containing two subframes, each carrying the
+    // next bank in the 0-16 (or 0-17 for AnvelinaPro3) round-robin. At 40 fps
+    // × 2 banks/frame, all 17 banks are refreshed every ~213 ms.
     static constexpr int kWatchdogTickMs       = 25;            // watchdog + ep2 command cadence
     static constexpr int kWatchdogSilenceMs    = 2000;          // silence → Error threshold
     static constexpr int kReconnectIntervalMs  = 5000;          // delay between retry attempts

--- a/src/core/P1RadioConnection.h
+++ b/src/core/P1RadioConnection.h
@@ -101,6 +101,7 @@ private:
     void composeCcAlexRx(quint8* out);
     void composeCcAlexTx(quint8* out);
     void composeCcOcOutputs(quint8* out);
+    void composeCcBank0Full(quint8 out[5]) const;
 
     // --- Per-board quirks — implemented in Tasks 11 & 12 ---
     void applyBoardQuirks();
@@ -161,10 +162,30 @@ private:
     int     m_activeRxCount{1};
     quint64 m_rxFreqHz[7]{};
     quint64 m_txFreqHz{0};
-    int     m_atten{0};
-    bool    m_preamp{false};
     bool    m_mox{false};
     int     m_antennaIdx{0};
+
+    // Per-ADC state — initialized from HardwareProfile at connect time
+    bool    m_dither[3]{true, true, true};
+    bool    m_random[3]{true, true, true};
+    bool    m_rxPreamp[3]{};
+    int     m_stepAttn[3]{};      // per-ADC step attenuator (0-31)
+    int     m_txStepAttn{0};
+
+    // Alex filter state — computed from frequency
+    quint8  m_alexHpfBits{0};     // Bank 10 C3: HPF select bits
+    quint8  m_alexLpfBits{0};     // Bank 10 C4: LPF select bits
+
+    // Hardware config from profile
+    int     m_txDrive{0};
+    bool    m_paEnabled{false};
+    bool    m_duplex{true};
+    bool    m_diversity{false};
+    quint8  m_ocOutput{0};
+    quint16 m_adcCtrl{0};          // ADC-to-DDC assignment bits
+
+    // Reconnect log guard
+    bool    m_reconnectedLogged{false};
 
     const BoardCapabilities* m_caps{nullptr};
 
@@ -178,7 +199,7 @@ private:
 public:
     // Test-only helpers — allow unit tests to inject board caps without a live radio.
     void setBoardForTest(HPSDRHW board) { m_caps = &BoardCapsTable::forBoard(board); applyBoardQuirks(); }
-    int currentAttenForTest() const { return m_atten; }
+    int currentAttenForTest() const { return m_stepAttn[0]; }
     bool hl2ThrottledForTest() const { return m_hl2Throttled; }
 #endif
 };

--- a/src/core/P2RadioConnection.cpp
+++ b/src/core/P2RadioConnection.cpp
@@ -124,8 +124,8 @@ void P2RadioConnection::connectToRadio(const RadioInfo& info)
     m_intentionalDisconnect = false;
     m_totalIqPackets = 0;
 
-    // Cache board capabilities — drives attenuator clamp, ADC count, etc.
-    m_caps = &BoardCapsTable::forBoard(info.boardType);
+    // Use HardwareProfile for capability lookup (Phase 3I-RP).
+    m_caps = m_hardwareProfile.caps;
 
     // Reset sequence counters
     m_seqGeneral = 0;
@@ -138,7 +138,7 @@ void P2RadioConnection::connectToRadio(const RadioInfo& info)
     // Use m_caps->adcCount instead of info.adcCount for capability-metadata consistency.
     // Both carry the same value (info.adcCount is populated from adcCountForBoard() which
     // reads the same BoardCapsTable). m_caps is authoritative.
-    m_numAdc = m_caps->adcCount;
+    m_numAdc = m_hardwareProfile.adcCount;
     m_numDac = 1;
     m_wdt = 1;  // Watchdog timer MUST be enabled — radio requires it for streaming
 

--- a/src/core/RadioConnection.h
+++ b/src/core/RadioConnection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RadioDiscovery.h"
+#include "HardwareProfile.h"
 
 #include <QObject>
 #include <QVector>
@@ -50,6 +51,9 @@ public:
     ConnectionState state() const { return m_state.load(); }
     bool isConnected() const { return m_state.load() == ConnectionState::Connected; }
     const RadioInfo& radioInfo() const { return m_radioInfo; }
+
+    void setHardwareProfile(const HardwareProfile& profile) { m_hardwareProfile = profile; }
+    const HardwareProfile& hardwareProfile() const { return m_hardwareProfile; }
 
 public slots:
     // Must be called on the worker thread after moveToThread().
@@ -109,6 +113,7 @@ protected:
 
     std::atomic<ConnectionState> m_state{ConnectionState::Disconnected};
     RadioInfo m_radioInfo;
+    HardwareProfile m_hardwareProfile;
 };
 
 } // namespace NereusSDR

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -40,6 +40,10 @@ struct RadioInfo {
     bool hasPureSignal{false};           // Boards supporting PA linearization
     int maxSampleRate{384000};           // Max supported sample rate in Hz
 
+    // Model override — set by user in ConnectionPanel, persisted per-MAC.
+    // When set to a value other than FIRST, overrides the auto-detected model.
+    HPSDRModel modelOverride{HPSDRModel::FIRST}; // FIRST = no override (auto-detect)
+
     // Display helpers
     QString displayName() const;
     static int adcCountForBoard(HPSDRHW type);

--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -195,6 +195,66 @@ void ConnectionPanel::buildUI()
     radioLayout->addWidget(m_radioTable);
     mainLayout->addWidget(radioGroup, /*stretch=*/1);
 
+    // --- Selected Radio detail panel (Phase 3I-RP) ---
+    m_detailGroup = new QGroupBox(QStringLiteral("Selected Radio"), this);
+    m_detailGroup->setVisible(false);
+    auto* detailLayout = new QVBoxLayout(m_detailGroup);
+    detailLayout->setSpacing(4);
+
+    // Info row 1: Board + Protocol + Firmware
+    auto* infoRow1 = new QHBoxLayout();
+    m_detailBoardLabel = new QLabel(m_detailGroup);
+    m_detailProtoLabel = new QLabel(m_detailGroup);
+    m_detailFwLabel    = new QLabel(m_detailGroup);
+    for (auto* lbl : {m_detailBoardLabel, m_detailProtoLabel, m_detailFwLabel}) {
+        lbl->setStyleSheet(QStringLiteral("QLabel { color: #8090a0; font-size: 12px; }"));
+    }
+    infoRow1->addWidget(m_detailBoardLabel);
+    infoRow1->addWidget(m_detailProtoLabel);
+    infoRow1->addWidget(m_detailFwLabel);
+    infoRow1->addStretch();
+    detailLayout->addLayout(infoRow1);
+
+    // Info row 2: IP + MAC
+    auto* infoRow2 = new QHBoxLayout();
+    m_detailIpLabel  = new QLabel(m_detailGroup);
+    m_detailMacLabel = new QLabel(m_detailGroup);
+    for (auto* lbl : {m_detailIpLabel, m_detailMacLabel}) {
+        lbl->setStyleSheet(QStringLiteral("QLabel { color: #8090a0; font-size: 12px; }"));
+    }
+    infoRow2->addWidget(m_detailIpLabel);
+    infoRow2->addWidget(m_detailMacLabel);
+    infoRow2->addStretch();
+    detailLayout->addLayout(infoRow2);
+
+    // Model selector row
+    auto* modelRow = new QHBoxLayout();
+    auto* modelLabel = new QLabel(QStringLiteral("Radio Model:"), m_detailGroup);
+    modelLabel->setStyleSheet(QStringLiteral("QLabel { color: #c8d8e8; font-weight: bold; }"));
+    m_modelCombo = new QComboBox(m_detailGroup);
+    m_modelCombo->setMinimumWidth(200);
+    m_modelCombo->setStyleSheet(QStringLiteral(
+        "QComboBox { background: #1a2a3a; color: #c8d8e8; border: 1px solid #304050;"
+        "  border-radius: 3px; padding: 4px 8px; }"
+        "QComboBox::drop-down { border: none; }"
+        "QComboBox QAbstractItemView { background: #12202e; color: #c8d8e8;"
+        "  selection-background-color: #005578; }"));
+    connect(m_modelCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &ConnectionPanel::onModelComboChanged);
+    modelRow->addWidget(modelLabel);
+    modelRow->addWidget(m_modelCombo);
+    modelRow->addStretch();
+    detailLayout->addLayout(modelRow);
+
+    // Hint label
+    m_modelHintLabel = new QLabel(m_detailGroup);
+    m_modelHintLabel->setStyleSheet(QStringLiteral(
+        "QLabel { color: #b08020; font-size: 11px; font-style: italic; }"));
+    m_modelHintLabel->setVisible(false);
+    detailLayout->addWidget(m_modelHintLabel);
+
+    mainLayout->addWidget(m_detailGroup);
+
     // --- Bottom strip buttons (plan §5.2 + Thetis layout) ---
     auto* btnLayout = new QHBoxLayout();
     btnLayout->setSpacing(6);
@@ -587,6 +647,12 @@ void ConnectionPanel::onConnectClicked()
         return;
     }
 
+    // Apply model override from dropdown (Phase 3I-RP)
+    if (m_modelCombo && m_modelCombo->currentIndex() >= 0) {
+        int modelInt = m_modelCombo->itemData(m_modelCombo->currentIndex()).toInt();
+        info.modelOverride = static_cast<HPSDRModel>(modelInt);
+    }
+
     if (info.inUse) {
         setStatusText(QStringLiteral("Warning: radio reports in use — attempting connection anyway"));
     } else {
@@ -676,6 +742,7 @@ void ConnectionPanel::onForgetClicked()
 void ConnectionPanel::onRadioSelectionChanged()
 {
     updateButtonStates();
+    updateDetailPanel();
 }
 
 // Source: ucRadioList.cs double-click action — select and connect
@@ -786,6 +853,88 @@ RadioInfo ConnectionPanel::selectedRadio() const
     }
     QString mac = cell->data(kMacRole).toString();
     return m_discoveredRadios.value(mac);
+}
+
+// ---------------------------------------------------------------------------
+// Detail panel — Phase 3I-RP
+// ---------------------------------------------------------------------------
+
+void ConnectionPanel::updateDetailPanel()
+{
+    RadioInfo info = selectedRadio();
+    if (info.macAddress.isEmpty()) {
+        m_detailGroup->setVisible(false);
+        return;
+    }
+
+    m_detailGroup->setVisible(true);
+
+    QString boardName = QString::fromLatin1(
+        BoardCapsTable::forBoard(info.boardType).displayName);
+    m_detailBoardLabel->setText(QStringLiteral("Board: %1 (0x%2)")
+        .arg(boardName)
+        .arg(static_cast<int>(info.boardType), 2, 16, QLatin1Char('0')));
+    m_detailProtoLabel->setText(QStringLiteral("Protocol: P%1")
+        .arg(info.protocol == ProtocolVersion::Protocol2 ? 2 : 1));
+    m_detailFwLabel->setText(QStringLiteral("Firmware: %1").arg(info.firmwareVersion));
+    m_detailIpLabel->setText(QStringLiteral("IP: %1").arg(info.address.toString()));
+    m_detailMacLabel->setText(QStringLiteral("MAC: %1").arg(info.macAddress));
+
+    // Populate model combo
+    m_modelCombo->blockSignals(true);
+    m_modelCombo->clear();
+    QList<HPSDRModel> models = compatibleModels(info.boardType);
+    HPSDRModel defaultModel = defaultModelForBoard(info.boardType);
+
+    HPSDRModel persisted = AppSettings::instance().modelOverride(info.macAddress);
+    HPSDRModel selected = (persisted != HPSDRModel::FIRST) ? persisted : defaultModel;
+
+    int selectIdx = 0;
+    for (int i = 0; i < models.size(); ++i) {
+        m_modelCombo->addItem(
+            QString::fromLatin1(displayName(models[i])),
+            static_cast<int>(models[i]));
+        if (models[i] == selected) {
+            selectIdx = i;
+        }
+    }
+    m_modelCombo->setCurrentIndex(selectIdx);
+    m_modelCombo->blockSignals(false);
+
+    if (selected != defaultModel) {
+        m_modelHintLabel->setText(QStringLiteral("Board reports \"%1\" -- model override applied")
+            .arg(boardName));
+        m_modelHintLabel->setVisible(true);
+    } else {
+        m_modelHintLabel->setVisible(false);
+    }
+}
+
+void ConnectionPanel::onModelComboChanged(int index)
+{
+    if (index < 0) { return; }
+    RadioInfo info = selectedRadio();
+    if (info.macAddress.isEmpty()) { return; }
+
+    int modelInt = m_modelCombo->itemData(index).toInt();
+    auto model = static_cast<HPSDRModel>(modelInt);
+
+    AppSettings::instance().setModelOverride(info.macAddress, model);
+    AppSettings::instance().save();
+
+    HPSDRModel defaultModel = defaultModelForBoard(info.boardType);
+    QString boardName = QString::fromLatin1(
+        BoardCapsTable::forBoard(info.boardType).displayName);
+    if (model != defaultModel) {
+        m_modelHintLabel->setText(QStringLiteral("Board reports \"%1\" -- model override applied")
+            .arg(boardName));
+        m_modelHintLabel->setVisible(true);
+    } else {
+        m_modelHintLabel->setVisible(false);
+    }
+
+    setStatusText(QStringLiteral("Model set to %1 for %2")
+        .arg(QString::fromLatin1(displayName(model)), info.macAddress));
 }
 
 } // namespace NereusSDR

--- a/src/gui/ConnectionPanel.h
+++ b/src/gui/ConnectionPanel.h
@@ -2,8 +2,11 @@
 
 #include "core/RadioDiscovery.h"
 #include "core/RadioConnection.h"
+#include "core/HardwareProfile.h"
 
+#include <QComboBox>
 #include <QDialog>
+#include <QGroupBox>
 #include <QTableWidget>
 #include <QPushButton>
 #include <QLabel>
@@ -74,6 +77,9 @@ private:
     // online=false renders the row with offline colour (manual adds start offline).
     void upsertRowForInfo(const RadioInfo& info, bool online);
 
+    void onModelComboChanged(int index);
+    void updateDetailPanel();
+
     // Get the RadioInfo for the currently selected table row
     RadioInfo selectedRadio() const;
     // Find row index by MAC, returns -1 if not found
@@ -91,6 +97,16 @@ private:
     QPushButton*   m_forgetBtn{nullptr};
     QPushButton*   m_closeBtn{nullptr};
     QLabel*        m_statusLabel{nullptr};
+
+    // Detail panel (Phase 3I-RP)
+    QGroupBox*   m_detailGroup{nullptr};
+    QLabel*      m_detailBoardLabel{nullptr};
+    QLabel*      m_detailProtoLabel{nullptr};
+    QLabel*      m_detailFwLabel{nullptr};
+    QLabel*      m_detailIpLabel{nullptr};
+    QLabel*      m_detailMacLabel{nullptr};
+    QComboBox*   m_modelCombo{nullptr};
+    QLabel*      m_modelHintLabel{nullptr};
 
     // Track discovered radios by MAC (row data role = MAC string)
     QMap<QString, RadioInfo> m_discoveredRadios;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -717,11 +717,13 @@ void MainWindow::buildMenuBar()
 
     radioMenu->addSeparator();
 
-    {
-        QAction* radioSetupAction = radioMenu->addAction(QStringLiteral("&Radio Setup..."));
-        radioSetupAction->setEnabled(false);
-        radioSetupAction->setToolTip(QStringLiteral("NYI — Phase X"));
-    }
+    radioMenu->addAction(QStringLiteral("&Radio Setup..."), this, [this]() {
+        if (!m_radioModel->isConnected()) {
+            showConnectionPanel();
+            return;
+        }
+        showConnectionPanel();
+    });
     {
         QAction* antennaSetupAction = radioMenu->addAction(QStringLiteral("&Antenna Setup..."));
         antennaSetupAction->setEnabled(false);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2333,7 +2333,13 @@ void MainWindow::tryAutoReconnect()
             QObject::disconnect(*connPtr);
             delete connPtr;
             m_autoReconnectInProgress = false;
-            m_radioModel->connectToRadio(found);
+            // Load persisted model override for auto-reconnect (Phase 3I-RP)
+            RadioInfo ri = found;
+            HPSDRModel mo = AppSettings::instance().modelOverride(ri.macAddress);
+            if (mo != HPSDRModel::FIRST) {
+                ri.modelOverride = mo;
+            }
+            m_radioModel->connectToRadio(ri);
         });
 
         // Kick off the Fast-profile discovery
@@ -2360,7 +2366,13 @@ void MainWindow::tryAutoReconnect()
         // Silent failure: if the radio doesn't respond, RadioConnection's
         // internal state machine eventually times out without any popup.
         if (!m_radioModel->isConnected()) {
-            m_radioModel->connectToRadio(saved->info);
+            // Load persisted model override for auto-reconnect (Phase 3I-RP)
+            RadioInfo ri = saved->info;
+            HPSDRModel mo = AppSettings::instance().modelOverride(ri.macAddress);
+            if (mo != HPSDRModel::FIRST) {
+                ri.modelOverride = mo;
+            }
+            m_radioModel->connectToRadio(ri);
         }
     }
 }

--- a/src/gui/setup/HardwarePage.cpp
+++ b/src/gui/setup/HardwarePage.cpp
@@ -20,6 +20,7 @@
 
 #include "core/AppSettings.h"
 #include "core/BoardCapabilities.h"
+#include "core/HardwareProfile.h"
 #include "core/RadioDiscovery.h"
 #include "models/RadioModel.h"
 
@@ -142,7 +143,8 @@ void HardwarePage::onCurrentRadioChanged(const RadioInfo& info)
 {
     m_currentMac = info.macAddress;
 
-    const BoardCapabilities& caps = BoardCapsTable::forBoard(info.boardType);
+    // Use HardwareProfile for capability lookup (Phase 3I-RP).
+    const BoardCapabilities& caps = *m_model->hardwareProfile().caps;
 
     // Radio Info is always visible.
     // Remaining tabs are shown only when the connected board supports them.

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4,6 +4,7 @@
 #include "core/RadioConnectionTeardown.h"
 #include "core/RadioDiscovery.h"
 #include "core/BoardCapabilities.h"
+#include "core/HardwareProfile.h"
 #include "core/ReceiverManager.h"
 #include "core/AudioEngine.h"
 #include "core/WdspEngine.h"
@@ -148,8 +149,19 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     m_lastRadioInfo = info;
     m_intentionalDisconnect = false;
 
+    // Compute HardwareProfile from model override (Phase 3I-RP).
+    HPSDRModel selectedModel = info.modelOverride;
+    if (selectedModel == HPSDRModel::FIRST) {
+        selectedModel = defaultModelForBoard(info.boardType);
+    }
+    m_hardwareProfile = profileForModel(selectedModel);
+
+    qCDebug(lcConnection) << "HardwareProfile: model=" << displayName(m_hardwareProfile.model)
+                          << "effectiveBoard=" << static_cast<int>(m_hardwareProfile.effectiveBoard)
+                          << "adcCount=" << m_hardwareProfile.adcCount;
+
     m_name = info.displayName();
-    m_model = QString::fromLatin1(BoardCapsTable::forBoard(info.boardType).displayName);
+    m_model = QString::fromLatin1(m_hardwareProfile.caps->displayName);
     m_version = QString::number(info.firmwareVersion);
     emit infoChanged();
 
@@ -274,6 +286,7 @@ void RadioModel::connectToRadio(const RadioInfo& info)
         return;
     }
     m_connection = conn.release();
+    m_connection->setHardwareProfile(m_hardwareProfile);
 
     // Create worker thread
     m_connThread = new QThread(this);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -7,6 +7,7 @@
 #include "TransmitModel.h"
 #include "core/RadioDiscovery.h"
 #include "core/RadioConnection.h"
+#include "core/HardwareProfile.h"
 
 #include <QObject>
 #include <QString>
@@ -98,6 +99,7 @@ public:
     QString name() const { return m_name; }
     QString model() const { return m_model; }
     QString version() const { return m_version; }
+    const HardwareProfile& hardwareProfile() const { return m_hardwareProfile; }
     bool isConnected() const;
 
     // Connection
@@ -169,6 +171,7 @@ private:
     QString m_name;
     QString m_model;
     QString m_version;
+    HardwareProfile m_hardwareProfile;
 
     // Reconnect state
     RadioInfo m_lastRadioInfo;


### PR DESCRIPTION
## Summary

- Add per-MAC radio model selector to ConnectionPanel — users can override the
  auto-detected board type (e.g. pick "Red Pitaya" when board byte says "Hermes")
- Complete P1 C&C 17-bank round-robin (port of Thetis networkproto1.c WriteMainLoop
  cases 0-17) — was only sending 3 of 17 banks with zeros for dither/random/preamp
- Add HardwareProfile engine (port of Thetis clsHardwareSpecific.cs) — maps
  HPSDRModel to correct ADC count, BPF, supply voltage, effective board capabilities
- Fix reconnect log spam (30-80 duplicate lines per cycle → 1 line)
- Wire "Radio Setup..." menu item (was disabled NYI)

Fixes #38

## Test plan

- [x] ANAN-G2 (P2/Saturn): auto-connects with correct profile, no regression
- [ ] Hermes Lite 2 (P1): verify full C&C cycle, no stream drops
- [ ] RedPitaya (P1/Hermes): verify model override applies correct caps + ADC count
- [ ] Model selector: set override, close app, reopen — confirm persistence
- [ ] Multi-radio: two radios with different models, confirm independent profiles

J.J. Boyd ~ KG4VCF