### PR TITLE
fix(cmake): auto-fetch libfftw3-3.dll on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,43 @@ endif()
 find_package(PkgConfig QUIET)
 if(WIN32)
     set(FFTW3_ROOT "${CMAKE_SOURCE_DIR}/third_party/fftw3")
+
+    # The double-precision FFTW DLL is GPLv2 and gitignored
+    # (third_party/fftw3/.gitignore), so a fresh Windows clone doesn't have
+    # it. Auto-fetch from fftw.org on first configure (same URL release.yml
+    # and ci.yml use). Without this, a clean Windows build fails with a
+    # cryptic "No rule to make target libfftw3-3.dll" link error.
+    if(NOT EXISTS "${FFTW3_ROOT}/bin/libfftw3-3.dll")
+        set(_fftw_url "https://fftw.org/pub/fftw/fftw-3.3.5-dll64.zip")
+        set(_fftw_zip "${CMAKE_BINARY_DIR}/fftw-3.3.5-dll64.zip")
+        set(_fftw_tmp "${CMAKE_BINARY_DIR}/fftw-tmp")
+        message(STATUS "FFTW3: libfftw3-3.dll missing, fetching ${_fftw_url}")
+        file(DOWNLOAD "${_fftw_url}" "${_fftw_zip}"
+             STATUS _fftw_dl_status
+             TLS_VERIFY ON
+             SHOW_PROGRESS)
+        list(GET _fftw_dl_status 0 _fftw_dl_code)
+        if(NOT _fftw_dl_code EQUAL 0)
+            list(GET _fftw_dl_status 1 _fftw_dl_msg)
+            message(FATAL_ERROR
+                "FFTW3 download failed (${_fftw_dl_msg}).\n"
+                "Manually download ${_fftw_url}, then extract:\n"
+                "  fftw3.h            -> ${FFTW3_ROOT}/include/\n"
+                "  libfftw3-3.dll     -> ${FFTW3_ROOT}/bin/\n"
+                "  libfftw3-3.def     -> ${FFTW3_ROOT}/lib/\n"
+                "and rerun CMake.")
+        endif()
+        file(MAKE_DIRECTORY "${_fftw_tmp}")
+        file(ARCHIVE_EXTRACT INPUT "${_fftw_zip}" DESTINATION "${_fftw_tmp}")
+        file(MAKE_DIRECTORY "${FFTW3_ROOT}/include")
+        file(MAKE_DIRECTORY "${FFTW3_ROOT}/bin")
+        file(MAKE_DIRECTORY "${FFTW3_ROOT}/lib")
+        file(COPY "${_fftw_tmp}/fftw3.h"        DESTINATION "${FFTW3_ROOT}/include")
+        file(COPY "${_fftw_tmp}/libfftw3-3.dll" DESTINATION "${FFTW3_ROOT}/bin")
+        file(COPY "${_fftw_tmp}/libfftw3-3.def" DESTINATION "${FFTW3_ROOT}/lib")
+        message(STATUS "FFTW3: fetched libfftw3-3.dll into ${FFTW3_ROOT}/bin/")
+    endif()
+
     if(EXISTS "${FFTW3_ROOT}/include/fftw3.h")
         set(FFTW3_FOUND TRUE)
         set(FFTW3_INCLUDE_DIRS "${FFTW3_ROOT}/include")

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ brew install qt@6 ninja cmake pkgconf fftw
 
 ### Windows (FFTW3 Setup)
 
-Download the [FFTW3 64-bit DLLs](https://fftw.org/install/windows.html) and place `fftw3.h` in `third_party/fftw3/include/` and `libfftw3-3.dll` in `third_party/fftw3/bin/`.
+No manual setup required. CMake auto-downloads [`fftw-3.3.5-dll64.zip`](https://fftw.org/pub/fftw/fftw-3.3.5-dll64.zip) on first configure and drops `fftw3.h` / `libfftw3-3.dll` / `libfftw3-3.def` into `third_party/fftw3/`. Requires network access on the first `cmake -B build` run; offline builds need to pre-populate those three files by hand.
 
 ### Build & Run
 


### PR DESCRIPTION
## Summary

- Windows builds from a fresh clone failed with `No rule to make target 'third_party/fftw3/bin/libfftw3-3.dll'` because the double-precision FFTW DLL is GPLv2 and gitignored, forcing users to download it by hand before CMake would succeed.
- CMake now auto-fetches `fftw-3.3.5-dll64.zip` from fftw.org on first configure (same URL `release.yml` and `ci.yml` use) and extracts `fftw3.h` / `libfftw3-3.dll` / `libfftw3-3.def` into `third_party/fftw3/`. Falls back to a FATAL_ERROR with manual-fetch instructions if the download fails.
- README Windows setup section updated: no manual DLL install required; offline builders are told which three files to pre-populate.

## Why

First external bug report of this — a user on v0.2.1 (Qt 6.11.0 MinGW, Qt Creator 19) hit the cryptic Make error and assumed they'd done something wrong. The project already knew how to download FFTW (CI does it), so lifting that logic into the top-level CMake makes a fresh Windows clone "just work."

## Test plan

- [x] `cmake -B build-verify` still configures on macOS (Windows branch skipped, syntax parses)
- [x] Pre-commit compliance hooks (Thetis header check, inline cite verify, compliance inventory) all green
- [ ] Fresh Windows clone without `third_party/fftw3/bin/libfftw3-3.dll` configures and builds without manual steps
- [ ] Re-configuring a tree that already has the DLL skips the download (idempotency)
- [ ] Download failure path (e.g. network off) surfaces the FATAL_ERROR with manual-fetch instructions

## Notes

- Min CMake version is 3.20 in this repo; `file(DOWNLOAD)` and `file(ARCHIVE_EXTRACT)` (3.18) are both available.
- No hash check on the download to match CI fidelity (`release.yml:366` also fetches without a hash). Could add `EXPECTED_HASH` as a follow-up.
- GPLv2 compliance unchanged: we still never redistribute the DLL from this repo; CMake pulls it into the user's local tree at build time, same as if they'd run the wget/Invoke-WebRequest themselves.