### PR TITLE
fix(gui): Windows container float/dock rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Windows container float/dock rendering** — five interlocking issues in
+  the meter container lifecycle on Windows D3D11 QRhi (#42):
+  - HWND collision on reparent — `E_ACCESSDENIED` →
+    `DXGI_ERROR_DEVICE_REMOVED` cascade from the old `MeterWidget`
+    lingering under the parent HWND during `setParent()`. Old widget now
+    detaches synchronously (`hide()` + `setParent(nullptr)`) before
+    `deleteLater`; `ContainerManager` swaps the meter around each reparent
+    so no `WA_NativeWindow` child is reparented.
+  - First float landed at `(0,0)` behind the main window —
+    `FloatingContainer::ensureVisiblePosition()` centers the form on the
+    anchor's screen when saved geometry is missing, at origin, or
+    off every connected screen.
+  - Use-after-free in `MeterPoller` — raw `MeterWidget*` targets dangled
+    when the reparent-swap destroyed them. Switched to
+    `QVector<QPointer<MeterWidget>>` with null-guarded `poll()`.
+  - Progressive stack compression across reparent cycles —
+    `inferStackFromGeometry` merged touching row intervals into one
+    cluster, collapsing N bar rows onto stack slot 0. Require strict
+    overlap > 0.002 before merging.
+  - Empty band below the meter stack on resizable containers — Thetis's
+    fixed `kNormalRowHNorm = 0.05` assumes fixed-aspect containers; stack
+    now shares `(1 − bandTop)` equally among rows. 24 px floor preserved
+    for small widgets.
+
+### Known issues
+- **ANAN MM preset** still shows empty space below the needle panel when
+  no bar rows are added. Thetis-faithful fix (per-container `AutoHeight`)
+  is scoped in
+  [`docs/architecture/meter-autoheight-plan.md`](docs/architecture/meter-autoheight-plan.md).
+- Exit-time segfault (exit 139) reproducible on close; root cause still
+  unknown, not implicated by the #42 changes.
+- One `QRhiWidget: No QRhi` warning per meter install cycle; benign,
+  under investigation.
+
+
 ## [0.1.7-rc1] - 2026-04-16
 
 Radio model selector and P1 protocol completion for RedPitaya and non-standard

--- a/docs/architecture/meter-autoheight-plan.md
+++ b/docs/architecture/meter-autoheight-plan.md
@@ -1,0 +1,144 @@
+# Meter Container `AutoHeight` — Follow-up Plan
+
+**Status:** Not started
+**Trigger:** PR #42 (Windows container float/dock rendering) left one
+symptom unresolved: the ANAN MM preset shows empty space below the
+44.1%-tall needle panel when no bar rows are added. Thetis handles this
+by auto-sizing the container to the meter's natural content height. This
+plan ports that mechanism.
+
+---
+
+## What Thetis does
+
+- `ucMeter` exposes a boolean `AutoHeight` property
+  (`Project Files/Source/Console/ucMeter.cs:903`). Serialized as field 17
+  of the per-container payload; added in Thetis 2.10.3.6.
+- `DirectXMeterRenderer.drawMeters(out int height)`
+  (`MeterManager.cs:31338`) walks each item group every frame and
+  computes `hh = y + h + padY` in pixels at the current widget width. The
+  running max across groups is the meter's natural height. Minimum floor
+  is `ucMeter.MIN_CONTAINER_HEIGHT`.
+- After each frame the renderer pushes the measured height back via
+  `MeterManager.SetContainerHeight(id, height)` →
+  `ucMeter.ChangeHeight(height)` → `forceResize()`
+  (`ucMeter.cs:416-449`). If `_autoHeight` is true, the container calls
+  `resize(Width, _height)`; otherwise `forceResize()` is a no-op
+  (container fills whatever parent gives it).
+- Item pixel height is `normalizedH × widgetWidth` — Thetis's render rect
+  is `(0, 0, w × XRatio, w × YRatio)`, i.e. composite aspect is
+  **width-driven**. That's why ANAN MM's `SizeF(1f, 0.441f)` produces a
+  container that's 44.1% of its own width, not its own height.
+
+**Net behavior:** items keep their authored proportions (stack rows stay
+at `_fHeight = 0.05`, composites at whatever aspect was authored); the
+container auto-shrinks to fit. The user toggles `AutoHeight` per
+container from the settings dialog.
+
+---
+
+## NereusSDR port scope
+
+### 1. `ContainerWidget` — `AutoHeight` property
+
+- Add `bool m_autoHeight` + `autoHeight() const` / `setAutoHeight(bool)`.
+- Serialize as **field 17** of `ContainerWidget::serialize()` (appending
+  a new field keeps Thetis field ordering and preserves forward
+  compatibility).
+- `ContainerWidget::deserialize()`: treat missing field 17 as `false` so
+  existing saved layouts keep their manual sizing.
+- `ContainerWidget::kMinContainerHeight` already exists; reuse as the
+  floor.
+
+### 2. `MeterWidget::naturalPixelHeight(int widthPx)`
+
+```cpp
+int MeterWidget::naturalPixelHeight(int widthPx) const;
+```
+
+Walks `m_items`, computes each item's `(y + h) × widthPx` in pixels,
+returns the max (clamped to `kMinContainerHeight`). For stack items this
+uses the reflowed `m_y` / `m_h` (already expressed relative to widget
+width in Thetis semantics — see `layoutInStackSlot` + `reflowStackedItems`).
+
+Pad term: Thetis uses `padY = (PadY − Height × 0.75) × widgetWidth`. Port
+the two constants (`_fPadY`, `_fHeight` from `clsMeter`) as static
+constexpr floats inside `MeterWidget` so the pixel result matches.
+
+### 3. Wire-up points
+
+After every install / reflow / resize event on a MeterWidget, if the
+host container's `autoHeight()` is `true`:
+
+- **Docked (PanelDocked, OverlayDocked):** call
+  `container->setFixedHeight(natural)` (or equivalent splitter sizing —
+  the existing splitter in `MainWindow` may need a splitter-sizes update
+  when a panel container shrinks).
+- **Floating:** resize the owning `FloatingContainer` to
+  `(currentWidth, natural + container chrome)`. Container chrome =
+  title-bar height (the hidden-but-reserved one for hover-reveal).
+
+Ideal place to trigger this is `MeterWidget::resizeEvent()` after it
+calls `reflowStackedItems()`. A signal `MeterWidget::naturalHeightChanged(int)`
+routes up through `ContainerWidget` → `ContainerManager` →
+FloatingContainer / splitter.
+
+### 4. UI toggle
+
+Container Settings dialog → "Auto-size height" checkbox. On toggle:
+
+- `setAutoHeight(true)` → immediately trigger a natural-height resize.
+- `setAutoHeight(false)` → no immediate resize; user regains free
+  vertical drag.
+
+### 5. Default behavior
+
+- **New containers: `autoHeight = true`.** NereusSDR's primary UX is
+  "hug-the-meter" per user feedback on PR #42. Differs from Thetis's
+  default-false, but this is a Qt widget behavior choice (not a DSP or
+  protocol port), so native NereusSDR default takes precedence per
+  `feedback_source_first_ui_vs_dsp.md`.
+- **Existing saved containers:** `autoHeight = false` (missing field →
+  false). Avoids surprise shrinking of layouts the user has already
+  arranged.
+
+### 6. Revert the PR #42 "share-the-band" reflow
+
+Once `AutoHeight` is in and defaulted on, the Thetis-parity `5%`-per-row
+layout is what users actually want. The temporary share-the-band scheme
+in `MeterWidget::reflowStackedItems()` (PR #42) should be reverted —
+restore `kNormalRowHNorm = 0.05` with the 24 px floor. With `AutoHeight`
+on, the container hugs the 5% rows; with it off, empty space is a
+user-chosen state.
+
+Keep the strict-overlap (`> 0.002`) clustering fix from PR #42 — that
+one is independent and correct.
+
+---
+
+## Test plan
+
+- Create a fresh ANAN MM container → hugs 44.1% aspect automatically.
+- Create a stacked bar-only meter → hugs the row stack (no empty below).
+- Add bar rows to an ANAN MM container → container grows.
+- Toggle `AutoHeight` off → container becomes free-resize; meter
+  renders at Thetis `5%` proportions with empty space.
+- Drag-resize a container with `AutoHeight` on → width drags freely,
+  height snaps back to natural each frame.
+- Load a pre-AutoHeight saved settings file → containers open with
+  `autoHeight = false`, layout unchanged.
+- Floating vs docked, panel vs overlay: all four dock modes honor the
+  auto-height path.
+- Serialize → restart → deserialize preserves the per-container flag.
+
+---
+
+## Out of scope for this plan
+
+- Thetis's `XRatio` / `YRatio` fields on the meter object
+  (`clsMeter.XRatio/YRatio`) — NereusSDR currently assumes both are 1.0
+  and doesn't persist them. If a future preset needs a non-square render
+  rect, that's a separate port.
+- The full `DirectXMeterRenderer` render-loop architecture. NereusSDR's
+  QRhi-based renderer measures natural height at reflow time, not per
+  frame, which is the right granularity for our needs.

--- a/src/gui/applets/AppletPanelWidget.cpp
+++ b/src/gui/applets/AppletPanelWidget.cpp
@@ -66,6 +66,8 @@ void AppletPanelWidget::setHeaderWidget(QWidget* widget, const QString& title,
                                          float aspectRatio)
 {
     if (!widget) { return; }
+    clearHeaderWidget();
+
     m_headerAspect = aspectRatio;
     m_headerWidget = widget;
 
@@ -74,11 +76,32 @@ void AppletPanelWidget::setHeaderWidget(QWidget* widget, const QString& title,
 
     QWidget* wrapped = wrapWithTitleBar(widget, title);
     wrapped->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    m_headerWrapper = wrapped;
     m_headerLayout->addWidget(wrapped);
 
     // Set initial height based on current width
     int h = qMax(80, static_cast<int>(width() / aspectRatio));
     widget->setFixedHeight(h);
+}
+
+void AppletPanelWidget::clearHeaderWidget()
+{
+    if (m_headerWrapper) {
+        m_headerLayout->removeWidget(m_headerWrapper);
+        // Detach from the widget tree SYNCHRONOUSLY before deleteLater.
+        // The wrapper's MeterWidget child is a WA_NativeWindow QRhiWidget
+        // with a live D3D11 swapchain. If the wrapper lingers in this
+        // panel's parent chain across an upcoming container reparent, the
+        // new MeterWidget's CreateSwapChainForHwnd returns E_ACCESSDENIED
+        // — Windows refuses to attach a second swapchain while the old
+        // native child is still under the parent HWND.
+        m_headerWrapper->hide();
+        m_headerWrapper->setParent(nullptr);
+        m_headerWrapper->deleteLater();
+        m_headerWrapper = nullptr;
+    }
+    m_headerWidget = nullptr;
+    m_headerAspect = 0.0f;
 }
 
 void AppletPanelWidget::resizeEvent(QResizeEvent* event)

--- a/src/gui/applets/AppletPanelWidget.h
+++ b/src/gui/applets/AppletPanelWidget.h
@@ -28,8 +28,18 @@ public:
 
     // Set a header widget (e.g., MeterWidget) that stays visible above
     // the scroll area. Height scales dynamically with width using the
-    // given aspect ratio (default 2.0 = AetherSDR's 280:140).
+    // given aspect ratio (default 2.0 = AetherSDR's 280:140). Calling
+    // again replaces the existing header (old wrapper + widget deleted).
     void setHeaderWidget(QWidget* widget, const QString& title, float aspectRatio = 2.0f);
+
+    // Remove the current header widget and its title-bar wrapper without
+    // installing a new one. Safe to call when no header is set. Used by
+    // ContainerManager to detach the MeterWidget before a top-level
+    // reparent (Qt 6.11.0 D3D11 QRhiWidget does not survive the HWND
+    // recreation that reparent triggers on Windows).
+    void clearHeaderWidget();
+
+    QWidget* headerWidget() const { return m_headerWidget; }
 
     // Add an applet — wraps it with a title bar and adds to the scroll stack
     void addApplet(AppletWidget* applet);
@@ -56,6 +66,7 @@ private:
     QList<AppletWidget*> m_applets;
     QMap<AppletWidget*, QWidget*> m_wrappers;  // applet → wrapper widget
     QWidget* m_headerWidget = nullptr;         // header widget for dynamic resize
+    QWidget* m_headerWrapper = nullptr;        // title-bar wrapper of the header
     float m_headerAspect = 0.0f;               // width/height ratio for header
 };
 

--- a/src/gui/containers/ContainerManager.cpp
+++ b/src/gui/containers/ContainerManager.cpp
@@ -4,6 +4,8 @@
 #include "FloatingContainer.h"
 #include "core/AppSettings.h"
 #include "core/LogCategories.h"
+#include "gui/applets/AppletPanelWidget.h"
+#include "gui/meters/MeterItem.h"
 #include "gui/meters/MeterWidget.h"
 
 #include <QSplitter>
@@ -71,6 +73,53 @@ void ContainerManager::wireContainer(ContainerWidget* container)
             emit meterReadyForPolling(meter);
         }
     });
+}
+
+QString ContainerManager::extractMeterItems(ContainerWidget* container)
+{
+    if (!container) { return {}; }
+    QWidget* content = container->content();
+    MeterWidget* meter = innerMeterWidget(content);
+    if (!meter) { return {}; }
+
+    const QString payload = meter->serializeItems();
+
+    if (qobject_cast<MeterWidget*>(content) == meter) {
+        // Bare MeterWidget as content — clear via setContent(nullptr) so
+        // the content holder layout is empty during the upcoming reparent.
+        container->setContent(nullptr);
+    } else if (auto* panel = qobject_cast<AppletPanelWidget*>(content)) {
+        // AppletPanelWidget header — detach the MeterWidget so the panel
+        // can reparent with no native-window child.
+        panel->clearHeaderWidget();
+    }
+    qCDebug(lcContainer) << "Extracted meter items from" << container->id()
+                          << "bytes:" << payload.size();
+    return payload;
+}
+
+void ContainerManager::installFreshMeter(ContainerWidget* container, const QString& payload)
+{
+    if (!container || payload.isEmpty()) { return; }
+
+    auto* fresh = new MeterWidget();
+    fresh->deserializeItems(payload);
+    fresh->inferStackFromGeometry();
+    for (MeterItem* item : fresh->items()) {
+        container->wireInteractiveItem(item);
+    }
+
+    QWidget* content = container->content();
+    if (auto* panel = qobject_cast<AppletPanelWidget*>(content)) {
+        panel->setHeaderWidget(fresh, QStringLiteral("Meters"), 1.3f);
+        emit meterReadyForPolling(fresh);
+    } else {
+        // Bare content path (user-created containers) — setContent emits
+        // contentChanged which routes into meterReadyForPolling.
+        container->setContent(fresh);
+    }
+    qCDebug(lcContainer) << "Installed fresh meter for" << container->id()
+                          << "items:" << fresh->items().size();
 }
 
 ContainerWidget* ContainerManager::duplicateContainer(const QString& sourceId)
@@ -203,10 +252,12 @@ void ContainerManager::panelDockContainer(const QString& id)
     form->setContainerFloating(false);
     form->hide();
     container->hide();
+    const QString payload = extractMeterItems(container);
     container->setParent(m_splitter);
     m_splitter->addWidget(container);
     container->setDockMode(DockMode::PanelDocked);
     container->show();
+    installFreshMeter(container, payload);
     m_panelContainerId = id;
 
     qCDebug(lcContainer) << "Panel-docked container:" << id;
@@ -224,11 +275,13 @@ void ContainerManager::overlayDockContainer(const QString& id)
     form->setContainerFloating(false);
     form->hide();
     container->hide();
+    const QString payload = extractMeterItems(container);
     container->setParent(m_dockParent);
     container->setDockMode(DockMode::OverlayDocked);
     container->restoreLocation();
     container->show();
     container->raise();
+    installFreshMeter(container, payload);
 
     qCDebug(lcContainer) << "Overlay-docked container:" << id;
 }
@@ -237,11 +290,14 @@ void ContainerManager::setMeterFloating(ContainerWidget* container, FloatingCont
 {
     // From Thetis MeterManager.cs:5894-5918
     container->hide();
+    const QString payload = extractMeterItems(container);
     form->takeOwner(container);
     form->setContainerFloating(true);
     container->setDockMode(DockMode::Floating);
     container->setTopMost();  // Re-apply pin-on-top now that parent is set
+    form->ensureVisiblePosition(m_dockParent);
     form->show();
+    installFreshMeter(container, payload);
     qCDebug(lcContainer) << "Floated container:" << container->id();
 }
 
@@ -251,11 +307,13 @@ void ContainerManager::returnMeterFromFloating(ContainerWidget* container, Float
     form->setContainerFloating(false);
     form->hide();
     container->hide();
+    const QString payload = extractMeterItems(container);
     container->setParent(m_dockParent);
     container->setDockMode(DockMode::OverlayDocked);
     container->restoreLocation();
     container->show();
     container->raise();
+    installFreshMeter(container, payload);
     qCDebug(lcContainer) << "Docked container:" << container->id();
 }
 

--- a/src/gui/containers/ContainerManager.h
+++ b/src/gui/containers/ContainerManager.h
@@ -97,6 +97,15 @@ private:
     void returnMeterFromFloating(ContainerWidget* container, FloatingContainer* form);
     void wireContainer(ContainerWidget* container);
 
+    // Windows D3D11 QRhiWidget (WA_NativeWindow) cannot survive the HWND
+    // recreation that setParent() triggers when moving a container between
+    // top-level windows. Call extractMeterItems() before a reparent to
+    // serialize and detach the MeterWidget, then installFreshMeter() after
+    // the reparent to rebuild meter content in the new parent's HWND
+    // context. No-op when the container holds placeholder content.
+    QString extractMeterItems(ContainerWidget* container);
+    void    installFreshMeter(ContainerWidget* container, const QString& payload);
+
     QWidget* m_dockParent{nullptr};
     QSplitter* m_splitter{nullptr};
     QMap<QString, ContainerWidget*> m_containers;

--- a/src/gui/containers/ContainerWidget.cpp
+++ b/src/gui/containers/ContainerWidget.cpp
@@ -160,6 +160,12 @@ void ContainerWidget::setContent(QWidget* widget)
     QLayout* layout = m_contentHolder->layout();
     if (m_content) {
         layout->removeWidget(m_content);
+        // Detach SYNCHRONOUSLY before deleteLater. When the content is a
+        // MeterWidget (WA_NativeWindow QRhiWidget), leaving it under this
+        // container's HWND through an upcoming reparent blocks the fresh
+        // MeterWidget's D3D11 swapchain with E_ACCESSDENIED on Windows.
+        m_content->hide();
+        m_content->setParent(nullptr);
         m_content->deleteLater();
     }
     m_content = widget;

--- a/src/gui/containers/FloatingContainer.cpp
+++ b/src/gui/containers/FloatingContainer.cpp
@@ -4,6 +4,8 @@
 #include "core/LogCategories.h"
 
 #include <QCloseEvent>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QVBoxLayout>
 
 namespace NereusSDR {
@@ -143,6 +145,59 @@ void FloatingContainer::restoreGeometry()
     if (ok1 && ok2 && ok3 && ok4) {
         setGeometry(x, y, w, h);
     }
+}
+
+void FloatingContainer::ensureVisiblePosition(QWidget* anchor)
+{
+    // A frameless Qt::Window with no explicit position defaults to (0,0)
+    // on Windows, where it's usually obscured by the main application
+    // window — which is how Container #0 "disappeared" when first
+    // floated. Saved geometry at (0,0) (e.g., after the user closed the
+    // invisible form) perpetuates the trap across restarts.
+    const QRect g = geometry();
+    const int minW = ContainerWidget::kMinContainerWidth;
+    const int minH = ContainerWidget::kMinContainerHeight;
+
+    bool onScreen = false;
+    for (QScreen* s : QGuiApplication::screens()) {
+        if (s && s->availableGeometry().intersects(g)) {
+            onScreen = true;
+            break;
+        }
+    }
+    const bool atOrigin = (g.x() == 0 && g.y() == 0);
+    if (onScreen && !atOrigin && g.width() >= minW && g.height() >= minH) {
+        return;
+    }
+
+    QScreen* screen = nullptr;
+    QRect anchorRect;
+    if (anchor && anchor->window()) {
+        screen = anchor->window()->screen();
+        anchorRect = anchor->window()->geometry();
+    }
+    if (!screen) {
+        screen = QGuiApplication::primaryScreen();
+    }
+    const QRect avail = screen ? screen->availableGeometry()
+                               : QRect(100, 100, 800, 600);
+
+    const int w = qMax(g.width(),  minW > 0 ? minW : 260);
+    const int h = qMax(g.height(), minH > 24 ? minH : 300);
+
+    int x = anchorRect.isValid()
+        ? anchorRect.center().x() - w / 2
+        : avail.x() + (avail.width()  - w) / 2;
+    int y = anchorRect.isValid()
+        ? anchorRect.center().y() - h / 2
+        : avail.y() + (avail.height() - h) / 2;
+
+    x = qBound(avail.x(), x, avail.right()  - w);
+    y = qBound(avail.y(), y, avail.bottom() - h);
+
+    setGeometry(x, y, w, h);
+    qCDebug(lcContainer) << "FloatingContainer: repositioned to visible area"
+                          << QRect(x, y, w, h) << "on screen" << (screen ? screen->name() : QStringLiteral("(null)"));
 }
 
 void FloatingContainer::updateTitle()

--- a/src/gui/containers/FloatingContainer.h
+++ b/src/gui/containers/FloatingContainer.h
@@ -42,6 +42,14 @@ public:
     void saveGeometry();
     void restoreGeometry();
 
+    // Ensure the form will be shown on a visible screen. Repositions the
+    // form when (a) no geometry was saved, or (b) saved geometry lands at
+    // the (0,0) origin or outside every connected screen. Pass the main
+    // window (or any widget on the target screen) as anchor; the form is
+    // centered on the anchor's screen. No-op when geometry is already on
+    // a screen and not at (0,0).
+    void ensureVisiblePosition(QWidget* anchor);
+
 signals:
     void aboutToClose();
 

--- a/src/gui/meters/MeterPoller.cpp
+++ b/src/gui/meters/MeterPoller.cpp
@@ -26,14 +26,20 @@ void MeterPoller::setRxChannel(RxChannel* channel)
 
 void MeterPoller::addTarget(MeterWidget* widget)
 {
-    if (widget && !m_targets.contains(widget)) {
-        m_targets.append(widget);
+    if (!widget) { return; }
+    // Drop any stale entries whose widgets have been destroyed, then add
+    // only if not already present.
+    m_targets.removeAll(QPointer<MeterWidget>(nullptr));
+    for (const auto& p : m_targets) {
+        if (p.data() == widget) { return; }
     }
+    m_targets.append(QPointer<MeterWidget>(widget));
 }
 
 void MeterPoller::removeTarget(MeterWidget* widget)
 {
-    m_targets.removeAll(widget);
+    m_targets.removeAll(QPointer<MeterWidget>(widget));
+    m_targets.removeAll(QPointer<MeterWidget>(nullptr));
 }
 
 void MeterPoller::setInterval(int ms)
@@ -69,7 +75,8 @@ void MeterPoller::poll()
     // endpoint's variable cache into each item with an MMIO
     // binding.
     auto& engine = ExternalVariableEngine::instance();
-    for (MeterWidget* target : m_targets) {
+    for (auto& guarded : m_targets) {
+        MeterWidget* target = guarded.data();
         if (!target) { continue; }
         for (MeterItem* item : target->items()) {
             if (!item || !item->hasMmioBinding()) { continue; }
@@ -95,7 +102,9 @@ void MeterPoller::poll()
         if (bindingId == MeterBinding::SignalAvg) {
             smeterDbm = value;
         }
-        for (MeterWidget* target : m_targets) {
+        for (auto& guarded : m_targets) {
+            MeterWidget* target = guarded.data();
+            if (!target) { continue; }
             target->updateMeterValue(bindingId, value);
         }
     }

--- a/src/gui/meters/MeterPoller.h
+++ b/src/gui/meters/MeterPoller.h
@@ -84,7 +84,10 @@ private slots:
 private:
     QTimer m_timer;
     QPointer<RxChannel> m_rxChannel;
-    QVector<MeterWidget*> m_targets;
+    // QPointer auto-clears to nullptr when the MeterWidget is destroyed.
+    // ContainerManager's float/dock swap replaces MeterWidgets mid-session;
+    // without QPointer, poll() would dereference the deleted old widgets.
+    QVector<QPointer<MeterWidget>> m_targets;
 };
 
 } // namespace NereusSDR

--- a/src/gui/meters/MeterWidget.cpp
+++ b/src/gui/meters/MeterWidget.cpp
@@ -270,23 +270,37 @@ void MeterWidget::reflowStackedItems()
     const int h = height();
     if (h <= 0) { return; }
 
-    // Thetis-parity stack layout with NereusSDR pixel floor:
-    //   slotHpx = max(kNormalRowHNorm * widgetH, kMinRowHeightPx)
-    //   bandTop = max(y + itemHeight) over items with itemHeight > 0.30
-    // Re-lays every stacked item from those two values so adding,
-    // removing, or resizing a composite shifts the stack without
-    // touching any per-item metadata.
-    constexpr float kNormalRowHNorm = 0.05f;  // Thetis _fHeight @ MeterManager.cs:21266
-    constexpr int   kMinRowHeightPx = 24;     // NereusSDR pixel floor
-    const int normalRowPx = static_cast<int>(kNormalRowHNorm * static_cast<float>(h));
-    const int slotHeightPx = qMax(normalRowPx, kMinRowHeightPx);
+    // Stack rows share the vertical band (bandTop .. 1.0) equally,
+    // so N stacked rows always fill the available space under the
+    // composite band. Thetis uses a fixed 5% per row because its
+    // meter containers are fixed-aspect (MeterManager.cs:21266) —
+    // NereusSDR's containers are freely resizable, so a fixed 5%
+    // would leave an empty gap below the stack whenever the user
+    // sizes the container larger than N × 5%. A 24px pixel floor
+    // keeps rows readable when the container is small enough that
+    // the per-slot share would otherwise drop below that; in that
+    // case the bottom rows overflow the widget (same as Thetis).
+    constexpr int kMinRowHeightPx = 24;
 
     float bandTop = 0.0f;
+    int maxSlot = -1;
     for (const MeterItem* item : m_items) {
         if (!item) { continue; }
-        if (item->itemHeight() <= 0.30f) { continue; }
-        const float bottom = item->y() + item->itemHeight();
-        if (bottom > bandTop) { bandTop = bottom; }
+        if (item->itemHeight() > 0.30f) {
+            const float bottom = item->y() + item->itemHeight();
+            if (bottom > bandTop) { bandTop = bottom; }
+        }
+        if (item->stackSlot() >= 0) {
+            maxSlot = qMax(maxSlot, item->stackSlot());
+        }
+    }
+
+    const int numSlots = maxSlot + 1;
+    int slotHeightPx = kMinRowHeightPx;
+    if (numSlots > 0) {
+        const int availablePx = static_cast<int>((1.0f - bandTop)
+                                                 * static_cast<float>(h));
+        slotHeightPx = qMax(availablePx / numSlots, kMinRowHeightPx);
     }
 
     for (MeterItem* item : m_items) {
@@ -321,6 +335,14 @@ void MeterWidget::inferStackFromGeometry()
         float yMax;
         QVector<MeterItem*> members;
     };
+    // Cluster only when y-intervals genuinely OVERLAP by more than an
+    // epsilon. Touching boundaries (yMax of row N == yMin of row N+1,
+    // the normal stack-row layout) or sub-ULP floating-point drift from
+    // repeated serialize/deserialize cycles must NOT merge: if adjacent
+    // rows collapse into one cluster they all collapse onto stack slot
+    // 0, cramming N rows into one row's height and visibly compressing
+    // the meter a little more on every reparent trip.
+    constexpr float kOverlapEps = 0.002f;
     QVector<Cluster> clusters;
     for (MeterItem* item : m_items) {
         if (!item) { continue; }
@@ -330,7 +352,7 @@ void MeterWidget::inferStackFromGeometry()
         const float yMax = item->y() + h;
         bool placed = false;
         for (Cluster& c : clusters) {
-            if (yMin <= c.yMax && yMax >= c.yMin) {
+            if (yMin + kOverlapEps < c.yMax && yMax > c.yMin + kOverlapEps) {
                 c.yMin = qMin(c.yMin, yMin);
                 c.yMax = qMax(c.yMax, yMax);
                 c.members.append(item);


### PR DESCRIPTION
## Summary

Fixes five interlocking bugs that broke meter containers on Windows when floated, docked, or first created with the D3D11 QRhi backend:

- Dark rectangle / dead hover-reveal after a reparent
- Floating form landed at (0,0) behind the main window and "disappeared"
- D3D11 swapchain `0x80070005` → `DXGI_ERROR_DEVICE_REMOVED` cascade
- Stack meter items progressively compressing each float/dock cycle
- Meter stack filling only ~45% of a resizable container

## Root causes + fixes

1. **HWND collision on reparent.** Old `MeterWidget` (WA_NativeWindow + live D3D11 swapchain) was `deleteLater`-ed, so it remained under the container's parent HWND during `setParent()`. New MeterWidget's `CreateSwapChainForHwnd` returned `E_ACCESSDENIED` while the old native child was still registered, cascading into `DEVICE_REMOVED`. Detach old widget synchronously (`hide()` + `setParent(nullptr)`) before `deleteLater`. Swap the MeterWidget around each reparent via `extractMeterItems` / `installFreshMeter` so no WA_NativeWindow child is reparented.
2. **Off-screen first float.** Saved geometry at `(0,0)` placed the frameless form behind the main window. `ensureVisiblePosition()` centers the form on the anchor's screen when geometry is missing, at origin, or off every connected screen.
3. **Use-after-free in `MeterPoller`.** Raw `MeterWidget*` targets dangled when the reparent-swap destroyed them. Switched to `QVector<QPointer<MeterWidget>>` with null-guarded `poll()`.
4. **Progressive stack compression.** `inferStackFromGeometry` clustered every bar row whose y-interval *touched* its neighbor (`yMax` of row N == `yMin` of row N+1), collapsing N rows onto stack slot 0 and losing vertical space by a factor of N per cycle. Require strict overlap > 0.002 before merging.
5. **Empty space below the stack.** Thetis's `kNormalRowHNorm = 0.05` per-row formula assumes fixed-aspect containers; NereusSDR's resizable containers left a gap when taller than `N × 5%`. Share the `(1 − bandTop)` band equally among stack rows, keeping the 24px floor for small widgets.

## Known limitations (follow-ups)

- **ANAN MM preset** still shows empty space below the needle panel when no bar rows are added. The Thetis-faithful fix is per-container `AutoHeight` (`ucMeter.cs:903` + `MeterManager.cs:31338` `drawMeters` natural-height measurement) — gets its own phase plan.
- Exit-time crash (exit 139 on close) still reproduces; not implicated by this PR.
- One `QRhiWidget: No QRhi` warning per install cycle; benign, investigating separately.

## Test plan

- [x] Repeated float↔dock cycles on Windows D3D11 — no swapchain failures or `DEVICE_REMOVED`.
- [x] Serialized payload stable at ~3160 bytes across cycles (previously drifted 3165 → 3207).
- [x] First float centers on anchor's screen when saved geometry is missing / at (0,0) / off-screen.
- [ ] macOS regression pass (no-op expected — the teardown ordering already worked there).
- [ ] Second Windows user on a different GPU/driver.

J.J. Boyd ~ KG4VCF
Co-Authored with Claude Code