### PR TITLE
fix(radio-model): stop recalling bandstack on VFO-tune crossings

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -344,11 +344,20 @@ int RadioModel::addPanadapter()
     // band's DSP state then restore the new band's DSP state.
     // Only the first panadapter drives the active slice; additional pans
     // are wired the same way for completeness (multi-pan is 3F scope).
+    //
+    // m_lastBand MUST be updated before restoreFromSettings() for the same
+    // reason as the frequencyChanged lambda below: restoreFromSettings emits
+    // frequencyChanged, which re-enters that lambda; if m_lastBand is still
+    // the old band there, it will saveToSettings(old_band, new_band_freq)
+    // and corrupt the old band's persisted frequency.
     connect(pan, &PanadapterModel::bandChanged, this, [this](Band newBand) {
-        if (m_activeSlice) {
-            m_activeSlice->saveToSettings(m_lastBand);
-            m_activeSlice->restoreFromSettings(newBand);
+        if (m_activeSlice && !m_inBandSwitch) {
+            m_inBandSwitch = true;
+            const Band oldBand = m_lastBand;
             m_lastBand = newBand;
+            m_activeSlice->saveToSettings(oldBand);
+            m_activeSlice->restoreFromSettings(newBand);
+            m_inBandSwitch = false;
         }
     });
 
@@ -724,11 +733,23 @@ void RadioModel::wireSliceSignals()
         }
         // Track band from VFO frequency so per-band saves target the correct
         // band even when the panadapter center hasn't crossed the boundary.
+        //
+        // m_lastBand MUST be updated before restoreFromSettings(). Restoring a
+        // band calls SliceModel::setFrequency(savedFreq), which emits
+        // frequencyChanged and re-enters this lambda. If m_lastBand were still
+        // the old band at that point, the reentrant call would run the
+        // save/restore branch again — infinite recursion that blows the main
+        // stack via the downstream QWidget::show() cascade in
+        // SpectrumWidget::updateVfoPositions. It would also clobber the old
+        // band's persisted frequency with the new band's value.
         Band newBand = bandFromFrequency(freq);
-        if (newBand != m_lastBand) {
-            m_activeSlice->saveToSettings(m_lastBand);
-            m_activeSlice->restoreFromSettings(newBand);
+        if (newBand != m_lastBand && !m_inBandSwitch) {
+            m_inBandSwitch = true;
+            const Band oldBand = m_lastBand;
             m_lastBand = newBand;
+            m_activeSlice->saveToSettings(oldBand);
+            m_activeSlice->restoreFromSettings(newBand);
+            m_inBandSwitch = false;
         }
         scheduleSettingsSave();
     });

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -339,27 +339,15 @@ int RadioModel::addPanadapter()
     int index = m_panadapters.size();
     m_panadapters.append(pan);
 
-    // Wire bandChanged for per-band DSP bandstack persistence.
-    // This fires whenever the VFO crosses a band boundary: save the old
-    // band's DSP state then restore the new band's DSP state.
-    // Only the first panadapter drives the active slice; additional pans
-    // are wired the same way for completeness (multi-pan is 3F scope).
-    //
-    // m_lastBand MUST be updated before restoreFromSettings() for the same
-    // reason as the frequencyChanged lambda below: restoreFromSettings emits
-    // frequencyChanged, which re-enters that lambda; if m_lastBand is still
-    // the old band there, it will saveToSettings(old_band, new_band_freq)
-    // and corrupt the old band's persisted frequency.
-    connect(pan, &PanadapterModel::bandChanged, this, [this](Band newBand) {
-        if (m_activeSlice && !m_inBandSwitch) {
-            m_inBandSwitch = true;
-            const Band oldBand = m_lastBand;
-            m_lastBand = newBand;
-            m_activeSlice->saveToSettings(oldBand);
-            m_activeSlice->restoreFromSettings(newBand);
-            m_inBandSwitch = false;
-        }
-    });
+    // PanadapterModel::bandChanged fires when the pan center crosses a band
+    // boundary. In NereusSDR's design m_lastBand tracks the VFO, not the pan
+    // (see comment on the frequencyChanged lambda in wireSliceSignals), so
+    // there is nothing to do here on a pan-centered crossing — per-band saves
+    // flow from the VFO path and the coalesced scheduleSettingsSave() timer.
+    // Intentionally left as a no-op hook so the connection survives future
+    // per-pan band-aware behavior without re-adding the recursion/corruption
+    // path that existed in v0.2.0.
+    connect(pan, &PanadapterModel::bandChanged, this, [](Band /*newBand*/) {});
 
     emit panadapterAdded(index);
     return index;
@@ -734,22 +722,21 @@ void RadioModel::wireSliceSignals()
         // Track band from VFO frequency so per-band saves target the correct
         // band even when the panadapter center hasn't crossed the boundary.
         //
-        // m_lastBand MUST be updated before restoreFromSettings(). Restoring a
-        // band calls SliceModel::setFrequency(savedFreq), which emits
-        // frequencyChanged and re-enters this lambda. If m_lastBand were still
-        // the old band at that point, the reentrant call would run the
-        // save/restore branch again — infinite recursion that blows the main
-        // stack via the downstream QWidget::show() cascade in
-        // SpectrumWidget::updateVfoPositions. It would also clobber the old
-        // band's persisted frequency with the new band's value.
+        // Do NOT recall bandstack state on a VFO-driven band crossing. From
+        // Thetis console.cs:45312 handleBSFChange [v2.10.3.13 @501e3f5]:
+        // on an oldBand != newBand transition, Thetis only updates the old
+        // and new band's LastVisited records — it does not restore saved
+        // DSP state. Bandstack recall is reserved for the explicit
+        // band-button press path. Trying to recall here on every wheel-tune
+        // caused two bugs in v0.2.0: (1) the VFO snaps to the newBand's
+        // stored frequency, breaking smooth wheel-tune across boundaries;
+        // (2) saveToSettings(oldBand) wrote the current (now post-tune)
+        // frequency into the oldBand slot — corrupting the stored value
+        // for that band. Letting the coalesced scheduleSettingsSave() flush
+        // keeps the CURRENT band's slot up to date without either bug.
         Band newBand = bandFromFrequency(freq);
-        if (newBand != m_lastBand && !m_inBandSwitch) {
-            m_inBandSwitch = true;
-            const Band oldBand = m_lastBand;
+        if (newBand != m_lastBand) {
             m_lastBand = newBand;
-            m_activeSlice->saveToSettings(oldBand);
-            m_activeSlice->restoreFromSettings(newBand);
-            m_inBandSwitch = false;
         }
         scheduleSettingsSave();
     });

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -256,6 +256,15 @@ private:
     // bandChanged can save the old band's state before restoring the new one.
     Band m_lastBand{Band::Band20m};
 
+    // Reentrancy guard for the per-band save/restore block. restoreFromSettings
+    // drives setFrequency, which emits frequencyChanged and can re-enter the
+    // same lambda; without the guard, corrupt per-band Frequency values (freq
+    // stored for band X actually in band Y) cascade through the band lookup
+    // indefinitely until the main-thread stack dies inside the downstream
+    // SpectrumWidget::updateVfoPositions layout. See v0.2.0 crash report
+    // 2026-04-19 015055 (depth 10,405).
+    bool m_inBandSwitch{false};
+
     // Settings save coalescing
     bool m_settingsSaveScheduled{false};
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -252,18 +252,13 @@ private:
     // RxDspWorker (src/models/RxDspWorker.h) so the DSP thread owns
     // its own state and the main thread never touches it.
 
-    // Per-slice-per-band persistence: track the last-known band so
-    // bandChanged can save the old band's state before restoring the new one.
+    // Per-slice-per-band persistence: tracks which band the VFO is currently
+    // on so the coalesced scheduleSettingsSave() timer writes to the right
+    // per-band slot. From Thetis console.cs:45312 handleBSFChange
+    // [v2.10.3.13 @501e3f5] — bandstack state is recalled via band-button
+    // press, not via VFO tune, so this lambda only tracks; it does NOT
+    // save or restore at the boundary.
     Band m_lastBand{Band::Band20m};
-
-    // Reentrancy guard for the per-band save/restore block. restoreFromSettings
-    // drives setFrequency, which emits frequencyChanged and can re-enter the
-    // same lambda; without the guard, corrupt per-band Frequency values (freq
-    // stored for band X actually in band Y) cascade through the band lookup
-    // indefinitely until the main-thread stack dies inside the downstream
-    // SpectrumWidget::updateVfoPositions layout. See v0.2.0 crash report
-    // 2026-04-19 015055 (depth 10,405).
-    bool m_inBandSwitch{false};
 
     // Settings save coalescing
     bool m_settingsSaveScheduled{false};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,9 @@ nereus_add_test(tst_dig_rtty_wire)
 # ── Phase 3G-10 Stage 2: per-slice-per-band DSP persistence (S2.P) ───────────
 nereus_add_test(tst_slice_persistence_per_band)
 
+# ── v0.2.0 regression: band-change lambda reentrancy guard ───────────────────
+nereus_add_test(tst_band_change_recursion_guard)
+
 # ── Step attenuator / ADC overload detection ─────────────────────────────
 nereus_add_test(tst_step_attenuator_controller)
 

--- a/tests/tst_band_change_recursion_guard.cpp
+++ b/tests/tst_band_change_recursion_guard.cpp
@@ -1,0 +1,184 @@
+// tst_band_change_recursion_guard.cpp
+//
+// Regression test for v0.2.0 crash: infinite recursion in the per-band
+// DSP save/restore lambda when a cross-band tune causes restoreFromSettings
+// to drive a setFrequency that re-enters the lambda.
+//
+// Crash signature (macOS, 2026-04-18/19, 7 reports):
+//   EXC_BAD_ACCESS — "Thread stack size exceeded due to excessive recursion"
+//   recursion depth: 10,405 frames
+//   key frame: void doActivate<false>(QObject*, int, void**)
+//   loop pattern:
+//     SliceModel::frequencyChanged
+//       → RadioModel::wireSliceSignals() lambda (src/models/RadioModel.cpp:713)
+//       → SliceModel::restoreFromSettings(Band)
+//       → SliceModel::setFrequency(savedFreq)
+//       → SliceModel::frequencyChanged  (recurses)
+//
+// Root cause: the lambda's guard `if (newBand != m_lastBand)` was not
+// reentrancy-safe. Re-entry via the synchronous frequencyChanged signal
+// observed m_lastBand in its pre-update state and re-ran the save/restore
+// branch. With corrupt per-band Frequency values (each band's stored freq
+// living in a different band), the cascade continues through the band
+// lookup until the main thread's stack guard triggers.
+//
+// Fix: a reentrancy flag (m_inBandSwitch) plus updating m_lastBand BEFORE
+// calling restoreFromSettings. See src/models/RadioModel.h §m_inBandSwitch
+// and the lambdas in src/models/RadioModel.cpp.
+//
+// This test replicates the lambda's topology in isolation and verifies
+// both invariants:
+//   1. The reentrancy guard observes re-entry (proving it is firing).
+//   2. The total number of lambda invocations is bounded.
+
+#include <QtTest/QtTest>
+
+#include "models/SliceModel.h"
+#include "models/Band.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TestBandChangeRecursionGuard : public QObject {
+    Q_OBJECT
+
+private:
+    // Strip every per-band and session key we write so each test starts clean.
+    static void resetPersistenceKeys() {
+        auto& s = AppSettings::instance();
+        for (const QString& band : {
+                 QStringLiteral("20m"), QStringLiteral("40m"),
+                 QStringLiteral("80m"), QStringLiteral("160m") }) {
+            const QString bp = QStringLiteral("Slice0/Band") + band + QStringLiteral("/");
+            for (const QString& field : {
+                     QStringLiteral("Frequency"),   QStringLiteral("AgcThreshold"),
+                     QStringLiteral("AgcHang"),     QStringLiteral("AgcSlope"),
+                     QStringLiteral("AgcAttack"),   QStringLiteral("AgcDecay"),
+                     QStringLiteral("FilterLow"),   QStringLiteral("FilterHigh"),
+                     QStringLiteral("DspMode"),     QStringLiteral("AgcMode"),
+                     QStringLiteral("StepHz") }) {
+                s.remove(bp + field);
+            }
+        }
+        const QString sp = QStringLiteral("Slice0/");
+        for (const QString& field : {
+                 QStringLiteral("Locked"),     QStringLiteral("Muted"),
+                 QStringLiteral("RitEnabled"), QStringLiteral("RitHz"),
+                 QStringLiteral("XitEnabled"), QStringLiteral("XitHz"),
+                 QStringLiteral("AfGain"),     QStringLiteral("RfGain"),
+                 QStringLiteral("RxAntenna"),  QStringLiteral("TxAntenna") }) {
+            s.remove(sp + field);
+        }
+    }
+
+private slots:
+
+    void init()    { resetPersistenceKeys(); }
+    void cleanup() { resetPersistenceKeys(); }
+
+    // ── Invariant 1: The guard fires on re-entry. ─────────────────────────────
+    //
+    // Pre-seed per-band Frequency values that cross-reference each other so
+    // a band crossing drives setFrequency → frequencyChanged and would
+    // otherwise re-enter the save/restore block. The guard must observe
+    // inBandSwitch=true on re-entry and skip the branch.
+
+    void guardBlocksReentryOnBandCrossing() {
+        auto& s = AppSettings::instance();
+
+        // Corrupt-data scenario that reproduces the v0.2.0 crash shape:
+        // each band's stored frequency lies in a different band.
+        s.setValue(QStringLiteral("Slice0/Band20m/Frequency"),  7100000.0);    // → 40m
+        s.setValue(QStringLiteral("Slice0/Band40m/Frequency"),  3700000.0);    // → 80m
+        s.setValue(QStringLiteral("Slice0/Band80m/Frequency"),  14225000.0);   // → 20m (cycle)
+
+        SliceModel slice;
+        slice.setSliceIndex(0);
+        slice.setFrequency(14225000.0);
+
+        Band lastBand = Band::Band20m;
+        bool inBandSwitch = false;
+        int  enterCount = 0;
+        int  guardFired = 0;
+        constexpr int kSafetyLimit = 50;
+
+        QObject::connect(&slice, &SliceModel::frequencyChanged,
+            [&](double freq) {
+                ++enterCount;
+                if (enterCount > kSafetyLimit) {
+                    // Belt-and-suspenders: prevents this test itself from
+                    // blowing the stack if the guard were ever removed.
+                    return;
+                }
+                const Band newBand = bandFromFrequency(freq);
+                if (inBandSwitch) {
+                    ++guardFired;
+                    return;
+                }
+                if (newBand != lastBand) {
+                    inBandSwitch = true;
+                    const Band oldBand = lastBand;
+                    lastBand = newBand;
+                    slice.saveToSettings(oldBand);
+                    slice.restoreFromSettings(newBand);
+                    inBandSwitch = false;
+                }
+            });
+
+        // Wheel-tune from 20m (14.225 MHz) to 40m (7.1 MHz).
+        slice.setFrequency(7100000.0);
+
+        QVERIFY2(enterCount < kSafetyLimit,
+                 qPrintable(QStringLiteral(
+                     "Lambda invoked %1 times — recursion guard not firing "
+                     "(regression of v0.2.0 crash 2026-04-19 015055).")
+                     .arg(enterCount)));
+
+        QVERIFY2(guardFired >= 1,
+                 "Guard should have blocked at least one re-entry through "
+                 "restoreFromSettings → setFrequency.");
+    }
+
+    // ── Invariant 2: Clean cross without corrupt data converges without
+    // extra recursion (baseline — the common case). ───────────────────────────
+
+    void cleanCrossConvergesInOneIteration() {
+        auto& s = AppSettings::instance();
+        s.setValue(QStringLiteral("Slice0/Band40m/Frequency"), 7150000.0);  // in 40m
+
+        SliceModel slice;
+        slice.setSliceIndex(0);
+        slice.setFrequency(14225000.0);
+
+        Band lastBand = Band::Band20m;
+        bool inBandSwitch = false;
+        int  enterCount = 0;
+        int  guardFired = 0;
+
+        QObject::connect(&slice, &SliceModel::frequencyChanged,
+            [&](double freq) {
+                ++enterCount;
+                const Band newBand = bandFromFrequency(freq);
+                if (inBandSwitch) { ++guardFired; return; }
+                if (newBand != lastBand) {
+                    inBandSwitch = true;
+                    const Band oldBand = lastBand;
+                    lastBand = newBand;
+                    slice.saveToSettings(oldBand);
+                    slice.restoreFromSettings(newBand);
+                    inBandSwitch = false;
+                }
+            });
+
+        slice.setFrequency(7100000.0);  // 40m — stored freq for 40m is 7.15 MHz
+
+        QCOMPARE(lastBand, Band::Band40m);
+        QVERIFY2(enterCount <= 3,
+                 qPrintable(QStringLiteral(
+                     "enterCount=%1 — clean band cross should not cascade")
+                     .arg(enterCount)));
+    }
+};
+
+QTEST_MAIN(TestBandChangeRecursionGuard)
+#include "tst_band_change_recursion_guard.moc"

--- a/tests/tst_band_change_recursion_guard.cpp
+++ b/tests/tst_band_change_recursion_guard.cpp
@@ -1,35 +1,36 @@
 // tst_band_change_recursion_guard.cpp
 //
-// Regression test for v0.2.0 crash: infinite recursion in the per-band
-// DSP save/restore lambda when a cross-band tune causes restoreFromSettings
-// to drive a setFrequency that re-enters the lambda.
+// no-port-check: Test file references Thetis behavior in commentary only;
+// no Thetis source is translated here.
 //
-// Crash signature (macOS, 2026-04-18/19, 7 reports):
+// Regression test for two v0.2.0 bugs exposed by wheel-tuning across a band
+// boundary:
+//
+// Bug 1 (crash, reported 2026-04-18/19, 7 reports):
 //   EXC_BAD_ACCESS — "Thread stack size exceeded due to excessive recursion"
-//   recursion depth: 10,405 frames
-//   key frame: void doActivate<false>(QObject*, int, void**)
-//   loop pattern:
-//     SliceModel::frequencyChanged
-//       → RadioModel::wireSliceSignals() lambda (src/models/RadioModel.cpp:713)
-//       → SliceModel::restoreFromSettings(Band)
-//       → SliceModel::setFrequency(savedFreq)
-//       → SliceModel::frequencyChanged  (recurses)
+//   recursion depth 10,405. The wireSliceSignals()/addPanadapter() band-
+//   switch lambdas called restoreFromSettings(newBand) synchronously;
+//   that emitted frequencyChanged and re-entered the same lambda
+//   indefinitely when per-band Frequency values were cross-referenced.
 //
-// Root cause: the lambda's guard `if (newBand != m_lastBand)` was not
-// reentrancy-safe. Re-entry via the synchronous frequencyChanged signal
-// observed m_lastBand in its pre-update state and re-ran the save/restore
-// branch. With corrupt per-band Frequency values (each band's stored freq
-// living in a different band), the cascade continues through the band
-// lookup until the main thread's stack guard triggers.
+// Bug 2 (VFO jump): with the recursion fixed via a guard in an interim
+//   commit, wheel-tuning across a band boundary snapped the VFO to the
+//   new band's stored frequency instead of the user-tuned value. That was
+//   divergence from Thetis console.cs:45312 handleBSFChange [v2.10.3.13
+//   @501e3f5], which updates the bandstack LastVisited record on a
+//   VFO-driven crossing but does NOT restore state. Restore is reserved
+//   for the explicit band-button press path.
 //
-// Fix: a reentrancy flag (m_inBandSwitch) plus updating m_lastBand BEFORE
-// calling restoreFromSettings. See src/models/RadioModel.h §m_inBandSwitch
-// and the lambdas in src/models/RadioModel.cpp.
+// Fix: the VFO-tune lambda only tracks m_lastBand; no save or restore at
+// the boundary. Per-band state is flushed via the coalesced
+// scheduleSettingsSave() timer, which targets m_lastBand. This test
+// replicates the lambda's topology and asserts:
 //
-// This test replicates the lambda's topology in isolation and verifies
-// both invariants:
-//   1. The reentrancy guard observes re-entry (proving it is firing).
-//   2. The total number of lambda invocations is bounded.
+//   1. A wheel-tune that crosses a band boundary leaves SliceModel's
+//      frequency equal to the user-tuned value (no snap-back).
+//   2. The lambda is invoked exactly once per setFrequency call — no
+//      recursion through frequencyChanged, even with cross-referenced
+//      per-band Frequency values seeded into AppSettings.
 
 #include <QtTest/QtTest>
 
@@ -43,7 +44,6 @@ class TestBandChangeRecursionGuard : public QObject {
     Q_OBJECT
 
 private:
-    // Strip every per-band and session key we write so each test starts clean.
     static void resetPersistenceKeys() {
         auto& s = AppSettings::instance();
         for (const QString& band : {
@@ -76,107 +76,82 @@ private slots:
     void init()    { resetPersistenceKeys(); }
     void cleanup() { resetPersistenceKeys(); }
 
-    // ── Invariant 1: The guard fires on re-entry. ─────────────────────────────
-    //
-    // Pre-seed per-band Frequency values that cross-reference each other so
-    // a band crossing drives setFrequency → frequencyChanged and would
-    // otherwise re-enter the save/restore block. The guard must observe
-    // inBandSwitch=true on re-entry and skip the branch.
+    // ── Invariant 1: wheel-tune across a band boundary leaves the VFO at the
+    // user-tuned frequency (no snap-back to the new band's stored value).
 
-    void guardBlocksReentryOnBandCrossing() {
+    void wheelTuneAcrossBoundaryPreservesFrequency() {
         auto& s = AppSettings::instance();
 
-        // Corrupt-data scenario that reproduces the v0.2.0 crash shape:
-        // each band's stored frequency lies in a different band.
-        s.setValue(QStringLiteral("Slice0/Band20m/Frequency"),  7100000.0);    // → 40m
-        s.setValue(QStringLiteral("Slice0/Band40m/Frequency"),  3700000.0);    // → 80m
-        s.setValue(QStringLiteral("Slice0/Band80m/Frequency"),  14225000.0);   // → 20m (cycle)
+        // Seed a stored frequency for 40m that differs from the value the
+        // user will wheel-tune to. If bandstack recall were still happening
+        // on the crossing, m_frequency would snap to 7150000 instead of
+        // staying at the user-tuned 7100000.
+        s.setValue(QStringLiteral("Slice0/Band40m/Frequency"), 7150000.0);
 
         SliceModel slice;
         slice.setSliceIndex(0);
         slice.setFrequency(14225000.0);
 
         Band lastBand = Band::Band20m;
-        bool inBandSwitch = false;
         int  enterCount = 0;
-        int  guardFired = 0;
+
+        QObject::connect(&slice, &SliceModel::frequencyChanged,
+            [&](double freq) {
+                ++enterCount;
+                const Band newBand = bandFromFrequency(freq);
+                if (newBand != lastBand) {
+                    lastBand = newBand;
+                }
+                // No saveToSettings / restoreFromSettings — Thetis parity.
+                // scheduleSettingsSave() in the real lambda is a production-
+                // only timer dispatch; not relevant for this signal-topology
+                // invariant check.
+            });
+
+        slice.setFrequency(7100000.0);  // wheel-tune from 20m into 40m
+
+        QCOMPARE(slice.frequency(), 7100000.0);  // stays where the user tuned
+        QCOMPARE(lastBand,          Band::Band40m);
+        QCOMPARE(enterCount,        1);  // single invocation, no recursion
+    }
+
+    // ── Invariant 2: even with the corrupt cross-referencing per-band
+    // Frequency values that reproduced the v0.2.0 cascade, the lambda must
+    // not recurse. With save/restore removed from the lambda, the recursion
+    // surface is simply gone.
+
+    void corruptPerBandFrequenciesDoNotCascade() {
+        auto& s = AppSettings::instance();
+
+        s.setValue(QStringLiteral("Slice0/Band20m/Frequency"),  7100000.0);    // value is in 40m
+        s.setValue(QStringLiteral("Slice0/Band40m/Frequency"),  3700000.0);    // value is in 80m
+        s.setValue(QStringLiteral("Slice0/Band80m/Frequency"),  14225000.0);   // value is in 20m (cycle)
+
+        SliceModel slice;
+        slice.setSliceIndex(0);
+        slice.setFrequency(14225000.0);
+
+        Band lastBand = Band::Band20m;
+        int  enterCount = 0;
         constexpr int kSafetyLimit = 50;
 
         QObject::connect(&slice, &SliceModel::frequencyChanged,
             [&](double freq) {
                 ++enterCount;
                 if (enterCount > kSafetyLimit) {
-                    // Belt-and-suspenders: prevents this test itself from
-                    // blowing the stack if the guard were ever removed.
-                    return;
+                    return;  // belt-and-suspenders guard for the test itself
                 }
                 const Band newBand = bandFromFrequency(freq);
-                if (inBandSwitch) {
-                    ++guardFired;
-                    return;
-                }
                 if (newBand != lastBand) {
-                    inBandSwitch = true;
-                    const Band oldBand = lastBand;
                     lastBand = newBand;
-                    slice.saveToSettings(oldBand);
-                    slice.restoreFromSettings(newBand);
-                    inBandSwitch = false;
                 }
             });
 
-        // Wheel-tune from 20m (14.225 MHz) to 40m (7.1 MHz).
         slice.setFrequency(7100000.0);
 
-        QVERIFY2(enterCount < kSafetyLimit,
-                 qPrintable(QStringLiteral(
-                     "Lambda invoked %1 times — recursion guard not firing "
-                     "(regression of v0.2.0 crash 2026-04-19 015055).")
-                     .arg(enterCount)));
-
-        QVERIFY2(guardFired >= 1,
-                 "Guard should have blocked at least one re-entry through "
-                 "restoreFromSettings → setFrequency.");
-    }
-
-    // ── Invariant 2: Clean cross without corrupt data converges without
-    // extra recursion (baseline — the common case). ───────────────────────────
-
-    void cleanCrossConvergesInOneIteration() {
-        auto& s = AppSettings::instance();
-        s.setValue(QStringLiteral("Slice0/Band40m/Frequency"), 7150000.0);  // in 40m
-
-        SliceModel slice;
-        slice.setSliceIndex(0);
-        slice.setFrequency(14225000.0);
-
-        Band lastBand = Band::Band20m;
-        bool inBandSwitch = false;
-        int  enterCount = 0;
-        int  guardFired = 0;
-
-        QObject::connect(&slice, &SliceModel::frequencyChanged,
-            [&](double freq) {
-                ++enterCount;
-                const Band newBand = bandFromFrequency(freq);
-                if (inBandSwitch) { ++guardFired; return; }
-                if (newBand != lastBand) {
-                    inBandSwitch = true;
-                    const Band oldBand = lastBand;
-                    lastBand = newBand;
-                    slice.saveToSettings(oldBand);
-                    slice.restoreFromSettings(newBand);
-                    inBandSwitch = false;
-                }
-            });
-
-        slice.setFrequency(7100000.0);  // 40m — stored freq for 40m is 7.15 MHz
-
+        QCOMPARE(enterCount, 1);
+        QCOMPARE(slice.frequency(), 7100000.0);
         QCOMPARE(lastBand, Band::Band40m);
-        QVERIFY2(enterCount <= 3,
-                 qPrintable(QStringLiteral(
-                     "enterCount=%1 — clean band cross should not cascade")
-                     .arg(enterCount)));
     }
 };
 


### PR DESCRIPTION
## Summary

Fixes the v0.2.0 crash where wheel-tuning across a band boundary blew the
main-thread stack (7 crash reports on macOS 2026-04-18/19, depth 10,405),
and the follow-on VFO-snap bug that was exposed once the crash was stopped.

**Root cause:** `wireSliceSignals()` and `addPanadapter()` each installed a
lambda that called `SliceModel::restoreFromSettings(newBand)` on a
VFO-driven band crossing. `restoreFromSettings` synchronously emitted
`frequencyChanged` and re-entered the same lambda; with cross-referenced
per-band `Frequency` values in AppSettings, the cascade ran until the stack
died inside `SpectrumWidget::updateVfoPositions` layout.

**Fix:** Align with Thetis `console.cs:45312 handleBSFChange` [v2.10.3.13
@501e3f5] — on a VFO-driven band change Thetis only updates bandstack
`LastVisited` records; it does **not** restore saved state. Bandstack
recall is reserved for the explicit band-button press path (separate
handler, not yet wired in NereusSDR).

Concretely:
- VFO lambda now tracks `m_lastBand` only; the coalesced 500 ms
  `scheduleSettingsSave()` timer already flushes the current band's slot,
  so the explicit `saveToSettings(oldBand)` was redundant (and buggy:
  it saved the post-tune frequency into the old band, corrupting the
  stored value).
- Pan `bandChanged` lambda becomes a no-op: `m_lastBand` follows the VFO,
  not the pan center, so pan crossings have nothing to save here.
- Interim `m_inBandSwitch` reentrancy guard from the earlier commit is no
  longer needed and was removed.

Two commits in this PR:
1. `aebee0e` — the interim guard that stopped the crash (kept for history;
   its approach was superseded after testing revealed the VFO-snap bug).
2. `d249207` — the Thetis-parity fix and rewritten regression test.

## Test plan

- [x] `tst_band_change_recursion_guard` — two new assertions:
      wheel-tune across a boundary leaves `SliceModel::frequency` at the
      user-tuned value; cross-referenced corrupt per-band frequencies do
      not cascade.
- [x] Teeth check: before landing the final approach, confirmed the test
      fails (51 invocations, safety limit tripped) when the guard /
      Thetis-parity path is bypassed.
- [x] Full test suite: 45/49 pass. The 4 pre-existing failures
      (`tst_container_persistence`, `tst_p1_loopback_connection`,
      `tst_hardware_page_capability_gating` SEGFAULT, `tst_about_dialog`)
      do not reference any of the code changed here.
- [x] Manual: ANAN-G2 connected, mouse-wheel tune across 20m→40m, 40m→80m,
      40m→20m — VFO glides smoothly to the scrolled value, no crash, no
      snap-back.

## Notes

- Per-band bandstack **recall** is now entirely unhooked from VFO tuning.
  When a band-button press path is wired (3G-10 completion or later), it
  should call `SliceModel::restoreFromSettings(band)` explicitly — and
  should be structured so the induced `frequencyChanged` does not re-enter
  any save/restore block (use `QSignalBlocker` or the m_updatingFromModel
  pattern called out in CONTRIBUTING.md).
- Users on v0.2.0 are still crashing in the wild. Cutting v0.2.1 with this
  fix is the suggested follow-up.

J.J. Boyd ~ KG4VCF