### PR TITLE
compliance: audit auditors + CI gates + §5(d)/§6 bundling polish

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -46,30 +46,54 @@ gpg --verify SHA256SUMS.txt.asc SHA256SUMS.txt
 sha256sum -c SHA256SUMS.txt
 ```
 
-## Source for bundled binaries (GPL §6 corresponding source)
+## Source & Licence (GPLv3 §6 / GPLv2 §3 corresponding source)
 
-NereusSDR is GPLv3, and several bundled or linked third-party libraries
-carry their own GPL/LGPL obligations. The corresponding source for every
-binary on this release page is provided here on the same medium:
+NereusSDR is distributed under **GPLv3** (see `LICENSE` inside any
+release artifact, or <https://github.com/boydsoftprez/NereusSDR/blob/main/LICENSE>).
+The combined work links/bundles:
+
+- **Thetis**-derived C++ ports (GPL-2.0-or-later; combined under GPLv3
+  via §5(b)) — see `licenses/thetis.txt`
+- **mi0bot/Thetis-HL2**-derived HL2 bits (GPL-2.0-or-later) — see
+  `licenses/mi0bot-thetis.txt`
+- **AetherSDR**-derived Qt6 scaffolding (GPL-3.0) — see
+  `licenses/aethersdr.txt`
+- **Qt 6** (LGPL-3.0, dynamic linking) — see `licenses/qt6.txt`
+- **FFTW3** (GPL-2.0-or-later, static on Windows / system on Linux+macOS)
+  — see `licenses/fftw3.txt`
+- **WDSP** (GPL-2.0-or-later, static) — see `licenses/wdsp.txt`
+
+Every release artifact ships a `licenses/` directory containing the
+three full FSF licence texts (`GPLv2.txt`, `GPLv3.txt`, `LGPLv3.txt`),
+all per-dependency notices listed above, and a written source offer at
+`licenses/SOURCE-OFFER.txt` covering GPLv3 §6(a) (primary: this release
+page) and §6(b) (fallback: 3-year offer via email).
+
+Corresponding source for every binary on this release page is provided
+on the same medium:
 
 - **NereusSDR** itself — `NereusSDR-vX.Y.Z-source.tar.gz` (this release).
-  Equivalent to a `git archive` of the tag commit.
+  Equivalent to a `git archive` of the tag commit. This archive also
+  contains the vendored WDSP sources (`third_party/wdsp/`) and the
+  FFTW3 Windows binary-plus-header tree (`third_party/fftw3/`).
 - **FFTW3** (GPLv2-or-later) — `fftw-3.3.5.tar.gz` (this release).
   Exact upstream archive used to build the bundled `libfftw3f-3.dll`
   shipped in the Windows installer and portable ZIP. Upstream:
-  <https://fftw.org/pub/fftw/fftw-3.3.5.tar.gz>.
-- **Qt6** (LGPLv3) — dynamically linked on all platforms; replace the
-  bundled Qt6 libraries with your own modified build per
-  `licenses/qt6.txt` in the install tree (Linux: `libQt6*.so.6` in the
-  AppImage's `usr/lib/`; macOS: `Qt*.framework` in the app bundle's
-  `Contents/Frameworks/`; Windows: `Qt6*.dll` in the install directory).
-  Upstream source: <https://download.qt.io/archive/qt/>.
+  <https://fftw.org/pub/fftw/fftw-3.3.5.tar.gz>. Provenance:
+  `docs/attribution/FFTW3-PROVENANCE.md` in the source archive.
+- **Qt 6** (LGPLv3) — dynamically linked on all platforms; replace the
+  bundled Qt 6 libraries with your own modified build per
+  `licenses/qt6.txt`. Linux: `libQt6*.so.6` in the AppImage's
+  `usr/lib/`; macOS: `Qt*.framework` in `NereusSDR.app/Contents/Frameworks/`;
+  Windows: `Qt6*.dll` in the install directory. Upstream source:
+  <https://download.qt.io/archive/qt/>.
 - **WDSP** (GPLv2-or-later) — statically aggregated; corresponding source
   is in NereusSDR's `third_party/wdsp/` (included in
-  `NereusSDR-vX.Y.Z-source.tar.gz`).
+  `NereusSDR-vX.Y.Z-source.tar.gz`). Provenance:
+  `docs/attribution/WDSP-PROVENANCE.md` in the source archive.
 
-A written 3-year offer for the same source is also available on request
-to <kg4vcf@gmail.com> (GPLv2 §3(b) / GPLv3 §6(b) compliance).
+A written 3-year source offer applies independently per
+`licenses/SOURCE-OFFER.txt`; contact <kg4vcf@gmail.com> to invoke it.
 
 ## Reporting Issues
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,59 @@ jobs:
         run: python3 scripts/check-new-ports.py
 
       # ------------------------------------------------------------------
+      # Phase 2/3 compliance auditors (added 2026-04-18, Plan Task 15)
+      # ------------------------------------------------------------------
+      - name: Verify AetherSDR + WDSP license-header markers
+        # Extends the Thetis-kind header check above to the two other
+        # lineage kinds (AetherSDR Bucket A + WDSP vendored sources).
+        # Fails if a Bucket A file is missing the project-level
+        # AetherSDR attribution, or if a WDSP source lost its upstream
+        # GPL permission block on re-import.
+        if: runner.os == 'Linux'
+        run: python3 scripts/verify-thetis-headers.py --all-kinds
+
+      - name: Verify provenance tables match the source tree
+        # Already enforced in pre-commit Ring 2. Re-run in CI Ring 3
+        # because squashed merges and rebases can introduce drift the
+        # hook never saw.
+        if: runner.os == 'Linux'
+        run: python3 scripts/verify-provenance-sync.py
+
+      - name: Verify inline '// From Thetis' cite version stamps
+        # Regression gate: fails if the count of unstamped cites
+        # exceeds the grandfathered baseline in
+        # tests/compliance/inline-cites-baseline.json (288 as of
+        # 2026-04-18 sweep). --strict will replace this once the
+        # baseline has been remediated to zero.
+        if: runner.os == 'Linux'
+        run: python3 scripts/verify-inline-cites.py
+
+      - name: Compliance inventory — no missing required markers
+        # Walks every git-tracked file, classifies by upstream lineage,
+        # verifies per-kind header markers. Fails on any missing marker.
+        if: runner.os == 'Linux'
+        run: python3 scripts/compliance-inventory.py --fail-on-unclassified
+
+      - name: WDSP header census drift detector
+        # Re-runs the third_party/wdsp/src/ classification and fails if
+        # the counts drift from WDSP-PROVENANCE.md's documented split
+        # (128 gpl2-or-later + 10 utility no-header). Catches a WDSP
+        # re-sync that forgets to update PROVENANCE.
+        if: runner.os == 'Linux'
+        run: python3 scripts/audit-wdsp-headers.py
+
+      - name: Set up Python for pytest
+        if: runner.os == 'Linux'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: pytest — compliance test suite
+        # Runs tests/compliance/ (inventory schema + cite baseline).
+        if: runner.os == 'Linux'
+        run: python3 -m pytest tests/compliance/ -v
+
+      # ------------------------------------------------------------------
       # Linux dependencies
       # ------------------------------------------------------------------
       - name: Install dependencies (Linux)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,12 @@ a dated modification note to the NereusSDR file. See
 for templates and [docs/attribution/THETIS-PROVENANCE.md](docs/attribution/THETIS-PROVENANCE.md)
 for the existing provenance inventory.
 
+Pulling a newer Thetis / mi0bot / AetherSDR / WDSP revision into
+NereusSDR? Follow
+[docs/attribution/UPSTREAM-SYNC-PROTOCOL.md](docs/attribution/UPSTREAM-SYNC-PROTOCOL.md)
+— it covers version-stamp refresh, cite re-verification, and how to
+log the sync in `REMEDIATION-LOG.md`.
+
 This is a merge-blocking requirement, not a style preference.
 
 ### Install the attribution pre-commit hook

--- a/docs/attribution/COMPLIANCE-INVENTORY.md
+++ b/docs/attribution/COMPLIANCE-INVENTORY.md
@@ -32,13 +32,12 @@ inventory and per-component provenance docs.
 
 # Compliance Inventory
 
-Total tracked files: **711**
+Total tracked files: **724**
 
-## aethersdr-port (38)
+## aethersdr-port (34)
 
 - `src/core/AudioEngine.cpp`
 - `src/core/AudioEngine.h`
-- `src/gui/AboutDialog.cpp`
 - `src/gui/SetupPage.cpp`
 - `src/gui/SpectrumOverlayMenu.h`
 - `src/gui/SpectrumOverlayPanel.cpp`
@@ -71,13 +70,11 @@ Total tracked files: **711**
 - `src/gui/widgets/TriBtn.h`
 - `src/gui/widgets/VfoLevelBar.cpp`
 - `src/gui/widgets/VfoStyles.h`
-- `tests/CMakeLists.txt`
-- `tests/tst_about_dialog.cpp`  warning: missing: Modification history (NereusSDR)
-- `tests/tst_container_persistence.cpp`  warning: missing: Modification history (NereusSDR)
 
-## attribution-doc (17)
+## attribution-doc (18)
 
 - `docs/attribution/ASSETS.md`
+- `docs/attribution/COMPLIANCE-INVENTORY.md`
 - `docs/attribution/FFTW3-PROVENANCE.md`
 - `docs/attribution/HOW-TO-PORT.md`
 - `docs/attribution/LICENSE-GPLv2`
@@ -195,7 +192,7 @@ Total tracked files: **711**
 - `third_party/fftw3/lib/libfftw3f-3.a`
 - `third_party/fftw3/lib/libfftw3f-3.def`
 
-## nereussdr-original (134)
+## nereussdr-original (138)
 
 - `.claude/commands/triage.md`
 - `.gitattributes`
@@ -215,6 +212,8 @@ Total tracked files: **711**
 - `captures/.gitignore`
 - `captures/thetis-3865-lsb-pcap-analysis.md`
 - `scripts/.gitkeep`
+- `scripts/audit-inline-markers.py`
+- `scripts/audit-wdsp-headers.py`
 - `scripts/check-new-ports.py`
 - `scripts/compliance-inventory.py`
 - `scripts/fix-multisource-samphire.py`
@@ -224,6 +223,7 @@ Total tracked files: **711**
 - `scripts/install-hooks.sh`
 - `scripts/repair-multisource-headers.py`
 - `scripts/rewrite-verbatim-headers.py`
+- `scripts/verify-inline-cites.py`
 - `scripts/verify-provenance-sync.py`
 - `scripts/verify-thetis-headers.py`
 - `scripts/windows/installer.nsi`
@@ -239,6 +239,7 @@ Total tracked files: **711**
 - `src/core/mmio/ITransportWorker.cpp`
 - `src/core/mmio/ITransportWorker.h`
 - `src/core/mmio/MmioEndpoint.cpp`
+- `src/gui/AboutDialog.cpp`
 - `src/gui/AboutDialog.h`
 - `src/gui/ColorSwatchButton.cpp`
 - `src/gui/ColorSwatchButton.h`
@@ -332,7 +333,7 @@ Total tracked files: **711**
 - `src/models/TransmitModel.h`
 - `third_party/.gitkeep`
 
-## packaging (13)
+## packaging (20)
 
 - `.github/ISSUE_TEMPLATE/bug_report.yml`
 - `.github/ISSUE_TEMPLATE/config.yml`
@@ -343,9 +344,16 @@ Total tracked files: **711**
 - `.github/workflows/codeql.yml`
 - `.github/workflows/docker-ci-image.yml`
 - `.github/workflows/release.yml`
+- `packaging/third-party-licenses/GPLv2.txt`
+- `packaging/third-party-licenses/GPLv3.txt`
+- `packaging/third-party-licenses/LGPLv3.txt`
 - `packaging/third-party-licenses/README.md`
+- `packaging/third-party-licenses/SOURCE-OFFER.txt`
+- `packaging/third-party-licenses/aethersdr.txt`
 - `packaging/third-party-licenses/fftw3.txt`
+- `packaging/third-party-licenses/mi0bot-thetis.txt`
 - `packaging/third-party-licenses/qt6.txt`
+- `packaging/third-party-licenses/thetis.txt`
 - `packaging/third-party-licenses/wdsp.txt`
 
 ## resource (34)
@@ -385,11 +393,14 @@ Total tracked files: **711**
 - `resources/shaders/waterfall.frag`
 - `resources/shaders/waterfall.vert`
 
-## test (32)
+## test (37)
 
+- `tests/CMakeLists.txt`
 - `tests/TestSandboxInit.cpp`
 - `tests/compliance/__init__.py`
+- `tests/compliance/inline-cites-baseline.json`
 - `tests/compliance/test_cite_versioning.py`
+- `tests/compliance/test_inline_cites.py`
 - `tests/compliance/test_inventory.py`
 - `tests/fakes/P1FakeRadio.cpp`
 - `tests/fakes/P1FakeRadio.h`
@@ -397,10 +408,12 @@ Total tracked files: **711**
 - `tests/fixtures/discovery/p1_angelia_reply.hex`
 - `tests/fixtures/discovery/p1_hermeslite_reply.hex`
 - `tests/fixtures/discovery/p2_saturn_reply.hex`
+- `tests/tst_about_dialog.cpp`
 - `tests/tst_board_capabilities.cpp`
 - `tests/tst_clarity_controller.cpp`
 - `tests/tst_clarity_defaults.cpp`
 - `tests/tst_connection_panel_saved_radios.cpp`
+- `tests/tst_container_persistence.cpp`
 - `tests/tst_cross_thread_teardown.cpp`
 - `tests/tst_hardware_page_capability_gating.cpp`
 - `tests/tst_hardware_page_persistence.cpp`
@@ -637,7 +650,7 @@ Total tracked files: **711**
 - `third_party/wdsp/CMakeLists.txt`
 - `third_party/wdsp/COPYING`
 - `third_party/wdsp/src/FDnoiseIQ.c`
-- `third_party/wdsp/src/FDnoiseIQ.h`  warning: missing: Copyright (C), General Public License
+- `third_party/wdsp/src/FDnoiseIQ.h`
 - `third_party/wdsp/src/RXA.c`
 - `third_party/wdsp/src/RXA.h`
 - `third_party/wdsp/src/TXA.c`

--- a/docs/attribution/README.md
+++ b/docs/attribution/README.md
@@ -10,6 +10,9 @@ This directory holds the public-facing attribution record for NereusSDR:
 - [`THETIS-PROVENANCE.md`](THETIS-PROVENANCE.md) — File-by-file inventory
   mapping each NereusSDR derived source file to its Thetis upstream source,
   line ranges, derivation type, and contributor set.
+- [`UPSTREAM-SYNC-PROTOCOL.md`](UPSTREAM-SYNC-PROTOCOL.md) — When and how
+  to pull from Thetis / mi0bot / AetherSDR / WDSP upstreams, refresh
+  inline-cite version stamps, and log the sync in `REMEDIATION-LOG.md`.
 - [`ASSETS.md`](ASSETS.md) — Inventory of every graphical/binary asset
   under `resources/` and `docs/images/` with origin, author, and license.
 

--- a/docs/attribution/REMEDIATION-LOG.md
+++ b/docs/attribution/REMEDIATION-LOG.md
@@ -1021,4 +1021,98 @@ checked, all properly attributed or skip-marked." Build: clean.
 
 ---
 
+## 2026-04-18 — Full-tree audit sweep (Phases 0–6 of the 2026-04-18 plan)
+
+**Discovered by:** Internal audit — J.J. Boyd (KG4VCF)
+**Reported via:** `docs/architecture/2026-04-18-gpl-compliance-full-audit-plan.md`
+**Affected files:** Tree-wide — 724 tracked files classified; 207 PROVENANCE-listed ports verified; 138 WDSP sources censused
+**Gap:** Three categories surfaced by the expanded auditors.
+
+1. **Binary recipients got URLs, not licence text.** Pre-sweep,
+   `packaging/third-party-licenses/{fftw3,qt6,wdsp}.txt` pointed at
+   gnu.org links for the actual licence text. GPLv2 §1 / LGPLv3 §4
+   require text-alongside, not text-by-reference.
+2. **Per-upstream-project notices absent from binary.** Binary-only
+   recipients saw no mention of Thetis, mi0bot/Thetis-HL2, or AetherSDR
+   as upstream origins of code compiled into NereusSDR; per-file
+   attribution was only in source headers and `docs/attribution/`.
+3. **No written source offer bundled.** GPLv3 §6(b) fallback (three-year
+   written offer) was absent from the release artifacts; the §6(a)
+   "source alongside binary" claim hinged on the Releases page being
+   up at fetch time.
+4. **Header verifier did not cover AetherSDR or WDSP lineages.**
+   `verify-thetis-headers.py` pre-sweep only enforced Thetis markers;
+   AetherSDR Bucket-A files and WDSP vendored sources were unaudited.
+5. **No tree-wide inline-cite stamp sweep.** PR-diff enforcement was
+   in place (via `check-new-ports.py`) but no mechanism caught
+   historical cites that pre-dated the diff-gate.
+6. **Inventory script flagged two incidental-reference test files.**
+   `tst_about_dialog.cpp` and `tst_container_persistence.cpp` matched
+   the `aethersdr-reconciliation.md` path parser even though they sit
+   in Buckets B/D (deletions / incidental mentions, not real
+   derivations).
+
+**Root cause:** The 2026-04-17 v0.2.0 remediation focused on the source
+tree. The 2026-04-18 plan added four additional audit axes — binary
+distribution artifacts, inline-cite version stamps, non-Thetis lineage
+headers, and tree-wide inventory — and these surfaced the gaps above.
+
+**Fix (commit range `49b576a..<pending>` on branches
+`compliance/full-audit-2026-04-18` + `compliance/audit-followup-2026-04-18`):**
+
+- Binary-distribution fixes (PR #55):
+  - Added verbatim `GPLv2.txt`, `GPLv3.txt`, `LGPLv3.txt` under
+    `packaging/third-party-licenses/` (fetched byte-identical from
+    gnu.org; SHA-256 recorded in the commit message).
+  - Added `thetis.txt`, `mi0bot-thetis.txt`, `aethersdr.txt` listing
+    upstream copyright chains.
+  - Added `SOURCE-OFFER.txt` formalising GPLv3 §6(a) + §6(b) + LGPLv3 §4
+    Qt source pointers.
+  - Refreshed existing per-dependency notices to reference bundled
+    full-text files instead of URLs.
+- Audit-infrastructure fixes (follow-up PR):
+  - `scripts/verify-thetis-headers.py` gained `--kind=aethersdr` and
+    `--kind=wdsp` modes with a documented 10-file WDSP exemption list
+    matching `WDSP-PROVENANCE.md`. Result: 43/43 AetherSDR Bucket-A,
+    128/128 WDSP eligible files pass.
+  - `scripts/verify-inline-cites.py` + `tests/compliance/test_inline_cites.py`
+    + `tests/compliance/inline-cites-baseline.json` added. Baseline
+    captured at 288 unstamped cites; regression gate passes today.
+  - `scripts/audit-inline-markers.py` added — sampling comparator
+    between Thetis upstream line ranges and NereusSDR ports; output
+    parked here for human triage (restructures legitimately drop
+    marker counts, so this is not a merge gate).
+  - `scripts/audit-wdsp-headers.py` added — independent census
+    confirming `WDSP-PROVENANCE.md`'s 128 + 10 split (and catches
+    future drift on upstream re-sync).
+  - `scripts/compliance-inventory.py` now scopes
+    `aethersdr-reconciliation.md` parsing to Bucket A only, eliminating
+    the three pre-existing false-positive flags on
+    `tst_about_dialog.cpp`, `tst_container_persistence.cpp`, and
+    (via the refined WDSP-NO-HEADER set) `FDnoiseIQ.h`.
+    Regenerated `docs/attribution/COMPLIANCE-INVENTORY.md` baseline.
+
+**Process improvement:**
+- Task 15 (follow-up): wire every auditor in `ci.yml` as merge-gated.
+- Task 16 (follow-up): add the new auditors to the pre-push hook.
+- Task 17 (follow-up): document the Thetis-upstream-sync cadence so
+  inline-cite stamps refresh automatically at each upstream pull.
+
+**Auditor status at sweep close:**
+
+| Auditor | Result |
+| --- | --- |
+| `verify-thetis-headers.py --kind=thetis` | 209/209 pass |
+| `verify-thetis-headers.py --kind=aethersdr` | 43/43 pass |
+| `verify-thetis-headers.py --kind=wdsp` | 128/128 pass |
+| `verify-provenance-sync.py` | 207/207 pass |
+| `verify-inline-cites.py` | 288 grandfathered, at baseline |
+| `audit-wdsp-headers.py` | Census matches WDSP-PROVENANCE.md |
+| `audit-inline-markers.py` | 68/75 below 0.5 ratio — sampling, human triage (expected noise on multi-source "full" rows) |
+| `compliance-inventory.py --fail-on-unclassified` | Exit 0 |
+| `check-new-ports.py` (full-tree) | 322/322 pass |
+| `pytest tests/compliance/` | 10/10 passing |
+
+---
+
 *(Subsequent entries will be appended as omissions are discovered and cured.)*

--- a/docs/attribution/UPSTREAM-SYNC-PROTOCOL.md
+++ b/docs/attribution/UPSTREAM-SYNC-PROTOCOL.md
@@ -1,0 +1,173 @@
+# Upstream Sync Protocol
+
+How NereusSDR pulls from the upstream Thetis / mi0bot-Thetis-HL2 /
+AetherSDR / WDSP repositories, refreshes its inline cite version
+stamps, and reconciles drift. Compliance Plan Task 17
+(`docs/architecture/2026-04-18-gpl-compliance-full-audit-plan.md`).
+
+The point of this doc is that upstream drift is inevitable — Thetis
+ships new releases on its own cadence, WDSP gets point updates, and
+AetherSDR occasionally refactors the skeleton we templated off.
+Without a defined cadence, our inline cites (`// From Thetis
+console.cs:4821 [v2.10.3.13]`) silently rot against whatever we
+pulled in 2026-04. This protocol keeps the rot bounded.
+
+---
+
+## When to sync
+
+**Mandatory:**
+
+1. **Before cutting any minor release** (x.Y.0). This is the hard gate;
+   never ship a minor without at least checking for upstream drift.
+2. **When Thetis ships a new tagged release.** Watch
+   <https://github.com/ramdor/Thetis/releases> (or subscribe to the
+   release feed); open a sync issue within one week.
+
+**Optional / ad-hoc:**
+
+3. Before starting work on a Phase that touches a heavily-ported
+   subsystem (e.g. a new DSP feature → sync Thetis first so the cites
+   match current upstream; a new P1 feature → sync mi0bot).
+4. When a contributor reports a cite that no longer resolves to the
+   line it claims (Thetis re-wrapped the file, line numbers shifted).
+
+---
+
+## Procedure
+
+### 1 — Fetch every upstream
+
+```bash
+git -C ../Thetis fetch --tags
+git -C ../mi0bot-Thetis fetch --tags   # if you have the fork clone
+git -C ../AetherSDR fetch              # AetherSDR doesn't tag; use main
+# WDSP is vendored — update via the WDSP import procedure below, not git fetch
+```
+
+### 2 — Record the new version stamps
+
+For each upstream, record the current verification stamp:
+
+```bash
+git -C ../Thetis describe --tags          # e.g. "v2.10.4.1"
+git -C ../Thetis rev-parse --short HEAD   # e.g. "a1b2c3d"
+git -C ../mi0bot-Thetis rev-parse --short HEAD
+git -C ../AetherSDR rev-parse --short HEAD
+```
+
+These are the stamps to use in new `// From Thetis ...` cites for the
+rest of the session / PR — either the tag (`[v2.10.4.1]`) or the
+short SHA (`[@a1b2c3d]`) per the grammar in
+[`HOW-TO-PORT.md`](HOW-TO-PORT.md) §Inline cite versioning.
+
+### 3 — Surface stale cites
+
+```bash
+python3 scripts/verify-inline-cites.py --format=json > /tmp/cites.json
+```
+
+The result groups findings by kind (`missing-stamp`,
+`malformed-stamp`). At this point every cite in the tree already
+carries some stamp — the relevant question is now "do those stamps
+point at a release the upstream still has?" That's a human judgement:
+stamps older than N major releases should probably be refreshed; a
+stamp that matches a tag the upstream has since retired should be
+re-verified against current HEAD.
+
+### 4 — Re-verify ports against new upstream
+
+Pick the PROVENANCE rows whose cites are >1 minor version old OR whose
+upstream lines could plausibly have moved (i.e. rows that cite
+`console.cs` / `setup.cs` / any file under active upstream
+maintenance). For each:
+
+1. Open the upstream file at the new HEAD and at the old stamp.
+2. Diff the cited line range:
+   ```bash
+   git -C ../Thetis diff <old-stamp>..<new-stamp> -- 'Project Files/Source/Console/console.cs'
+   ```
+3. If the cited range moved but the logic is unchanged, update the
+   cite to the new line number and refresh the stamp.
+4. If the logic itself changed, open an issue against NereusSDR and
+   decide: port the change, document the intentional divergence in
+   the source file's Modification-history block, or both.
+
+### 5 — Refresh WDSP (separate cadence)
+
+WDSP is vendored, not fetched live:
+
+1. Re-run `scripts/audit-wdsp-headers.py` against the current tree
+   (drift detection).
+2. If `TAPR/OpenHPSDR-wdsp` has a new tag since our last import:
+   - Diff the new upstream tree against `third_party/wdsp/src/`.
+   - Import unchanged files as-is; for changed files preserve the
+     verbatim upstream header.
+   - Re-run `scripts/audit-wdsp-headers.py`; if the census counts
+     drift, update the EXPECTED dict in the script (in a separate
+     commit, with reasoning in the message).
+   - Run `scripts/verify-thetis-headers.py --kind=wdsp` to confirm
+     the exemption set is still accurate.
+
+### 6 — Log the sync
+
+Append a new dated entry to
+[`REMEDIATION-LOG.md`](REMEDIATION-LOG.md) covering:
+
+- Which upstreams were synced (Thetis / mi0bot / AetherSDR / WDSP).
+- Old and new stamps.
+- How many cites were refreshed, how many files re-verified.
+- Any drift documented as intentional divergence.
+- Commit SHAs for the sync work.
+
+The log entry closes the loop: future reviewers can see we sync on
+a cadence and can reproduce exactly what we compared against.
+
+---
+
+## What "stale" means
+
+| Stamp age | Treatment |
+|---|---|
+| Same tag | No action |
+| Same minor (e.g. v2.10.3.X vs v2.10.3.Y) | Advisory — refresh opportunistically |
+| One minor behind (v2.10.3 vs v2.10.4) | Refresh before next NereusSDR minor release |
+| Two+ minors behind | Mandatory refresh before any touch on the cited file |
+| Upstream retired the tag | Immediate re-verify against current HEAD |
+
+"Refresh" means: open the upstream file at the new revision, confirm
+the cited logic is still where the cite says it is, update the line
+numbers + stamp if it moved, document divergence if the logic changed.
+
+---
+
+## Non-goals
+
+- This protocol does **not** require mirroring every upstream change.
+  NereusSDR is a port, not a downstream fork — we pull upstream
+  changes when they affect logic we already ported, and we explicitly
+  *skip* upstream changes we don't want (with a documented "divergence"
+  note in the source file's Modification history).
+- This protocol does **not** require daily fetching. Quarterly-ish +
+  release-triggered is enough given Thetis's cadence.
+
+---
+
+## Tooling status
+
+Implemented:
+
+- `scripts/verify-inline-cites.py` (tree-wide stamp presence audit)
+- `scripts/verify-thetis-headers.py --all-kinds` (per-kind header markers)
+- `scripts/audit-wdsp-headers.py` (WDSP census)
+- `scripts/verify-provenance-sync.py` (PROVENANCE-vs-tree orphan check)
+
+Not yet implemented (future work):
+
+- Automatic "which stamps are >N releases old" reporter. Today the
+  judgement is manual per step 3 above; a follow-up script could parse
+  every `[vX.Y.Z.W]` and compare against a configured "oldest
+  acceptable" threshold.
+- CI job that runs the sync check on a schedule (cron workflow). Plan
+  Task 15 lands the on-every-PR gate; the scheduled variant is a
+  follow-on.

--- a/packaging/third-party-licenses/thetis.txt
+++ b/packaging/third-party-licenses/thetis.txt
@@ -26,15 +26,14 @@ source files under `src/`. The authoritative per-file attribution is in
 `docs/attribution/THETIS-PROVENANCE.md` and in the top-of-file headers
 of each ported source file.
 
-  Copyright (C)  FlexRadio Systems (PowerSDR lineage)
-  Copyright (C)  Bob McGwier, N4HY (original PowerSDR DSP work)
-  Copyright (C)  Frank Brickle, AB2KT (original PowerSDR DSP work)
+  Copyright (C)  FlexRadio Systems (PowerSDR lineage that Thetis forked)
   Copyright (C)  Doug Wigley, W5WC (Thetis maintainer)
   Copyright (C)  Warren Pratt, NR0V (WDSP author; Thetis DSP integration)
   Copyright (C)  Richard Samphire, MW0LGE (Thetis contributions)
   Copyright (C)  Chris Codella, W2PA (Thetis contributions)
   Copyright (C)  Phil Harman, VK6APH (HPSDR contributions)
-  Copyright (C)  John Melton, G0ORX (HPSDR contributions)
+  Copyright (C)  John Melton, G0ORX/N6LYT (HPSDR contributions;
+                                           WDSP linux_port co-author)
   Copyright (C)  Laurence Barker, G8NJJ (Thetis contributions)
   Copyright (C)  Bill Tracey, KD5TFD (HPSDR contributions)
 

--- a/scripts/audit-inline-markers.py
+++ b/scripts/audit-inline-markers.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Sample-compare inline-attribution markers between Thetis upstream
+sources and the NereusSDR ports.
+
+Compliance Plan Task 9. For every file registered in
+``docs/attribution/THETIS-PROVENANCE.md``, count occurrences of the
+well-known contributor markers in the upstream Thetis source(s) named
+in the provenance row's source-list cell, then count the same markers
+in the NereusSDR port, and emit the per-file ratio.
+
+This is a *sampling* audit. When a port restructures code, marker
+count can legitimately drop even if every retained marker was preserved
+verbatim. Files below ``--threshold`` (default 0.5) are flagged for
+human review, not automatic rejection. CLAUDE.md's "preserve verbatim"
+rule is the authoritative standard; this script is the smoke detector.
+
+The upstream Thetis checkout is read from ``../Thetis/`` relative to
+the NereusSDR repo root (matches CLAUDE.md SOURCE-FIRST PORTING
+PROTOCOL). Override with ``--thetis=PATH``.
+
+Usage:
+    python3 scripts/audit-inline-markers.py
+    python3 scripts/audit-inline-markers.py --threshold=0.4
+    python3 scripts/audit-inline-markers.py --format=json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PROVENANCE = REPO / "docs" / "attribution" / "THETIS-PROVENANCE.md"
+
+# Contributor markers preserved verbatim in Thetis source files. Regex
+# tolerates whitespace around the dash and the callsign. Order
+# intentionally lists the most common markers first — output is
+# per-marker so sparse-hit files are still useful.
+MARKERS = {
+    "MW0LGE":   re.compile(r"//\s*MW0LGE", re.IGNORECASE),
+    "W2PA":     re.compile(r"//-?\s*W2PA",  re.IGNORECASE),
+    "VK6APH":   re.compile(r"//-?\s*VK6APH", re.IGNORECASE),
+    "G8NJJ":    re.compile(r"//-?\s*G8NJJ",  re.IGNORECASE),
+    "KD5TFD":   re.compile(r"//-?\s*KD5TFD", re.IGNORECASE),
+    "MI0BOT":   re.compile(r"//\s*MI0BOT",   re.IGNORECASE),
+    "DH1KLM":   re.compile(r"//\s*DH1KLM",   re.IGNORECASE),
+    "N4HY":     re.compile(r"//-?\s*N4HY",   re.IGNORECASE),
+    "AB2KT":    re.compile(r"//-?\s*AB2KT",  re.IGNORECASE),
+}
+
+
+def parse_provenance_rows(text: str):
+    """Yield (nereus_rel, source_cell, line_ranges_cell) for each row."""
+    out = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line.startswith("|") or line.startswith("|---"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 3:
+            continue
+        first = cells[0].replace("`", "")
+        if not first or first.lower() in ("nereussdr file", "file"):
+            continue
+        if not (REPO / first).is_file():
+            continue
+        out.append((first, cells[1], cells[2]))
+    return out
+
+
+def extract_thetis_source_paths(source_cell: str):
+    """From a PROVENANCE row's source-list cell, pick file paths that
+    look like real Thetis sources. A cell can hold multiple
+    semicolon-separated sources with inline annotations; we keep only
+    those that end in .cs/.c/.h and look like a relative path.
+    """
+    paths = []
+    for frag in re.split(r"[;,]", source_cell):
+        frag = frag.strip()
+        if not frag:
+            continue
+        # Strip annotations like "(mi0bot/OpenHPSDR-Thetis fork)"
+        frag = re.sub(r"\s*\([^)]*\)\s*$", "", frag).strip()
+        if not frag.endswith((".cs", ".c", ".h")):
+            continue
+        paths.append(frag)
+    return paths
+
+
+def parse_line_ranges(cell: str):
+    """Parse line-range cell like "85-184; 164-171" or "5866" or "full".
+
+    Returns None for "full" (no scoping — full-file comparison) or an
+    empty result. Otherwise a list of (start, end) 1-based inclusive
+    tuples, or None for a single-line cite.
+    """
+    cell = cell.strip().lower()
+    if not cell or cell == "full":
+        return None
+    ranges = []
+    for frag in re.split(r"[;,]", cell):
+        frag = frag.strip()
+        if not frag:
+            continue
+        m = re.match(r"^(\d+)\s*-\s*(\d+)$", frag)
+        if m:
+            ranges.append((int(m.group(1)), int(m.group(2))))
+            continue
+        m = re.match(r"^(\d+)$", frag)
+        if m:
+            n = int(m.group(1))
+            ranges.append((n, n))
+    return ranges or None
+
+
+def count_markers(text: str, ranges=None):
+    """Count markers, optionally scoped to specific 1-based line ranges."""
+    if ranges is None:
+        return {name: len(rx.findall(text)) for name, rx in MARKERS.items()}
+    lines = text.splitlines()
+    selected = []
+    for start, end in ranges:
+        # Expand context ±20 lines to capture a marker comment that
+        # precedes a ported block of code.
+        lo = max(1, start - 20)
+        hi = min(len(lines), end + 20)
+        selected.extend(lines[lo - 1:hi])
+    blob = "\n".join(selected)
+    return {name: len(rx.findall(blob)) for name, rx in MARKERS.items()}
+
+
+def audit(thetis_root: Path, rows):
+    findings = []
+    for rel, source_cell, line_ranges_cell in rows:
+        ns_text = (REPO / rel).read_text(errors="replace")
+        ns_counts = count_markers(ns_text)  # port is small — count whole file
+
+        up_counts = {name: 0 for name in MARKERS}
+        upstream_paths = extract_thetis_source_paths(source_cell)
+        ranges = parse_line_ranges(line_ranges_cell)
+        resolved = []
+        for up_rel in upstream_paths:
+            full = thetis_root / up_rel
+            if not full.is_file():
+                continue
+            try:
+                up_text = full.read_text(errors="replace")
+            except OSError:
+                continue
+            resolved.append(str(full.relative_to(thetis_root)))
+            per = count_markers(up_text, ranges=ranges)
+            for name, n in per.items():
+                up_counts[name] += n
+
+        up_total = sum(up_counts.values())
+        ns_total = sum(ns_counts.values())
+
+        # Skip rows where we couldn't resolve any upstream file (line
+        # ranges, multi-source rows with annotations that mask the path,
+        # etc.) — not actionable without a tighter provenance parse.
+        if not resolved:
+            continue
+        # Skip rows where upstream has zero markers — ratio is undefined
+        # and there's nothing to preserve.
+        if up_total == 0:
+            continue
+
+        ratio = ns_total / up_total if up_total else 1.0
+        findings.append({
+            "path": rel,
+            "upstream_sources": resolved,
+            "upstream_counts": up_counts,
+            "port_counts": ns_counts,
+            "upstream_total": up_total,
+            "port_total": ns_total,
+            "ratio": round(ratio, 3),
+        })
+    return findings
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--thetis",
+        default=str((REPO.parent / "Thetis").resolve()),
+        help="Path to the upstream Thetis checkout (default: ../Thetis)",
+    )
+    ap.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Flag files whose port/upstream marker ratio is below this",
+    )
+    ap.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+    )
+    args = ap.parse_args()
+
+    thetis_root = Path(args.thetis)
+    if not thetis_root.is_dir():
+        print(f"ERROR: Thetis checkout not found at {thetis_root}", file=sys.stderr)
+        print(
+            "  Clone https://github.com/ramdor/Thetis at this path, or pass "
+            "--thetis=<path> to override.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not PROVENANCE.is_file():
+        print(f"ERROR: {PROVENANCE} not found", file=sys.stderr)
+        return 2
+
+    rows = parse_provenance_rows(PROVENANCE.read_text())
+    if not rows:
+        print("ERROR: no PROVENANCE rows parsed", file=sys.stderr)
+        return 2
+
+    findings = audit(thetis_root, rows)
+
+    flagged = [f for f in findings if f["ratio"] < args.threshold]
+
+    if args.format == "json":
+        print(json.dumps({
+            "scanned": len(findings),
+            "threshold": args.threshold,
+            "flagged_count": len(flagged),
+            "flagged": flagged,
+        }, indent=2))
+    else:
+        print(f"Inline-marker audit — {len(findings)} scannable row(s)")
+        print(f"Threshold: ratio < {args.threshold} flagged for review\n")
+        if not flagged:
+            print("No files below threshold. ✓")
+        else:
+            print(f"{len(flagged)} file(s) below threshold:\n")
+            for f in flagged:
+                tags = ", ".join(
+                    f"{k}={f['upstream_counts'][k]}->{f['port_counts'][k]}"
+                    for k in MARKERS
+                    if f['upstream_counts'][k] or f['port_counts'][k]
+                )
+                print(
+                    f"  {f['path']}  ratio={f['ratio']}  "
+                    f"({f['port_total']}/{f['upstream_total']})  {tags}"
+                )
+                print(f"    upstream: {', '.join(f['upstream_sources'])}")
+        print(f"\n{len(findings) - len(flagged)}/{len(findings)} files >= threshold")
+
+    # Sampling audit — always exit 0 so it doesn't gate CI. Use the
+    # output to populate a Task-10 triage punchlist.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit-wdsp-headers.py
+++ b/scripts/audit-wdsp-headers.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Walk third_party/wdsp/src/, classify each file's licence header.
+
+Compliance Plan Task 11. ``verify-thetis-headers.py --kind=wdsp`` (Task 7)
+enforces the GPLv2-or-later markers with an explicit exemption set;
+this script is the independent census that re-verifies the
+WDSP-PROVENANCE.md claim (128 full-header files + 10 exempt utilities).
+
+Use this whenever the WDSP vendored tree is re-synced from upstream to
+catch drift before the verifier's exemption set goes stale.
+
+Usage:
+    python3 scripts/audit-wdsp-headers.py
+    python3 scripts/audit-wdsp-headers.py --format=json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WDSP_SRC = REPO / "third_party" / "wdsp" / "src"
+
+# Expected classification totals per WDSP-PROVENANCE.md (2026-04-17).
+# Used to flag drift when the census shifts without a docs update.
+EXPECTED = {
+    "gpl2-or-later": 128,
+    "copyright-no-permission-block": 0,
+    "no-header": 10,
+}
+
+
+def classify(text: str) -> str:
+    # Normalise whitespace so permission text that wraps across lines
+    # still matches. WDSP headers use hard-wrapped C comments like:
+    #   "either version 2\nof the License, or (at your option) any later version."
+    import re
+    head = text[:2000]
+    flat = re.sub(r"\s+", " ", head)
+    perm_markers = (
+        "either version 2 of the License, or",
+        "any later version",
+    )
+    if all(m in flat for m in perm_markers):
+        return "gpl2-or-later"
+    if "Warren Pratt" in head or "Copyright (C)" in head:
+        return "copyright-no-permission-block"
+    return "no-header"
+
+
+def scan():
+    rows = []
+    if not WDSP_SRC.is_dir():
+        return rows
+    for p in sorted(WDSP_SRC.glob("*")):
+        if p.suffix not in (".c", ".h"):
+            continue
+        text = p.read_text(errors="replace")
+        rows.append({
+            "path": str(p.relative_to(REPO)),
+            "classification": classify(text),
+        })
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--format", choices=["text", "json"], default="text")
+    args = ap.parse_args()
+
+    rows = scan()
+    counts = Counter(r["classification"] for r in rows)
+
+    drift = {
+        kind: counts.get(kind, 0) - expected
+        for kind, expected in EXPECTED.items()
+        if counts.get(kind, 0) != expected
+    }
+
+    if args.format == "json":
+        print(json.dumps({
+            "total": len(rows),
+            "counts": dict(counts),
+            "expected": EXPECTED,
+            "drift": drift,
+            "files": rows,
+        }, indent=2))
+        return 1 if drift else 0
+
+    print(f"WDSP header census — {len(rows)} files scanned under "
+          f"{WDSP_SRC.relative_to(REPO)}/")
+    for kind in ("gpl2-or-later", "copyright-no-permission-block", "no-header"):
+        n = counts.get(kind, 0)
+        expected = EXPECTED[kind]
+        marker = "" if n == expected else f"  ⚠ expected {expected}"
+        print(f"  {kind:35s} {n:4d}{marker}")
+
+    no_header = [r["path"] for r in rows if r["classification"] == "no-header"]
+    if no_header:
+        print("\nFiles with no header (should match verifier exemption set):")
+        for n in no_header:
+            print(f"  {n}")
+
+    covered = [r["path"] for r in rows
+               if r["classification"] == "copyright-no-permission-block"]
+    if covered:
+        print("\nFiles with Copyright but no permission block "
+              "(investigate — possible upstream drift):")
+        for n in covered:
+            print(f"  {n}")
+
+    if drift:
+        print(
+            f"\nFAIL: WDSP-PROVENANCE.md counts disagree with tree: {drift}",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nCensus matches WDSP-PROVENANCE.md ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compliance-inventory.py
+++ b/scripts/compliance-inventory.py
@@ -54,8 +54,43 @@ def _paths_from_table(md_path: Path) -> set[str]:
     return paths
 
 
+def _aethersdr_bucket_a_paths(md_path: Path) -> set[str]:
+    """Bucket-A-only extractor for aethersdr-reconciliation.md.
+
+    The reconciliation doc's tables cover four buckets (A: genuine
+    derivations, B: false boilerplate, C: mixed, D: incidental mentions).
+    Only Bucket A files carry a real AetherSDR derivation claim that
+    needs the project-level attribution header. The inventory must not
+    flag Buckets B/C/D as "aethersdr-port" — those rows are either
+    deletions or incidental mentions.
+    """
+    if not md_path.exists():
+        return set()
+    paths: set[str] = set()
+    in_bucket_a = False
+    for line in md_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## Bucket A"):
+            in_bucket_a = True
+            continue
+        if stripped.startswith("## Bucket "):
+            in_bucket_a = False
+            continue
+        if not in_bucket_a:
+            continue
+        if not stripped.startswith("|") or stripped.startswith("|---"):
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if not cells:
+            continue
+        first = cells[0].strip("`")
+        if first.startswith(("src/", "tests/")):
+            paths.add(first)
+    return paths
+
+
 THETIS_PORTS = _paths_from_table(THETIS_PROVENANCE)
-AETHER_PORTS = _paths_from_table(AETHER_RECONCILIATION)
+AETHER_PORTS = _aethersdr_bucket_a_paths(AETHER_RECONCILIATION)
 
 
 def classify(path: str) -> str:
@@ -109,9 +144,11 @@ REQUIRED_MARKERS: dict[str, list[str]] = {
 TEXT_SUFFIXES = {".c", ".h", ".hpp", ".cpp", ".cc", ".py"}
 
 # Within wdsp-vendored, these basenames are documented as utility/data/no-
-# header files per WDSP-PROVENANCE.md and must not be flagged.
+# header files per WDSP-PROVENANCE.md and must not be flagged. Keep in
+# sync with WDSP_HEADER_EXEMPTIONS in scripts/verify-thetis-headers.py.
 WDSP_NO_HEADER_BASENAMES = {
-    "calculus.c", "calculus.h", "FDnoiseIQ.c", "resource.h", "resource1.h",
+    "calculus.c", "calculus.h", "FDnoiseIQ.c", "FDnoiseIQ.h",
+    "resource.h", "resource1.h",
     "version.c", "version.h", "fastmath.h", "fftw3.h",
 }
 

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -56,4 +56,43 @@ if ! CHECK_NEW_PORTS_FULL=1 python3 scripts/check-new-ports.py; then
     exit 1
 fi
 
+# Compliance Plan Task 16: parity with ci.yml compliance job.
+# Added 2026-04-18 alongside the new audit scripts from Tasks 7–11.
+# Runs after the attribution gates above because a pristine header is
+# a prerequisite for meaningful inventory / cite-stamp checks.
+
+echo "[pre-commit] verify-thetis-headers.py --all-kinds (AetherSDR + WDSP)"
+if ! python3 scripts/verify-thetis-headers.py --all-kinds >/dev/null; then
+    # Re-run with output so the user sees the failures
+    python3 scripts/verify-thetis-headers.py --all-kinds || true
+    echo
+    echo "[pre-commit] BLOCKED: AetherSDR or WDSP header markers missing."
+    echo "             Cure by adding the project-level attribution (AetherSDR)"
+    echo "             or preserving the upstream GPL header (WDSP)."
+    exit 1
+fi
+
+echo "[pre-commit] verify-inline-cites.py (baseline regression gate)"
+if ! python3 scripts/verify-inline-cites.py >/dev/null 2>&1; then
+    python3 scripts/verify-inline-cites.py || true
+    echo
+    echo "[pre-commit] BLOCKED: unstamped '// From Thetis ...' cite added."
+    echo "             Append [vX.Y.Z.W] or [@shortsha] per"
+    echo "             docs/attribution/HOW-TO-PORT.md §Inline cite versioning."
+    echo "             If this is a bulk upstream pull, recapture the baseline"
+    echo "             with 'python3 scripts/verify-inline-cites.py --baseline'"
+    echo "             and commit tests/compliance/inline-cites-baseline.json."
+    exit 1
+fi
+
+echo "[pre-commit] compliance-inventory.py --fail-on-unclassified"
+if ! python3 scripts/compliance-inventory.py --fail-on-unclassified >/dev/null; then
+    python3 scripts/compliance-inventory.py --fail-on-unclassified || true
+    echo
+    echo "[pre-commit] BLOCKED: inventory flagged missing markers."
+    echo "             Add the required header markers or register the file"
+    echo "             in the appropriate provenance doc."
+    exit 1
+fi
+
 exit 0

--- a/scripts/list-copyright-holders.py
+++ b/scripts/list-copyright-holders.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Dump distinct copyright-holder names referenced in the attribution
+docs, so the About-dialog §5(d) line can be diffed against the tree's
+current lineage.
+
+Compliance Plan Task 14. Sources:
+
+- ``docs/attribution/THETIS-PROVENANCE.md`` (ramdor/Thetis +
+  mi0bot/Thetis-HL2 rows)
+- ``docs/attribution/aethersdr-reconciliation.md`` (Bucket A rows)
+- ``docs/attribution/WDSP-PROVENANCE.md`` (copyright-statement dump)
+- ``third_party/wdsp/src/*.c`` header lines (cross-check)
+
+Output: sorted list of "Name (CALLSIGN)" tuples where we can extract
+both, otherwise bare names / callsigns. Use the output to diff against
+``src/gui/AboutDialog.cpp`` principals list when refreshing at release
+time.
+
+Usage:
+    python3 scripts/list-copyright-holders.py
+    python3 scripts/list-copyright-holders.py --format=json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Callsign regex — approximate, covers ham-radio amateur prefixes:
+# 1-2 letter country + optional digit(s) + 1-4 letter suffix.
+CALLSIGN_RE = re.compile(r"\b([A-Z]{1,2}[0-9][A-Z]{2,4})\b")
+
+# Structured "Name (CALLSIGN)" pattern.
+NAME_CALL_RE = re.compile(
+    r"([A-Z][a-zA-Z.\-']+(?:\s+[A-Z][a-zA-Z.\-']+){0,3})"
+    r"\s*[,(]\s*"
+    r"([A-Z]{1,2}[0-9][A-Z]{2,4}|KG4VCF)"
+    r"\)?"
+)
+
+DOCS = [
+    REPO / "docs" / "attribution" / "THETIS-PROVENANCE.md",
+    REPO / "docs" / "attribution" / "aethersdr-reconciliation.md",
+    REPO / "docs" / "attribution" / "WDSP-PROVENANCE.md",
+    REPO / "docs" / "attribution" / "thetis-contributor-index.md",
+]
+
+# Strings that look like callsigns but aren't.
+FALSE_POSITIVES = {
+    "PWM", "WWV", "WPM", "WSA", "WSJT", "FT8", "CW",
+    "PSK", "SWR", "ALC", "LSB", "USB", "CTU", "MOX",
+    "TCI", "CAT", "RBN", "ADC", "DAC", "FFT", "DSP",
+    "GPL", "IQC", "NSA", "UDP", "GPU", "UDP", "BSD",
+    "MIT", "FSF", "TAPR", "PTT", "SDR", "VAC", "RF",
+    "VCO", "VHF", "UHF", "HF", "CFG", "EQ", "NR",
+    "NB", "AGC", "ANF", "APF", "BPF", "LPF", "HPF",
+    "RXA", "TXA", "EMNR", "SNB", "VFO", "DDC", "DUC",
+}
+
+
+def harvest_name_call(text: str):
+    hits = set()
+    for m in NAME_CALL_RE.finditer(text):
+        name = m.group(1).strip().rstrip(".")
+        call = m.group(2).strip()
+        if not call or call in FALSE_POSITIVES:
+            continue
+        # Skip if the "name" is actually another callsign that got
+        # title-cased (e.g. "Mw0lge, W2PA" matches).
+        if CALLSIGN_RE.fullmatch(name.upper()):
+            continue
+        hits.add((name, call))
+    return hits
+
+
+def harvest_bare_calls(text: str):
+    hits = set()
+    for m in CALLSIGN_RE.finditer(text):
+        call = m.group(1)
+        if call in FALSE_POSITIVES:
+            continue
+        hits.add(call)
+    return hits
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--format", choices=["text", "json"], default="text")
+    args = ap.parse_args()
+
+    paired = set()
+    bare = set()
+    for doc in DOCS:
+        if not doc.is_file():
+            continue
+        text = doc.read_text(errors="replace")
+        paired.update(harvest_name_call(text))
+        bare.update(harvest_bare_calls(text))
+
+    # Also walk WDSP headers for any callsigns in the Copyright lines.
+    wdsp_src = REPO / "third_party" / "wdsp" / "src"
+    if wdsp_src.is_dir():
+        for p in wdsp_src.glob("*.c"):
+            head = p.read_text(errors="replace")[:1500]
+            # "Warren Pratt, NR0V" style
+            paired.update(harvest_name_call(head))
+
+    paired_calls = {c for _, c in paired}
+    orphan_calls = {c for c in bare if c not in paired_calls}
+
+    if args.format == "json":
+        print(json.dumps({
+            "paired": sorted([{"name": n, "callsign": c} for n, c in paired],
+                             key=lambda r: r["callsign"]),
+            "orphan_callsigns": sorted(orphan_calls),
+        }, indent=2))
+        return 0
+
+    print("Name + callsign pairs (alphabetical by callsign):\n")
+    for name, call in sorted(paired, key=lambda r: r[1]):
+        print(f"  {call}   {name}")
+
+    if orphan_calls:
+        print("\nBare callsigns (no associated name found in docs):\n")
+        for c in sorted(orphan_calls):
+            print(f"  {c}")
+
+    print(f"\n{len(paired)} pair(s), {len(orphan_calls)} orphan callsign(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-inline-cites.py
+++ b/scripts/verify-inline-cites.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tree-wide audit of ``// From Thetis <file>:<line>`` inline cites.
+
+Compliance Plan Task 8. ``scripts/check-new-ports.py`` already enforces
+the version-stamp requirement on *new or modified* cites in a PR diff;
+this script is the matching tree-wide sweep that catches historical
+stamps missed before the diff-gate existed.
+
+Every cite must carry a version stamp matching ``[vX.Y.Z[.W][+shortsha]]``
+or ``[@shortsha]`` so a reviewer can reproduce the upstream line number
+against a known Thetis revision. Grammar is documented at
+``docs/attribution/HOW-TO-PORT.md §Inline cite versioning``.
+
+Usage:
+    python3 scripts/verify-inline-cites.py                    # text
+    python3 scripts/verify-inline-cites.py --format=json      # JSON
+    python3 scripts/verify-inline-cites.py --baseline         # print count
+
+Findings are emitted in both modes. Exit code 0 iff the count of
+``missing-stamp`` findings is <= the grandfathered baseline in
+``tests/compliance/inline-cites-baseline.json`` (lets the pre-push hook
+block *regressions* without requiring a tree-wide remediation first).
+
+Use ``--strict`` to fail on any finding (CI will flip to this once the
+baseline has been remediated to zero).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCAN_ROOTS = ["src", "tests"]
+SCAN_SUFFIXES = {".cpp", ".cc", ".c", ".h", ".hpp"}
+BASELINE_FILE = REPO / "tests" / "compliance" / "inline-cites-baseline.json"
+
+# Reuse the exact regexes from scripts/check-new-ports.py so this
+# tree-wide auditor and the PR-diff auditor stay in lockstep.
+RE_THETIS_CITE = re.compile(
+    r"//\s*From\s+Thetis\s+[\w./-]+\.(?:cs|c|h|cpp)(?::\d+(?:[,\s]+\d+)*)"
+)
+RE_HAS_VERSION_STAMP = re.compile(
+    r"\[(?:v\d+(?:\.\d+)+(?:\+[0-9a-f]{7,})?|@[0-9a-f]{7,})\]"
+)
+
+
+def iter_source_files():
+    for root in SCAN_ROOTS:
+        base = REPO / root
+        if not base.is_dir():
+            continue
+        for p in base.rglob("*"):
+            if not p.is_file():
+                continue
+            if p.suffix not in SCAN_SUFFIXES:
+                continue
+            yield p
+
+
+def scan():
+    """Return list of findings dicts."""
+    findings = []
+    for path in iter_source_files():
+        try:
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if not RE_THETIS_CITE.search(line):
+                continue
+            if RE_HAS_VERSION_STAMP.search(line):
+                continue
+            findings.append({
+                "path": str(path.relative_to(REPO)),
+                "line": lineno,
+                "kind": "missing-stamp",
+                "cite": line.strip(),
+            })
+    findings.sort(key=lambda f: (f["path"], f["line"]))
+    return findings
+
+
+def load_baseline() -> int:
+    if not BASELINE_FILE.is_file():
+        return 0
+    try:
+        data = json.loads(BASELINE_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return 0
+    return int(data.get("missing_stamp_baseline", 0))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--format", choices=["text", "json"], default="text")
+    ap.add_argument(
+        "--baseline",
+        action="store_true",
+        help="Print the count and exit 0 — used when capturing a baseline",
+    )
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on any finding, ignoring the grandfathered baseline",
+    )
+    args = ap.parse_args()
+
+    findings = scan()
+    missing = [f for f in findings if f["kind"] == "missing-stamp"]
+
+    if args.baseline:
+        print(len(missing))
+        return 0
+
+    if args.format == "json":
+        print(json.dumps(findings, indent=2))
+    else:
+        for f in findings:
+            print(f"{f['path']}:{f['line']}  [{f['kind']}]  {f['cite']}")
+        print()
+        print(f"{len(missing)} cite(s) without version stamp")
+        if not args.strict:
+            baseline = load_baseline()
+            print(f"grandfathered baseline: {baseline}")
+
+    if args.strict:
+        return 1 if missing else 0
+    baseline = load_baseline()
+    if len(missing) > baseline:
+        print(
+            f"\nFAIL: missing-stamp count {len(missing)} exceeds baseline "
+            f"{baseline}. Either add a version stamp "
+            f"(`[vX.Y.Z.W]` or `[@shortsha]`) to the new cite(s), or "
+            f"capture a new baseline with `--baseline` (only when the "
+            f"regression is intentional, e.g. after a bulk upstream pull).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-thetis-headers.py
+++ b/scripts/verify-thetis-headers.py
@@ -1,11 +1,29 @@
 #!/usr/bin/env python3
-"""Verify that every file declared in THETIS-PROVENANCE.md carries the
-required Thetis license header markers. Exit 1 on any failure.
+"""Verify upstream license-header markers are present in every derived
+NereusSDR source file.
 
-Verbatim-preservation model (Pass 5, 2026-04-17 onward): each NereusSDR
-file's header must contain the upstream source's own top-of-file header
-BYTE-FOR-BYTE. The verifier therefore only checks for anchor markers
-that every Thetis-derived file will carry:
+Originally this script covered only Thetis-derived files listed in
+``docs/attribution/THETIS-PROVENANCE.md``. Pass 7 (2026-04-18, Compliance
+Plan T7) extended coverage to two additional lineage kinds:
+
+  * ``aethersdr`` — files in Bucket A of
+    ``docs/attribution/aethersdr-reconciliation.md`` (genuine AetherSDR
+    derivations). AetherSDR has no per-file copyright headers, so the
+    check is for the project-level attribution we require in the port
+    (``AetherSDR`` mention + Modification-history block).
+
+  * ``wdsp`` — every ``.c``/``.h`` under ``third_party/wdsp/src/``. These
+    are vendored verbatim from TAPR/OpenHPSDR-wdsp; the check ensures the
+    Warren Pratt copyright + GPL permission block survived the import.
+
+Use ``--all-kinds`` (or ``--kind=KIND``) to run non-default verifiers.
+Default remains ``thetis`` for backwards compatibility with existing CI
+and pre-push hook invocations.
+
+Verbatim-preservation model (Pass 5, 2026-04-17 onward, thetis kind):
+each NereusSDR file's header must contain the upstream source's own
+top-of-file header BYTE-FOR-BYTE. The verifier therefore only checks for
+anchor markers that every Thetis-derived file will carry:
 
   1. "Ported from" — anchors the NereusSDR port-citation block
   2. "Thetis"      — upstream identity (present in all cited Thetis sources)
@@ -37,6 +55,7 @@ Files under `docs/attribution/` themselves are exempt (they document the
 templates, they are not themselves derived source).
 """
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -44,14 +63,27 @@ from typing import Optional
 
 REPO = Path(__file__).resolve().parent.parent
 PROVENANCE = REPO / "docs" / "attribution" / "THETIS-PROVENANCE.md"
+AETHERSDR_RECONCILIATION = REPO / "docs" / "attribution" / "aethersdr-reconciliation.md"
+WDSP_SRC_DIR = REPO / "third_party" / "wdsp" / "src"
 
-REQUIRED_MARKERS = [
-    "Ported from",
-    "Thetis",
-    "Copyright (C)",
-    "General Public License",
-    "Modification history (NereusSDR)",
-]
+# Per-kind required-marker tables. Keys must match the --kind CLI choices.
+MARKERS_BY_KIND = {
+    "thetis": [
+        "Ported from",
+        "Thetis",
+        "Copyright (C)",
+        "General Public License",
+        "Modification history (NereusSDR)",
+    ],
+    "aethersdr": [
+        "AetherSDR",
+        "Modification history (NereusSDR)",
+    ],
+    "wdsp": [
+        "Copyright (C)",
+        "General Public License",
+    ],
+}
 
 # Header must appear within this many lines of top of file
 HEADER_WINDOW = 160
@@ -92,6 +124,34 @@ SAMPHIRE_AUTHORED_SOURCES = {
     "PSForm.cs",
 }
 
+# WDSP utility/build files exempt from the copyright-header check. These
+# ship without a permission block in TAPR upstream, so we track the set
+# explicitly rather than silently ignoring missing markers. Any new file
+# added upstream fails the check until a human confirms the exemption is
+# intentional.
+#
+# Documented in docs/attribution/WDSP-PROVENANCE.md under "10 files have
+# no license headers (non-copyrightable or build infrastructure)".
+WDSP_HEADER_EXEMPTIONS = {
+    # Data tables (lookup arrays, not copyrightable expression)
+    "calculus.c",
+    "calculus.h",
+    "FDnoiseIQ.c",
+    "FDnoiseIQ.h",
+    # MSVC IDE artifacts (generated, no human authorship)
+    "resource.h",
+    "resource1.h",
+    # Minimal wrappers (version stubs, empty headers)
+    "version.c",
+    "version.h",
+    "fastmath.h",
+    # FFTW3 third-party header vendored into WDSP (GPLv2-or-later; the
+    # full GPLv2 text lives at third_party/fftw3/COPYING, and the
+    # standalone FFTW3 provenance doc is
+    # docs/attribution/FFTW3-PROVENANCE.md)
+    "fftw3.h",
+}
+
 
 def parse_provenance(text: str):
     """Yield (file_path, source_cell) tuples from the PROVENANCE.md tables.
@@ -121,9 +181,63 @@ def parse_provenance(text: str):
     return rows
 
 
-def check_required_markers(path: Path):
+def parse_aethersdr_bucket_a(text: str):
+    """Extract file paths from Bucket A of aethersdr-reconciliation.md.
+
+    Bucket A is delimited by "## Bucket A" ... "## Bucket B". Within,
+    per-topic tables list NereusSDR files in the first column.
+    Returns a list of relative paths.
+    """
+    in_bucket_a = False
+    paths = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("## Bucket A"):
+            in_bucket_a = True
+            continue
+        if line.startswith("## Bucket "):
+            in_bucket_a = False
+            continue
+        if not in_bucket_a:
+            continue
+        if not line.startswith("|") or line.startswith("|---"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+        candidate = cells[0].replace("`", "")
+        if not candidate.startswith(("src/", "tests/")):
+            continue
+        if (REPO / candidate).is_file():
+            paths.append(candidate)
+    # De-dupe while preserving order
+    seen = set()
+    out = []
+    for p in paths:
+        if p in seen:
+            continue
+        seen.add(p)
+        out.append(p)
+    return out
+
+
+def list_wdsp_sources():
+    """Every .c/.h under third_party/wdsp/src/ except documented exempt."""
+    if not WDSP_SRC_DIR.is_dir():
+        return []
+    out = []
+    for p in sorted(WDSP_SRC_DIR.glob("*")):
+        if p.suffix not in (".c", ".h"):
+            continue
+        if p.name in WDSP_HEADER_EXEMPTIONS:
+            continue
+        out.append(str(p.relative_to(REPO)))
+    return out
+
+
+def check_required_markers(path: Path, markers):
     head = "\n".join(path.read_text(errors="replace").splitlines()[:HEADER_WINDOW])
-    return [m for m in REQUIRED_MARKERS if m not in head]
+    return [m for m in markers if m not in head]
 
 
 def check_orphan_pair(rel: str, listed) -> Optional[str]:
@@ -178,21 +292,23 @@ def check_samphire_marker(path: Path, source_cell: str) -> Optional[str]:
     )
 
 
-def main():
+def verify_thetis_kind():
+    """Original THETIS-PROVENANCE verifier logic."""
     if not PROVENANCE.is_file():
         print(f"ERROR: {PROVENANCE} not found", file=sys.stderr)
-        return 2
+        return None
     rows = parse_provenance(PROVENANCE.read_text())
     if not rows:
         print("ERROR: no derived-file rows parsed from PROVENANCE.md",
               file=sys.stderr)
-        return 2
+        return None
     listed = {rel for rel, _ in rows}
+    markers = MARKERS_BY_KIND["thetis"]
     failures = 0
     for rel, source_cell in rows:
         path = REPO / rel
         problems = []
-        missing = check_required_markers(path)
+        missing = check_required_markers(path, markers)
         if missing:
             problems.append(f"missing-markers: {', '.join(missing)}")
         orphan = check_orphan_pair(rel, listed)
@@ -204,11 +320,88 @@ def main():
         if problems:
             failures += 1
             for p in problems:
-                print(f"FAIL {rel} — {p}")
+                print(f"FAIL [thetis] {rel} — {p}")
     total = len(rows)
-    ok = total - failures
-    print(f"\n{ok}/{total} files pass header check")
-    return 0 if failures == 0 else 1
+    print(f"\n[thetis]   {total - failures}/{total} files pass header check")
+    return failures
+
+
+def verify_aethersdr_kind():
+    if not AETHERSDR_RECONCILIATION.is_file():
+        print(f"ERROR: {AETHERSDR_RECONCILIATION} not found", file=sys.stderr)
+        return None
+    paths = parse_aethersdr_bucket_a(AETHERSDR_RECONCILIATION.read_text())
+    if not paths:
+        print("ERROR: no Bucket A rows parsed from aethersdr-reconciliation.md",
+              file=sys.stderr)
+        return None
+    markers = MARKERS_BY_KIND["aethersdr"]
+    failures = 0
+    for rel in paths:
+        path = REPO / rel
+        missing = check_required_markers(path, markers)
+        if missing:
+            failures += 1
+            print(f"FAIL [aethersdr] {rel} — missing-markers: {', '.join(missing)}")
+    total = len(paths)
+    print(f"[aethersdr] {total - failures}/{total} files pass header check")
+    return failures
+
+
+def verify_wdsp_kind():
+    paths = list_wdsp_sources()
+    if not paths:
+        print(f"ERROR: no sources found under {WDSP_SRC_DIR}", file=sys.stderr)
+        return None
+    markers = MARKERS_BY_KIND["wdsp"]
+    failures = 0
+    for rel in paths:
+        path = REPO / rel
+        missing = check_required_markers(path, markers)
+        if missing:
+            failures += 1
+            print(f"FAIL [wdsp] {rel} — missing-markers: {', '.join(missing)}")
+    total = len(paths)
+    print(f"[wdsp]     {total - failures}/{total} files pass header check")
+    return failures
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--kind",
+        choices=["thetis", "aethersdr", "wdsp"],
+        default="thetis",
+        help="Which lineage kind to verify (default: thetis)",
+    )
+    ap.add_argument(
+        "--all-kinds",
+        action="store_true",
+        help="Verify all kinds (thetis + aethersdr + wdsp)",
+    )
+    args = ap.parse_args()
+
+    if args.all_kinds:
+        kinds = ["thetis", "aethersdr", "wdsp"]
+    else:
+        kinds = [args.kind]
+
+    total_failures = 0
+    for k in kinds:
+        if k == "thetis":
+            f = verify_thetis_kind()
+        elif k == "aethersdr":
+            f = verify_aethersdr_kind()
+        elif k == "wdsp":
+            f = verify_wdsp_kind()
+        else:
+            print(f"ERROR: unknown kind {k!r}", file=sys.stderr)
+            return 2
+        if f is None:
+            return 2
+        total_failures += f
+
+    return 0 if total_failures == 0 else 1
 
 
 if __name__ == "__main__":

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -234,6 +234,7 @@ void AboutDialog::buildUI()
             "Copyright © 2004-2026 FlexRadio Systems, "
             "Bill Tracey (KD5TFD), Doug Wigley (W5WC), "
             "Richard Samphire (MW0LGE), Warren Pratt (NR0V), "
+            "John Melton (G0ORX/N6LYT), "
             "Phil Harman (VK6APH), Chris Codella (W2PA), "
             "Laurence Barker (G8NJJ), Reid Campbell (MI0BOT), DH1KLM, "
             "Jeremy (KK7GWY), other Thetis / mi0bot / AetherSDR / WDSP / "

--- a/tests/compliance/inline-cites-baseline.json
+++ b/tests/compliance/inline-cites-baseline.json
@@ -1,0 +1,7 @@
+{
+  "missing_stamp_baseline": 288,
+  "captured_on": "2026-04-18",
+  "captured_by": "scripts/verify-inline-cites.py --baseline",
+  "purpose": "Grandfathered count of `// From Thetis file:line` cites without a version stamp. New cites added after this date must carry `[vX.Y.Z.W]` or `[@shortsha]` per docs/attribution/HOW-TO-PORT.md. This baseline is the upper bound; drops are welcome (recapture with --baseline); growth is a CI failure.",
+  "plan_task": "Compliance Plan Task 8 — 2026-04-18-gpl-compliance-full-audit-plan.md"
+}

--- a/tests/compliance/test_inline_cites.py
+++ b/tests/compliance/test_inline_cites.py
@@ -1,0 +1,72 @@
+"""Regression gate on `scripts/verify-inline-cites.py`.
+
+See ``tests/compliance/inline-cites-baseline.json`` for the current
+grandfathered count. Any new cite without a version stamp pushes the
+total above the baseline and fails this test — preventing drift.
+
+Drops below the baseline are welcome. Recapture with:
+
+    python3 scripts/verify-inline-cites.py --baseline
+
+…and commit the updated ``inline-cites-baseline.json``.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+BASELINE = REPO / "tests" / "compliance" / "inline-cites-baseline.json"
+
+
+def test_missing_stamp_count_does_not_exceed_baseline():
+    result = subprocess.run(
+        ["python3", "scripts/verify-inline-cites.py", "--format=json"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    findings = json.loads(result.stdout)
+    missing = [f for f in findings if f["kind"] == "missing-stamp"]
+    baseline = json.loads(BASELINE.read_text())["missing_stamp_baseline"]
+    assert len(missing) <= baseline, (
+        f"{len(missing)} cites without version stamp; baseline is {baseline}. "
+        f"Either stamp the new cite(s) or (only if intentional) recapture "
+        f"the baseline with `scripts/verify-inline-cites.py --baseline`.\n"
+        f"First 5 new findings: {missing[:5]}"
+    )
+
+
+def test_verifier_exit_zero_when_at_baseline():
+    result = subprocess.run(
+        ["python3", "scripts/verify-inline-cites.py"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"verify-inline-cites.py exited {result.returncode} at baseline\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_strict_mode_fails_when_any_findings():
+    """Sanity: --strict flips behaviour. When the tree actually has
+    findings (baseline > 0), strict mode must exit 1."""
+    result = subprocess.run(
+        ["python3", "scripts/verify-inline-cites.py", "--strict"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    baseline = json.loads(BASELINE.read_text())["missing_stamp_baseline"]
+    if baseline == 0:
+        assert result.returncode == 0
+    else:
+        assert result.returncode == 1, (
+            "--strict should fail when there are unstamped cites"
+        )


### PR DESCRIPTION
## Summary

Closes Phases 2, 3, 4 (remainder), 5, 6 of
[`docs/architecture/2026-04-18-gpl-compliance-full-audit-plan.md`](docs/architecture/2026-04-18-gpl-compliance-full-audit-plan.md).
Stacked on top of #55 (full GPL text + upstream-port notices + source
offer). This PR closes the plan — merge #55 first, then rebase and
merge this.

- **Audit-scope expansion.** `verify-thetis-headers.py` now has
  `--kind=aethersdr` and `--kind=wdsp` modes with a 10-file WDSP
  exemption matching `WDSP-PROVENANCE.md`; three new scripts
  (`verify-inline-cites.py`, `audit-inline-markers.py`,
  `audit-wdsp-headers.py`) plus a helper
  (`list-copyright-holders.py`). Results today:
  thetis 209/209, aethersdr 43/43, wdsp 128/128; WDSP census matches
  the doc claim; 288 unstamped inline cites grandfathered as the
  baseline.
- **Regression gates.** New `tests/compliance/test_inline_cites.py`
  with a JSON baseline; `scripts/compliance-inventory.py` tightened
  to parse AetherSDR-reconciliation Bucket A only (drops three
  pre-existing false-positive flags on incidental test-body mentions).
- **CI + hook parity.** All six new auditors wired into
  `.github/workflows/ci.yml` as merge-gated Linux steps;
  `scripts/git-hooks/pre-commit` extended to match (Ring 2 + Ring 3
  enforce the same invariants).
- **Binary-side §5(d)/§6 polish.** About-dialog copyright line adds
  John Melton (G0ORX/N6LYT) — co-copyright of WDSP `linux_port.{h,c}`
  compiled into every non-Windows binary; drops Bob McGwier (N4HY) +
  Frank Brickle (AB2KT) from `thetis.txt` (overclaim: their DttSP
  code is not in WDSP / not in our binary). Release-notes template
  tightened to point at the new bundled licence files and
  `SOURCE-OFFER.txt`.
- **Process doc.** New
  [`docs/attribution/UPSTREAM-SYNC-PROTOCOL.md`](docs/attribution/UPSTREAM-SYNC-PROTOCOL.md)
  covering when/how to pull Thetis / mi0bot / AetherSDR / WDSP
  upstreams, refresh inline-cite stamps, and log the sync in
  `REMEDIATION-LOG.md`.
- **REMEDIATION-LOG entry** dated 2026-04-18 summarising the sweep.

## Test plan

- [x] All new scripts invocable standalone; exit codes match spec
- [x] `pytest tests/compliance/` — 10/10 passing (7 inventory + 3 cite)
- [x] `verify-thetis-headers.py --all-kinds` — 209+43+128
- [x] `audit-wdsp-headers.py` — 128/0/10, matches PROVENANCE
- [x] `compliance-inventory.py --fail-on-unclassified` — exit 0
- [x] `pre-commit` hook locally — all six gates fire, exit 0
- [ ] Green CI run on this branch — will verify once pushed
- [ ] First `--strict` `verify-inline-cites.py` flip (after baseline
      remediation) — follow-up PR

## Follow-ups (out of scope)

- Tree-wide inline-cite stamp remediation (drop the 288 baseline to 0
  over the next few PRs)
- Inline-marker audit human-triage punchlist (68/75 flagged is
  expected noise on multi-source "full" rows; real gaps need per-file
  eyeballing)
- Per-release bot that refreshes the About-dialog §5(d) copyright
  line from `list-copyright-holders.py` output (currently manual)

J.J. Boyd ~ KG4VCF