### PR TITLE
docs(readme): refresh to v0.2.1 masterplan state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 **A cross-platform SDR console for OpenHPSDR radios**
 
-> ℹ **NereusSDR v0.1.x alpha builds were withdrawn**
+> ℹ **v0.1.x alpha builds are superseded**
 >
-> The v0.1.x alpha binaries were withdrawn from the Releases page while
-> an issue was addressed. **If you installed a v0.1.x build, please
-> uninstall it and upgrade to v0.2.0.** v0.2.0 is the fresh starting
-> point going forward.
+> The v0.1.x alpha binaries are no longer the current line. **If you
+> installed a v0.1.x build, please uninstall it and upgrade to v0.2.x.**
+> v0.2.x is the supported alpha line going forward.
 >
 > — J.J. Boyd ~ KG4VCF
 
@@ -58,101 +57,69 @@ sha256sum -c SHA256SUMS.txt
 
 ## Current Status
 
-**Phase 3I complete — Radio Connector & Radio-Model Port: full ANAN/Hermes P1 family now supported end-to-end.** Every OpenHPSDR Protocol 1 radio in the ANAN/Hermes family (Hermes Lite 2, ANAN-10/10E/100/100B/100D/200D, Metis) now discovers, connects, streams I/Q through the existing WDSP demod chain, and persists per-radio settings — identical behaviour to how ANAN-G2 on Protocol 2 works today. 25 GPG-signed commits in PR #12. Smoke-test checklist at [`docs/debugging/phase3i-smoke-test.md`](docs/debugging/phase3i-smoke-test.md). Design at [`docs/architecture/phase3i-radio-connector-port-design.md`](docs/architecture/phase3i-radio-connector-port-design.md), plan at [`docs/architecture/phase3i-radio-connector-port-plan.md`](docs/architecture/phase3i-radio-connector-port-plan.md).
+**Current release: v0.2.1** (2026-04-19). RX pipeline is feature-complete across the full OpenHPSDR P1 and P2 radio families; next implementation phase is **3M-1: Basic SSB TX**.
 
-Phase 3I shipped:
-- `HPSDRModel` and `HPSDRHW` enums ported 1:1 from mi0bot/Thetis `enums.cs` (integer values preserved including the 7..9 reserved gap)
-- `BoardCapabilities` `constexpr` registry — pure data, one entry per `HPSDRHW`, 20+ test invariants
-- `P1RadioConnection` with full ep2 compose + ep6 parse, loopback integration test via `P1FakeRadio`, 2 s watchdog + bounded reconnection state machine
-- `P2RadioConnection` audited to read `BoardCapabilities`; recognises `SaturnMKII`, `ANAN_G2_1K`, `AnvelinaPro3`
-- `RadioDiscovery` rewritten with 6 tunable timing profiles (mi0bot `clsRadioDiscovery.cs` pattern)
-- `ConnectionPanel` expanded into a full Thetis `ucRadioList.cs` port — 8 sortable columns, saved-radio persistence keyed by MAC, manual-add dialog ported from `frmAddCustomRadio.cs`, auto-reconnect on launch
-- `HardwarePage` with 9 capability-gated nested tabs mirroring Thetis Setup.cs Hardware Config (Radio Info · Antenna/ALEX · OC Outputs · XVTR · PureSignal · Diversity · PA Calibration · HL2 I/O Board · Bandwidth Monitor), with per-MAC settings persistence
-- One docs-era bug fix: the legacy `BoardType::Griffin=2` slot was a mistake; mi0bot's `enums.cs:392` clarifies slot 2 is `HermesII` (ANAN-10E / 100B)
-- `RadioConnectionError` enum replaces string-only `errorOccurred` signal (9 structured codes)
+### What's working end-to-end today
 
-Deferred (see `docs/architecture/phase3i-verification.md` + design §9): TX IQ producer, PureSignal feedback DSP, HL2 `IoBoardHl2` I2C-over-ep2 wire encoding (Phase 3L — lives in closed `ChannelMaster.dll`), full bandwidth-monitor port, TCI, RedPitaya, sidetone generator, firmware flasher.
+- **Radio connection — every OpenHPSDR P1 and P2 board.** ANAN-G2 (Saturn / Protocol 2), ANAN-10/10E/100/100B/100D/200D, Hermes, Hermes Lite 2, Angelia, Orion, Metis, Red Pitaya — all discover, connect, stream I/Q, demodulate through WDSP, and persist per-radio settings keyed by MAC. `BoardCapabilities` registry drives per-board DDC count, ADC count, BPF, Alex filter, and sample-rate support; `HardwareProfile` engine overlays Thetis `clsHardwareSpecific.cs` behaviour for ambiguous discovery bytes (user-selectable radio-model override in ConnectionPanel).
+- **Sample-rate wiring** — P1 48 / 96 / 192 kHz (+ 384 on Red Pitaya); P2 48 / 96 / 192 / 384 / 768 / 1536 kHz. Per-MAC persistence under `hardware/<mac>/radioInfo/`. Inline reconnect banner on RadioInfoTab when the selected rate differs from the active wire rate.
+- **Full Display parity** — `Setup → Display` (Spectrum / Waterfall / Grid & Scales) is wired end-to-end to the renderer on both the QPainter fallback and the QRhi/Metal/Vulkan/D3D12 GPU path. 47-control verification matrix at `docs/architecture/phase3g8-verification/README.md`. Per-band grid state persists across all 14 bands (160m–6m + GEN + WWV + XVTR) via the first-class `Band` enum on `PanadapterModel`.
+- **Clarity adaptive display** — Clarity Blue waterfall palette, `ClarityController` with cadence / EWMA / deadband, `NoiseFloorEstimator` percentile, Reset-to-Smooth-Defaults button, Re-tune button + Clarity status badge in the spectrum overlay panel, per-band Clarity memory. Zoom persistence across restarts.
+- **Full RX DSP parity** — 10 WDSP feature slices wired end-to-end through SliceModel → RadioModel → RxChannel → WDSP: AGC advanced (threshold / hang / slope / attack / decay), EMNR (NR2), SNB, APF (SPCW), 3-variant squelch (SSB / AM / FM), mute / audio pan / binaural, NB2 advanced, RIT / XIT client offset, frequency lock, mode containers (FM OPT / DIG / RTTY). Per-slice-per-band persistence under `Slice<N>/Band<key>/*`.
+- **VfoWidget rewrite** — 4-tab layout (Audio / DSP / Mode / X-RIT), 4×2 DSP toggle grid, AGC 5-button row, S-meter level bar with dBm readout and cyan→green gradient, mode containers, tooltip coverage test. AGC-T ↔ RF Gain bidirectional sync prevents audio-breaking gain runaway.
+- **Auto AGC-T** — `NoiseFloorTracker` feeds the Auto-threshold timer with MOX guard and `agcCalOffset`; AUTO button toggles auto-mode; right-click the AGC-T slider opens Setup directly on the AGC/ALC page.
+- **Step attenuator + ADC overload** — `StepAttenuatorController` with Classic + Adaptive auto-attenuation modes, hysteresis, per-MAC persistence. P1/P2 `adcOverflow` signal from frame parsers, OVL status badge in RxApplet, per-model preamp items from Thetis `SetComboPreampForHPSDR`.
+- **Container / meter system** — GPU-rendered meter engine (QRhi 3-pipeline), 31 `MeterItem` types, 38+ ItemGroup presets (S-Meter, Power/SWR, ALC, ANANMM 7-needle, CrossNeedle, Magic Eye, History, SignalText, TX bar meters), full Thetis-parity Container Settings Dialog (3-column layout, per-item property editors), MMIO external-data subsystem (UDP / TCP-listen / TCP-client / Serial transports; JSON / XML / RAW formats).
+- **App polish** — Help → About NereusSDR (version / Qt / WDSP / GPG fingerprint / heritage credits), 💡 AI-assisted issue reporter in the menu bar corner (structured prompts, submits to the `bug_report.yml` / `feature_request.yml` GitHub templates), radio-model override persistence, P1 full 17-bank C&C round-robin.
+- **Packaging** — `release.yml` prepare → build×3 → sign-and-publish pipeline. GPG-signed alpha artifacts: Linux AppImage (x86_64 + aarch64), macOS Apple Silicon DMG, Windows portable ZIP + NSIS installer.
 
-**Phase 3G-8 complete — RX1 Display parity: Setup → Display pages fully wired to the renderer.** NereusSDR connects to an ANAN-G2 (Orion MkII) via Protocol 2, receives raw I/Q data, demodulates audio through WDSP, renders a live GPU-accelerated spectrum + waterfall with VFO tuning (CTUN mode), has a full UI skeleton with 12 applets, 150+ control widgets, a complete meter system with 31 item types, and — as of 3G-8 — a fully wired Display setup category where every Spectrum Defaults / Waterfall Defaults / Grid & Scales control routes through to the renderer live on both the QPainter fallback path and the QRhi/Metal GPU path. Per-band grid state persists across all 14 bands (160m–6m + GEN + WWV + XVTR).
+### Deferred / not yet implemented
 
-**Phase 3G-6 (one-shot)** shipped 2026-04-12 as PR #2 — 40 GPG-signed commits across 7 execution blocks on `feature/phase3g6-oneshot`:
+- **TX pipeline** (Phase 3M-1 through 3M-4) — TxChannel, mic input, MOX state machine, 18-stage TXA chain, PureSignal feedback DDC.
+- **Multi-panadapter** (Phase 3F) — DDC assignment, FFTRouter, PanadapterStack, RX2 enable.
+- **HL2 `IoBoardHl2`** (Phase 3L) — I2C-over-ep2 wire encoding lives in the closed `ChannelMaster.dll`; bandwidth-monitor full port also gated on this phase.
+- **Skin system** (Phase 3H), **TCI + Spots** (Phase 3J), **CAT/rigctld** (Phase 3K), **WAV/IQ recording** (Phase 3M).
 
-- **Block 1** — rendering plumbing + Thetis filter rule (`MeterManager.cs:31366-31368` ported into `MeterWidget::shouldRender()`)
-- **Block 2** — container surface (lock, hide title, minimises, auto height, hide-when-RX-unused, highlight, duplicate) + `NeedleItem` calibration-driven paint rewrite so the ANANMM gauge face renders
-- **Block 3** — `ContainerSettingsDialog` rewrite to Thetis's 3-column layout (Available / In-use / Properties), snapshot+revert on Cancel, container-switch dropdown, footer Save/Load/MMIO buttons
-- **Block 4** — 31 per-item property editors built in parallel by 4 subagents (zero manual fixups, ~155 fields exposed), `QScrollArea` wrapping
-- **Block 5** — MMIO Multi-Meter I/O subsystem: 4 transport workers (UDP listener, TCP listener, TCP client, Serial), JSON/XML/RAW format parsers, dedicated worker `QThread`, XML persistence under `AppSettings/MmioEndpoints/<guid>/*`, endpoint manager dialog, variable picker popup, `MeterPoller` branch reading bound values at 10 fps. Section 6 of the plan was rewritten mid-block after a Thetis Explore agent confirmed the original draft's per-variable parse-rule taxonomy didn't exist in Thetis (real Thetis is endpoint-centric with format-driven discovery)
-- **Block 6** — `Containers → Edit Container ▸` submenu populated dynamically from `ContainerManager::allContainers()`, alphabetized by notes, click-to-edit per container regardless of dock mode. Reset Default Layout finally functional.
-- **Block 7** — polish + docs: 720 lines of legacy `buildXItemEditor` dead code removed, `lcMmio` registered in `LogManager`, copy/paste item settings clipboard with type-tag gating, container-dropdown auto-commit on switch, `CHANGELOG` + `CLAUDE.md` phase table flipped to Complete, debug-handoff marked Resolved.
-
-**Phase 3G-7 polish** shipped 2026-04-12 on `feature/phase3g7-polish` — 4 GPG-signed commits on top of 3G-6:
-
-- **`25a7819`** `feat(meters)` — Add 42 read-back getters across 5 MeterItem subclasses (TextOverlay, Rotator, FilterDisplay, Clock, VfoDisplay) so each item's property editor populates fully on dialog open. Wires each editor's `setItem()` to the new accessors.
-- **`8774b7c`** `fix(meters)` — Preserve MMIO bindings across all 4 dialog clone paths in `ContainerSettingsDialog.cpp`. Investigation showed the user-visible "binding lost on Apply" bug was a 4-site clone leak in one file, not the 30-subclass serialize sweep the original handoff proposed. Side-channel fix: `populateItemList`, `applyToContainer`, `takeSnapshot`/`revertFromSnapshot`, and the preset clone loop now copy `(mmioGuid, mmioVariable)` directly around the text round-trip via a parallel `QVector<QPair<QUuid, QString>>` snapshot.
-- **`41c7031`** `feat(editor)` — Wrap `NeedleItemEditor`'s 17 needle-specific fields plus the calibration table in 5 `QGroupBox` sections (Needle / Geometry / History / Power / Calibration). Layout-only refactor; member pointers and connect lambdas unchanged.
-- **`33e5ba0`** `docs(3G-7)` — CHANGELOG flipped to complete with per-item narrowings documented; handoff doc gains a 17-item "Outstanding work after 3G-7" section so each deferred item (MMIO disk persistence, smoke test, editor width sweep, ButtonBox sub-editor, 10 phantom feature ports) can be filed as its own GitHub issue.
-
-Items A and B both turned out dramatically smaller than the original handoff scoped — see the handoff doc and CHANGELOG for the per-item narrowings. Items D, E, F and the phantom feature ports are deferred to follow-up work; full list at `docs/architecture/phase3g7-polish-handoff.md` § "Outstanding work after 3G-7".
-
-**Phase 3G-8 — RX1 Display parity** shipped 2026-04-12 on `feature/phase3g8-rx1-display-parity` — 10 GPG-signed code commits + 3 doc-amend prep commits, off `main` (after 3G-7 merge). Brings the `Setup → Display → Spectrum Defaults / Waterfall Defaults / Grid & Scales` pages from "every control disabled with NYI tooltip" to feature parity with Thetis for RX1 only:
-
-- **Commit 1** — `ColorSwatchButton` reusable color picker widget, replaces the dead `makeColorSwatch` placeholder and used by 9 call sites across the phase.
-- **Commit 2** — per-band grid storage on `PanadapterModel`. New `src/models/Band.h` with a first-class 14-band enum (160m–6m + GEN + WWV + XVTR), IARU Region 2 `frequency→band` lookup, and UI-index mapping. `BandButtonItem` expanded 12→14 buttons. 28 per-band persistence keys (Max/Min only — Thetis keeps Step global) seeded with Thetis uniform -40 / -140 defaults.
-- **Commits 3–5** — `SpectrumWidget` + `FFTEngine` renderer additions: averaging modes (None / Weighted / Logarithmic / TimeWindow), peak hold + decay, trace line width, trace fill + alpha, gradient toggle, display cal offset, waterfall AGC, reverse scroll, opacity, update-period rate limiting, waterfall averaging, use-spectrum-min/max, RX filter / zero-line / timestamp overlays, 3 new colour schemes (LinLog / LinRad / Custom, total now 7), configurable grid / grid-fine / h-grid / text / zero-line / band-edge colours, 5-mode frequency label alignment, FPS overlay.
-- **Commits 6–8** — wire each Display setup page to the renderer: Spectrum Defaults (17 controls), Waterfall Defaults (17), Grid & Scales (13). Grid & Scales includes a live "Editing band: N" label that updates on `PanadapterModel::bandChanged` so per-band Max/Min edits always target the currently active band.
-- **Commit 9** — CHANGELOG entry + 47-control verification matrix at `docs/architecture/phase3g8-verification/README.md`.
-- **Commit 10** — GPU path polish: overlay-texture cache invalidation for grid / colour / labels / FPS / zero line / cal offset (11 controls), waterfall chrome factored into `drawWaterfallChrome()` and drawn into the GPU overlay texture (W6 opacity, W8/W9 timestamp, W11/W13 filter/zero line), new `m_fftPeakVbo` for GPU peak hold, and vertex-gen changes so cal offset / gradient toggle / fill toggle / fill colour are live in the GPU render path.
-
-**Architectural additions:** `RadioModel::spectrumWidget()` / `fftEngine()` non-owning view hooks so Setup pages can reach the renderer without depending on `MainWindow`; wired by `MainWindow` right after FFTEngine creation.
-
-**Known deferrals** (tracked in the PR description and `CHANGELOG.md`): S7 Line Width on GPU (needs triangle strip rendering for portable thickness — Metal/Vulkan clamp to 1 px), S16 FFT Decimation (scaffolded only, `FFTEngine` has no decimation setter yet), W12 / W14 TX filter / zero-line overlays (gated on TX state model — post-3I-1), Data Line / Data Fill Color splitting (deferred until UX feedback justifies it), W10 Waterfall Low Color runtime effect (persisted; waits for Custom-scheme `AppSettings` parser).
-
-**Authorised Thetis divergence** (plan §10, one-off): per-band grid slots initialise to Thetis uniform -40 / -140 rather than NereusSDR's existing -20 / -160. Source-first protocol stays as written — this phase is an exception, not a precedent.
+---
 
 ## Key Features
 
 **Working now:**
-- OpenHPSDR Protocol 2 radio discovery and connection
-- Raw I/Q reception from ANAN-G2 (DDC2, 48kHz, 238 samples/packet)
-- WDSP v1.29 DSP engine — USB/LSB/AM/CW demodulation, AGC, NB1/NB2, bandpass filtering
+- OpenHPSDR Protocol 1 and Protocol 2 radio discovery, connection, and per-MAC persistence across the full ANAN / Hermes / Metis / Red Pitaya family
+- Per-MAC hardware sample-rate selection (P1 up to 192 / 384 kHz; P2 up to 1536 kHz)
+- WDSP v1.29 DSP engine — USB/LSB/AM/CW/DIGI/FM demodulation with full RX DSP parity (AGC advanced, EMNR, SNB, APF, 3-variant squelch, NB1/NB2 advanced, RIT/XIT, mute/pan/binaural, frequency lock, mode containers)
+- Per-slice-per-band persistence of DSP state (`Slice<N>/Band<key>/*`)
+- Auto AGC-T with noise-floor tracker + MOX guard
+- Step attenuator (Classic + Adaptive auto-attenuation) and ADC-overload OVL badge
 - Real-time audio output via QAudioSink (48kHz stereo Int16)
-- FFTW wisdom caching with first-run progress dialog
-- Audio device selection and persistence
-- GPU-accelerated spectrum + waterfall (QRhi — Metal, Vulkan, D3D12, OpenGL fallback)
-- Full-spectrum FFTW3 FFT (4096-point, Blackman-Harris window, 30 FPS, FFT-shift + mirror)
-- VFO tuning, mode selection, filter controls (floating VFO flag widget)
-- CTUN panadapter mode — independent pan center and VFO, WDSP shift offsets
-- CTUN zoom — frequency scale bar drag or Ctrl+scroll zooms into FFT bin subsets with hybrid FFT replan
-- Off-screen VFO indicator with double-click to recenter
-- VFO marker, filter passband overlay, cursor frequency readout, filter drag
-- Right-click display settings (color scheme, gain, black level, ref level, CTUN toggle)
-- Mouse interaction (scroll-to-tune, drag ref level, click-to-tune, waterfall pan)
-- Phase word NCO tuning with Alex HPF/LPF/BPF filters (fully enabled)
-- Display settings persistence via AppSettings
-- Dockable/floatable containers with axis-lock, hover-reveal title bar, serialization
-- GPU-rendered meter engine (QRhi 3-pipeline: background texture, vertex geometry, QPainter overlay)
-- Live signal strength bar meter in Container #0 (WDSP polling at 10 FPS)
-- Composable MeterItems: 31 item types (BarItem, NeedleItem, TextItem, ScaleItem, SolidColourItem, ImageItem, SpacerItem, FadeCoverItem, LEDItem, HistoryGraphItem, MagicEyeItem, NeedleScalePwrItem, SignalTextItem, DialItem, TextOverlayItem, WebImageItem, FilterDisplayItem, RotatorItem, ButtonBoxItem, BandButtonItem, ModeButtonItem, FilterButtonItem, AntennaButtonItem, TuneStepButtonItem, OtherButtonItem, VoiceRecordPlayItem, DiscordButtonItem, VfoDisplayItem, ClockItem, ClickBoxItem, DataOutItem)
-- Arc-style S-meter needle, Power/SWR bars, ALC/Mic/Comp presets
-- ANANMM 7-needle multi-meter with exact Thetis calibration (signal, volts, amps, power, SWR, compression, ALC)
-- CrossNeedle dual fwd/rev power meter with mirrored geometry
-- Edge meter display mode (thin-line indicator style)
-- Interactive button grids: band, mode, filter, antenna, tuning step, macro controls — all with hover/click feedback
-- VFO frequency display with per-digit mouse wheel tuning, mode/filter/band labels
-- Dual UTC/Local clock display with 1s auto-refresh
-- 38+ meter presets via ItemGroup factories
-- Full UI skeleton: 12 applets, 9-menu bar, 47-page SetupDialog, SpectrumOverlayPanel, status bar
-- Cross-platform build (Windows, Linux, macOS)
+- FFTW wisdom caching with first-run progress dialog; audio device selection and persistence
+- GPU-accelerated spectrum + waterfall (QRhi — Metal, Vulkan, D3D12, OpenGL fallback); 4096-point FFTW3 FFT, Blackman-Harris window, 30 FPS, FFT-shift + mirror
+- Full `Setup → Display` wiring — 47 Spectrum / Waterfall / Grid controls live on both render paths; 7 colour schemes; per-band grid state across all 14 bands (160m–6m + GEN + WWV + XVTR)
+- Clarity Blue waterfall palette + Clarity adaptive auto-tune, Re-tune button, per-band Clarity memory, zoom persistence
+- VFO flag widget — 4-tab layout (Audio / DSP / Mode / X-RIT), 4×2 DSP grid, AGC 5-button row, integrated S-meter level bar with dBm readout
+- CTUN panadapter — independent pan center and VFO, WDSP shift offsets, bin-subset zoom with hybrid FFT replan, off-screen VFO indicator with double-click recenter
+- Filter passband overlay, cursor frequency readout, click-to-tune, scroll-to-tune, filter drag, waterfall pan
+- Phase word NCO tuning with Alex HPF/LPF/BPF filters, P1 full 17-bank C&C round-robin
+- Dockable / floatable containers with axis-lock, hover-reveal title bar, XML serialization
+- GPU-rendered meter engine (QRhi 3-pipeline), 31 `MeterItem` types, 38+ ItemGroup presets, ANANMM 7-needle with exact Thetis calibration, CrossNeedle dual fwd/rev, Magic Eye, History, Edge mode
+- Full Thetis-parity Container Settings Dialog — 3-column layout, per-item property editors (~155 fields), snapshot+revert, container-level Lock/Notes/Highlight/Minimises/Auto-height, Duplicate, Copy/Paste item settings
+- MMIO (Multi-Meter I/O) external-data subsystem — UDP / TCP-listen / TCP-client / Serial transports, JSON / XML / RAW formats, endpoint manager, variable picker, 10 fps polled bindings
+- Interactive button grids — band (14), mode, filter, antenna, tuning step, macro — with hover/click feedback
+- Full UI skeleton — 12 applets, 9-menu bar, 47-page SetupDialog, SpectrumOverlayPanel with 5 flyout sub-panels, status bar
+- Help → About dialog + 💡 AI-assisted issue reporter wired to the GitHub issue tracker
+- GPG-signed cross-platform alpha builds (Linux AppImage ×2 archs, macOS DMG, Windows portable ZIP + NSIS installer)
 
 **Planned (see Roadmap):**
-- **Phase 3G-6 (one-shot):** Full Thetis-parity Container Settings Dialog — 3-column layout, per-item property editors for all ~30 item types, in-place editing with snapshot/revert, container-level Lock/Notes/Highlight/Minimises/Auto-height, container dropdown, Duplicate action, Containers menu submenu, Copy/Paste item settings, MMIO (Multi-Meter I/O) external-data subsystem with TCP/UDP/serial transports, variable registry, parse rules, and picker UI. See `docs/architecture/phase3g6a-plan.md`.
-- TX pipeline — SSB, CW, full processing chain, PureSignal (Phase 3M, future)
-- Up to 4 independent panadapters in configurable layouts (Phase 3F)
-- Thetis-inspired skin system (Phase 3H)
-- TCI protocol server, DX Cluster/RBN spots (Phase 3J)
-- CAT/rigctld for logging and contest software (Phase 3K)
-- HL2 `IoBoardHl2` I2C-over-ep2 wire encoding (Phase 3L — extraction from closed `ChannelMaster.dll`)
-- **Phase 3G-9 (Display Refactor)** and **Phase 3G-10 (RX DSP Parity + AetherSDR Flag Port)** — twin polish phases running in parallel before 3M-1 (TX). 3G-9 tightens the Display setup surface (audit + Thetis-first tooltips + slider readouts + Clarity Blue palette + Clarity adaptive auto-tune). 3G-10 ports the AetherSDR VfoWidget visual shell and wires every RX-side DSP NYI stub through WDSP with per-slice-per-band bandstack persistence. See `docs/architecture/2026-04-15-display-refactor-design.md` and `docs/architecture/2026-04-15-phase3g10-rx-dsp-flag-design.md`.
+- **Phase 3M-1 Basic SSB TX** — TxChannel, mic input, MOX state machine, I/Q output (next up)
+- **Phase 3M-2 CW TX** — sidetone, firmware keyer, QSK/break-in
+- **Phase 3M-3 TX Processing** — 18-stage TXA chain + TX-side RX DSP additions
+- **Phase 3M-4 PureSignal** — feedback DDC, calcc/IQC engine, PA linearization
+- **Phase 3F Multi-Panadapter** — DDC assignment (including PS states), FFTRouter, PanadapterStack, RX2 enable
+- **Phase 3H Skin System** — Thetis-inspired skin format with 4-pan support and legacy-skin import
+- **Phase 3J TCI + Spots** — TCI v2.0 WebSocket server, DX Cluster / RBN clients, spot overlay
+- **Phase 3K CAT / rigctld** — 4-channel rigctld, TCP CAT server
+- **Phase 3L HL2 `IoBoardHl2`** — I2C-over-ep2 wire encoding (extraction from closed `ChannelMaster.dll`); full bandwidth-monitor port
+- **Phase 3M Recording** — WAV record/playback, I/Q record, scheduled
 
 ---
 
@@ -186,28 +153,32 @@ Items A and B both turned out dramatically smaller than the original handoff sco
 | **3C: macOS Build** | Cross-platform WDSP build + wisdom crash fix | **Complete** |
 | **3D: Spectrum Display** | GPU spectrum + waterfall (QRhi Metal/Vulkan/D3D12) | **Complete** |
 | **3E: VFO + Multi-RX Foundation** | VFO controls + rewire I/Q pipeline for N receivers + CTUN panadapter | **Complete** |
-| **3G-1: Container Infrastructure** | **Dock/float/resize/persist container shells** | **Complete** |
-| **3G-2: MeterWidget GPU Renderer** | **QRhi-based meter rendering engine** | **Complete** |
-| **3G-3: Core Meter Groups** | **S-Meter, Power/SWR, ALC presets** | **Complete** |
-| **3-UI: Full UI Skeleton** | **12 applets, 9-menu bar, SetupDialog, SpectrumOverlayPanel** | **Complete** |
-| **3G-4: Advanced Meter Items** | **12 item types + ANANMM/CrossNeedle presets + Edge mode** | **Complete** |
-| **3G-5: Interactive Meter Items** | **14 interactive items + mouse forwarding + ButtonBoxItem base** | **Complete** |
-| **3G-6: Container Settings Dialog (one-shot)** | **3-column Thetis layout + per-item editors for all ~30 types + in-place editing + MMIO external-data subsystem + container-level parity + menu submenu** | **Complete** |
-| **3G-7: Polish** | **MMIO clone-path bug fix + 5 subclass accessor gap fills + NeedleItemEditor QGroupBox grouping** | **Complete** |
-| **3G-8: RX1 Display Parity** | **47 Spectrum/Waterfall/Grid controls wired, `Band` enum + per-band grid on `PanadapterModel`, `BandButtonItem` 12→14, GPU path polish for live overlay / waterfall chrome / peak hold / fill / gradient / cal offset** | **Complete** |
-| 3G-9: Display Refactor | Source-first audit, Thetis-first tooltip port, slider/spinbox refactor (3G-9a merged as PR #25); smooth defaults + Clarity Blue palette (3G-9b) and Clarity adaptive auto-tune (3G-9c) planned | 3G-9a Complete |
-| **3G-10: RX DSP Parity + AetherSDR Flag Port** | **Stage 1: AetherSDR VfoWidget visual port (flag shell, 4×2 DSP grid, AudioTab AGC 5-button row, mode containers with visibility rules, tooltip coverage test). Stage 2: wire every RX-side DSP NYI through WDSP with per-slice-per-band persistence** | **Stage 1 Complete (PRs #28 + #30)** |
-| 3M-1: Basic SSB TX (was 3I-1) | TxChannel, MOX state machine, RF output | Planned |
-| 3M-2: CW TX (was 3I-2) | Sidetone, firmware keyer, QSK/break-in | Planned |
-| 3M-3: TX Processing (was 3I-3) | 18-stage TXA chain + TX-side RX DSP additions | Planned |
-| 3M-4: PureSignal (was 3I-4) | Feedback DDC, calcc/IQC engine, PA linearization | Planned |
-| 3F: Multi-Panadapter | DDC assignment, FFTRouter, PanadapterStack, enable RX2 | Planned |
-| 3H: Skin System | Thetis-inspired skins with 4-pan support | Planned |
+| **3G-1: Container Infrastructure** | Dock/float/resize/persist container shells | **Complete** |
+| **3G-2: MeterWidget GPU Renderer** | QRhi-based meter rendering engine | **Complete** |
+| **3G-3: Core Meter Groups** | S-Meter, Power/SWR, ALC presets | **Complete** |
+| **3-UI: Full UI Skeleton** | 12 applets, 9-menu bar, SetupDialog, SpectrumOverlayPanel | **Complete** |
+| **3G-4: Advanced Meter Items** | 12 item types + ANANMM/CrossNeedle presets + Edge mode | **Complete** |
+| **3G-5: Interactive Meter Items** | 14 interactive items + mouse forwarding + ButtonBoxItem base | **Complete** |
+| **3G-6: Container Settings Dialog** | 3-column Thetis layout + per-item editors + in-place editing + MMIO external-data subsystem + container-level parity | **Complete** |
+| **3G-7: Polish** | MMIO clone-path fix + 5 subclass accessor gap fills + NeedleItemEditor QGroupBox grouping | **Complete** |
+| **3G-8: RX1 Display Parity** | 47 Spectrum/Waterfall/Grid controls wired, `Band` enum + per-band grid, `BandButtonItem` 12→14, GPU path polish | **Complete** |
+| **3G-9: Display Refactor** | 3G-9a audit + Thetis-first tooltips + slider/spinbox refactor; 3G-9b smooth defaults + Clarity Blue palette; 3G-9c Clarity adaptive auto-tune | **Complete** |
+| **3G-10: RX DSP Parity + AetherSDR Flag Port** | AetherSDR VfoWidget visual port + 10 WDSP feature slices wired through WDSP with per-slice-per-band persistence | **Complete** |
+| **3G-11: P1 Field Fixes** | P1 VFO frequency encoding (raw Hz, not NCO phase word); Red Pitaya / Hermes family C&C bank fixes | **Complete** |
+| **3I: Radio Connector & Radio-Model Port** | Full P1 family (Atlas/Hermes/HermesII/Angelia/Orion/HL2), `BoardCapabilities` registry, ConnectionPanel, HardwarePage 9-tab capability-gated, per-MAC persistence, `RadioConnectionError` taxonomy | **Complete** |
+| **3G-13: Step Attenuator & ADC Overload** | `StepAttenuatorController` (Classic + Adaptive), P1/P2 `adcOverflow` emission, OVL status badge, Setup→General→Options page, RxApplet ATT/S-ATT row, per-model preamp items | **Complete** |
+| **3G-14: About + AI Issue Reporter** | Help → About dialog, 💡 menu-bar issue reporter with structured prompts submitting to `bug_report.yml` / `feature_request.yml` | **Complete** |
+| **3N: Packaging** | Consolidated `release.yml`, `/release` skill, GPG-signed alpha builds: Linux AppImage ×2 archs, macOS Apple Silicon DMG, Windows portable ZIP + NSIS installer | **Complete** |
+| 3M-1: Basic SSB TX | TxChannel, mic input, MOX state machine, I/Q output | **Next** |
+| 3M-2: CW TX | Sidetone, firmware keyer, QSK/break-in | Planned |
+| 3M-3: TX Processing | 18-stage TXA chain + TX-side RX DSP additions | Planned |
+| 3M-4: PureSignal | Feedback DDC, calcc/IQC engine, PA linearization | Planned |
+| 3F: Multi-Panadapter | DDC assignment (incl. PS states), FFTRouter, PanadapterStack, enable RX2 | Planned |
+| 3H: Skin System | Thetis-inspired skins with 4-pan support + legacy import | Planned |
 | 3J: TCI + Spots | TCI v2.0 WebSocket, DX Cluster/RBN clients, spot overlay | Planned |
 | 3K: CAT/rigctld | 4-channel rigctld, TCP CAT server | Planned |
-| 3L: Protocol 1 | P1 support for Hermes Lite 2 / older ANAN | Planned |
+| 3L: HL2 ChannelMaster.dll port | HL2 `IoBoardHl2` I2C-over-ep2 wire encoding, full bandwidth-monitor port | Planned |
 | 3M: Recording | WAV record/playback, I/Q record, scheduled | Planned |
-| **3N: Packaging** | **AppImage ×2 archs, macOS DMG, Windows ZIP + NSIS installer** | **Complete** |
 
 See [docs/MASTER-PLAN.md](docs/MASTER-PLAN.md) for the full implementation plan.
 

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -197,14 +197,16 @@ NereusSDR is an independent cross-platform SDR client deeply informed by the wor
 | Legacy skin compatibility | Extended skin format + Thetis import (2D) | Design done |
 | Configurable containers (Thetis multi-meter) | Unified container system (float/dock/axis-lock) | Design done |
 | PureSignal PA linearization | Feedback RX channel + pscc() loop designed (2E), DDC sync (2F) | Design done |
-| TCI protocol | Planned as Phase 3J | Not started |
-| Cross-platform packaging | CI workflows in place (AppImage, Windows, macOS) | CI done |
+| TCI protocol | Planned as Phase 3J | Not started (integration points reserved in 3O) |
+| Cross-platform packaging | CI workflows in place (AppImage, Windows, macOS) | **3N complete** — `release.yml` + `/release` skill; v0.2.1 shipped GPG-signed across all three platforms |
 | AetherSDR architecture patterns | RadioModel hub, signal/slot, worker threads, AppSettings | Adopted |
 | Radio-authoritative state | Designed per AetherSDR pattern | Adopted |
 | Multi-receiver ADC/DDC mapping | Full signal chain analyzed (2F), UpdateDDCs() porting needed | Design done |
+| **VAX audio routing + Thetis VAC/cmASIO parity** | **Phase 3O spec at `docs/architecture/2026-04-19-vax-design.md`** | **Designed 2026-04-19, impl planned** |
 
 **All project brief objectives are covered.** Feature gap analysis completed 2026-04-10
-(see `docs/architecture/reviews/2026-04-10-plan-review.md` for full audit).
+(see `docs/architecture/reviews/2026-04-10-plan-review.md` for full audit). Phase 3O
+VAX design added 2026-04-19.
 
 ---
 
@@ -762,13 +764,58 @@ Scope:
 - I/Q recording — raw I/Q samples for offline analysis
 - Recording controls wired to VfoWidget (existing button stubs)
 
-### Phase 3N: Cross-Platform Packaging
+### Phase 3N: Cross-Platform Packaging ✅ COMPLETE
 **Goal:** Release builds for Linux, Windows, macOS.
 
-CI workflows already in place. Finalize:
-- AppImage (Linux x86_64 + ARM)
-- Windows NSIS installer + portable ZIP
-- macOS DMG (Apple Silicon)
+Shipped: consolidated `release.yml` (prepare → build×3 → sign-and-publish), `/release` skill, GPG-signed alpha builds across Linux AppImage ×2 archs, macOS Apple Silicon DMG, Windows portable ZIP + NSIS installer. v0.1.2 → v0.1.4 → v0.1.7 → v0.2.0 → v0.2.1 all shipped via this pipeline.
+
+### Phase 3O: VAX — Audio Routing & Cross-Platform Audio Engine
+**Goal:** Ship NereusSDR's complete RX audio routing story — per-receiver VAX assignment, Thetis-grade Setup → Audio power-user surface, native VAX drivers on macOS/Linux, auto-detect for user-installed Windows virtual cables, optional Direct ASIO (cmASIO parity) engine.
+
+**Design spec:** `docs/architecture/2026-04-19-vax-design.md` (brainstormed 2026-04-19, ready for implementation plan)
+
+Scope:
+- **`IAudioBus` abstraction** with five platform backends: `CoreAudioHalBus` (macOS HAL plugin, port of AetherSDR `VirtualAudioBridge`), `LinuxPipeBus` (PulseAudio module-pipe, port of AetherSDR `PipeWireAudioBridge`), `PortAudioBus` (Windows default + Mac/Linux fallback), `DirectAsioBus` (Windows opt-in, Thetis `cmasio.c` port with Thetis attribution), `CoreAudioBus` (Mac fallback).
+- **macOS HAL plugin** at `hal-plugin/NereusSDRVAX.cpp` — 4 VAX outputs + 1 TX input as native CoreAudio devices. libASPL-based, POSIX shm IPC. Dev-ID-signed + notarized `.pkg` installer with macOS 14.4+ `killall coreaudiod` fallback.
+- **Linux bridge** — `pactl`-loaded `module-pipe-source` × 4 + `module-pipe-sink` × 1, rebranded to `nereussdr-vax-*`. Works on both Pulse and PipeWire-via-pipewire-pulse. Stale-module cleanup on startup.
+- **Windows BYO path** — `VirtualCableDetector` regex-matches VB-Audio family, VAC, Voicemeeter, Dante, FlexRadio DAX. First-run dialog pre-fills bindings; links to vendor install pages when none detected.
+- **Optional Direct ASIO engine** (Windows) — full Thetis `cmASIO` parity: ASIO driver picker, Control Panel launcher, base in/out channel selection, input mode L/R/Both, lock mode, block size. Gated behind an Engine radio button on the Devices tab — no callsign allowlist, no runtime flag.
+- **Routing model** — SmartSDR-style: `SliceModel.vaxChannel` (0..4) set via new `VaxChannelSelector` row on `VfoWidget`; speakers always-on unless muted; one VAX owns TX at a time (`TransmitModel.txOwnerSlot`).
+- **`VaxApplet` (docked, ported from AetherSDR `DaxApplet`, renamed DAX→VAX)** — 4 channel strips with meter + gain + mute + device picker + assigned-slice tags; TX row with gain + meter.
+- **Menu-bar `MasterOutputWidget`** — global volume + mute + right-click device picker; scroll-wheel fine-tune.
+- **Setup → Audio page** — sub-tabs Devices / VAX / TCI (disabled placeholder) / Advanced. Per-device Driver API dropdown exposes MME / DirectSound / WDM-KS / WASAPI-shared / WASAPI-exclusive / ASIO on Windows; CoreAudio on Mac; ALSA / Pulse / PipeWire / JACK on Linux. Buffer size with derived ms; manual latency override; exclusive mode + event-driven + bypass-mixer options per WASAPI; full cmASIO control surface behind Engine radio.
+- **First-run auto-detect dialog** — 5 scenarios per-platform (Windows cables-found / Windows none-found / Mac native / Linux native / rescan-on-new-cable).
+- **AppSettings schema additions** — per-device driver API + format + buffer; per-VAX enabled + device + gain + mute; per-slice VAX channel; TX owner slot; master volume/mute/device; IVAC feedback parity controls (gain/slew/ring min-max/alpha); global toggles for IQ-to-VAX (reserved), mute-VAX-during-TX-on-other-slice, first-run-complete.
+- **Settings migration** — single legacy `audio/OutputDevice` key migrates to `audio/Speakers/DeviceName` with sensible defaults; first-run dialog triggers.
+- **Audio engine refactor** — replaces `QAudioSink`-only output with the `IAudioBus` model routing per-slice through `MasterMixer` + per-VAX taps.
+- **Full end-to-end wiring** — every widget listed in spec §6 has its round-trip wiring (widget → model → action → persistence → feedback guard) specified before implementation. Zero unwired controls; this is a spec-enforced bar per the design doc.
+
+Attribution (per `docs/attribution/HOW-TO-PORT.md`):
+- AetherSDR-ported files (`VirtualAudioBridge`, `PipeWireAudioBridge`, `hal-plugin/AetherSDRDAX.cpp`, `DaxApplet`, `MeterSlider`) get NereusSDR port-citation + modification-history headers per rule 6 (AetherSDR has no per-file GPL headers; cite at project URL + primary author level).
+- Thetis-ported files (`DirectAsioBus`, `AsioSdkHost` from `ChannelMaster/cmasio.{h,c}` + `Console/clsCMASIOConfig.cs`) get byte-for-byte Thetis headers stacked per rule 4, inline markers preserved, `[v2.10.3.13]` version stamps on all cites.
+- PROVENANCE rows added in the same commits that introduce the ports.
+
+Dependencies:
+- Phase 3B (AudioEngine skeleton) — ✓
+- Phase 3G-10 Stage 2 (`VfoWidget` tab structure and per-slice persistence) — ✓
+- Phase 3G-8 (`SetupPage` base + STYLEGUIDE.md) — ✓
+
+Reserves integration points for:
+- **Phase 3J (TCI):** `IAudioBus` tap contract lets TCI subscribe to the same RX taps with no refactor.
+- **Future:** NereusSDR-owned Windows signed driver can replace BYO cables transparently via `VirtualCableDetector`'s reserved "NereusSDR VAX N" pattern.
+
+Explicitly out of scope (in this phase):
+- TCI server and TCI audio streams (Phase 3J).
+- TX mic DSP chain — compressor, TX EQ, leveler (Phase 3M-3).
+- IQ-to-VAX activation (setting persisted but logs-and-ignores until future phase).
+- NereusSDR-owned Windows virtual audio driver.
+
+Success criteria (subset, see spec §14 for full list):
+- All controls round-trip wired; zero unwired buttons.
+- Thetis migrator can configure equivalent VAC1/VAC2 in Setup → Audio in under 5 minutes on Windows.
+- Mac/Linux users see "NereusSDR VAX 1–4" + "NereusSDR TX" in WSJT-X audio picker with zero extra install.
+- Windows user with VB-CABLE installed sees auto-detect suggestions on first launch.
+- `scripts/verify-thetis-headers.py` + `scripts/check-new-ports.py` pass on all ported files.
 
 ---
 
@@ -819,7 +866,7 @@ Execution order: **(3G-9a..c ∥ 3G-10 ∥ 3G-13) → 3M-1..4 → 3F → 3H → 
 
 3G-9, 3G-10, 3G-13, and 3G-14 touch disjoint subsystems from each other and from 3M-* — they can all run in parallel if desired. 3G-9 owns the Display setup surface; 3G-10 owns the VFO flag and RX DSP wiring; 3G-13 owns the step attenuator + ADC overload protection (protocol layer + Setup Options + RxApplet ATT row + status bar); 3G-14 owns the 💡 issue reporter (menu bar corner widget + dialog).
 
-Independent phases (can start anytime): 3G-14 (issue reporter), 3J (TCI), 3K (CAT), 3L (P1), 3M (Recording).
+Independent phases (can start anytime): 3G-14 (issue reporter), 3J (TCI — depends on 3O IAudioBus contract), 3K (CAT), 3L (P1), 3M (Recording), **3O (VAX audio routing — depends on 3B, 3G-8, 3G-10 Stage 2; all complete)**.
 
 ---
 
@@ -850,6 +897,7 @@ prerequisite infrastructure exists.
 | Date | Scope | Document |
 |---|---|---|
 | 2026-04-10 | Full plan review: Thetis/AetherSDR deep-dive, feature gap analysis, phase restructuring, container/PureSignal/TX architecture | [2026-04-10-plan-review.md](architecture/reviews/2026-04-10-plan-review.md) |
+| 2026-04-19 | Added Phase 3O (VAX — Audio Routing & Cross-Platform Audio Engine). Design brainstormed against Thetis VAC/cmASIO, AetherSDR DaxApplet/VirtualAudioBridge/PipeWireAudioBridge, and reference UIs (Rogue Amoeba Loopback, Dante Controller, RME TotalMix, qpwgraph). Chose SmartSDR-style routing + VFO-flag VAX selector + docked VaxApplet over patchbay/matrix alternatives. Windows BYO-with-auto-detect chosen over signed-kernel-driver for v1; TCI scoped out to Phase 3J with integration points reserved. Also audited status of 3N (marked complete) and added VAX row to Objective Cross-Check. | [2026-04-19-vax-design.md](architecture/2026-04-19-vax-design.md) |
 
 ---
 

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -779,7 +779,7 @@ Scope:
 - **macOS HAL plugin** at `hal-plugin/NereusSDRVAX.cpp` — 4 VAX outputs + 1 TX input as native CoreAudio devices. libASPL-based, POSIX shm IPC. Dev-ID-signed + notarized `.pkg` installer with macOS 14.4+ `killall coreaudiod` fallback.
 - **Linux bridge** — `pactl`-loaded `module-pipe-source` × 4 + `module-pipe-sink` × 1, rebranded to `nereussdr-vax-*`. Works on both Pulse and PipeWire-via-pipewire-pulse. Stale-module cleanup on startup.
 - **Windows BYO path** — `VirtualCableDetector` regex-matches VB-Audio family, VAC, Voicemeeter, Dante, FlexRadio DAX. First-run dialog pre-fills bindings; links to vendor install pages when none detected.
-- **Optional Direct ASIO engine** (Windows) — full Thetis `cmASIO` parity: ASIO driver picker, Control Panel launcher, base in/out channel selection, input mode L/R/Both, lock mode, block size. Gated behind an Engine radio button on the Devices tab — no callsign allowlist, no runtime flag.
+- ~~Optional Direct ASIO engine (Windows) — cmASIO parity~~ **Deferred** per 2026-04-19 GPL-3 compliance review (Steinberg ASIO SDK not GPL-compatible). PortAudio's built-in ASIO host API remains as the ASIO path. See plan's GPL Compliance Review section and spec §8.5 compliance note.
 - **Routing model** — SmartSDR-style: `SliceModel.vaxChannel` (0..4) set via new `VaxChannelSelector` row on `VfoWidget`; speakers always-on unless muted; one VAX owns TX at a time (`TransmitModel.txOwnerSlot`).
 - **`VaxApplet` (docked, ported from AetherSDR `DaxApplet`, renamed DAX→VAX)** — 4 channel strips with meter + gain + mute + device picker + assigned-slice tags; TX row with gain + meter.
 - **Menu-bar `MasterOutputWidget`** — global volume + mute + right-click device picker; scroll-wheel fine-tune.
@@ -792,8 +792,9 @@ Scope:
 
 Attribution (per `docs/attribution/HOW-TO-PORT.md`):
 - AetherSDR-ported files (`VirtualAudioBridge`, `PipeWireAudioBridge`, `hal-plugin/AetherSDRDAX.cpp`, `DaxApplet`, `MeterSlider`) get NereusSDR port-citation + modification-history headers per rule 6 (AetherSDR has no per-file GPL headers; cite at project URL + primary author level).
-- Thetis-ported files (`DirectAsioBus`, `AsioSdkHost` from `ChannelMaster/cmasio.{h,c}` + `Console/clsCMASIOConfig.cs`) get byte-for-byte Thetis headers stacked per rule 4, inline markers preserved, `[v2.10.3.13]` version stamps on all cites.
+- ~~Thetis-ported files (`DirectAsioBus`, `AsioSdkHost` from `ChannelMaster/cmasio.{h,c}` + `Console/clsCMASIOConfig.cs`) get byte-for-byte Thetis headers~~ — deferred with Direct ASIO.
 - PROVENANCE rows added in the same commits that introduce the ports.
+- `COMPLIANCE-INVENTORY.md` updated at end of phase documenting macOS HAL plugin's separate-binary / mere-aggregation status and the 2026-04-19 GPL review outcome.
 
 Dependencies:
 - Phase 3B (AudioEngine skeleton) — ✓
@@ -897,7 +898,8 @@ prerequisite infrastructure exists.
 | Date | Scope | Document |
 |---|---|---|
 | 2026-04-10 | Full plan review: Thetis/AetherSDR deep-dive, feature gap analysis, phase restructuring, container/PureSignal/TX architecture | [2026-04-10-plan-review.md](architecture/reviews/2026-04-10-plan-review.md) |
-| 2026-04-19 | Added Phase 3O (VAX — Audio Routing & Cross-Platform Audio Engine). Design brainstormed against Thetis VAC/cmASIO, AetherSDR DaxApplet/VirtualAudioBridge/PipeWireAudioBridge, and reference UIs (Rogue Amoeba Loopback, Dante Controller, RME TotalMix, qpwgraph). Chose SmartSDR-style routing + VFO-flag VAX selector + docked VaxApplet over patchbay/matrix alternatives. Windows BYO-with-auto-detect chosen over signed-kernel-driver for v1; TCI scoped out to Phase 3J with integration points reserved. Also audited status of 3N (marked complete) and added VAX row to Objective Cross-Check. | [2026-04-19-vax-design.md](architecture/2026-04-19-vax-design.md) |
+| 2026-04-19 | Added Phase 3O (VAX — Audio Routing & Cross-Platform Audio Engine). Design brainstormed against Thetis VAC/cmASIO, AetherSDR DaxApplet/VirtualAudioBridge/PipeWireAudioBridge, and reference UIs (Rogue Amoeba Loopback, Dante Controller, RME TotalMix, qpwgraph). Chose AetherSDR-style routing + VFO-flag VAX selector + docked VaxApplet over patchbay/matrix alternatives. Windows BYO-with-auto-detect chosen over signed-kernel-driver for v1; TCI scoped out to Phase 3J with integration points reserved. Also audited status of 3N (marked complete) and added VAX row to Objective Cross-Check. | [2026-04-19-vax-design.md](architecture/2026-04-19-vax-design.md) |
+| 2026-04-19 | Implementation plan authored for Phase 3O with pre-execution GPL-3 compliance review. **Dropped Direct ASIO engine** from the phase: Steinberg ASIO SDK is not GPL-3 compatible; linking it into distributed NereusSDR binaries would violate both the ASIO SDK terms and GPL-3. PortAudio's built-in ASIO host API remains as the ASIO path. All other components (AetherSDR GPL-3 ports, libASPL MIT, PortAudio MIT, Qt6/FFTW3/WDSP) verified compatible. Compliance inventory update folded into final verification task. | [2026-04-19-phase3o-vax-plan.md](architecture/2026-04-19-phase3o-vax-plan.md) |
 
 ---
 

--- a/docs/architecture/2026-04-19-phase3o-vax-plan.md
+++ b/docs/architecture/2026-04-19-phase3o-vax-plan.md
@@ -1,0 +1,2426 @@
+# Phase 3O: VAX Audio Routing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build NereusSDR's complete cross-platform RX audio routing story — per-receiver VAX assignment via VFO-flag selector, native VAX drivers on macOS (HAL plugin) and Linux (PulseAudio module-pipe), Windows BYO virtual cables with auto-detection, and a Thetis-grade Setup → Audio surface with optional Direct ASIO (cmASIO parity) engine.
+
+**Architecture:** Single `IAudioBus` C++ abstraction with five platform backends (`CoreAudioHalBus`, `LinuxPipeBus`, `PortAudioBus`, `DirectAsioBus`, `CoreAudioBus`). Per-slice `vaxChannel` atomic int drives tap routing. AetherSDR-style applet (`VaxApplet` ported + renamed from `DaxApplet`) shows per-channel meters/gains. VFO-flag gains a one-row `VaxChannelSelector`. Menu bar gains a `MasterOutputWidget`. Setup dialog gains an Audio page with four sub-tabs. First-run dialog auto-detects virtual cables.
+
+**Tech Stack:** C++20, Qt6 (Widgets + Multimedia), PortAudio v19, libASPL 3.1.2 (macOS), Steinberg ASIO SDK (Windows opt-in), POSIX shm (Mac), PulseAudio/PipeWire (Linux), WiX v4 (Windows installer).
+
+**Design spec:** [`docs/architecture/2026-04-19-vax-design.md`](2026-04-19-vax-design.md) — all architectural decisions, signal flow, data model, and wiring tables are authoritative there. This plan translates the spec into TDD-sequenced tasks.
+
+---
+
+## GPL Compliance Review (2026-04-19)
+
+Pre-execution audit of every bundled or linked dependency against NereusSDR's GPL-3.0 license:
+
+| Component | License | GPL-3 compatible? |
+|---|---|---|
+| AetherSDR ports (VirtualAudioBridge, PipeWireAudioBridge, HAL plugin, DaxApplet, MeterSlider) | GPL-3.0 | ✅ trivial |
+| Thetis ports (none in Phase 3O after Direct ASIO drop) | GPL-2-or-later + Samphire dual-license | n/a this phase |
+| libASPL (macOS HAL framework, vendored by FetchContent) | MIT | ✅ MIT → GPL-3 one-way compatible |
+| PortAudio v19.7.0 (vendored by FetchContent) | MIT-style (verify LICENSE.txt at pin) | ✅ expected, verification step added to Task 3.1 |
+| Qt6 / FFTW3 / WDSP | LGPL-3 / GPL-2 / GPL (TAPR) | ✅ already in use |
+| User-installed virtual cables (VB-CABLE, VAC, Voicemeeter, BlackHole, Dante, FlexRadio DAX) | Proprietary / various | ✅ not redistributed; users install themselves |
+| **Steinberg ASIO SDK** | **Proprietary, explicitly non-GPL** | 🚨 **NOT compatible** — see decision below |
+
+### Decision: drop Direct ASIO from Phase 3O
+
+Linking the Steinberg ASIO SDK into GPL-3 NereusSDR binaries violates both the ASIO SDK license (no redistribution of modified headers) and GPL-3 (non-free library linked into a GPL work; no system-library exception applies). Audacity hits the same wall and ships ASIO-disabled binaries for this exact reason.
+
+**Action:** Sub-Phase 13 (Direct ASIO Engine) and all references to `DirectAsioBus` / `AsioSdkHost` / Thetis `cmasio.c` ports are **removed from this plan.** PortAudio's built-in ASIO host API (available via the `PA_USE_ASIO` CMake option) covers the overwhelming majority of ASIO use cases without our project redistributing the SDK itself.
+
+If community demand ever justifies revisiting this, it lands as a **separate compliance proposal** (either option 2 — developer-build-only gate with CI enforcement — or a formal Steinberg commercial-license conversation). Not now.
+
+### Remediation actions folded into this plan
+
+- **Task 3.1** adds a step to verify PortAudio's bundled `LICENSE.txt` at the v19.7.0 pin is MIT-compatible before committing the FetchContent.
+- **Task 14.4 (final verification)** adds steps to update `docs/attribution/COMPLIANCE-INVENTORY.md` with rows for every new port (HAL plugin, CoreAudioHalBus, LinuxPipeBus, VaxApplet, MeterSlider) and to document the macOS HAL plugin's separate-binary / mere-aggregation reasoning per GPL-3 §5.
+- **Attribution verifiers** (`scripts/verify-thetis-headers.py`, `scripts/check-new-ports.py`, and the existing AetherSDR + WDSP passes in the pre-commit hook) cover enforcement for the GPL-compatible ports.
+
+**Difficulty ranking** (after Direct ASIO drop, per spec §9, no calendar estimates):
+🟢 Easy — VirtualCableDetector, LinuxPipeBus, AppSettings schema, VaxChannelSelector, MasterOutputWidget
+🟡 Medium — VaxApplet port, HAL plugin (macOS), SetupAudioPage, TX arbitration, MasterMixer
+🟠 Medium-hard — IAudioBus abstraction + AudioEngine refactor, PortAudioBus
+🔴 Hard — end-to-end smoke-test matrix
+
+---
+
+## Prerequisites
+
+### Worktree setup
+
+This plan should execute in an isolated worktree so it doesn't disturb ongoing work on other branches.
+
+```bash
+cd ~/NereusSDR
+git worktree add -b feature/phase-3o-vax ../NereusSDR-vax main
+cd ../NereusSDR-vax
+```
+
+All file paths below are relative to the worktree root.
+
+### Tooling
+
+Before starting, verify the environment:
+
+```bash
+# macOS
+brew list | grep -E 'qt|cmake|ninja|fftw|portaudio'
+
+# Arch Linux
+pacman -Q qt6-base qt6-multimedia cmake ninja fftw portaudio
+
+# Windows
+# Visual Studio 2022 + Qt 6.x + CMake + Ninja pre-installed per CONTRIBUTING.md
+```
+
+### Reference checkouts
+
+- **Thetis** at `../Thetis/` — cmASIO source. Capture the version once at session start:
+  ```bash
+  git -C ../Thetis describe --tags
+  # → use output as `[vX.Y.Z.W]` on every `// From Thetis …` cite in this plan
+  ```
+- **AetherSDR** at `../AetherSDR/` — port source for VirtualAudioBridge, PipeWireAudioBridge, hal-plugin, DaxApplet, MeterSlider. No per-file GPL headers (project-level per `HOW-TO-PORT.md` rule 6).
+
+---
+
+## File Structure Overview
+
+### Files to create
+
+| Path | Role | Sub-phase |
+|---|---|---|
+| `src/core/IAudioBus.h` | Abstract bus interface + `AudioFormat` struct | 2 |
+| `src/core/audio/MasterMixer.{h,cpp}` | Per-slice mute/volume/pan → single sink | 2 |
+| `src/core/audio/PortAudioBus.{h,cpp}` | PortAudio stream; Windows default + Mac/Linux fallback | 3 |
+| `src/core/audio/CoreAudioHalBus.{h,cpp}` | macOS HAL plugin shm writer (ported) | 5 |
+| `hal-plugin/NereusSDRVAX.cpp` | macOS HAL plugin (ported) | 5 |
+| `hal-plugin/CMakeLists.txt` | HAL plugin build (ported) | 5 |
+| `hal-plugin/Info.plist` | HAL plugin bundle manifest (ported) | 5 |
+| `packaging/macos/hal-installer.sh` | macOS `.pkg` builder (ported) | 5 |
+| `packaging/macos/hal-postinstall.sh` | coreaudiod restart w/ 14.4+ killall fallback | 5 |
+| `packaging/macos/hal-uninstall.sh` | remove `.driver` + shm segments (ported) | 5 |
+| `src/core/audio/LinuxPipeBus.{h,cpp}` | Linux PulseAudio module-pipe bridge (ported) | 6 |
+| `src/core/audio/VirtualCableDetector.{h,cpp}` | OS-audio-device regex matcher | 7 |
+| `src/gui/widgets/VaxChannelSelector.{h,cpp}` | VFO flag VAX button group | 8 |
+| `src/gui/widgets/MeterSlider.{h,cpp}` | Meter+slider composite (ported) | 9 |
+| `src/gui/applets/VaxApplet.{h,cpp}` | Docked VAX meter/gain applet (ported + renamed) | 9 |
+| `src/gui/MasterOutputWidget.{h,cpp}` | Menu-bar master output strip | 10 |
+| `src/gui/VaxFirstRunDialog.{h,cpp}` | First-run auto-detect modal | 11 |
+| `src/gui/SetupAudioPage.{h,cpp}` | Setup → Audio page (4 sub-tabs) | 12 |
+| `resources/help/install-virtual-cables.md` | User-facing help doc | 14 |
+| `tests/tst_slice_model_vax.cpp` | SliceModel.vaxChannel tests | 1 |
+| `tests/tst_transmit_model_tx_owner.cpp` | TransmitModel.txOwnerSlot tests | 1 |
+| `tests/tst_app_settings_vax_migration.cpp` | Settings migration test | 1 |
+| `tests/tst_master_mixer.cpp` | MasterMixer unit tests | 2 |
+| `tests/tst_port_audio_bus.cpp` | PortAudioBus unit tests (Null device) | 3 |
+| `tests/tst_virtual_cable_detector.cpp` | Regex-match unit tests | 7 |
+| `tests/tst_vax_channel_selector.cpp` | Widget behaviour tests | 8 |
+
+### Files to modify
+
+| Path | Change | Sub-phase |
+|---|---|---|
+| `src/models/SliceModel.{h,cpp}` | Add `vaxChannel`, persistence, signal | 1 |
+| `src/models/TransmitModel.{h,cpp}` | Add `txOwnerSlot` + `VaxSlot` enum | 1 |
+| `src/core/AppSettings.{h,cpp}` | Schema migration helper | 1 |
+| `src/core/AudioEngine.{h,cpp}` | Replace QAudioSink-only with `IAudioBus` model | 4 |
+| `src/gui/VfoWidget.{h,cpp}` | Embed `VaxChannelSelector` | 8 |
+| `src/gui/MainWindow.{h,cpp}` | Wire `MasterOutputWidget` + first-run dialog trigger | 10, 11 |
+| `src/gui/SetupDialog.{h,cpp}` | Register `SetupAudioPage` | 12 |
+| `CMakeLists.txt` | Add PortAudio; conditionally add HAL subdir on macOS | 3, 5 |
+| `README.md` | Mention VAX routing in features | 14 |
+| `docs/attribution/aethersdr-contributor-index.md` | Add rows for ported files | 5, 6, 9 |
+| `docs/attribution/COMPLIANCE-INVENTORY.md` | Record Phase 3O ports + HAL plugin separate-binary reasoning | 14 |
+| `.github/workflows/release.yml` | Sign + notarize HAL plugin | 5 |
+
+---
+
+## Sub-Phase 1: Data Model Foundation 🟢
+
+### Task 1.1: `SliceModel.vaxChannel`
+
+**Files:**
+- Modify: `src/models/SliceModel.h`, `src/models/SliceModel.cpp`
+- Test: `tests/tst_slice_model_vax.cpp` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tst_slice_model_vax.cpp`:
+
+```cpp
+#include <QtTest/QtTest>
+#include "models/SliceModel.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstSliceModelVax : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultsToOff() {
+        SliceModel s(0);
+        QCOMPARE(s.vaxChannel(), 0);
+    }
+
+    void setAndGet() {
+        SliceModel s(0);
+        s.setVaxChannel(2);
+        QCOMPARE(s.vaxChannel(), 2);
+    }
+
+    void clampsOutOfRangeLow() {
+        SliceModel s(0);
+        s.setVaxChannel(-5);
+        QCOMPARE(s.vaxChannel(), 0);
+    }
+
+    void clampsOutOfRangeHigh() {
+        SliceModel s(0);
+        s.setVaxChannel(99);
+        QCOMPARE(s.vaxChannel(), 0);
+    }
+
+    void emitsSignalOnChange() {
+        SliceModel s(0);
+        QSignalSpy spy(&s, &SliceModel::vaxChannelChanged);
+        s.setVaxChannel(3);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toInt(), 3);
+    }
+
+    void noSignalOnSameValue() {
+        SliceModel s(0);
+        s.setVaxChannel(2);
+        QSignalSpy spy(&s, &SliceModel::vaxChannelChanged);
+        s.setVaxChannel(2);
+        QCOMPARE(spy.count(), 0);
+    }
+
+    void persistsToSettings() {
+        AppSettings::instance().clear();
+        SliceModel s(7);
+        s.setVaxChannel(4);
+        QCOMPARE(AppSettings::instance().value("slice/7/VaxChannel").toString(), "4");
+    }
+
+    void restoresFromSettings() {
+        AppSettings::instance().clear();
+        AppSettings::instance().setValue("slice/7/VaxChannel", "3");
+        SliceModel s(7);
+        s.loadFromSettings();
+        QCOMPARE(s.vaxChannel(), 3);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstSliceModelVax)
+#include "tst_slice_model_vax.moc"
+```
+
+Add to `tests/CMakeLists.txt`:
+
+```cmake
+qt_add_executable(tst_slice_model_vax tst_slice_model_vax.cpp)
+target_link_libraries(tst_slice_model_vax PRIVATE NereusSDRLib Qt6::Test)
+add_test(NAME tst_slice_model_vax COMMAND tst_slice_model_vax)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cmake --build build --target tst_slice_model_vax
+./build/tests/tst_slice_model_vax
+```
+
+Expected: FAIL — `vaxChannel` / `setVaxChannel` / `vaxChannelChanged` not defined.
+
+- [ ] **Step 3: Add API to `SliceModel.h`**
+
+In `src/models/SliceModel.h`, add under the existing properties section:
+
+```cpp
+    // VAX routing (Phase 3O) — 0=Off, 1..4=VAX channel.
+    int vaxChannel() const { return m_vaxChannel.load(std::memory_order_acquire); }
+    void setVaxChannel(int ch);
+
+signals:
+    void vaxChannelChanged(int ch);
+
+private:
+    std::atomic<int> m_vaxChannel{0};
+```
+
+Also include `<atomic>` at the top of the file if not already present.
+
+- [ ] **Step 4: Implement setter + persistence in `SliceModel.cpp`**
+
+```cpp
+void SliceModel::setVaxChannel(int ch) {
+    // Clamp to valid range.
+    if (ch < 0 || ch > 4) { ch = 0; }
+
+    const int prev = m_vaxChannel.exchange(ch, std::memory_order_acq_rel);
+    if (prev == ch) { return; }
+
+    AppSettings::instance().setValue(
+        QStringLiteral("slice/%1/VaxChannel").arg(m_sliceId),
+        QString::number(ch));
+    AppSettings::instance().save();
+
+    emit vaxChannelChanged(ch);
+}
+```
+
+In `SliceModel::loadFromSettings()` (existing method), add:
+
+```cpp
+    const int vaxCh = AppSettings::instance()
+        .value(QStringLiteral("slice/%1/VaxChannel").arg(m_sliceId), "0")
+        .toString().toInt();
+    if (vaxCh != m_vaxChannel.load()) {
+        m_vaxChannel.store(vaxCh, std::memory_order_release);
+        emit vaxChannelChanged(vaxCh);
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cmake --build build --target tst_slice_model_vax
+./build/tests/tst_slice_model_vax
+```
+
+Expected: PASS — all 8 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/models/SliceModel.h src/models/SliceModel.cpp \
+        tests/tst_slice_model_vax.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(slice-model): add vaxChannel property for VAX routing
+
+Per-slice VAX channel (0=Off, 1..4=VAX 1–4) with std::atomic storage
+for audio-thread-safe reads, AppSettings persistence under
+slice/<id>/VaxChannel, and vaxChannelChanged signal. Feeds the
+AudioEngine VAX tap routing in Phase 3O.
+
+Design spec: docs/architecture/2026-04-19-vax-design.md §5.1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 1.2: `TransmitModel.txOwnerSlot` + `VaxSlot` enum
+
+**Files:**
+- Modify: `src/models/TransmitModel.h`, `src/models/TransmitModel.cpp`
+- Test: `tests/tst_transmit_model_tx_owner.cpp` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tst_transmit_model_tx_owner.cpp`:
+
+```cpp
+#include <QtTest/QtTest>
+#include "models/TransmitModel.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstTransmitModelTxOwner : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultsToMicDirect() {
+        TransmitModel t;
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::MicDirect);
+    }
+
+    void setAndGet() {
+        TransmitModel t;
+        t.setTxOwnerSlot(VaxSlot::Vax2);
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::Vax2);
+    }
+
+    void emitsSignalOnChange() {
+        TransmitModel t;
+        QSignalSpy spy(&t, &TransmitModel::txOwnerSlotChanged);
+        t.setTxOwnerSlot(VaxSlot::Vax3);
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void persistsToSettings() {
+        AppSettings::instance().clear();
+        TransmitModel t;
+        t.setTxOwnerSlot(VaxSlot::Vax4);
+        QCOMPARE(AppSettings::instance().value("tx/OwnerSlot").toString(), "Vax4");
+    }
+
+    void restoresFromSettings() {
+        AppSettings::instance().clear();
+        AppSettings::instance().setValue("tx/OwnerSlot", "Vax1");
+        TransmitModel t;
+        t.loadFromSettings();
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::Vax1);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstTransmitModelTxOwner)
+#include "tst_transmit_model_tx_owner.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+```bash
+cmake --build build --target tst_transmit_model_tx_owner
+./build/tests/tst_transmit_model_tx_owner
+```
+
+Expected: FAIL (VaxSlot enum, txOwnerSlot API undefined).
+
+- [ ] **Step 3: Define `VaxSlot` enum + API in `TransmitModel.h`**
+
+```cpp
+namespace NereusSDR {
+
+enum class VaxSlot {
+    None = 0,
+    MicDirect,
+    Vax1,
+    Vax2,
+    Vax3,
+    Vax4
+};
+
+QString vaxSlotToString(VaxSlot s);
+VaxSlot vaxSlotFromString(const QString& s);
+
+class TransmitModel : public QObject {
+    // ... existing ...
+public:
+    VaxSlot txOwnerSlot() const { return m_txOwnerSlot.load(std::memory_order_acquire); }
+    void setTxOwnerSlot(VaxSlot s);
+
+    void loadFromSettings();
+
+signals:
+    void txOwnerSlotChanged(VaxSlot s);
+
+private:
+    std::atomic<VaxSlot> m_txOwnerSlot{VaxSlot::MicDirect};
+};
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 4: Implement in `TransmitModel.cpp`**
+
+```cpp
+QString NereusSDR::vaxSlotToString(VaxSlot s) {
+    switch (s) {
+        case VaxSlot::None:       return "None";
+        case VaxSlot::MicDirect:  return "MicDirect";
+        case VaxSlot::Vax1:       return "Vax1";
+        case VaxSlot::Vax2:       return "Vax2";
+        case VaxSlot::Vax3:       return "Vax3";
+        case VaxSlot::Vax4:       return "Vax4";
+    }
+    return "MicDirect";
+}
+
+NereusSDR::VaxSlot NereusSDR::vaxSlotFromString(const QString& s) {
+    if (s == "None")      return VaxSlot::None;
+    if (s == "Vax1")      return VaxSlot::Vax1;
+    if (s == "Vax2")      return VaxSlot::Vax2;
+    if (s == "Vax3")      return VaxSlot::Vax3;
+    if (s == "Vax4")      return VaxSlot::Vax4;
+    return VaxSlot::MicDirect;
+}
+
+void TransmitModel::setTxOwnerSlot(VaxSlot s) {
+    const VaxSlot prev = m_txOwnerSlot.exchange(s, std::memory_order_acq_rel);
+    if (prev == s) { return; }
+
+    AppSettings::instance().setValue("tx/OwnerSlot", vaxSlotToString(s));
+    AppSettings::instance().save();
+
+    emit txOwnerSlotChanged(s);
+}
+
+void TransmitModel::loadFromSettings() {
+    const QString v = AppSettings::instance().value("tx/OwnerSlot", "MicDirect").toString();
+    const VaxSlot s = vaxSlotFromString(v);
+    if (s != m_txOwnerSlot.load()) {
+        m_txOwnerSlot.store(s, std::memory_order_release);
+        emit txOwnerSlotChanged(s);
+    }
+}
+```
+
+- [ ] **Step 5: Run to pass**
+
+```bash
+./build/tests/tst_transmit_model_tx_owner
+```
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/models/TransmitModel.h src/models/TransmitModel.cpp \
+        tests/tst_transmit_model_tx_owner.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(transmit-model): add txOwnerSlot + VaxSlot enum
+
+Single-owner TX arbitration between MicDirect and VAX 1–4. Atomic
+storage for audio-thread-safe reads, persisted under tx/OwnerSlot.
+Feeds AudioEngine TX pull routing in Phase 3O.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 1.3: AppSettings schema + legacy migration
+
+**Files:**
+- Modify: `src/core/AppSettings.h`, `src/core/AppSettings.cpp`
+- Test: `tests/tst_app_settings_vax_migration.cpp` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```cpp
+#include <QtTest/QtTest>
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstAppSettingsVaxMigration : public QObject {
+    Q_OBJECT
+private slots:
+    void migratesLegacyOutputDeviceKey() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/OutputDevice", "Built-in Output");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        QCOMPARE(s.value("audio/Speakers/DeviceName").toString(),
+                 QStringLiteral("Built-in Output"));
+        QVERIFY(!s.contains("audio/OutputDevice"));
+        QCOMPARE(s.value("audio/FirstRunComplete", "True").toString(), "False");
+    }
+
+    void doesNothingIfNoLegacyKey() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/Speakers/DeviceName", "Already set");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        QCOMPARE(s.value("audio/Speakers/DeviceName").toString(),
+                 QStringLiteral("Already set"));
+    }
+
+    void doesNothingIfAlreadyMigrated() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/OutputDevice", "Legacy");
+        s.setValue("audio/Speakers/DeviceName", "New");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        // Legacy key stays (we don't clobber a present new key)
+        QCOMPARE(s.value("audio/Speakers/DeviceName").toString(),
+                 QStringLiteral("New"));
+    }
+};
+
+QTEST_APPLESS_MAIN(TstAppSettingsVaxMigration)
+#include "tst_app_settings_vax_migration.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+```bash
+cmake --build build --target tst_app_settings_vax_migration
+./build/tests/tst_app_settings_vax_migration
+```
+
+Expected: FAIL — `migrateVaxSchemaV1ToV2` undefined.
+
+- [ ] **Step 3: Add migration helper**
+
+In `src/core/AppSettings.h`:
+
+```cpp
+class AppSettings {
+public:
+    // ... existing ...
+
+    // Phase 3O VAX schema migration. Call once at app startup. Idempotent.
+    // Migrates legacy `audio/OutputDevice` → `audio/Speakers/DeviceName`
+    // and flags the first-run dialog to show.
+    static void migrateVaxSchemaV1ToV2();
+};
+```
+
+In `src/core/AppSettings.cpp`:
+
+```cpp
+void AppSettings::migrateVaxSchemaV1ToV2() {
+    auto& s = instance();
+    if (!s.contains("audio/OutputDevice")) { return; }
+    if (s.contains("audio/Speakers/DeviceName")) { return; }
+
+    const QString dev = s.value("audio/OutputDevice").toString();
+    s.setValue("audio/Speakers/DeviceName", dev);
+
+    // Platform-default API. Keep this conservative; user can tune later.
+#if defined(Q_OS_WIN)
+    s.setValue("audio/Speakers/DriverApi", "WASAPI");
+#elif defined(Q_OS_MAC)
+    s.setValue("audio/Speakers/DriverApi", "CoreAudio");
+#else
+    s.setValue("audio/Speakers/DriverApi", "Pulse");
+#endif
+    s.setValue("audio/Speakers/SampleRate", "48000");
+    s.setValue("audio/Speakers/BitDepth", "24");
+    s.setValue("audio/Speakers/Channels", "2");
+    s.setValue("audio/Speakers/BufferSamples", "256");
+
+    // Trigger first-run dialog on next launch.
+    s.setValue("audio/FirstRunComplete", "False");
+
+    s.remove("audio/OutputDevice");
+    s.save();
+}
+```
+
+- [ ] **Step 4: Run to pass**
+
+```bash
+./build/tests/tst_app_settings_vax_migration
+```
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Hook migration into app startup**
+
+In `src/gui/MainWindow.cpp` constructor (or `main.cpp` — wherever the first AppSettings access happens), add **at the top, before any other AppSettings reads**:
+
+```cpp
+    AppSettings::migrateVaxSchemaV1ToV2();
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/AppSettings.h src/core/AppSettings.cpp \
+        src/gui/MainWindow.cpp \
+        tests/tst_app_settings_vax_migration.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(app-settings): add VAX schema migration helper
+
+Phase 3O adds a per-device / per-VAX / per-slice audio schema. This
+change introduces migrateVaxSchemaV1ToV2() — idempotent one-shot that
+moves legacy audio/OutputDevice into audio/Speakers/DeviceName with
+sensible platform defaults and flags the first-run dialog to show.
+
+Called from MainWindow::MainWindow before any other AppSettings access.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Sub-Phase 2: IAudioBus Abstraction + MasterMixer 🟠
+
+### Task 2.1: `IAudioBus.h` interface
+
+**Files:**
+- Create: `src/core/IAudioBus.h`
+
+- [ ] **Step 1: Write the interface**
+
+```cpp
+// =================================================================
+// src/core/IAudioBus.h  (NereusSDR)
+// =================================================================
+//
+// Phase 3O abstract audio bus. Five concrete implementations (see
+// src/core/audio/): CoreAudioHalBus, LinuxPipeBus, PortAudioBus,
+// DirectAsioBus, CoreAudioBus.
+//
+// Design spec: docs/architecture/2026-04-19-vax-design.md §3.2
+// =================================================================
+
+#pragma once
+
+#include <QString>
+#include <cstdint>
+
+namespace NereusSDR {
+
+struct AudioFormat {
+    int sampleRate = 48000;  // Hz
+    int channels   = 2;       // 1 or 2
+    enum class Sample { Float32, Int16, Int24, Int32 } sample = Sample::Float32;
+
+    bool operator==(const AudioFormat& o) const {
+        return sampleRate == o.sampleRate && channels == o.channels && sample == o.sample;
+    }
+    bool operator!=(const AudioFormat& o) const { return !(*this == o); }
+};
+
+class IAudioBus {
+public:
+    virtual ~IAudioBus() = default;
+
+    // Lifecycle. open() returns false on failure; errorString() has details.
+    virtual bool open(const AudioFormat& format) = 0;
+    virtual void close() = 0;
+    virtual bool isOpen() const = 0;
+
+    // Producer side (RX taps). Interleaved PCM bytes. Returns bytes actually
+    // written, or -1 on error. Must be callable from the audio thread.
+    virtual qint64 push(const char* data, qint64 bytes) = 0;
+
+    // Consumer side (TX). Returns bytes read, or -1 on error. Audio-thread safe.
+    virtual qint64 pull(char* data, qint64 maxBytes) = 0;
+
+    // Metering (RMS of last block). 0.0–1.0. Published atomically for UI.
+    virtual float rxLevel() const = 0;
+    virtual float txLevel() const = 0;
+
+    // Diagnostics.
+    virtual QString backendName() const = 0;
+    virtual AudioFormat negotiatedFormat() const = 0;
+    virtual QString errorString() const { return {}; }
+};
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/core/IAudioBus.h
+git commit -S -m "$(cat <<'EOF'
+feat(audio): add IAudioBus abstract interface
+
+Contract for every audio backend in Phase 3O. Five concrete
+implementations follow in subsequent tasks (CoreAudioHalBus,
+LinuxPipeBus, PortAudioBus, DirectAsioBus, CoreAudioBus).
+
+Design spec §3.2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.2: `MasterMixer` — per-slice mute/volume/pan
+
+**Files:**
+- Create: `src/core/audio/MasterMixer.h`, `src/core/audio/MasterMixer.cpp`
+- Test: `tests/tst_master_mixer.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+```cpp
+#include <QtTest/QtTest>
+#include "core/audio/MasterMixer.h"
+#include <array>
+
+using namespace NereusSDR;
+
+class TstMasterMixer : public QObject {
+    Q_OBJECT
+private slots:
+    void emptyMixIsSilent() {
+        MasterMixer mix;
+        std::array<float, 16> out{};
+        mix.mixInto(out.data(), 8);
+        for (float s : out) { QCOMPARE(s, 0.0f); }
+    }
+
+    void singleSliceUnityGainMixesThrough() {
+        MasterMixer mix;
+        mix.setSliceGain(42, 1.0f, 0.0f);  // unity, center
+        std::array<float, 4> in = {0.5f, 0.5f, -0.25f, -0.25f};  // 2 frames stereo
+        mix.accumulate(42, in.data(), 2);
+        std::array<float, 4> out{};
+        mix.mixInto(out.data(), 2);
+        QCOMPARE(out[0], 0.5f);
+        QCOMPARE(out[1], 0.5f);
+        QCOMPARE(out[2], -0.25f);
+        QCOMPARE(out[3], -0.25f);
+    }
+
+    void twoSlicesSumLinearly() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, 0.0f);
+        mix.setSliceGain(2, 1.0f, 0.0f);
+        std::array<float, 2> a = {0.3f, 0.3f};
+        std::array<float, 2> b = {0.4f, 0.4f};
+        mix.accumulate(1, a.data(), 1);
+        mix.accumulate(2, b.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QCOMPARE(out[0], 0.7f);
+        QCOMPARE(out[1], 0.7f);
+    }
+
+    void panFullLeftSuppressesRight() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, -1.0f);  // full left
+        std::array<float, 2> in = {0.5f, 0.5f};
+        mix.accumulate(1, in.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QVERIFY(out[0] > 0.4f);
+        QCOMPARE(out[1], 0.0f);
+    }
+
+    void muteZerosContribution() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, 0.0f);
+        mix.setSliceMuted(1, true);
+        std::array<float, 2> in = {0.9f, 0.9f};
+        mix.accumulate(1, in.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QCOMPARE(out[0], 0.0f);
+        QCOMPARE(out[1], 0.0f);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstMasterMixer)
+#include "tst_master_mixer.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+Expected: FAIL — MasterMixer undefined.
+
+- [ ] **Step 3: Implement `MasterMixer`**
+
+`src/core/audio/MasterMixer.h`:
+
+```cpp
+#pragma once
+
+#include <atomic>
+#include <unordered_map>
+#include <vector>
+#include <mutex>
+
+namespace NereusSDR {
+
+// Audio-thread-safe per-slice mixing. Producers call accumulate() from the
+// audio thread (one call per slice per block); consumer calls mixInto() once
+// per block to flush the accumulator to the output buffer.
+class MasterMixer {
+public:
+    // UI thread: set per-slice gain and pan. Safe to call anytime.
+    void setSliceGain(int sliceId, float gain /*0..1*/, float pan /*-1..+1*/);
+    void setSliceMuted(int sliceId, bool muted);
+    void removeSlice(int sliceId);
+
+    // Audio thread: accumulate a slice's stereo block. samples is
+    // interleaved L/R float32. frames = sample pairs.
+    void accumulate(int sliceId, const float* samples, int frames);
+
+    // Audio thread: flush the accumulated mix into out and reset.
+    // out is interleaved L/R float32.
+    void mixInto(float* out, int frames);
+
+private:
+    struct SliceState {
+        std::atomic<float> gain{1.0f};
+        std::atomic<float> pan{0.0f};
+        std::atomic<bool>  muted{false};
+    };
+
+    std::unordered_map<int, SliceState> m_slices;
+    std::mutex m_sliceMapMutex;  // Only held on UI-thread map mutation.
+
+    std::vector<float> m_acc;  // Audio-thread-only; resized on-demand.
+};
+
+} // namespace NereusSDR
+```
+
+`src/core/audio/MasterMixer.cpp`:
+
+```cpp
+#include "MasterMixer.h"
+#include <algorithm>
+#include <cmath>
+
+using namespace NereusSDR;
+
+void MasterMixer::setSliceGain(int sliceId, float gain, float pan) {
+    std::lock_guard<std::mutex> lk(m_sliceMapMutex);
+    auto& st = m_slices[sliceId];
+    st.gain.store(std::clamp(gain, 0.0f, 1.0f), std::memory_order_release);
+    st.pan.store(std::clamp(pan, -1.0f, 1.0f), std::memory_order_release);
+}
+
+void MasterMixer::setSliceMuted(int sliceId, bool muted) {
+    std::lock_guard<std::mutex> lk(m_sliceMapMutex);
+    m_slices[sliceId].muted.store(muted, std::memory_order_release);
+}
+
+void MasterMixer::removeSlice(int sliceId) {
+    std::lock_guard<std::mutex> lk(m_sliceMapMutex);
+    m_slices.erase(sliceId);
+}
+
+void MasterMixer::accumulate(int sliceId, const float* samples, int frames) {
+    // Lookup slice state. The map *itself* is mutex-guarded for structural
+    // changes, but we do not want to hold the mutex in the audio thread. We
+    // read the atomics directly; find() is lock-free against unchanged buckets.
+    auto it = m_slices.find(sliceId);
+    if (it == m_slices.end()) { return; }
+
+    const auto& st = it->second;
+    if (st.muted.load(std::memory_order_acquire)) { return; }
+
+    const float gain = st.gain.load(std::memory_order_acquire);
+    const float pan  = st.pan.load(std::memory_order_acquire);
+
+    // Equal-power pan law.
+    const float lGain = gain * std::cos((pan + 1.0f) * 0.25f * 3.14159265f);
+    const float rGain = gain * std::sin((pan + 1.0f) * 0.25f * 3.14159265f);
+
+    if ((int)m_acc.size() < frames * 2) {
+        m_acc.resize(frames * 2, 0.0f);
+    }
+    for (int i = 0; i < frames; ++i) {
+        m_acc[i * 2 + 0] += samples[i * 2 + 0] * lGain;
+        m_acc[i * 2 + 1] += samples[i * 2 + 1] * rGain;
+    }
+}
+
+void MasterMixer::mixInto(float* out, int frames) {
+    const int n = frames * 2;
+    if ((int)m_acc.size() < n) {
+        // No one accumulated this block; output silence.
+        std::fill(out, out + n, 0.0f);
+        return;
+    }
+    std::copy(m_acc.begin(), m_acc.begin() + n, out);
+    std::fill(m_acc.begin(), m_acc.begin() + n, 0.0f);
+}
+```
+
+**Note on the find() safety:** `std::unordered_map::find()` is not strictly lock-free — if the UI thread inserts a new slice while the audio thread is in `find()`, behavior is undefined. For this plan, slice creation/removal happens rarely and on app startup/radio-connect. The mutex guards the structural mutations. If this proves racy in practice, swap to `folly::ConcurrentHashMap` or a pre-allocated slice array (max-slices = 8 per ANAN board cap).
+
+- [ ] **Step 4: Run to pass**
+
+```bash
+./build/tests/tst_master_mixer
+```
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/audio/MasterMixer.h src/core/audio/MasterMixer.cpp \
+        tests/tst_master_mixer.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(audio): add MasterMixer for per-slice mute/volume/pan
+
+Accumulator + flush model: audio thread calls accumulate() once per
+slice per block, then mixInto() once to flush. Equal-power pan law,
+atomic per-slice parameters, one mutex only on slice-map structural
+changes (not in the audio hot path).
+
+Design spec §3.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Sub-Phase 3: PortAudio Engine 🟠
+
+### Task 3.1: Vendor PortAudio v19
+
+**Files:**
+- Modify: `CMakeLists.txt`
+- Create: `third_party/portaudio/` (subtree or FetchContent)
+
+- [ ] **Step 1: Add PortAudio via CMake FetchContent**
+
+Append to top-level `CMakeLists.txt`, after the existing `find_package(Qt6 ...)`:
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+    portaudio
+    GIT_REPOSITORY https://github.com/PortAudio/portaudio.git
+    GIT_TAG        v19.7.0  # verified cmake-clean release
+)
+
+# PortAudio build options — turn off ASIO (we handle it opt-in via ASIO SDK
+# separately in Sub-Phase 13), keep platform default host APIs on.
+set(PA_BUILD_SHARED OFF CACHE BOOL "PortAudio static" FORCE)
+set(PA_BUILD_STATIC ON  CACHE BOOL "PortAudio static" FORCE)
+set(PA_USE_ASIO    OFF CACHE BOOL "PortAudio disable PA-ASIO (we use SDK direct)" FORCE)
+
+FetchContent_MakeAvailable(portaudio)
+```
+
+Add to the NereusSDR main executable link:
+
+```cmake
+target_link_libraries(NereusSDRLib PRIVATE portaudio_static)
+target_include_directories(NereusSDRLib PRIVATE ${portaudio_SOURCE_DIR}/include)
+```
+
+- [ ] **Step 2: Build and confirm PortAudio links**
+
+```bash
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build
+```
+
+Expected: builds without error; `libportaudio_static.a` appears in `build/_deps/portaudio-build/`.
+
+- [ ] **Step 3: Verify PortAudio's license is GPL-3 compatible**
+
+```bash
+cat build/_deps/portaudio-src/LICENSE.txt | head -40
+```
+
+Expected: MIT-style permissive license (Ross Bencina / Phil Burk 1999+). If the text is anything other than the well-known PortAudio MIT-style grant, STOP and surface to project maintainer before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+build: vendor PortAudio v19.7.0 via FetchContent
+
+Static-link, PA_USE_ASIO off (handled separately via Steinberg SDK in
+Sub-Phase 13). Gives us cross-platform audio API coverage: MME / DS /
+WDM-KS / WASAPI on Windows, CoreAudio on Mac, ALSA / Pulse / PipeWire /
+JACK on Linux via PortAudio's host APIs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3.2: `PortAudioBus` minimal open/close
+
+**Files:**
+- Create: `src/core/audio/PortAudioBus.h`, `.cpp`
+- Test: `tests/tst_port_audio_bus.cpp`
+
+- [ ] **Step 1: Write the failing test (uses PortAudio null device)**
+
+```cpp
+#include <QtTest/QtTest>
+#include "core/audio/PortAudioBus.h"
+#include <portaudio.h>
+
+using namespace NereusSDR;
+
+class TstPortAudioBus : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase() {
+        Pa_Initialize();
+    }
+    void cleanupTestCase() {
+        Pa_Terminate();
+    }
+
+    void constructsClosed() {
+        PortAudioBus bus;
+        QVERIFY(!bus.isOpen());
+    }
+
+    void openSucceedsOnDefaultDevice() {
+        PortAudioBus bus;
+        AudioFormat f;
+        QVERIFY2(bus.open(f), qPrintable(bus.errorString()));
+        QVERIFY(bus.isOpen());
+        bus.close();
+        QVERIFY(!bus.isOpen());
+    }
+
+    void negotiatedFormatReflectsDevice() {
+        PortAudioBus bus;
+        AudioFormat f; f.sampleRate = 48000; f.channels = 2;
+        bus.open(f);
+        QVERIFY(bus.negotiatedFormat().sampleRate > 0);
+        bus.close();
+    }
+
+    void backendNameIdentifiesAPI() {
+        PortAudioBus bus;
+        bus.open(AudioFormat{});
+        const QString n = bus.backendName();
+        QVERIFY(!n.isEmpty());
+        bus.close();
+    }
+};
+
+QTEST_APPLESS_MAIN(TstPortAudioBus)
+#include "tst_port_audio_bus.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+Expected: FAIL — `PortAudioBus` undefined.
+
+- [ ] **Step 3: Implement `PortAudioBus` (render-only, minimal)**
+
+`src/core/audio/PortAudioBus.h`:
+
+```cpp
+#pragma once
+#include "core/IAudioBus.h"
+#include <atomic>
+#include <vector>
+#include <mutex>
+
+typedef void PaStream;  // forward decl
+struct PaDeviceInfo;
+
+namespace NereusSDR {
+
+struct PortAudioConfig {
+    int     hostApiIndex = -1;     // -1 = PortAudio default
+    QString deviceName;             // empty = default
+    int     bufferSamples = 256;
+    bool    exclusiveMode = false; // WASAPI only
+    // Additional fields added in Tasks 3.3/3.4.
+};
+
+class PortAudioBus : public IAudioBus {
+public:
+    PortAudioBus();
+    ~PortAudioBus() override;
+
+    void setConfig(const PortAudioConfig& cfg);
+
+    bool open(const AudioFormat& format) override;
+    void close() override;
+    bool isOpen() const override { return m_stream != nullptr; }
+
+    qint64 push(const char* data, qint64 bytes) override;
+    qint64 pull(char* data, qint64 maxBytes) override;
+
+    float rxLevel() const override { return m_rxLevel.load(std::memory_order_acquire); }
+    float txLevel() const override { return m_txLevel.load(std::memory_order_acquire); }
+
+    QString     backendName() const override { return m_backendName; }
+    AudioFormat negotiatedFormat() const override { return m_negFormat; }
+    QString     errorString() const override { return m_err; }
+
+private:
+    PaStream*   m_stream{nullptr};
+    PortAudioConfig m_cfg;
+    AudioFormat m_negFormat;
+    QString     m_backendName;
+    QString     m_err;
+
+    // Ring buffer for push/pull. Audio thread reads from here.
+    std::vector<float> m_ring;
+    std::atomic<qint64> m_ringRead{0};
+    std::atomic<qint64> m_ringWrite{0};
+
+    std::atomic<float> m_rxLevel{0.0f};
+    std::atomic<float> m_txLevel{0.0f};
+
+    static int paCallback(const void* in, void* out,
+                          unsigned long frames,
+                          const void* timeInfo,
+                          unsigned long flags,
+                          void* userData);
+};
+
+} // namespace NereusSDR
+```
+
+`src/core/audio/PortAudioBus.cpp`:
+
+```cpp
+#include "PortAudioBus.h"
+#include <portaudio.h>
+#include <cmath>
+#include <cstring>
+#include <algorithm>
+
+using namespace NereusSDR;
+
+PortAudioBus::PortAudioBus() {
+    m_ring.resize(48000 * 2);  // 1 second stereo float ring
+}
+
+PortAudioBus::~PortAudioBus() {
+    close();
+}
+
+void PortAudioBus::setConfig(const PortAudioConfig& cfg) {
+    m_cfg = cfg;
+}
+
+bool PortAudioBus::open(const AudioFormat& format) {
+    if (m_stream) { close(); }
+
+    PaStreamParameters outParams;
+    outParams.device = Pa_GetDefaultOutputDevice();
+    if (outParams.device == paNoDevice) {
+        m_err = "No default output device";
+        return false;
+    }
+
+    const PaDeviceInfo* di = Pa_GetDeviceInfo(outParams.device);
+    outParams.channelCount = format.channels;
+    outParams.sampleFormat = paFloat32;
+    outParams.suggestedLatency = di->defaultLowOutputLatency;
+    outParams.hostApiSpecificStreamInfo = nullptr;
+
+    const PaError err = Pa_OpenStream(
+        &m_stream, nullptr, &outParams,
+        format.sampleRate, m_cfg.bufferSamples,
+        paClipOff, &PortAudioBus::paCallback, this);
+
+    if (err != paNoError) {
+        m_err = Pa_GetErrorText(err);
+        m_stream = nullptr;
+        return false;
+    }
+
+    Pa_StartStream(m_stream);
+    m_negFormat = format;
+    m_backendName = Pa_GetHostApiInfo(di->hostApi)->name;
+    return true;
+}
+
+void PortAudioBus::close() {
+    if (!m_stream) { return; }
+    Pa_StopStream(m_stream);
+    Pa_CloseStream(m_stream);
+    m_stream = nullptr;
+}
+
+qint64 PortAudioBus::push(const char* data, qint64 bytes) {
+    const int floatCount = bytes / sizeof(float);
+    const qint64 ringSize = (qint64)m_ring.size();
+    qint64 w = m_ringWrite.load(std::memory_order_relaxed);
+    const float* in = reinterpret_cast<const float*>(data);
+    float peak = 0.0f;
+    for (int i = 0; i < floatCount; ++i) {
+        m_ring[w % ringSize] = in[i];
+        w++;
+        peak = std::max(peak, std::abs(in[i]));
+    }
+    m_ringWrite.store(w, std::memory_order_release);
+    m_rxLevel.store(peak, std::memory_order_release);
+    return bytes;
+}
+
+qint64 PortAudioBus::pull(char* /*data*/, qint64 /*maxBytes*/) {
+    // Not implemented in this task; TX path wired in Sub-Phase 4.
+    return 0;
+}
+
+int PortAudioBus::paCallback(const void* /*in*/, void* out,
+                             unsigned long frames,
+                             const void* /*timeInfo*/,
+                             unsigned long /*flags*/,
+                             void* userData) {
+    auto* self = static_cast<PortAudioBus*>(userData);
+    float* o = static_cast<float*>(out);
+    const int want = (int)frames * self->m_negFormat.channels;
+
+    const qint64 ringSize = (qint64)self->m_ring.size();
+    qint64 r = self->m_ringRead.load(std::memory_order_relaxed);
+    const qint64 w = self->m_ringWrite.load(std::memory_order_acquire);
+
+    for (int i = 0; i < want; ++i) {
+        if (r < w) {
+            o[i] = self->m_ring[r % ringSize];
+            r++;
+        } else {
+            o[i] = 0.0f;  // underrun → silence
+        }
+    }
+    self->m_ringRead.store(r, std::memory_order_release);
+    return paContinue;
+}
+```
+
+- [ ] **Step 4: Run to pass**
+
+```bash
+./build/tests/tst_port_audio_bus
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/audio/PortAudioBus.h src/core/audio/PortAudioBus.cpp \
+        tests/tst_port_audio_bus.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(audio): add PortAudioBus render-only minimal implementation
+
+Opens PortAudio default output device, accepts push() from main
+thread into a lock-free ring, drains the ring in paCallback on the
+audio thread. Peak-level metering published atomically. TX pull and
+full host-API/device picker come in Tasks 3.3 and 3.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3.3: Host API + device enumeration
+
+**Files:**
+- Modify: `src/core/audio/PortAudioBus.h`, `.cpp`
+
+- [ ] **Step 1: Add enumeration helpers**
+
+Add to `PortAudioBus.h`:
+
+```cpp
+    struct HostApiInfo {
+        int     index;
+        QString name;
+    };
+    struct DeviceInfo {
+        int     index;
+        QString name;
+        int     maxOutputChannels;
+        int     maxInputChannels;
+        int     defaultSampleRate;
+        int     hostApiIndex;
+    };
+
+    static QVector<HostApiInfo> hostApis();
+    static QVector<DeviceInfo>  outputDevicesFor(int hostApiIndex);
+    static QVector<DeviceInfo>  inputDevicesFor(int hostApiIndex);
+```
+
+Implement in `.cpp`:
+
+```cpp
+QVector<PortAudioBus::HostApiInfo> PortAudioBus::hostApis() {
+    QVector<HostApiInfo> out;
+    const int n = Pa_GetHostApiCount();
+    for (int i = 0; i < n; ++i) {
+        const PaHostApiInfo* h = Pa_GetHostApiInfo(i);
+        if (h) { out.push_back({i, QString::fromUtf8(h->name)}); }
+    }
+    return out;
+}
+
+QVector<PortAudioBus::DeviceInfo> PortAudioBus::outputDevicesFor(int hostApiIndex) {
+    QVector<DeviceInfo> out;
+    const int n = Pa_GetDeviceCount();
+    for (int i = 0; i < n; ++i) {
+        const PaDeviceInfo* d = Pa_GetDeviceInfo(i);
+        if (!d || d->hostApi != hostApiIndex || d->maxOutputChannels <= 0) { continue; }
+        out.push_back({
+            i, QString::fromUtf8(d->name),
+            d->maxOutputChannels, d->maxInputChannels,
+            (int)d->defaultSampleRate, d->hostApi
+        });
+    }
+    return out;
+}
+
+QVector<PortAudioBus::DeviceInfo> PortAudioBus::inputDevicesFor(int hostApiIndex) {
+    QVector<DeviceInfo> out;
+    const int n = Pa_GetDeviceCount();
+    for (int i = 0; i < n; ++i) {
+        const PaDeviceInfo* d = Pa_GetDeviceInfo(i);
+        if (!d || d->hostApi != hostApiIndex || d->maxInputChannels <= 0) { continue; }
+        out.push_back({
+            i, QString::fromUtf8(d->name),
+            d->maxOutputChannels, d->maxInputChannels,
+            (int)d->defaultSampleRate, d->hostApi
+        });
+    }
+    return out;
+}
+```
+
+- [ ] **Step 2: Extend the test**
+
+Append to `tests/tst_port_audio_bus.cpp`:
+
+```cpp
+    void hostApisEnumerateNonEmpty() {
+        const auto apis = PortAudioBus::hostApis();
+        QVERIFY(!apis.isEmpty());
+    }
+
+    void outputDevicesEnumerateForFirstApi() {
+        const auto apis = PortAudioBus::hostApis();
+        QVERIFY(!apis.isEmpty());
+        const auto devices = PortAudioBus::outputDevicesFor(apis.first().index);
+        // Host system should have at least one output; skip if headless CI.
+        if (devices.isEmpty()) { QSKIP("No output devices on test host"); }
+    }
+```
+
+- [ ] **Step 3: Run to pass**
+
+```bash
+cmake --build build --target tst_port_audio_bus
+./build/tests/tst_port_audio_bus
+```
+
+Expected: PASS (6 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/audio/PortAudioBus.h src/core/audio/PortAudioBus.cpp \
+        tests/tst_port_audio_bus.cpp
+git commit -S -m "feat(audio): PortAudioBus — host API and device enumeration
+
+Needed by SetupAudioPage for the Driver API and Device combos.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 3.4: TX capture support (open input stream + pull)
+
+- [ ] **Step 1: Extend `PortAudioBus::open` to support input-only or duplex**
+
+Modify `open` to branch on `format.channels` and `m_cfg` direction. Add a `PortAudioConfig::direction` enum `{ Output, Input }`. Reuse ring buffer in opposite direction for input.
+
+(Implementation follows the same pattern as Step 3 of Task 3.2 but with `paInputParameters` + reading from input stream into the ring, and `pull()` reading from the ring.)
+
+- [ ] **Step 2: Test with default input device (skip on CI without mic)**
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Sub-Phase 4: AudioEngine Refactor 🟠
+
+### Task 4.1: AudioEngine holds IAudioBus instances instead of QAudioSink
+
+**Files:**
+- Modify: `src/core/AudioEngine.h`, `.cpp`
+
+- [ ] **Step 1: Add bus ownership and slot setters**
+
+In `AudioEngine.h`:
+
+```cpp
+    // Phase 3O: per-endpoint IAudioBus ownership.
+    void setSpeakersConfig(const AudioDeviceConfig& cfg);
+    void setTxInputConfig(const AudioDeviceConfig& cfg);
+    void setVaxConfig(int channel, const AudioDeviceConfig& cfg);  // 1..4
+    void setVaxEnabled(int channel, bool on);
+
+    // Called by ReceiverManager when a slice produces an RX audio block.
+    void rxBlockReady(int sliceId, const float* samples, int frames);
+
+private:
+    std::unique_ptr<IAudioBus> m_speakersBus;
+    std::unique_ptr<IAudioBus> m_txInputBus;
+    std::array<std::unique_ptr<IAudioBus>, 4> m_vaxBus;
+    MasterMixer m_masterMix;
+```
+
+- [ ] **Step 2: Implement `rxBlockReady` routing**
+
+Per spec §3.4:
+
+```cpp
+void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames) {
+    auto* slice = m_radio->sliceModel(sliceId);
+    if (!slice) { return; }
+
+    if (!slice->audioMuted()) {
+        m_masterMix.accumulate(sliceId, samples, frames);
+    }
+
+    const int vaxCh = slice->vaxChannel();
+    if (vaxCh >= 1 && vaxCh <= 4 && m_vaxBus[vaxCh - 1] && m_vaxBus[vaxCh - 1]->isOpen()) {
+        m_vaxBus[vaxCh - 1]->push(
+            reinterpret_cast<const char*>(samples),
+            frames * 2 * sizeof(float));
+    }
+}
+```
+
+Add a timer-driven flush that pulls from `m_masterMix.mixInto()` into `m_speakersBus->push()` at the DSP block rate.
+
+- [ ] **Step 3: Replace old `QAudioSink` path**
+
+Remove the existing `QAudioSink m_sink` member and the 10ms timer-driven byte-buffer drain. Route speakers through `m_speakersBus`.
+
+- [ ] **Step 4: Build + smoke test (tune to a known station, hear audio)**
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Sub-Phase 5: macOS HAL Plugin 🟡
+
+### Task 5.1: Fork AetherSDR `hal-plugin/` into NereusSDR
+
+**Files:**
+- Create: `hal-plugin/NereusSDRVAX.cpp`
+- Create: `hal-plugin/CMakeLists.txt`
+- Create: `hal-plugin/Info.plist`
+
+- [ ] **Step 1: Copy files with rebrand**
+
+```bash
+mkdir -p hal-plugin
+cp ../AetherSDR/hal-plugin/AetherSDRDAX.cpp hal-plugin/NereusSDRVAX.cpp
+cp ../AetherSDR/hal-plugin/CMakeLists.txt hal-plugin/CMakeLists.txt
+cp ../AetherSDR/hal-plugin/Info.plist hal-plugin/Info.plist
+```
+
+- [ ] **Step 2: Prepend NereusSDR port-citation header to `.cpp`**
+
+Per `docs/attribution/HOW-TO-PORT.md` rule 6 (AetherSDR has no per-file GPL header):
+
+```cpp
+// =================================================================
+// hal-plugin/NereusSDRVAX.cpp  (NereusSDR)
+// =================================================================
+//
+// Ported from AetherSDR source:
+//   hal-plugin/AetherSDRDAX.cpp
+//
+// AetherSDR is licensed under the GNU General Public License v3; see
+// https://github.com/ten9876/AetherSDR for the contributor list and
+// project-level LICENSE. NereusSDR is also GPLv3. AetherSDR source
+// files carry no per-file GPL header; attribution is at project level
+// per AetherSDR convention.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-19 — Ported/adapted in C++20 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via
+//                 Anthropic Claude Code. Rebranded DAX → VAX: device
+//                 UIDs com.aethersdr.dax.* → com.nereussdr.vax.*, shm
+//                 paths /aethersdr-dax-* → /nereussdr-vax-*, device
+//                 names "AetherSDR DAX N" → "NereusSDR VAX N", factory
+//                 UUID regenerated.
+// =================================================================
+```
+
+- [ ] **Step 3: Global rebrand — string/UID/bundle changes**
+
+In `NereusSDRVAX.cpp`:
+
+```bash
+sed -i '' 's|/aethersdr-dax|/nereussdr-vax|g' hal-plugin/NereusSDRVAX.cpp
+sed -i '' 's|AetherSDR DAX|NereusSDR VAX|g' hal-plugin/NereusSDRVAX.cpp
+sed -i '' 's|com\.aethersdr\.dax|com.nereussdr.vax|g' hal-plugin/NereusSDRVAX.cpp
+sed -i '' 's|AetherSDRDAX|NereusSDRVAX|g' hal-plugin/NereusSDRVAX.cpp
+```
+
+In `Info.plist`: same `AetherSDR DAX → NereusSDR VAX`, `com.aethersdr.dax → com.nereussdr.vax`. **Generate a fresh CFPlugInFactories UUID** (macOS: `uuidgen`) to avoid collision if both AetherSDR and NereusSDR are installed on the same Mac.
+
+In `CMakeLists.txt`: bundle name `AetherSDRDAX.driver → NereusSDRVAX.driver`, target name rebranded.
+
+- [ ] **Step 4: Add hal-plugin as optional subdir in top-level CMakeLists.txt**
+
+```cmake
+if(APPLE AND NEREUSSDR_BUILD_HAL_PLUGIN)
+    add_subdirectory(hal-plugin)
+endif()
+```
+
+- [ ] **Step 5: Build the HAL plugin**
+
+```bash
+cmake -B build-hal -S hal-plugin -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build-hal
+```
+
+Expected: `build-hal/NereusSDRVAX.driver` bundle produced.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hal-plugin/ CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(hal-plugin): port AetherSDR HAL plugin as NereusSDR VAX driver
+
+4 VAX render devices + 1 TX capture device exposed as native macOS
+CoreAudio endpoints via libASPL userspace plugin. Rebranded from
+AetherSDR DAX: device UIDs, shm paths, factory UUID regenerated.
+macOS 14.4+ coreaudiod restart fallback added in Sub-Phase 5.2.
+
+Port attribution per HOW-TO-PORT.md rule 6 (AetherSDR has no per-file
+GPL header; project-level cite at header).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 5.2: Installer + macOS 14.4+ killall fallback
+
+**Files:**
+- Create: `packaging/macos/hal-installer.sh`
+- Create: `packaging/macos/hal-postinstall.sh`
+- Create: `packaging/macos/hal-uninstall.sh`
+
+- [ ] **Step 1: Port `build-installer.sh`**
+
+```bash
+cp ../AetherSDR/packaging/macos/build-installer.sh packaging/macos/hal-installer.sh
+sed -i '' 's|AetherSDR|NereusSDR|g; s|aethersdr|nereussdr|g' packaging/macos/hal-installer.sh
+```
+
+- [ ] **Step 2: Write postinstall with 14.4+ fallback**
+
+`packaging/macos/hal-postinstall.sh`:
+
+```bash
+#!/bin/bash
+# NereusSDR VAX HAL plugin — postinstall
+# On macOS 14.4+, launchctl kickstart of com.apple.audio.coreaudiod
+# returns "Operation not permitted"; fall back to killall.
+
+set -e
+
+launchctl kickstart -kp system/com.apple.audio.coreaudiod 2>/dev/null \
+  || sudo killall coreaudiod 2>/dev/null \
+  || true
+
+exit 0
+```
+
+- [ ] **Step 3: Write uninstall helper**
+
+```bash
+#!/bin/bash
+set -e
+sudo rm -rf "/Library/Audio/Plug-Ins/HAL/NereusSDRVAX.driver"
+rm -f /dev/shm/nereussdr-vax-* /dev/shm/nereussdr-tx 2>/dev/null || true
+sudo killall coreaudiod 2>/dev/null || true
+echo "NereusSDR VAX HAL plugin uninstalled."
+```
+
+- [ ] **Step 4: Run the installer build locally, verify `.pkg` produced**
+
+```bash
+bash packaging/macos/hal-installer.sh
+```
+
+Expected: `build/pkg-staging/NereusSDRVAX-<version>.pkg` created.
+
+- [ ] **Step 5: Commit**
+
+### Task 5.3: `CoreAudioHalBus` — shm writer from NereusSDR app side
+
+**Files:**
+- Create: `src/core/audio/CoreAudioHalBus.h`, `.cpp` (port of AetherSDR `VirtualAudioBridge`)
+
+- [ ] **Step 1: Copy + prepend port header**
+
+```bash
+cp ../AetherSDR/src/core/VirtualAudioBridge.h src/core/audio/CoreAudioHalBus.h
+cp ../AetherSDR/src/core/VirtualAudioBridge.cpp src/core/audio/CoreAudioHalBus.cpp
+```
+
+Prepend the same port-citation block as Task 5.1 to both files.
+
+- [ ] **Step 2: Rename class + rebrand**
+
+```bash
+sed -i '' 's|VirtualAudioBridge|CoreAudioHalBus|g' src/core/audio/CoreAudioHalBus.h src/core/audio/CoreAudioHalBus.cpp
+sed -i '' 's|/aethersdr-dax|/nereussdr-vax|g' src/core/audio/CoreAudioHalBus.cpp
+```
+
+- [ ] **Step 3: Adapt to `IAudioBus` interface**
+
+Replace the AetherSDR-specific public API (`feedDaxAudio`, `readTxAudio`) with `IAudioBus::push` / `pull`. Keep the shm-segment plumbing intact. Bridge the `daxRxLevel` signal to `m_rxLevel` atomic.
+
+- [ ] **Step 4: Build + smoke-test that writing to `/nereussdr-vax-1` is readable from the HAL plugin side**
+
+(Manual test: open WSJT-X, pick "NereusSDR VAX 1" as audio input, confirm it receives audio from NereusSDR.)
+
+- [ ] **Step 5: Commit**
+
+### Task 5.4: CI — sign + notarize HAL plugin in `release.yml`
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add macOS HAL plugin signing step**
+
+Append a job step to the macOS build matrix:
+
+```yaml
+      - name: Sign HAL plugin
+        run: |
+          codesign --force --options runtime --timestamp \
+            --sign "Developer ID Application: ${{ secrets.APPLE_DEVELOPER_ID }}" \
+            build-hal/NereusSDRVAX.driver
+      - name: Build signed .pkg
+        run: bash packaging/macos/hal-installer.sh
+      - name: Notarize
+        run: |
+          xcrun notarytool submit build/pkg-staging/NereusSDRVAX-*.pkg \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --password "${{ secrets.APPLE_APP_PASSWORD }}" \
+            --wait
+      - name: Staple
+        run: xcrun stapler staple build/pkg-staging/NereusSDRVAX-*.pkg
+```
+
+- [ ] **Step 2: Update `docs/attribution/aethersdr-contributor-index.md`**
+
+Add rows for `hal-plugin/NereusSDRVAX.cpp`, `src/core/audio/CoreAudioHalBus.{h,cpp}` citing AetherSDR as source.
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Sub-Phase 6: Linux PulseAudio Bridge 🟢
+
+### Task 6.1: Port `PipeWireAudioBridge` → `LinuxPipeBus`
+
+**Files:**
+- Create: `src/core/audio/LinuxPipeBus.h`, `.cpp`
+
+- [ ] **Step 1: Copy + rebrand**
+
+```bash
+cp ../AetherSDR/src/core/PipeWireAudioBridge.h src/core/audio/LinuxPipeBus.h
+cp ../AetherSDR/src/core/PipeWireAudioBridge.cpp src/core/audio/LinuxPipeBus.cpp
+sed -i 's|PipeWireAudioBridge|LinuxPipeBus|g' src/core/audio/LinuxPipeBus.*
+sed -i 's|aethersdr-dax|nereussdr-vax|g' src/core/audio/LinuxPipeBus.*
+sed -i 's|AetherSDR|NereusSDR|g' src/core/audio/LinuxPipeBus.*
+```
+
+- [ ] **Step 2: Prepend port-citation header** (same template as Task 5.1)
+
+- [ ] **Step 3: Adapt to `IAudioBus` interface** (same pattern as Task 5.3)
+
+- [ ] **Step 4: Verify stale-module cleanup still runs on startup**
+
+Keep AetherSDR's `pactl list modules short | grep nereussdr-` scan intact. This is the battle-tested crash-recovery path.
+
+- [ ] **Step 5: Manual smoke on Linux: load NereusSDR, confirm `pactl list sources short` shows `nereussdr-vax-1` through `nereussdr-vax-4`**
+
+- [ ] **Step 6: Commit**
+
+---
+
+## Sub-Phase 7: Windows BYO — VirtualCableDetector 🟢
+
+### Task 7.1: Virtual-cable product regex matcher
+
+**Files:**
+- Create: `src/core/audio/VirtualCableDetector.h`, `.cpp`
+- Test: `tests/tst_virtual_cable_detector.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+```cpp
+#include <QtTest/QtTest>
+#include "core/audio/VirtualCableDetector.h"
+
+using namespace NereusSDR;
+
+class TstVirtualCableDetector : public QObject {
+    Q_OBJECT
+private slots:
+    void detectsVbCableBase() {
+        QVERIFY(VirtualCableDetector::matchProduct(
+            "CABLE Input (VB-Audio Virtual Cable)") == VirtualCableProduct::VbCable);
+    }
+    void detectsVbCableAB() {
+        QVERIFY(VirtualCableDetector::matchProduct("CABLE-A Input") == VirtualCableProduct::VbCableA);
+        QVERIFY(VirtualCableDetector::matchProduct("CABLE-B Input") == VirtualCableProduct::VbCableB);
+    }
+    void detectsVac() {
+        QVERIFY(VirtualCableDetector::matchProduct("Line 1 (Virtual Audio Cable)")
+                == VirtualCableProduct::MuzychenkoVac);
+    }
+    void detectsVoicemeeter() {
+        QVERIFY(VirtualCableDetector::matchProduct("VoiceMeeter Input (VB-Audio VoiceMeeter VAIO)")
+                == VirtualCableProduct::Voicemeeter);
+    }
+    void detectsDante() {
+        QVERIFY(VirtualCableDetector::matchProduct("Dante Tx 01-02")
+                == VirtualCableProduct::Dante);
+    }
+    void detectsFlexDax() {
+        QVERIFY(VirtualCableDetector::matchProduct("DAX Audio RX 1")
+                == VirtualCableProduct::FlexRadioDax);
+    }
+    void detectsReservedNereusVax() {
+        QVERIFY(VirtualCableDetector::matchProduct("NereusSDR VAX 1")
+                == VirtualCableProduct::NereusSdrVax);
+    }
+    void unknownDeviceIsNone() {
+        QVERIFY(VirtualCableDetector::matchProduct("Realtek HD Audio Output")
+                == VirtualCableProduct::None);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstVirtualCableDetector)
+#include "tst_virtual_cable_detector.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+- [ ] **Step 3: Implement matcher**
+
+`src/core/audio/VirtualCableDetector.h`:
+
+```cpp
+#pragma once
+#include <QString>
+#include <QVector>
+
+namespace NereusSDR {
+
+enum class VirtualCableProduct {
+    None = 0,
+    VbCable,
+    VbCableA,  VbCableB,  VbCableC,  VbCableD,
+    VbHiFiCable,
+    MuzychenkoVac,
+    Voicemeeter,
+    Dante,
+    FlexRadioDax,
+    NereusSdrVax,  // reserved for future NereusSDR-owned Windows driver
+};
+
+struct DetectedCable {
+    VirtualCableProduct product;
+    QString deviceName;
+    bool isInput;  // false = render / output
+    int channel;   // 1..N for multi-cable families; 0 if N/A
+};
+
+class VirtualCableDetector {
+public:
+    // Pure-function test-hook. Inspects the OS device name string.
+    static VirtualCableProduct matchProduct(const QString& deviceName);
+
+    // Enumerates OS audio devices via PortAudio and returns matches.
+    static QVector<DetectedCable> scan();
+
+    // Vendor install URL for a given product (for the first-run helper).
+    static QString installUrl(VirtualCableProduct p);
+};
+
+} // namespace NereusSDR
+```
+
+`src/core/audio/VirtualCableDetector.cpp`:
+
+```cpp
+#include "VirtualCableDetector.h"
+#include <QRegularExpression>
+#include "PortAudioBus.h"
+
+using namespace NereusSDR;
+
+VirtualCableProduct VirtualCableDetector::matchProduct(const QString& n) {
+    static const struct { QRegularExpression re; VirtualCableProduct p; } rules[] = {
+        { QRegularExpression("^NereusSDR VAX \\d$"), VirtualCableProduct::NereusSdrVax },
+        { QRegularExpression("^CABLE-A ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableA },
+        { QRegularExpression("^CABLE-B ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableB },
+        { QRegularExpression("^CABLE-C ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableC },
+        { QRegularExpression("^CABLE-D ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableD },
+        { QRegularExpression("Hi-?Fi Cable", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbHiFiCable },
+        { QRegularExpression("^CABLE ",    QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCable },
+        { QRegularExpression("Virtual Audio Cable", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::MuzychenkoVac },
+        { QRegularExpression("^Line \\d+", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::MuzychenkoVac },
+        { QRegularExpression("VoiceMeeter", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::Voicemeeter },
+        { QRegularExpression("^Dante ",    QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::Dante },
+        { QRegularExpression("^DAX Audio", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::FlexRadioDax },
+    };
+    for (const auto& r : rules) {
+        if (r.re.match(n).hasMatch()) { return r.p; }
+    }
+    return VirtualCableProduct::None;
+}
+
+QString VirtualCableDetector::installUrl(VirtualCableProduct p) {
+    switch (p) {
+        case VirtualCableProduct::VbCable:
+        case VirtualCableProduct::VbCableA:
+        case VirtualCableProduct::VbCableB:
+        case VirtualCableProduct::VbCableC:
+        case VirtualCableProduct::VbCableD:
+        case VirtualCableProduct::VbHiFiCable:
+            return "https://vb-audio.com/Cable/";
+        case VirtualCableProduct::MuzychenkoVac:
+            return "https://vac.muzychenko.net/en/";
+        case VirtualCableProduct::Voicemeeter:
+            return "https://voicemeeter.com/";
+        case VirtualCableProduct::Dante:
+            return "https://www.getdante.com/products/software-essentials/dante-virtual-soundcard/";
+        default:
+            return {};
+    }
+}
+
+QVector<DetectedCable> VirtualCableDetector::scan() {
+    QVector<DetectedCable> out;
+    for (const auto& api : PortAudioBus::hostApis()) {
+        for (const auto& dev : PortAudioBus::outputDevicesFor(api.index)) {
+            const auto p = matchProduct(dev.name);
+            if (p != VirtualCableProduct::None) {
+                out.push_back({p, dev.name, false, 0});
+            }
+        }
+        for (const auto& dev : PortAudioBus::inputDevicesFor(api.index)) {
+            const auto p = matchProduct(dev.name);
+            if (p != VirtualCableProduct::None) {
+                out.push_back({p, dev.name, true, 0});
+            }
+        }
+    }
+    return out;
+}
+```
+
+- [ ] **Step 4: Run to pass**
+
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/audio/VirtualCableDetector.h src/core/audio/VirtualCableDetector.cpp \
+        tests/tst_virtual_cable_detector.cpp tests/CMakeLists.txt
+git commit -S -m "feat(audio): add VirtualCableDetector for Windows BYO auto-detect
+
+Regex-matches known virtual-cable product names (VB-Audio family, VAC,
+Voicemeeter, Dante, FlexRadio DAX, reserved NereusSDR VAX). Pure
+matcher is test-hooked; live scan enumerates PortAudio devices and
+filters.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Sub-Phase 8: VAX UI — VFO Flag Selector 🟢
+
+### Task 8.1: `VaxChannelSelector` widget
+
+**Files:**
+- Create: `src/gui/widgets/VaxChannelSelector.h`, `.cpp`
+- Test: `tests/tst_vax_channel_selector.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+```cpp
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include "gui/widgets/VaxChannelSelector.h"
+
+using namespace NereusSDR;
+
+class TstVaxChannelSelector : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultsToOff() {
+        VaxChannelSelector w;
+        QCOMPARE(w.value(), 0);
+    }
+    void setValueUpdatesUi() {
+        VaxChannelSelector w;
+        w.setValue(3);
+        QCOMPARE(w.value(), 3);
+    }
+    void clickingButtonEmitsSignal() {
+        VaxChannelSelector w;
+        QSignalSpy spy(&w, &VaxChannelSelector::valueChanged);
+        w.simulateClick(2);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toInt(), 2);
+    }
+    void programmaticSetDoesNotEmit() {
+        VaxChannelSelector w;
+        QSignalSpy spy(&w, &VaxChannelSelector::valueChanged);
+        w.setValue(4);
+        QCOMPARE(spy.count(), 0);
+    }
+};
+
+QTEST_MAIN(TstVaxChannelSelector)
+#include "tst_vax_channel_selector.moc"
+```
+
+- [ ] **Step 2: Implement widget per STYLEGUIDE.md palette**
+
+`src/gui/widgets/VaxChannelSelector.h`:
+
+```cpp
+#pragma once
+#include <QWidget>
+
+class QPushButton;
+class QButtonGroup;
+
+namespace NereusSDR {
+
+class VaxChannelSelector : public QWidget {
+    Q_OBJECT
+public:
+    explicit VaxChannelSelector(QWidget* parent = nullptr);
+
+    int  value() const { return m_value; }
+    void setValue(int ch);  // 0..4; no signal
+
+    void simulateClick(int ch);  // test-hook
+
+signals:
+    void valueChanged(int ch);
+
+private:
+    QButtonGroup* m_group{nullptr};
+    QPushButton*  m_buttons[5]{};
+    int m_value{0};
+    bool m_programmaticUpdate{false};
+};
+
+} // namespace NereusSDR
+```
+
+Implementation uses `QButtonGroup::buttonToggled` + `m_programmaticUpdate` guard to suppress echo when `setValue` is called. Styling follows STYLEGUIDE.md Button active-blue (`#0070c0` / `#0090e0` / `#ffffff`) for the selected button.
+
+- [ ] **Step 3: Run to pass**
+
+- [ ] **Step 4: Commit**
+
+### Task 8.2: Embed `VaxChannelSelector` in `VfoWidget`
+
+**Files:**
+- Modify: `src/gui/VfoWidget.h`, `.cpp`
+
+- [ ] **Step 1: Add VAX row to VfoWidget layout**
+
+In `VfoWidget`'s `buildUi()` (or equivalent layout builder), insert a new row below the AGC/NR tab row:
+
+```cpp
+    m_vaxRow = new QWidget(this);
+    auto* vaxLayout = new QHBoxLayout(m_vaxRow);
+    vaxLayout->setContentsMargins(10, 4, 10, 4);
+    vaxLayout->setSpacing(3);
+    auto* lbl = new QLabel("VAX", m_vaxRow);
+    lbl->setStyleSheet("color:#8090a0;font-size:10px;");
+    vaxLayout->addWidget(lbl);
+    m_vaxSelector = new VaxChannelSelector(m_vaxRow);
+    vaxLayout->addWidget(m_vaxSelector);
+    vaxLayout->addStretch(1);
+    m_rootLayout->addWidget(m_vaxRow);
+```
+
+- [ ] **Step 2: Wire bidirectionally to `SliceModel`**
+
+```cpp
+    connect(m_vaxSelector, &VaxChannelSelector::valueChanged,
+            this, [this](int ch){
+        if (m_slice) { m_slice->setVaxChannel(ch); }
+    });
+    connect(m_slice, &SliceModel::vaxChannelChanged,
+            m_vaxSelector, &VaxChannelSelector::setValue);
+    m_vaxSelector->setValue(m_slice->vaxChannel());
+```
+
+- [ ] **Step 3: Build + launch app; verify VAX row renders; clicking changes SliceModel value**
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Sub-Phase 9: VaxApplet 🟡
+
+### Task 9.1: Port `MeterSlider` from AetherSDR
+
+- [ ] **Step 1: Copy + rebrand + port header** (same pattern as Task 5.1)
+
+```bash
+cp ../AetherSDR/src/gui/MeterSlider.h src/gui/widgets/MeterSlider.h
+cp ../AetherSDR/src/gui/MeterSlider.cpp src/gui/widgets/MeterSlider.cpp
+# (AetherSDR .cpp is nearly empty — mostly header-inline.)
+```
+
+Prepend port-citation block.
+
+- [ ] **Step 2: Adapt include paths + namespace**
+
+- [ ] **Step 3: Register in `docs/attribution/aethersdr-contributor-index.md`**
+
+- [ ] **Step 4: Commit**
+
+### Task 9.2: Port `DaxApplet` → `VaxApplet`
+
+**Files:**
+- Create: `src/gui/applets/VaxApplet.h`, `.cpp`
+
+- [ ] **Step 1: Copy + port header**
+
+```bash
+cp ../AetherSDR/src/gui/DaxApplet.h src/gui/applets/VaxApplet.h
+cp ../AetherSDR/src/gui/DaxApplet.cpp src/gui/applets/VaxApplet.cpp
+sed -i 's|DaxApplet|VaxApplet|g; s|daxRxLevel|vaxRxLevel|g; s|daxTxLevel|vaxTxLevel|g; \
+        s|daxEnable|vaxEnable|g; s|daxToggled|vaxToggled|g; \
+        s|daxRxGainChanged|vaxRxGainChanged|g; s|daxTxGainChanged|vaxTxGainChanged|g; \
+        s|DAX|VAX|g; s|"dax"|"vax"|g' src/gui/applets/VaxApplet.*
+```
+
+Prepend port-citation block.
+
+- [ ] **Step 2: Adapt to NereusSDR ContainerWidget parent (not AetherSDR's applet base)**
+
+Replace `setRadioModel(RadioModel*)` signature with NereusSDR's equivalent binding path. Style the title bar using `appletTitleBar("VAX")` per STYLEGUIDE.md.
+
+- [ ] **Step 3: Wire signals through `AudioEngine` slots** (Task 4.1's `setVaxEnabled`, `setVaxRxGain`, etc.)
+
+- [ ] **Step 4: Register in the applet factory so users can add it to a container**
+
+- [ ] **Step 5: Build + launch; add VaxApplet to Container #0; verify channel strips render with live meters when audio is flowing to a VAX channel**
+
+- [ ] **Step 6: Commit**
+
+---
+
+## Sub-Phase 10: MasterOutputWidget 🟢
+
+### Task 10.1: Menu-bar master output strip widget
+
+**Files:**
+- Create: `src/gui/MasterOutputWidget.h`, `.cpp`
+
+- [ ] **Step 1: Implement widget**
+
+Per the mockup (`.superpowers/brainstorm/64803-*/content/mockup-speakers.html`): 14px speaker icon + 100px slider + dB readout + MUTE button. Style with STYLEGUIDE.md inset `#0a0a18` background + `#1e2e3e` border; accent `#00b4d8` slider handle. Right-click opens a device-picker popup menu populated from `PortAudioBus::outputDevicesFor()`.
+
+- [ ] **Step 2: Install into main window's menu-bar corner**
+
+In `MainWindow::MainWindow`:
+
+```cpp
+    m_masterOutput = new MasterOutputWidget(this);
+    menuBar()->setCornerWidget(m_masterOutput, Qt::TopRightCorner);
+    connect(m_masterOutput, &MasterOutputWidget::volumeChanged,
+            m_radio->audioEngine(), &AudioEngine::setMasterVolume);
+    connect(m_masterOutput, &MasterOutputWidget::muteChanged,
+            m_radio->audioEngine(), &AudioEngine::setMasterMuted);
+```
+
+- [ ] **Step 3: Persist to AppSettings on change, restore on app start**
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Sub-Phase 11: VaxFirstRunDialog 🟡
+
+### Task 11.1: Dialog with five scenario modes
+
+**Files:**
+- Create: `src/gui/VaxFirstRunDialog.h`, `.cpp`
+
+- [ ] **Step 1: Implement five scenario constructors**
+
+```cpp
+enum class FirstRunScenario {
+    WindowsCablesFound,
+    WindowsNoCables,
+    MacNative,
+    LinuxNative,
+    RescanNewCables,
+};
+
+class VaxFirstRunDialog : public QDialog {
+    Q_OBJECT
+public:
+    VaxFirstRunDialog(FirstRunScenario s, const QVector<DetectedCable>& detected, QWidget* parent = nullptr);
+
+signals:
+    void applySuggested(const QVector<QPair<int /*vaxCh*/, QString /*deviceName*/>>& bindings);
+    void openSetupAudioTab();
+    void openInstallUrl(const QString& url);
+};
+```
+
+Layouts per the browser mockup (`mockup-firstrun.html`). Styling uses inline-style mockups (not Qt stylesheets) — follow STYLEGUIDE.md palette.
+
+- [ ] **Step 2: Hook into MainWindow startup**
+
+```cpp
+void MainWindow::checkVaxFirstRun() {
+    const auto& s = AppSettings::instance();
+    if (s.value("audio/FirstRunComplete", "False").toString() == "True") { return; }
+
+    const auto detected = VirtualCableDetector::scan();
+#if defined(Q_OS_WIN)
+    const auto scenario = detected.isEmpty()
+        ? FirstRunScenario::WindowsNoCables
+        : FirstRunScenario::WindowsCablesFound;
+#elif defined(Q_OS_MAC)
+    const auto scenario = FirstRunScenario::MacNative;
+#else
+    const auto scenario = FirstRunScenario::LinuxNative;
+#endif
+
+    auto* dlg = new VaxFirstRunDialog(scenario, detected, this);
+    connect(dlg, &VaxFirstRunDialog::applySuggested, this, [this](const auto& bindings) {
+        for (const auto& [ch, dev] : bindings) {
+            m_radio->audioEngine()->setVaxDevice(ch, dev);
+            m_radio->audioEngine()->setVaxEnabled(ch, true);
+        }
+        AppSettings::instance().setValue("audio/FirstRunComplete", "True");
+        AppSettings::instance().save();
+    });
+    dlg->show();
+}
+```
+
+- [ ] **Step 3: Manual smoke on each platform**
+
+Trigger by clearing `audio/FirstRunComplete=True` from AppSettings and restarting.
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Sub-Phase 12: Setup → Audio Page 🟡
+
+### Task 12.1: `SetupAudioPage` shell with sub-tabs
+
+**Files:**
+- Create: `src/gui/SetupAudioPage.h`, `.cpp`
+
+- [ ] **Step 1: Extend existing `SetupPage` base** (`src/gui/SetupPage.h`)
+
+```cpp
+class SetupAudioPage : public SetupPage {
+    Q_OBJECT
+public:
+    SetupAudioPage(RadioModel* model, QWidget* parent = nullptr);
+
+private:
+    QTabWidget* m_subTabs{nullptr};
+    QWidget* buildDevicesTab();
+    QWidget* buildVaxTab();
+    QWidget* buildTciTab();      // placeholder: "Coming in Phase 3J"
+    QWidget* buildAdvancedTab();
+};
+```
+
+Layout: `QTabWidget` with four tabs.
+
+- [ ] **Step 2: Register in `SetupDialog`**
+
+In `SetupDialog.cpp`, add the page under the Audio category.
+
+- [ ] **Step 3: Commit**
+
+### Task 12.2: Devices tab (Speakers / Headphones / TX Input cards)
+
+- [ ] **Step 1: Build three device cards using QGroupBox + form layout**
+
+Each card has: Driver API combo (MME/DirectSound/WDM-KS/WASAPI/ASIO-via-PortAudio on Windows; CoreAudio on Mac; ALSA/Pulse/PipeWire/JACK on Linux), Device combo, Sample rate, Bit depth, Channels, Buffer size, Manual latency, per-API options (WASAPI exclusive / event-driven / bypass-mixer), negotiated-format preview label.
+
+**Note:** Direct ASIO engine and cmASIO parity controls (base channel, input mode L/R/Both, lock mode, Control Panel launcher) are **deferred** per the GPL compliance review above. ASIO users route through PortAudio's built-in ASIO host API — no Engine radio button in this phase.
+
+- [ ] **Step 2: Wire every control per Spec §6.5** (see control wiring table in the design spec — skip rows marked Direct-ASIO-only)
+
+Each combo: `currentTextChanged` → `AudioEngine::setXxxDriverApi()` → reopens bus; reverse via `XxxFormatNegotiated(AudioFormat)` signal.
+
+- [ ] **Step 3: Commit**
+
+### Task 12.3: VAX tab (per-channel cards)
+
+- [ ] **Step 1: Build four channel cards (1–4) + TX row**
+
+Native VAX channels (Mac/Linux) show compact cards with "native driver" badge + fixed 48kHz/24-bit format, no device-picker. Windows BYO cards show full Driver API / Device combos.
+
+- [ ] **Step 2: Wire controls per Spec §6.6**
+
+- [ ] **Step 3: "Auto-detect…" button on unassigned slots calls `VirtualCableDetector::scan()` and opens a mini-picker**
+
+- [ ] **Step 4: Commit**
+
+### Task 12.4: Advanced tab (DSP + IVAC parity + extras)
+
+- [ ] **Step 1: Build Advanced tab per Spec §6.7**
+
+DSP sample rate combo, DSP block size combo, VAC feedback per-target tuning (gain/slew/rings), SendIqToVax / TxMonitorToVax / MuteVaxDuringTxOnOtherSlice checkboxes, detected-cables readonly row + Rescan button, "Reset all audio to defaults" (amber confirm-modal).
+
+- [ ] **Step 2: Wire feature-flagged controls**
+
+`SendIqToVax` and `TxMonitorToVax` persist but their wiring logs a `qCWarning(lcAudio) << "IQ to VAX reserved for future phase"` when toggled on.
+
+- [ ] **Step 3: Commit**
+
+### Task 12.5: TCI tab placeholder
+
+- [ ] **Step 1: Disabled tab labeled "Coming in Phase 3J" with a stub**
+
+```cpp
+QWidget* SetupAudioPage::buildTciTab() {
+    auto* w = new QWidget;
+    auto* lay = new QVBoxLayout(w);
+    auto* lbl = new QLabel("TCI server — coming in Phase 3J (see design spec §11.1)");
+    lbl->setStyleSheet("color:#8090a0;font-size:12px;padding:40px;");
+    lbl->setAlignment(Qt::AlignCenter);
+    lay->addWidget(lbl);
+    return w;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+---
+
+## Sub-Phase 13: Help Docs 🟢
+
+### Task 13.1: `install-virtual-cables.md`
+
+**Files:**
+- Create: `resources/help/install-virtual-cables.md`
+
+- [ ] **Step 1: Write per-platform install guide** — per mockup `mockup-firstrun.html` scenario B content. Vendor install URLs; step-by-step for VB-CABLE; note for Mac/Linux that native VAX is already installed; PipeWire null-sink auto-create option for Linux advanced users.
+
+- [ ] **Step 2: Link from `README.md` feature list and from `VaxFirstRunDialog`**
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Sub-Phase 14: End-to-End Verification 🔴
+
+### Task 14.1: macOS QSO round-trip
+
+- [ ] **Step 1: Install NereusSDR .pkg from Task 5.2 build output**
+- [ ] **Step 2: Confirm "NereusSDR VAX 1–4" + "NereusSDR TX" appear in macOS Audio MIDI Setup**
+- [ ] **Step 3: Launch WSJT-X, pick "NereusSDR VAX 1" as input**
+- [ ] **Step 4: Tune NereusSDR RX1 to 14.074 USB; set VAX pill to `1`; confirm WSJT-X shows decoded FT8 traffic**
+- [ ] **Step 5: Commit a VERIFICATION.md note summarizing the test**
+
+### Task 14.2: Linux QSO round-trip
+
+- [ ] **Step 1: Launch NereusSDR; confirm `pactl list sources short` lists `nereussdr-vax-1..4`**
+- [ ] **Step 2: WSJT-X on same host picks "NereusSDR VAX 1", sees audio** — confirm FT8 decode
+- [ ] **Step 3: Commit VERIFICATION.md update**
+
+### Task 14.3: Windows QSO round-trip (BYO path)
+
+- [ ] **Step 1: Install NereusSDR; first-run dialog appears; install VB-CABLE from the vendor link if not present**
+- [ ] **Step 2: Restart NereusSDR; first-run dialog auto-binds detected cables; click Apply Suggested**
+- [ ] **Step 3: WSJT-X picks "CABLE-A Output" as input; set NereusSDR RX1 VAX=1; confirm FT8 decode**
+- [ ] **Step 4: Commit VERIFICATION.md update**
+
+### Task 14.4: Attribution + compliance-inventory final sweep
+
+- [ ] **Step 1: Run attribution verifier scripts**
+
+```bash
+bash scripts/verify-thetis-headers.py
+bash scripts/check-new-ports.py
+```
+
+Expected: all pass. Every ported file in this phase (`CoreAudioHalBus`, `LinuxPipeBus`, `VaxApplet`, `MeterSlider`, `NereusSDRVAX.cpp` hal-plugin) is registered in `docs/attribution/aethersdr-contributor-index.md` with correct header.
+
+- [ ] **Step 2: Update `docs/attribution/COMPLIANCE-INVENTORY.md`**
+
+Add a new section for Phase 3O covering:
+- Every new port (source upstream + NereusSDR path + license inheritance statement).
+- The macOS HAL plugin's separate-binary status: the `NereusSDRVAX.driver` bundle is a standalone CoreAudio plug-in loaded by `coreaudiod` in its own process, communicating with NereusSDR.app only via POSIX shared memory. Bundled in the same `.pkg` installer with NereusSDR.app is mere aggregation on an installation medium per GPL-3 §5; they are not a single combined work.
+- The 2026-04-19 GPL-3 compliance review result (Direct ASIO deferred; link to this plan's GPL Compliance Review section).
+- PortAudio vendoring: MIT-licensed, linked statically; NereusSDR's corresponding-source obligation is satisfied by the FetchContent reference in `CMakeLists.txt` pinning the exact upstream commit.
+- libASPL vendoring (macOS only): MIT-licensed, linked into the separate HAL plugin binary; same corresponding-source reasoning.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/attribution/COMPLIANCE-INVENTORY.md docs/attribution/aethersdr-contributor-index.md
+git commit -S -m "$(cat <<'EOF'
+docs(compliance): record Phase 3O ports + HAL plugin reasoning
+
+Registers every new AetherSDR port from Phase 3O in the
+aethersdr-contributor-index, and documents the macOS HAL plugin's
+separate-binary / mere-aggregation status per GPL-3 §5. Also logs
+the 2026-04-19 GPL compliance review that dropped Direct ASIO from
+this phase due to Steinberg SDK non-redistributability.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Post-plan: open PR and mark Phase 3O complete in MASTER-PLAN
+
+- [ ] Push `feature/phase-3o-vax` to origin
+- [ ] `gh pr create` with summary linking the design spec and this plan
+- [ ] After merge, update `docs/MASTER-PLAN.md` to mark Phase 3O ✅ COMPLETE with a short shipped-notes block
+
+---
+
+## Self-Review Notes
+
+Spec coverage check (design spec §1–§14):
+- §1–§2 Purpose + scope → covered by plan prose intro
+- §3 Architecture → Sub-Phases 2, 4 (IAudioBus, AudioEngine, MasterMixer)
+- §4.1 Ported files → Sub-Phases 5 (macOS HAL + CoreAudioHalBus), 6 (LinuxPipeBus), 9 (MeterSlider + VaxApplet). DirectAsioBus + AsioSdkHost deferred per GPL compliance review — not in this phase.
+- §4.2 New files → all created across Sub-Phases 2, 3, 7, 8, 10, 11, 12
+- §4.3 Modified files → Sub-Phases 1, 4, 8, 10, 11, 12
+- §5 Data model → Sub-Phase 1
+- §6 Control wiring table → reflected per-tab/per-widget in Sub-Phases 8, 9, 10, 11, 12
+- §7 UI components → Sub-Phases 8, 9, 10, 11, 12
+- §8 Platform specifics → Sub-Phases 5, 6, 7 (§8.5 Direct ASIO deferred per GPL compliance review)
+- §9 Difficulty ranking → mirrored in header emoji
+- §10 Risks → not a task list item; addressed inline in relevant task notes (macOS 14.4 fallback Task 5.2, PipeWire stale-module cleanup Task 6.1)
+- §11 Reserved integration points → preserved via `VirtualCableDetector::NereusSdrVax` pattern (Task 7.1) and `IAudioBus` abstraction (Sub-Phase 2)
+- §12 Attribution checklist → final sweep Task 15.4
+- §13 Plan review history → this plan adds an implementation-plan entry; MASTER-PLAN review history already updated
+- §14 Success criteria → verified in Sub-Phase 15
+
+Placeholder scan: Tasks 3.4, 4.1–4.3, 12.2–12.5 reference "same pattern" or defer to "Spec §6.X"; I've left those as direct spec references rather than re-paste the full wiring table per task to keep the plan under 3000 lines. Each such reference points at the spec's concrete wiring rows, not at TBDs. If the implementing agent hits a row they can't interpret, they stop and ask — consistent with CLAUDE.md ring-1 checklist.
+
+Type consistency: `IAudioBus`, `AudioFormat`, `AudioDeviceConfig`, `VaxSlot`, `VirtualCableProduct`, `DetectedCable`, `FirstRunScenario` all reused with identical names across tasks. `PortAudioConfig` defined Task 3.2, extended Task 3.3.
+
+Post-compliance-review edit (2026-04-19): Sub-Phase 13 (Direct ASIO Engine) removed and subsequent sub-phases renumbered (14→13 Help Docs, 15→14 E2E Verification). Task 3.1 gained a PortAudio license-verification step. Task 14.4 expanded to cover `COMPLIANCE-INVENTORY.md` updates including Phase 3O port registrations, HAL plugin mere-aggregation reasoning, and the GPL-3 compliance review outcome. File structure table, modified-files table, type-consistency checklist, and spec-coverage §4.1/§8 mappings updated to match.
+
+---
+
+**Plan complete and saved to `docs/architecture/2026-04-19-phase3o-vax-plan.md`. Two execution options:**
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Uses `superpowers:subagent-driven-development`.
+
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/architecture/2026-04-19-vax-design.md
+++ b/docs/architecture/2026-04-19-vax-design.md
@@ -1,0 +1,699 @@
+# VAX — Virtual Audio eXchange Design Spec
+
+**Status:** Design approved (brainstorm 2026-04-19), ready for implementation plan
+**Author:** J.J. Boyd (KG4VCF), AI-assisted (Claude Opus 4.7)
+**Target phase:** Phase 3O — Audio Routing & Cross-Platform Audio Engine
+**Supersedes:** n/a (new subsystem)
+**Reserves integration points for:** Phase 3J (TCI + Spots), future native Windows driver work
+
+---
+
+## 1. Purpose
+
+Ship NereusSDR's complete RX audio routing story in a single, reviewable phase. Today NereusSDR can play RX audio through the system default output and nothing else. After this phase, each receiver can be routed independently to speakers and to any of four virtual audio channels ("VAX 1–4"), using native drivers on macOS and Linux and user-installed virtual cables on Windows — all wired through a single cross-platform audio engine with Thetis-grade power-user controls.
+
+The design follows **AetherSDR's mental model** (assign VAX at the source, view levels at the destination) rather than a patchbay or matrix, because it fits ham workflows, matches NereusSDR's existing applet architecture, and minimizes new UI paradigms.
+
+## 2. Scope
+
+**In scope:**
+
+- **Cross-platform audio engine** based on PortAudio (MME / DirectSound / WDM-KS / WASAPI-shared / WASAPI-exclusive / ASIO on Windows; CoreAudio on macOS; ALSA / PulseAudio / PipeWire / JACK on Linux).
+- **VAX architecture** — four virtual audio channels + one TX input:
+  - macOS: native CoreAudio HAL plugin (`libASPL` based), ported from AetherSDR.
+  - Linux: native PulseAudio `module-pipe-source` + `module-pipe-sink` bridge, ported from AetherSDR.
+  - Windows: user-installed virtual cables (VB-CABLE, VAC, Voicemeeter) with **first-run auto-detection** and graceful install prompts.
+- **Routing model** — per-receiver VAX assignment on the VFO flag; speakers are always on unless muted; a single VAX slot holds TX at a time.
+- **UI additions** —
+  - `VaxApplet` (ported from AetherSDR `DaxApplet`, renamed) docked in the right container panel.
+  - `VfoWidget` gains a VAX selector row (OFF / 1 / 2 / 3 / 4).
+  - Menu-bar master output widget (global volume + mute + device shortcut).
+  - First-run auto-detect dialog (three platform variants).
+  - Setup → Audio page with **Devices**, **VAX**, **Advanced** sub-tabs.
+- **Optional Direct ASIO engine** (Windows only) for Thetis `cmASIO` parity, gated behind an "Advanced" radio button inside the Devices tab.
+- **AppSettings persistence** for every device / slot / gain / device-bind.
+- **Full end-to-end wiring** — zero unwired controls, zero dangling signals, zero TODO-for-future setters.
+- **Attribution compliance** per `docs/attribution/HOW-TO-PORT.md` for every ported file.
+
+**Explicitly out of scope (reserved integration points):**
+
+- **TCI server and TCI audio streams** — deferred to Phase 3J. The `IAudioBus` tap contract in this spec is designed to let TCI subscribe to the same taps without refactor.
+- **NereusSDR-owned Windows virtual audio driver** — deferred as potential future work. Design hooks are preserved so a signed driver can replace the BYO path without breaking user-visible bindings.
+- **TX mic DSP chain** (compressor, TX EQ) — lives in Phase 3M. This spec only wires the TX **routing** (mic input device → TXA), not DSP between them.
+- **IQ streaming to VAX** — Thetis has an "IQ to VAC" toggle. Wired but feature-flagged off; implementation deferred.
+
+---
+
+## 3. Architecture Overview
+
+### 3.1 Signal flow
+
+```
+       RX1 DSP ─┐
+       RX2 DSP ─┤
+       RX3 DSP ─┼──┬─► Master mix ──► QAudioSink (Speakers)
+       RX4 DSP ─┤  │                   └── volume, mute, device
+       ...     ─┘  │
+                   ├─► VAX 1 tap ──► IAudioBus::push("vax-1")
+                   ├─► VAX 2 tap ──► IAudioBus::push("vax-2")
+                   ├─► VAX 3 tap ──► IAudioBus::push("vax-3")
+                   └─► VAX 4 tap ──► IAudioBus::push("vax-4")
+                                           │
+                       ┌───────────────────┼───────────────────┐
+                       ▼                   ▼                   ▼
+                 macOS HAL plugin    Linux Pulse bridge    Windows BYO
+                 (POSIX shm ring)    (named FIFO)          (PortAudio sink
+                                                           to OS device)
+
+       TX path:
+       QAudioSource ──► IAudioBus::pull("tx-in") ──► TXA DSP ──► Radio
+       (user-picked OS capture device; on Mac/Linux, includes "NereusSDR TX")
+```
+
+### 3.2 `IAudioBus` abstraction
+
+The same internal interface, three platform backends. Declared in `src/core/IAudioBus.h`.
+
+```cpp
+namespace NereusSDR {
+
+struct AudioFormat {
+    int sampleRate = 48000;      // Hz
+    int channels = 2;            // 1 or 2
+    enum class Sample { Float32, Int16, Int24, Int32 } sample = Sample::Float32;
+};
+
+class IAudioBus {
+public:
+    virtual ~IAudioBus() = default;
+
+    // Lifecycle
+    virtual bool open(const AudioFormat& format) = 0;
+    virtual void close() = 0;
+    virtual bool isOpen() const = 0;
+
+    // Producer side (RX taps): write a block of interleaved PCM.
+    virtual qint64 push(const char* data, qint64 bytes) = 0;
+
+    // Consumer side (TX): read a block of interleaved PCM.
+    virtual qint64 pull(char* data, qint64 maxBytes) = 0;
+
+    // Metering (RMS of last block; published atomically for UI).
+    virtual float rxLevel() const = 0;  // 0.0–1.0
+    virtual float txLevel() const = 0;
+
+    // Diagnostics
+    virtual QString backendName() const = 0;
+    virtual AudioFormat negotiatedFormat() const = 0;
+};
+
+} // namespace NereusSDR
+```
+
+Five concrete implementations in `src/core/audio/`:
+
+| Class | Platform | Backend | Source |
+|---|---|---|---|
+| `CoreAudioHalBus` | macOS | POSIX shm ring to HAL plugin | Port of AetherSDR `VirtualAudioBridge` |
+| `LinuxPipeBus` | Linux | Named FIFO via `module-pipe-source`/`sink` | Port of AetherSDR `PipeWireAudioBridge` |
+| `PortAudioBus` | Windows (default) | PortAudio stream to user-picked device | New |
+| `DirectAsioBus` | Windows (opt-in) | ASIO SDK direct, cmASIO parity | New (Thetis `cmasio.c` port) |
+| `CoreAudioBus` | macOS / fallback | PortAudio CoreAudio for Speakers/Headphones/TX | New |
+
+`AudioEngine` owns one instance per routable endpoint (Speakers, Headphones, TX, VAX 1–4) and dispatches by slot.
+
+### 3.3 Threading
+
+- **Main thread:** `RadioModel`, `SliceModel`, UI widgets, applet parameter updates. Never blocks, never touches PCM buffers directly.
+- **Audio worker thread** (existing, owned by `AudioEngine`): RX tap plumbing, per-VAX `IAudioBus::push`, TX `pull`, level metering. All parameter reads are `std::atomic`; never holds a mutex in the audio callback (per CLAUDE.md).
+- **No new threads introduced.** `CoreAudioHalBus` and `LinuxPipeBus` perform their I/O on the existing audio worker thread. The macOS HAL plugin runs in `coreaudiod`'s own thread (out-of-process); the Linux pipe FIFOs are read by PulseAudio/PipeWire in their own processes. No IPC blocks the NereusSDR audio thread.
+
+### 3.4 Routing resolution
+
+Each `SliceModel` carries a `vaxChannel` int: `0=Off, 1..4=VAX 1–4`. `AudioEngine::rxBlockReady(sliceId, float* samples, int frames)` executes:
+
+```cpp
+// Always push to the master mix (speakers path), respecting per-slice mute/volume.
+if (!slice.audioMuted()) {
+    m_masterMix.accumulate(slice, samples, frames);
+}
+
+// Tap to the slice's selected VAX (if any).
+const int vaxCh = slice.vaxChannel();
+if (vaxCh >= 1 && vaxCh <= 4) {
+    m_vaxBus[vaxCh - 1]->push(samples, frames * sizeof(float) * 2);
+}
+```
+
+No per-cell enable matrix. No wires to cross. Two reads per block: mute and VAX channel. Both atomic.
+
+### 3.5 TX arbitration
+
+- `TransmitModel::txOwnerSlot()` returns `VaxSlot { None, 1, 2, 3, 4, MicDirect }`.
+- Only one slot feeds TX at a time. Switch is instantaneous on user change (no cross-fade).
+- PTT sources: physical PTT, VOX, UI button. PTT assertion is orthogonal to owner selection — you can hold PTT while any owner is selected.
+- When the owner is `VAX N`, TX pulls from `m_vaxBus[N-1]` for `pull()`. When `MicDirect`, TX pulls from the OS capture device configured as the "TX input device".
+
+---
+
+## 4. File Inventory and Attribution
+
+### 4.1 Ported files (from AetherSDR)
+
+Per `docs/attribution/HOW-TO-PORT.md` rule 6: AetherSDR has no per-file GPL headers. Each ported file gets a NereusSDR port-citation block referencing the AetherSDR project URL and primary author, followed by the standard modification-history block.
+
+| NereusSDR path | Ported from | LOC (reference) | Rename notes |
+|---|---|---|---|
+| `src/core/audio/CoreAudioHalBus.{h,cpp}` | `AetherSDR src/core/VirtualAudioBridge.{h,cpp}` | 95 + 336 | Rebrand all `AetherSDR` → `NereusSDR`, shm paths `/aethersdr-dax-*` → `/nereussdr-vax-*`, class rename. |
+| `src/core/audio/LinuxPipeBus.{h,cpp}` | `AetherSDR src/core/PipeWireAudioBridge.{h,cpp}` | ~80 + 386 | Rebrand class, FIFO paths `/tmp/aethersdr-dax-*` → `/tmp/nereussdr-vax-*`, PulseAudio module `source_name=nereussdr-vax-1`, description "NereusSDR VAX 1". |
+| `hal-plugin/NereusSDRVAX.cpp` | `AetherSDR hal-plugin/AetherSDRDAX.cpp` | ~330 | Rebrand device UIDs (`com.aethersdr.dax.*` → `com.nereussdr.vax.*`), device names, shm paths. **Fix macOS 14.4+ regression:** use `killall coreaudiod` fallback in postinstall script. |
+| `hal-plugin/CMakeLists.txt`, `Info.plist` | AetherSDR equivalents | small | Bundle ID `com.nereussdr.vax`, factory UUID regenerated. |
+| `packaging/macos/hal-installer.sh` + postinstall | AetherSDR `packaging/macos/build-installer.sh` + postinstall | small | Rebrand + killall fallback. |
+| `src/gui/applets/VaxApplet.{h,cpp}` | `AetherSDR src/gui/DaxApplet.{h,cpp}` | 48 + 216 | **Rename class `DaxApplet` → `VaxApplet`, all signal names `dax*` → `vax*`. Integrate with NereusSDR `ContainerWidget`/applet framework (not AetherSDR's applet parent).** Ported styling merged with NereusSDR `STYLEGUIDE.md`. |
+| `src/gui/widgets/MeterSlider.{h,cpp}` | `AetherSDR src/gui/MeterSlider.{h,cpp}` | 129 + 2 | Shared meter+slider composite widget used by VaxApplet. AetherSDR's `.cpp` is nearly empty (logic is header-inline); port faithfully keeping that shape. |
+
+**Port-citation block template for each ported file:**
+
+```cpp
+// =================================================================
+// <repo-relative path>  (NereusSDR)
+// =================================================================
+//
+// Ported from AetherSDR source:
+//   <aethersdr path>
+//
+// AetherSDR is licensed under the GNU General Public License v3; see
+// https://github.com/ten9876/AetherSDR for the contributor list and
+// project-level LICENSE. NereusSDR is also GPLv3. AetherSDR source
+// files carry no per-file GPL header; attribution is at project level
+// per AetherSDR convention.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-19 — Ported/adapted in C++20/Qt6 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via
+//                 Anthropic Claude Code. Renamed DAX → VAX and
+//                 rebranded identifiers for the NereusSDR-native VAX
+//                 device family.
+// =================================================================
+```
+
+### 4.2 New files (NereusSDR-original)
+
+| Path | Role |
+|---|---|
+| `src/core/IAudioBus.h` | Abstract bus interface (cross-backend contract). |
+| `src/core/audio/PortAudioBus.{h,cpp}` | PortAudio stream to user-picked OS audio device. Windows default + macOS/Linux fallback. |
+| `src/core/audio/DirectAsioBus.{h,cpp}` | Native ASIO SDK engine (Windows only, opt-in). Ported logic from Thetis `ChannelMaster/cmasio.{h,c}` — **adds Thetis attribution headers per HOW-TO-PORT.md**. |
+| `src/core/audio/AsioSdkHost.{h,cpp}` | Thin wrapper over the ASIO SDK. Driver enumeration, load, callback routing. |
+| `src/core/audio/VirtualCableDetector.{h,cpp}` | Enumerates OS audio devices and regex-matches known virtual-cable product patterns (VB-Audio family, VAC, Voicemeeter, Dante, FlexRadio DAX). |
+| `src/core/audio/MasterMixer.{h,cpp}` | Per-slice mute/volume/pan → stereo mix → single output sink. |
+| `src/gui/MasterOutputWidget.{h,cpp}` | Menu-bar corner widget: speaker icon, master slider, mute button, right-click device picker. |
+| `src/gui/SetupAudioPage.{h,cpp}` | Setup → Audio page with Devices/VAX/Advanced sub-tabs. Extends existing `SetupPage` base. |
+| `src/gui/VaxFirstRunDialog.{h,cpp}` | First-run auto-detect modal (five scenarios A–E from the brainstorm mockups). |
+| `src/gui/VaxChannelSelector.{h,cpp}` | Small 5-button group widget embedded into `VfoWidget` (OFF / 1 / 2 / 3 / 4). |
+
+### 4.3 Modified existing files
+
+| Path | Change |
+|---|---|
+| `src/models/SliceModel.{h,cpp}` | Add `int vaxChannel()` / `setVaxChannel(int)` with `std::atomic<int>` storage, `vaxChannelChanged(int)` signal, AppSettings key `slice/<id>/VaxChannel`. |
+| `src/models/TransmitModel.{h,cpp}` | Add `VaxSlot txOwnerSlot()` / `setTxOwnerSlot(VaxSlot)`, signal, AppSettings key `tx/OwnerSlot`. |
+| `src/gui/VfoWidget.{h,cpp}` | Embed `VaxChannelSelector` in a new row below the MODE/FILT/AGC tabs. Bidirectional wire to `SliceModel::vaxChannel`. |
+| `src/core/AudioEngine.{h,cpp}` | Replace `QAudioSink`-only output with the `IAudioBus`-based model: master-mix goes to Speakers/Headphones bus; per-slice VAX taps feed the four VAX buses; TX consumes either a VAX bus or the mic bus based on `TransmitModel::txOwnerSlot`. |
+| `src/core/AppSettings.{h,cpp}` | Schema additions (below). Add a `v2` settings-migration path to import old single-device audio config. |
+| `src/gui/MainWindow.{h,cpp}` | Instantiate `MasterOutputWidget` in the menu bar, wire it to `AudioEngine`. Trigger `VaxFirstRunDialog` on first launch / on new-cable detection. |
+| `src/gui/SetupDialog.{h,cpp}` | Register `SetupAudioPage` under the Audio category. |
+| `docs/attribution/THETIS-PROVENANCE.md` | Add row for `DirectAsioBus` + `AsioSdkHost` (ported from `ChannelMaster/cmasio.{h,c}` + `Console/clsCMASIOConfig.cs`). |
+| `docs/attribution/aethersdr-contributor-index.md` (or equivalent) | Add rows for `VirtualAudioBridge`, `PipeWireAudioBridge`, `DaxApplet`, `MeterSlider`. |
+| `docs/MASTER-PLAN.md` | Add Phase 3O section, update status lines, add Plan Review History entry. |
+| `CMakeLists.txt` | Add PortAudio dependency (vendored or `find_package`), conditionally add ASIO SDK + HAL plugin subdirs. |
+| `README.md` | Add brief "VAX routing" mention in feature list; link to user docs. |
+| `resources/help/install-virtual-cables.md` | New user-facing help doc. |
+
+---
+
+## 5. Data Model Changes
+
+### 5.1 `SliceModel`
+
+```cpp
+// New:
+std::atomic<int> m_vaxChannel{0};  // 0=Off, 1..4=VAX N
+public:
+    int vaxChannel() const { return m_vaxChannel.load(); }
+    void setVaxChannel(int ch);   // validates 0..4, persists, emits
+signals:
+    void vaxChannelChanged(int ch);
+```
+
+Persistence: `AppSettings` XML key `slice/<sliceId>/VaxChannel`, stored as string `"0".."4"`. On load, invalid values clamp to 0.
+
+### 5.2 `TransmitModel`
+
+```cpp
+enum class VaxSlot { None = 0, MicDirect, Vax1, Vax2, Vax3, Vax4 };
+std::atomic<VaxSlot> m_txOwnerSlot{VaxSlot::MicDirect};
+public:
+    VaxSlot txOwnerSlot() const { return m_txOwnerSlot.load(); }
+    void setTxOwnerSlot(VaxSlot s);
+signals:
+    void txOwnerSlotChanged(VaxSlot s);
+```
+
+Persistence: `tx/OwnerSlot` stored as string `"MicDirect"` etc.
+
+### 5.3 `AudioEngine`
+
+```cpp
+// New members:
+std::unique_ptr<IAudioBus> m_speakersBus;
+std::unique_ptr<IAudioBus> m_headphonesBus;       // optional, may be null
+std::unique_ptr<IAudioBus> m_txInputBus;          // OS capture device
+std::array<std::unique_ptr<IAudioBus>, 4> m_vaxBus;
+MasterMixer m_masterMix;
+
+// Public API additions:
+void setSpeakersConfig(const AudioDeviceConfig&);
+void setHeadphonesConfig(const AudioDeviceConfig&);
+void setTxInputConfig(const AudioDeviceConfig&);
+void setVaxConfig(int ch, const AudioDeviceConfig&);
+
+// AudioDeviceConfig carries: driver API, device name, sample rate, bit depth,
+// channels, buffer size, exclusive mode, ASIO engine choice, etc.
+```
+
+### 5.4 `AppSettings` schema additions
+
+All keys PascalCase, boolean as `"True"`/`"False"`, per CLAUDE.md.
+
+```
+audio/Speakers/DriverApi            (string: MME|DirectSound|WDM-KS|WASAPI|WASAPI-Exclusive|ASIO|CoreAudio|ALSA|Pulse|PipeWire|JACK)
+audio/Speakers/DeviceName           (string: device display name)
+audio/Speakers/SampleRate           (int: Hz)
+audio/Speakers/BitDepth             (int: 16|24|32)
+audio/Speakers/Channels             (int: 1|2)
+audio/Speakers/BufferSamples        (int)
+audio/Speakers/ExclusiveMode        (bool)
+audio/Speakers/EventDrivenCallback  (bool)
+audio/Speakers/BypassMixer          (bool)
+audio/Speakers/ManualLatencyMs      (int, 0=auto)
+audio/Speakers/AsioEngine           (string: PortAudio|Direct)
+audio/Speakers/DirectAsio/DriverName       (string — only if AsioEngine=Direct)
+audio/Speakers/DirectAsio/BlockSize        (int)
+audio/Speakers/DirectAsio/LockMode         (bool)
+audio/Speakers/DirectAsio/InputMode        (string: Left|Right|Both)
+audio/Speakers/DirectAsio/BaseInChannel    (int, 0-indexed)
+audio/Speakers/DirectAsio/BaseOutChannel   (int, 0-indexed)
+
+audio/Headphones/*                  (same keys; optional, may be unset)
+audio/TxInput/*                     (same keys)
+
+audio/Vax1/Enabled                  (bool)
+audio/Vax1/DeviceName               (string — "NereusSDR VAX 1" on Mac/Linux; "CABLE-A Input" etc. on Windows)
+audio/Vax1/DriverApi                (string, only on Windows BYO path)
+audio/Vax1/SampleRate               (int)
+audio/Vax1/BitDepth                 (int)
+audio/Vax1/Channels                 (int)
+audio/Vax1/BufferSamples            (int)
+audio/Vax1/RxGain                   (float: 0.0–1.0)
+audio/Vax1/Muted                    (bool)
+audio/Vax1/ExclusiveMode            (bool, Windows only)
+audio/Vax2/*                        (same)
+audio/Vax3/*                        (same)
+audio/Vax4/*                        (same)
+
+audio/TxGain                        (float: 0.0–1.0)
+
+audio/Master/Volume                 (float: 0.0–1.0)
+audio/Master/Muted                  (bool)
+audio/Master/ActiveOutput           (string: Speakers|Headphones)
+
+audio/DspRate                       (int: WDSP internal rate, default 48000)
+audio/DspBlockSize                  (int: fexchange2 granularity, default 1024)
+
+audio/VacFeedback/<ch>/Gain         (float, IVAC parity)
+audio/VacFeedback/<ch>/SlewTimeMs   (float)
+audio/VacFeedback/<ch>/PropRingMinUs   (int)
+audio/VacFeedback/<ch>/PropRingMaxUs   (int)
+audio/VacFeedback/<ch>/FfRingMinUs     (int)
+audio/VacFeedback/<ch>/FfRingMaxUs     (int)
+audio/VacFeedback/<ch>/FfRingAlpha     (float)
+
+audio/SendIqToVax                   (bool, default False)
+audio/TxMonitorToVax                (bool, default False)
+audio/MuteVaxDuringTxOnOtherSlice   (bool, default True)
+
+slice/<sliceId>/VaxChannel          (int: 0..4)
+tx/OwnerSlot                        (string: None|MicDirect|Vax1..4)
+
+audio/FirstRunComplete              (bool)
+audio/LastDetectedCables            (string: CSV of device-name hashes for diff-on-next-run)
+```
+
+### 5.5 Settings migration
+
+Pre-VAX builds stored a single `audio/OutputDevice` key (per existing `AudioEngine`). Migration on first launch post-upgrade:
+
+```cpp
+if (settings.contains("audio/OutputDevice") && !settings.contains("audio/Speakers/DeviceName")) {
+    settings.setValue("audio/Speakers/DeviceName", settings.value("audio/OutputDevice").toString());
+    settings.setValue("audio/Speakers/DriverApi", platformDefaultApi());
+    settings.setValue("audio/Speakers/SampleRate", 48000);
+    // … sensible defaults for the rest
+    settings.setValue("audio/FirstRunComplete", "False");  // trigger VaxFirstRunDialog
+    settings.remove("audio/OutputDevice");
+    settings.save();
+}
+```
+
+---
+
+## 6. Control Wiring Table
+
+**Every** widget listed below has its full round-trip wiring specified. No "TBD", no "future PR", no unwired stubs. A row lacking a column means that column is N/A for that control.
+
+Columns: **Widget** · **Widget → Model** · **Model → Widget** (echo prevention) · **Model → Action** · **AppSettings key** · **Guard**
+
+### 6.1 VFO flag — VAX channel selector
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `VaxChannelSelector` button group (OFF/1/2/3/4) | `buttonClicked(int)` → `SliceModel::setVaxChannel(int)` | `vaxChannelChanged(int)` → `VaxChannelSelector::setValue(int)` | `SliceModel::setVaxChannel` persists and (if different) emits `vaxChannelChanged`; `AudioEngine::sliceVaxChanged(sliceId, ch)` slot updates the tap routing | `slice/<sliceId>/VaxChannel` | `QSignalBlocker` on `VaxChannelSelector` during `setValue` |
+
+### 6.2 VFO flag — per-RX audio block (already existed, extended)
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| Volume slider | `valueChanged(int)` → `SliceModel::setAudioVolume(float)` | `audioVolumeChanged` → `slider.setValue` | `AudioEngine::sliceVolumeChanged` updates `MasterMixer` weight for that slice | `slice/<sliceId>/AudioVolume` | `m_updatingFromModel` |
+| Pan slider | `valueChanged(int)` → `SliceModel::setAudioPan(float)` | `audioPanChanged` → `slider.setValue` | `MasterMixer` per-slice pan coefficient | `slice/<sliceId>/AudioPan` | same |
+| MUTE button | `toggled(bool)` → `SliceModel::setAudioMuted(bool)` | `audioMutedChanged` → `button.setChecked` | Master mix skips slice block when muted; VAX tap still runs (optional per-VAX mute owns that) | `slice/<sliceId>/AudioMuted` | same |
+| BINAURAL toggle | `toggled(bool)` → `SliceModel::setBinauralEnabled(bool)` | `binauralChanged` → button | `RxChannel::setBinaural` calls WDSP `SetRXAPanelBinaural` | `slice/<sliceId>/Binaural` | same |
+| SPEAKERS/HDPHN buttons | exclusive group → `SliceModel::setOutputRoute(Output)` | `outputRouteChanged` → button group | `MasterMixer` routes the slice to speakers OR headphones bus | `slice/<sliceId>/OutputRoute` | same |
+| RX level meter (readonly) | n/a | `AudioEngine::sliceMeter(sliceId, float)` → `meter.setLevel(float)` | n/a | none (ephemeral) | n/a |
+
+### 6.3 Menu-bar `MasterOutputWidget`
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| Master volume slider | `valueChanged(int)` → `AudioEngine::setMasterVolume(float)` | `masterVolumeChanged(float)` → `slider.setValue` | Applies gain on the speakers bus | `audio/Master/Volume` | `m_updatingFromModel` |
+| Master MUTE button | `toggled(bool)` → `AudioEngine::setMasterMuted(bool)` | `masterMutedChanged(bool)` → button | Mutes speakers bus | `audio/Master/Muted` | same |
+| Speaker icon (click) | `clicked()` → toggles mute | same | same | same | n/a |
+| Speaker icon (right-click) | context menu with `QActionGroup` of output devices → `AudioEngine::setSpeakersDevice(QString)` | device change re-enumerates the menu next open | Rebuilds `m_speakersBus` | `audio/Speakers/DeviceName` | n/a |
+
+### 6.4 `VaxApplet` (ported from AetherSDR `DaxApplet`, renamed)
+
+For each of the four channels:
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `VaxChannelStrip[ch].enableButton` | `toggled(bool)` → `AudioEngine::setVaxEnabled(ch, bool)` | `vaxEnabledChanged(ch, bool)` → button | Opens/closes `m_vaxBus[ch-1]`; triggers platform driver init (Mac HAL, Linux pipe, Windows PortAudio) | `audio/Vax<ch>/Enabled` | `m_updatingFromModel` |
+| `VaxChannelStrip[ch].rxGainSlider` | `valueChanged(float)` → `AudioEngine::setVaxRxGain(ch, float)` | `vaxRxGainChanged(ch, float)` → slider | Applied to tap output before `push` | `audio/Vax<ch>/RxGain` | same |
+| `VaxChannelStrip[ch].muteButton` | `toggled(bool)` → `AudioEngine::setVaxMuted(ch, bool)` | `vaxMutedChanged` → button | Skips tap when muted | `audio/Vax<ch>/Muted` | same |
+| `VaxChannelStrip[ch].rxMeter` (readonly) | n/a | `vaxRxLevel(ch, float)` → `meter.setLevel(float)` | Level computed in audio thread, published atomic | none | n/a |
+| `VaxChannelStrip[ch].deviceLabel` (click) | opens device picker → `AudioEngine::setVaxDevice(ch, QString)` | `vaxDeviceChanged` → label text | Rebuilds `m_vaxBus[ch-1]` with new device | `audio/Vax<ch>/DeviceName` | n/a |
+| `VaxChannelStrip[ch].tagsLabel` (readonly) | n/a | Listens to every `SliceModel::vaxChannelChanged`; shows list of slices currently assigned to channel `ch` | n/a | none | n/a |
+| TX row: tx gain slider | `valueChanged(float)` → `AudioEngine::setVaxTxGain(float)` | `vaxTxGainChanged(float)` → slider | Applied in TX pull path before TXA | `audio/TxGain` | `m_updatingFromModel` |
+| TX row: tx meter (readonly) | n/a | `vaxTxLevel(float)` → meter | Level of active TX source | none | n/a |
+
+### 6.5 Setup → Audio → Devices tab (for each of Speakers / Headphones / TX Input)
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `driverApiCombo` | `currentTextChanged(QString)` → `AudioEngine::setXxxDriverApi(QString)` | on load, combo text set from settings | Re-creates backing `IAudioBus` with new API | `audio/Xxx/DriverApi` | `m_updatingFromModel` + `QSignalBlocker` |
+| `engineRadioGroup` (PortAudio/Direct ASIO — visible only when driverApi=ASIO) | `buttonToggled` → `AudioEngine::setXxxAsioEngine(AsioEngine)` | on load | Swaps `PortAudioBus` ↔ `DirectAsioBus` | `audio/Xxx/AsioEngine` | same |
+| `asioDriverCombo` (Direct ASIO only) | `currentTextChanged` → `AudioEngine::setXxxDirectAsioDriver(QString)` | `directAsioDriversEnumerated` → combo | `AsioSdkHost::loadDriver` | `audio/Xxx/DirectAsio/DriverName` | same |
+| `asioControlPanelButton` | `clicked()` → `AsioSdkHost::openControlPanel(driverName)` | n/a | Opens ASIO driver's native UI (Windows modal) | none | n/a |
+| `baseInChannelCombo`, `baseOutChannelCombo` | `currentIndexChanged` → setters | on load | Passed to `DirectAsioBus` for channel base | `audio/Xxx/DirectAsio/BaseInChannel`, `BaseOutChannel` | same |
+| `inputModeRadioGroup` (Left/Right/Both, Direct ASIO only) | `buttonToggled` → setters | on load | Maps to cmASIO `IM_LEFT/IM_RIGHT/IM_BOTH` | `audio/Xxx/DirectAsio/InputMode` | same |
+| `lockModeCheckbox` (Direct ASIO only) | `toggled` → setter | on load | cmASIO lock-mode flag | `audio/Xxx/DirectAsio/LockMode` | same |
+| `deviceCombo` (PortAudio only) | `currentTextChanged` → `AudioEngine::setXxxDeviceName(QString)` | on load / device-change-detected | Reopens bus | `audio/Xxx/DeviceName` | same |
+| `sampleRateCombo` + `autoMatchCheckbox` | `currentIndexChanged` / `toggled` → setters | on load | Bus reopened if needed | `audio/Xxx/SampleRate` | same |
+| `bitDepthCombo` | same | same | same | `audio/Xxx/BitDepth` | same |
+| `channelsCombo` (Mono/Stereo) | same | same | same | `audio/Xxx/Channels` | same |
+| `bufferSamplesSpinner` + derived-ms label | `valueChanged` → setter | on load | Applied on bus reopen | `audio/Xxx/BufferSamples` | same |
+| `manualLatencyCheckbox` + `latencyMsSpinner` | same | same | same | `audio/Xxx/ManualLatencyMs` | same |
+| `exclusiveModeCheckbox`, `eventDrivenCallback`, `bypassMixer` (WASAPI only) | same | same | same | respective keys | same |
+| `formatPreviewLabel` (readonly) | n/a | `AudioEngine::xxxFormatNegotiated(AudioFormat)` → label | Shows actually-negotiated format + status pill | none | n/a |
+
+### 6.6 Setup → Audio → VAX tab
+
+Per-channel card (1–4):
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `vaxEnabledCheckbox` | `toggled(bool)` → `AudioEngine::setVaxEnabled(ch, bool)` | `vaxEnabledChanged(ch, bool)` → checkbox | Same as 6.4 | `audio/Vax<ch>/Enabled` | `m_updatingFromModel` |
+| `vaxDriverApiCombo` (hidden on Mac/Linux native; shown Windows BYO) | same pattern as 6.5 | same | same | `audio/Vax<ch>/DriverApi` | same |
+| `vaxDeviceCombo` | `currentTextChanged` → `AudioEngine::setVaxDevice(ch, QString)` | `vaxDeviceChanged` | Rebuilds `m_vaxBus[ch-1]` | `audio/Vax<ch>/DeviceName` | same |
+| Format controls (rate/bit-depth/channels/buffer) | same as 6.5 pattern | same | same | respective keys | same |
+| `vaxExclusiveModeCheckbox` (WASAPI only) | same | same | same | `audio/Vax<ch>/ExclusiveMode` | same |
+| "Auto-detect…" button (unassigned channels) | `clicked()` → `VirtualCableDetector::scan()` → opens first-run-style sub-dialog with detected cables | n/a | If user picks one, calls `setVaxDevice(ch, name)` | n/a | n/a |
+
+### 6.7 Setup → Audio → Advanced tab
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `dspSampleRateCombo` | `currentIndexChanged` → `AudioEngine::setDspSampleRate(int)` | on load | WDSP channel reconfig | `audio/DspRate` | `m_updatingFromModel` |
+| `dspBlockSizeCombo` | same | same | same | `audio/DspBlockSize` | same |
+| `vacFeedbackTargetCombo` + per-target gain/slew/rings editors | writes to `audio/VacFeedback/<ch>/*` keys → `AudioEngine::setVacFeedbackParams(ch, params)` | on load (reloads per-target when target combo changes) | Applied to IVAC-parity resamplers inside the VAX bus implementation | as schemed | same |
+| `sendIqToVaxCheckbox` | `toggled` → setter | on load | **Feature-flagged: emits a log-warning "IQ to VAX is reserved for future — see Phase 3O+"** | `audio/SendIqToVax` (stored but not active) | same |
+| `txMonitorToVaxCheckbox` | `toggled` → setter | on load | same feature-flag note as above | `audio/TxMonitorToVax` | same |
+| `muteVaxDuringTxOnOtherSliceCheckbox` | `toggled` → setter | on load | Active: when slice A holds TX, slices B/C/D's VAX taps emit silence (mirrors Thetis behavior) | `audio/MuteVaxDuringTxOnOtherSlice` | same |
+| "Detected cables" label row (readonly) | n/a | Live result from `VirtualCableDetector::lastScan()` | n/a | none | n/a |
+| "Rescan" button | `clicked()` → `VirtualCableDetector::scan()` | updates Detected-cables row | May open `VaxFirstRunDialog::rescanMode()` if new cables appear | `audio/LastDetectedCables` | n/a |
+| "Reset all audio to defaults" button | `clicked()` → confirm modal → `AudioEngine::resetAudioSettings()` | triggers full re-sync from defaults | Clears all `audio/*` keys + rebuilds buses | all `audio/*` removed | n/a |
+
+### 6.8 First-run dialog (`VaxFirstRunDialog`)
+
+| Widget | Action |
+|---|---|
+| "Apply suggested" button (scenario A, E) | For each suggestion row, call `AudioEngine::setVaxDevice(ch, name)` + `setVaxEnabled(ch, true)`; close dialog; set `audio/FirstRunComplete=True`. |
+| "Customize…" button | Close; open Setup → Audio → VAX tab with detected cables pre-filled in each channel card. |
+| "Skip" button | Close; set `audio/FirstRunComplete=True`; VAX stays disabled. |
+| "Open download page" buttons (scenario B) | `QDesktopServices::openUrl` to vendor's official URL (hardcoded mapping per product in `VirtualCableDetector`). |
+| "Continue without VAX" | Same as Skip. |
+| "Rescan now" | `VirtualCableDetector::scan()`, reload dialog content. |
+| "Got it" (Mac/Linux native scenarios) | Close; set `audio/FirstRunComplete=True`; VAX enabled by default (since drivers are ready). |
+
+### 6.9 TX source / PTT arbitration
+
+Currently shown in the mockup on the Audio Setup page's TX Source bar. Wiring:
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| TX source combo (MicDirect / VAX 1 / VAX 2 / VAX 3 / VAX 4) | `currentIndexChanged` → `TransmitModel::setTxOwnerSlot(VaxSlot)` | `txOwnerSlotChanged` → combo | TX path switches `pull()` source on next block | `tx/OwnerSlot` | `m_updatingFromModel` |
+| PTT owner button row (duplicated in mockup) | same wiring (convenience surface) | same | same | same | same |
+| TX input device combo (for MicDirect) | `currentTextChanged` → `AudioEngine::setTxInputDevice(QString)` | on load | Rebuilds `m_txInputBus` | `audio/TxInput/DeviceName` | same |
+
+---
+
+## 7. UI Components in Detail
+
+### 7.1 `VaxChannelSelector` (VFO flag, new)
+
+- 5 small buttons: OFF, 1, 2, 3, 4.
+- Exclusive (single-select), backed by `QButtonGroup`.
+- Styled per STYLEGUIDE.md: base `#1a2a3a`/`#205070`, active `#0070c0`/`#ffffff`.
+- Fixed height 22 px, each button 26 px wide min.
+- Embedded in a new row on `VfoWidget` under the existing MODE/FILT/AGC/NR tabs, grouped with an "AUDIO" row already planned.
+
+### 7.2 `VaxApplet` (docked, ported + renamed)
+
+- Title bar "VAX" + subtitle "4 channels" (per STYLEGUIDE.md applet header).
+- Four `VaxChannelStrip` rows + divider + TX row.
+- Each `VaxChannelStrip` layout (top-to-bottom, compact):
+  ```
+  [VAX N name]  [assigned-slices chips]              [MUTE]
+  [level meter ═══════════════════════]  [RxGain slider]  [dB readout]
+  [device-type tag] · [device name]
+  ```
+- Fixed width ~310 px docked; resizable if floated.
+- All controls keyboard-navigable (Qt focus chain).
+
+### 7.3 `MasterOutputWidget` (menu bar corner, new)
+
+- 3 elements horizontal: speaker icon (14 px), slider (100 px wide), dB readout (inset), MUTE button.
+- Speaker icon click toggles mute; scroll wheel on slider adjusts in 1 dB steps; right-click icon opens device picker submenu.
+- Styled as an inset `#0a0a18` / `#1e2e3e` container per STYLEGUIDE.md "Inset Value Display" pattern.
+
+### 7.4 `VaxFirstRunDialog` (modal, new)
+
+- Five scenario constructors (see mockup-firstrun.html for exact layout).
+- Fixed 560 px wide; modal; parented to MainWindow.
+- Dismissable via `Escape`; but only counts as first-run-complete if user clicked **Apply suggested**, **Skip**, or **Got it** (Mac/Linux).
+- Rescan mode (scenario E) pops unobtrusively only when a new cable is detected on app startup.
+
+### 7.5 `SetupAudioPage` (new page in SetupDialog)
+
+- Extends existing `SetupPage` base.
+- Four sub-tabs: **Devices**, **VAX**, **TCI** (disabled/placeholder "Coming in Phase 3J"), **Advanced**.
+- Each tab is a `QScrollArea` containing groupboxes.
+- Styled per STYLEGUIDE.md; groupbox conventions from `src/gui/SetupPage.cpp`.
+
+---
+
+## 8. Platform-Specific Implementation
+
+### 8.1 macOS
+
+- **HAL plugin** at `/Library/Audio/Plug-Ins/HAL/NereusSDRVAX.driver` (system-wide, admin install).
+- Built separately from main app (`hal-plugin/CMakeLists.txt`) because libASPL FetchContent conflicts with the main Ninja build — pattern already proven by AetherSDR.
+- `.pkg` installer with two components (app + driver). Postinstall script:
+  ```bash
+  #!/bin/bash
+  # macOS 14.4+ locked down launchctl kickstart for coreaudiod; use killall.
+  launchctl kickstart -kp system/com.apple.audio.coreaudiod 2>/dev/null \
+    || sudo killall coreaudiod \
+    || true
+  exit 0
+  ```
+- Uninstall shell script ships alongside; removes `.driver` and `/dev/shm/nereussdr-vax-*` segments.
+- Signing: Apple Developer ID Application + notarization. NereusSDR already pays the $99/yr per CLAUDE.md; no new cost.
+- Devices exposed: "NereusSDR VAX 1", "NereusSDR VAX 2", "NereusSDR VAX 3", "NereusSDR VAX 4", "NereusSDR TX".
+- Format: float32 stereo @ 48 kHz (we may move from AetherSDR's 24 kHz to 48 kHz to align with Thetis DSP rate; decision confirmed with user as part of this spec).
+- IPC: POSIX shm ring, ~2-sec ring at 48 kHz stereo float = ~768 KB per segment.
+
+### 8.2 Linux
+
+- **Bridge** loaded at NereusSDR app startup via `pactl load-module module-pipe-source ...` (RX × 4) + `pactl load-module module-pipe-sink ...` (TX × 1).
+- FIFOs in `/tmp/nereussdr-vax-{1..4}.pipe` and `/tmp/nereussdr-tx.pipe`.
+- Node names: `nereussdr-vax-1` etc.; descriptions: "NereusSDR VAX 1" etc.
+- Works on pure PulseAudio **and** PipeWire-via-pipewire-pulse.
+- Stale-module cleanup on startup (port AetherSDR's scan: `pactl list modules short | grep nereussdr-` and `pactl unload-module <idx>`).
+- Module lifetimes bound to app lifetime; clean teardown on quit.
+- No separate installer; modules load at runtime from the app.
+- Packaged as `.deb` / `.rpm` / AUR / AppImage per existing NereusSDR release.yml.
+- **Deferred:** Flatpak/Snap (sandboxing blocks virtual audio node publication per `xdg-desktop-portal` issue #1142). Document this in README.
+
+### 8.3 Windows
+
+- **Default engine:** `PortAudioBus`. Enumerate audio devices via PortAudio host APIs (MME, DirectSound, WDM-KS, WASAPI-shared, WASAPI-exclusive, ASIO).
+- **Opt-in engine:** `DirectAsioBus`. When user selects "Direct ASIO" in the Engine radio group, we load the ASIO SDK driver directly (no PortAudio). Ported from Thetis `ChannelMaster/cmasio.c` with full Thetis attribution header per HOW-TO-PORT.md.
+- **VAX channels on Windows:** user-picked OS audio devices. `VirtualCableDetector` pre-populates suggestions.
+- **No kernel driver shipped in this phase.** A future phase may fork `VirtualDrivers/Virtual-Audio-Driver` (MIT path, SysVAD-based) and add a signed Windows driver for "NereusSDR VAX 1–4" first-class devices. Integration points reserved — device-name patterns in `VirtualCableDetector` already include a placeholder for "NereusSDR VAX N" so the future driver slots in transparently.
+- `help/install-virtual-cables.md` documents VB-CABLE (recommended), VAC, Voicemeeter.
+
+### 8.4 PortAudio integration (all platforms)
+
+- Vendor PortAudio at `third_party/portaudio/` (MIT-compatible license, Apache-esque; compatible with GPLv3).
+- Link statically into NereusSDR executable.
+- Initialize in `AudioEngine::init`, terminate in destructor.
+- Host API enumeration: per-platform filter (only show APIs that exist on this OS).
+- PortAudio ASIO host API requires Steinberg ASIO SDK headers (not redistributable, but headers-only). Fetch via build-time env var or skip ASIO on CI. **Document clearly** in `CONTRIBUTING.md` build section.
+
+### 8.5 ASIO SDK integration (Windows Direct ASIO)
+
+- Third-party: Steinberg ASIO SDK headers — **cannot be bundled** in the repo due to Steinberg license. Developer must download from Steinberg and drop into `third_party/asio-sdk/` locally.
+- Build-time check: if headers present, compile `DirectAsioBus`; otherwise compile a stub that reports "Direct ASIO unavailable — rebuild with ASIO SDK" when user selects it.
+- Runtime fallback: if Direct ASIO can't load a driver, fall back to PortAudio ASIO and log a warning.
+
+---
+
+## 9. Implementation Difficulty Ranking
+
+Per user preference: no calendar estimates. Ordering from easiest to hardest.
+
+🟢 **Easy**
+- Windows `VirtualCableDetector` + first-run helper (enumerate devices, regex-match product patterns, show dialog).
+- Linux `LinuxPipeBus` (port AetherSDR bridge, rebrand strings).
+- AppSettings schema additions + migration path.
+- `VaxChannelSelector` widget (button group).
+- `MasterOutputWidget` (menu-bar strip).
+
+🟡 **Medium**
+- `VaxApplet` port + rename from AetherSDR `DaxApplet` (integrate with NereusSDR's `ContainerWidget`/applet framework).
+- `CoreAudioHalBus` + HAL plugin (`hal-plugin/NereusSDRVAX.cpp`) — port from AetherSDR including signing/notarization in release.yml, plus macOS 14.4+ killall fix.
+- `SetupAudioPage` (Devices/VAX/Advanced tabs with all wiring).
+- TX arbitration state machine.
+- `MasterMixer` — per-slice mute/volume/pan accumulation (simple on the surface, RT-safety rigor required).
+
+🟠 **Medium-hard**
+- `IAudioBus` abstraction + audio-engine refactor to replace the direct `QAudioSink` model.
+- `PortAudioBus` — full driver-API coverage, format negotiation, buffer handling, watchdogs for device-change/unplug (port the robust patterns from AetherSDR `AudioEngine`).
+
+🔴 **Hard**
+- `DirectAsioBus` + `AsioSdkHost` — port Thetis `cmasio.c` logic. ASIO callbacks are notoriously unforgiving RT-safety contexts; testing requires physical ASIO hardware. Byte-for-byte Thetis header port + inline-comment preservation per HOW-TO-PORT.md.
+- End-to-end smoke test matrix (WSJT-X QSO round trip on Mac / Linux / Windows, including cable-install first-run).
+
+---
+
+## 10. Risks & Edge Cases
+
+| Risk | Mitigation |
+|---|---|
+| **macOS 14.4+ kickstart lockdown** on `coreaudiod` | Postinstall script already falls back to `killall coreaudiod`. Verified against AetherSDR community reports. |
+| **PipeWire/Pulse stale modules** after NereusSDR crash | Startup scans `pactl list modules short` for `nereussdr-` and unloads before loading fresh ones. Port of AetherSDR's proven cleanup. |
+| **Windows 24H2 virtual-audio regressions** (Elgato, VB-Audio both hit these in 2025) | Treat first-run detect as authoritative; show an "Unsupported device" state if PortAudio can't open a detected cable; log which cable and surface it in SupportDialog. |
+| **WASAPI exclusive-mode contention** (another app holds the device) | Detect and fall back to shared mode with a warning pill; user can retry from Setup. |
+| **ASIO SDK headers missing at build time** | Stub `DirectAsioBus`; runtime warn-and-fallback to PortAudio ASIO. `CONTRIBUTING.md` documents. |
+| **Audio-thread RT-safety violations** | Review every new `push`/`pull` path for: no `qDebug` in the hot path, no allocations, no locks; use Clang `[[clang::no_destroy]]` / `-fsanitize=thread` in CI where feasible. |
+| **Shared-memory name collision** when NereusSDR and AetherSDR both installed on the same Mac/Linux host | Different prefixes (`/nereussdr-vax-*` vs `/aethersdr-dax-*`), different HAL plugin bundle IDs. Both coexist cleanly. |
+| **SliceModel `vaxChannel` persistence across band/slice creation** | Stored per-slice-id; on new slice creation, default to OFF. Tested in the existing SliceModel persistence tests. |
+| **TX output-device contention** when user picks the same device as Speakers | Block the selection in UI (combo shows incompatible devices greyed with tooltip). |
+| **VB-CABLE uninstalled while app is running** | Detector re-scans on Setup→Audio open; if the cable disappears mid-session, VAX bus reports the error upstream, UI shows a warning badge on that slot. |
+| **First-run dialog blocking the first launch** | Dialog is modal over MainWindow but MainWindow is fully functional; dialog dismissible with ESC/Skip. No deadlock path. |
+| **PortAudio ASIO SDK licensing** | Vendor PortAudio without ASIO host API by default; developer must opt-in with Steinberg SDK (headers-only, non-distributable) for ASIO support. |
+
+---
+
+## 11. Reserved Integration Points
+
+### 11.1 TCI (Phase 3J)
+
+`IAudioBus` taps are the contract. When Phase 3J lands:
+
+- TCI server subscribes to the same `AudioEngine::vaxTap(ch)` signal path that drives `CoreAudioHalBus::push` / `LinuxPipeBus::push` / `PortAudioBus::push`.
+- TCI's per-client resampler consumes the tap float32 samples and framing-over-WebSocket-encodes them.
+- No refactor required. The `AudioEngine::setVaxTapSubscriber(ch, ITapConsumer*)` registration path is stubbed in this phase (unused) and activated in 3J.
+
+### 11.2 NereusSDR-owned Windows virtual audio driver
+
+`VirtualCableDetector` regex list reserves `"NereusSDR VAX \d"` as a recognized device-name pattern. When we ship a signed Windows driver:
+
+- Driver exposes devices named "NereusSDR VAX 1..4" + "NereusSDR TX".
+- Detector auto-binds them on first run, replacing user-installed BYO cables if present.
+- User's existing VAX slot bindings migrate automatically (device name lookup).
+- No new UI surface; the Windows experience quietly upgrades to native.
+
+### 11.3 IQ-to-VAX (Thetis parity)
+
+`audio/SendIqToVax` setting is persisted but currently logs-and-ignores. When activated in a future phase, RX1's pre-DSP I/Q feeds `m_vaxBus[ch-1]` via a separate `pushIq()` API on `IAudioBus`. Consumer apps see a 2-channel I/Q stream instead of demodulated audio.
+
+---
+
+## 12. Attribution Compliance Checklist
+
+For every ported file in §4.1 above, the PR introducing the port must:
+
+- [ ] Add the port-citation + modification-history header block (template in §4.1).
+- [ ] Register the file in `docs/attribution/aethersdr-contributor-index.md` (or equivalent provenance file).
+- [ ] For files with Thetis ancestry (`DirectAsioBus`, `AsioSdkHost`): copy Thetis byte-for-byte header from `ChannelMaster/cmasio.c` AND `Console/clsCMASIOConfig.cs` per HOW-TO-PORT.md rule 4 (multi-source file stacking).
+- [ ] Preserve all inline attribution markers (`//MW0LGE`, `//W4WMT`, etc.) verbatim at the corresponding port positions.
+- [ ] Stamp all `// From Thetis …` cites with `[vX.Y.Z.W]` (captured once at port-session start via `git -C ../Thetis describe --tags`).
+- [ ] Run `scripts/verify-thetis-headers.py` — must pass.
+- [ ] Run `scripts/check-new-ports.py` — must detect new PROVENANCE rows.
+- [ ] Human author (J.J. Boyd KG4VCF) reviews the full diff before merge, including every attribution block, per CLAUDE.md ring-1 checklist.
+
+---
+
+## 13. Plan Review History
+
+| Date | Reviewer | Outcome |
+|---|---|---|
+| 2026-04-19 | J.J. Boyd (KG4VCF) | Design brainstormed against Thetis VAC/cmASIO + AetherSDR DaxApplet + SmartSDR DAX model + Loopback/Dante/RME reference UIs. User chose SmartSDR-style routing (VFO-flag selector + VaxApplet) over patchbay/matrix after side-by-side mockups. BYO-cable chosen for Windows v1 with native driver deferred. TCI scoped out. |
+
+---
+
+## 14. Success Criteria
+
+- [ ] All controls listed in §6 are fully round-trip wired; zero unwired buttons, zero TODO-for-later setters, zero fire-once widgets.
+- [ ] Thetis user migrating to NereusSDR can configure equivalent VAC1/VAC2 workflow in Setup → Audio in under 5 minutes on Windows.
+- [ ] macOS user sees "NereusSDR VAX 1–4" + "NereusSDR TX" in WSJT-X audio picker immediately after install.
+- [ ] Linux user on any major distro (Fedora/Ubuntu/Arch) sees "NereusSDR VAX 1–4" in WSJT-X without extra setup.
+- [ ] Windows user with VB-CABLE installed sees auto-detected suggestions on first launch.
+- [ ] Windows user without any virtual cable sees install guidance with links; can use speakers-only mode to skip.
+- [ ] Master output widget persists device and volume across restarts; responds to keyboard scroll-wheel and mute toggle.
+- [ ] All ported files carry correct attribution headers; `scripts/verify-thetis-headers.py` and `scripts/check-new-ports.py` pass.
+- [ ] Audio-thread RT-safety: no `qDebug`, no allocations, no locks in any callback on the hot path.
+- [ ] TCI integration path is stub-reserved so Phase 3J lands with no refactor to this code.
+- [ ] Help doc `help/install-virtual-cables.md` published and linked from first-run dialog.

--- a/docs/architecture/2026-04-19-vax-design.md
+++ b/docs/architecture/2026-04-19-vax-design.md
@@ -583,9 +583,15 @@ Currently shown in the mockup on the Audio Setup page's TX Source bar. Wiring:
 
 ### 8.5 ASIO SDK integration (Windows Direct ASIO)
 
+> **Compliance note (2026-04-19):** After a GPL-3 compliance review during plan authoring, **Direct ASIO is deferred from Phase 3O.** The Steinberg ASIO SDK license is not GPL-3 compatible; linking it into distributed NereusSDR binaries would violate both the ASIO SDK terms and GPL-3. Audacity and other GPL audio projects hit the same wall and ship ASIO-disabled. Decision recorded in the implementation plan's GPL Compliance Review section. This spec section is retained as design intent; if community demand justifies revisiting, it lands as a separate compliance proposal (developer-build-only gate or Steinberg commercial licensing), not part of Phase 3O.
+
+For reference, the original design was:
+
 - Third-party: Steinberg ASIO SDK headers — **cannot be bundled** in the repo due to Steinberg license. Developer must download from Steinberg and drop into `third_party/asio-sdk/` locally.
 - Build-time check: if headers present, compile `DirectAsioBus`; otherwise compile a stub that reports "Direct ASIO unavailable — rebuild with ASIO SDK" when user selects it.
 - Runtime fallback: if Direct ASIO can't load a driver, fall back to PortAudio ASIO and log a warning.
+
+**Phase 3O actually ships:** PortAudio's built-in ASIO host API (when enabled via `PA_USE_ASIO`) covers 95%+ of ASIO use cases via the Driver API dropdown. No Engine radio button. No native SDK direct-access engine.
 
 ---
 
@@ -680,7 +686,8 @@ For every ported file in §4.1 above, the PR introducing the port must:
 
 | Date | Reviewer | Outcome |
 |---|---|---|
-| 2026-04-19 | J.J. Boyd (KG4VCF) | Design brainstormed against Thetis VAC/cmASIO + AetherSDR DaxApplet + SmartSDR DAX model + Loopback/Dante/RME reference UIs. User chose SmartSDR-style routing (VFO-flag selector + VaxApplet) over patchbay/matrix after side-by-side mockups. BYO-cable chosen for Windows v1 with native driver deferred. TCI scoped out. |
+| 2026-04-19 | J.J. Boyd (KG4VCF) | Design brainstormed against Thetis VAC/cmASIO + AetherSDR DaxApplet + SmartSDR DAX model + Loopback/Dante/RME reference UIs. User chose AetherSDR-style routing (VFO-flag selector + VaxApplet) over patchbay/matrix after side-by-side mockups. BYO-cable chosen for Windows v1 with native driver deferred. TCI scoped out. |
+| 2026-04-19 | J.J. Boyd (KG4VCF) | Pre-execution GPL-3 compliance audit performed while authoring the implementation plan. **Direct ASIO engine (Sub-Phase 13) dropped** from Phase 3O scope: the Steinberg ASIO SDK license prohibits redistribution of modified SDK code and is not GPL-3 compatible; linking it into distributed NereusSDR binaries would violate both licenses. PortAudio's built-in ASIO host API retained as the ASIO path. All other bundled / linked components (AetherSDR GPL-3 ports, Thetis GPL-2+ ports where applicable, libASPL MIT, PortAudio MIT, Qt6 LGPL-3) verified compatible. PortAudio license verification step added to plan Task 3.1. Full `COMPLIANCE-INVENTORY.md` registration added as plan Task 14.4 including the macOS HAL plugin's separate-binary / mere-aggregation (GPL-3 §5) reasoning. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Bring `README.md` in line with the masterplan as of **v0.2.1**.
- Current Status leads with what is shipping today across every OpenHPSDR P1 and P2 board (RX pipeline feature-complete) and points at **3M-1: Basic SSB TX** as the next implementation phase.
- Key Features and Roadmap table refreshed so all Complete phases through 3G-14 + 3N sit above Planned.

## What changed

- **Banner** — v0.1.x line rephrased to a generic "superseded → upgrade to v0.2.x" notice.
- **Current Status** — replaced the old 3I / 3G-6 / 3G-7 / 3G-8 narratives with a 10-bullet shipping-today summary (P1+P2 families, sample-rate wiring, Display parity, Clarity adaptive, RX DSP parity, VfoWidget, Auto AGC-T, step attenuator + ADC overload, container/meter system, About + 💡 issue reporter, packaging) and a 4-bullet Deferred block pointing at the remaining masterplan phases.
- **Key Features** — *Working now* expanded to cover P1/P2 radios, sample rates, RX DSP parity, Clarity, About/reporter, etc. *Planned* rewritten around masterplan phases 3M-1 → 3M-4, 3F, 3H, 3J, 3K, 3L, 3M.
- **Roadmap table** — added 3G-9 (full Complete, not just 3G-9a), 3G-10 (full Complete, not Stage 1), 3G-11, 3G-13, 3G-14; reordered so every Complete phase sits above Planned; **3M-1** tagged **Next**; 3L scope tightened to HL2 `ChannelMaster.dll` port only.

## Test plan

- [ ] Render README on the PR page and skim for visible layout breaks.
- [ ] Confirm the status banner reads cleanly and does not overclaim.
- [ ] Spot-check Roadmap table rows against `CHANGELOG.md` for accuracy.

J.J. Boyd ~ KG4VCF