### PR TITLE
chore(compliance): close authoring-time + pre-commit attribution gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,40 @@ file's header comment:
 4. A trailing "Modification history (NereusSDR)" block with the port date,
    human author, and AI tooling disclosure
 
-Templates live in `docs/attribution/HEADER-TEMPLATES.md`. Failure to
+Templates live in `docs/attribution/HOW-TO-PORT.md`. Failure to
 preserve these notices on a new port is a GPL compliance bug, not a style
 nit — reject the PR.
+
+### Pre-port checklist (Ring 1 — authoring-time)
+
+Before reading any Thetis source file (`../Thetis/...`), state out loud:
+
+1. **Thetis file** you're about to read.
+2. **NereusSDR file(s)** the port will touch (new or existing).
+3. **Provenance status** of each NereusSDR file — run:
+    ```
+    grep -l "<nereussdr-path>" docs/attribution/THETIS-PROVENANCE.md
+    ```
+   If the file is not registered, the port is a **new attribution event**.
+4. **Plan**: if (3) returned nothing, you will add the verbatim upstream
+   header AND a PROVENANCE row in the same commit that introduces the
+   ported logic. Use `docs/attribution/HOW-TO-PORT.md` for the format.
+
+If you cannot answer (3) confidently, **stop and grep** before continuing.
+The cost of asking is one shell command; the cost of skipping is a
+merge-blocking CI failure (or worse, a missed gap that ships to main).
+
+This applies equally to:
+- New files that port Thetis logic.
+- Edits to NereusSDR-original files that **add** new ported logic
+  (e.g. wiring in a new Thetis-derived constant or formula).
+- Ports from non-Thetis upstreams (`../mi0bot-Thetis/`, `../AetherSDR/`,
+  WDSP) — same protocol, different PROVENANCE table / variant.
+
+Verifier scripts (`scripts/verify-thetis-headers.py`,
+`scripts/check-new-ports.py`) are the safety net (Ring 3, in CI). The
+local pre-commit hook installed via `scripts/install-hooks.sh` runs the
+same scripts pre-push (Ring 2). The primary control is this checklist.
 
 ### What Counts As "Guessing" (NEVER Do These)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,11 +196,26 @@ Any PR that ports, translates, or materially adapts Thetis source code
 into NereusSDR must preserve the original license header, copyright
 lines, and dual-licensing notices from the Thetis source file, and append
 a dated modification note to the NereusSDR file. See
-[docs/attribution/HEADER-TEMPLATES.md](docs/attribution/HEADER-TEMPLATES.md)
+[docs/attribution/HOW-TO-PORT.md](docs/attribution/HOW-TO-PORT.md)
 for templates and [docs/attribution/THETIS-PROVENANCE.md](docs/attribution/THETIS-PROVENANCE.md)
 for the existing provenance inventory.
 
 This is a merge-blocking requirement, not a style preference.
+
+### Install the attribution pre-commit hook
+
+After cloning, run once:
+
+```bash
+bash scripts/install-hooks.sh
+```
+
+This points `git config core.hooksPath` at `scripts/git-hooks/` so the
+attribution verifiers (`verify-thetis-headers.py` + `check-new-ports.py`)
+run before every commit. Same scripts CI runs, but locally — catches
+missing headers and unregistered ports before push, not after a 7-minute
+CI cycle. Do not bypass the hook with `--no-verify`; fix the attribution
+instead.
 
 ## Code of Conduct
 

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Pre-commit hook: run the attribution verifiers before every commit.
+#
+# This is Ring 2 of the attribution-gap-closure scheme (CLAUDE.md
+# "Pre-port checklist" is Ring 1; CI is Ring 3). Catches missing
+# headers / unregistered ports before they leave your laptop.
+#
+# Activation:
+#   bash scripts/install-hooks.sh
+# (sets git config core.hooksPath to scripts/git-hooks/)
+#
+# Bypass: do NOT use --no-verify. If a verifier fails, fix the
+# attribution. Per CLAUDE.md "License-preservation rule
+# (non-negotiable)" — that is the rule, not a suggestion.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Skip if no source files are staged — these hooks only care about
+# source / docs provenance.
+if ! git diff --cached --name-only --diff-filter=ACMR | \
+     grep -qE '\.(cpp|h|hpp|cc|c|hxx|md|py)$'; then
+    exit 0
+fi
+
+echo "[pre-commit] verify-thetis-headers.py"
+if ! python3 scripts/verify-thetis-headers.py; then
+    echo
+    echo "[pre-commit] BLOCKED: header verifier failed."
+    echo "             Fix the headers, then re-stage and re-commit."
+    exit 1
+fi
+
+echo "[pre-commit] check-new-ports.py"
+if ! CHECK_NEW_PORTS_BASE_REF="${CHECK_NEW_PORTS_BASE_REF:-origin/main}" \
+     python3 scripts/check-new-ports.py; then
+    echo
+    echo "[pre-commit] BLOCKED: new-port detector flagged a file."
+    echo "             Either register it in THETIS-PROVENANCE.md +"
+    echo "             add the verbatim upstream header, or add the"
+    echo "             'Independently implemented from <upstream>' or"
+    echo "             'no-port-check: <reason>' marker if genuinely"
+    echo "             not a port. See docs/attribution/HOW-TO-PORT.md."
+    exit 1
+fi
+
+exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# One-time install: point git at the versioned hooks directory.
+#
+# Run from anywhere inside the repo:
+#   bash scripts/install-hooks.sh
+#
+# This sets repo-local `core.hooksPath` to scripts/git-hooks/, so all
+# hooks under that directory become active. Versioned in the repo, so
+# every contributor / clone gets the same set after running this once.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$REPO_ROOT/scripts/git-hooks"
+
+if [ ! -d "$HOOKS_DIR" ]; then
+    echo "ERROR: $HOOKS_DIR not found" >&2
+    exit 1
+fi
+
+chmod +x "$HOOKS_DIR"/*
+
+git -C "$REPO_ROOT" config core.hooksPath scripts/git-hooks
+
+echo "Installed git hooks from scripts/git-hooks/"
+echo
+echo "Active hooks:"
+ls -1 "$HOOKS_DIR" | sed 's/^/  - /'
+echo
+echo "To uninstall: git config --unset core.hooksPath"


### PR DESCRIPTION
## Summary

Adds two new defensive rings on top of the v0.2.0 license-compliance
posture, motivated by the attribution gap discovered while merging
PR #44 (`feature/sample-rate-wiring`):

- **Ring 1 (authoring-time):** new "Pre-port checklist" subsection in
  CLAUDE.md. Forces the contributor (or AI agent) to state the Thetis
  source, target NereusSDR file, PROVENANCE registration status, and
  attribution plan **before** reading any Thetis source. Closes the
  ~80% of realistic gaps that come from forgetting to think about
  attribution at the start of work.
- **Ring 2 (pre-commit):** local git hook + one-time installer. Runs
  the same `verify-thetis-headers.py` + `check-new-ports.py` scripts
  that CI runs, but locally before every commit. Catches missing
  headers and unregistered ports before push, not after a 7-min CI
  cycle.
- **Ring 3 (CI):** unchanged — the existing `verify-thetis-headers.py`
  + `check-new-ports.py` jobs in `ci.yml` remain as the authoritative
  safety net.

The three rings are layered on purpose: each catches what the others
might miss. Ring 1 is process; Ring 2 is local mechanism; Ring 3 is
remote enforcement.

## Why now

PR #44 (`feature/sample-rate-wiring`) was opened before the v0.2.0
compliance protocol shipped to main. When main caught up, the
SampleRateCatalog files were missing the verbatim `setup.cs` header
and were not registered in `THETIS-PROVENANCE.md` — caught only at
merge time, requiring a follow-up commit. Same thing could happen on
any future PR that ports a new Thetis surface. This PR makes the
"forget at authoring time, find out at PR time" failure mode much
harder.

## What's in here

- `CLAUDE.md` — new "Pre-port checklist (Ring 1 — authoring-time)"
  subsection under "License-preservation rule". Stale
  `HEADER-TEMPLATES.md` reference fixed to `HOW-TO-PORT.md` while
  there.
- `scripts/git-hooks/pre-commit` — versioned pre-commit hook that
  runs both verifiers.
- `scripts/install-hooks.sh` — one-time installer (sets repo-local
  `core.hooksPath`).
- `CONTRIBUTING.md` — adds "Install the attribution pre-commit hook"
  subsection under License Preservation, with the install command.

## Test plan

- [x] `python3 scripts/verify-thetis-headers.py` → 193/193 files pass.
- [x] `python3 scripts/check-new-ports.py` → no source files in this
  PR's diff, scanner reports clean.
- [x] `bash scripts/install-hooks.sh` → installs cleanly, prints
  active hook list.
- [x] All three commits GPG-signed (verified locally).
- [ ] Maintainer: after merge, run `bash scripts/install-hooks.sh`
  in your local clone so the hook is active for your next commit.

## Independence from PR #44

Fully independent — no shared files. PR #44 can merge in either
order.

J.J. Boyd ~ KG4VCF