### PR TITLE
Phase 3O sub-phases 1–4: VAX data model + audio bus + PortAudio engine + AudioEngine refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,7 @@ set(CORE_SOURCES
     src/core/ClarityController.cpp
     src/core/StepAttenuatorController.cpp
     src/core/audio/MasterMixer.cpp
+    src/core/audio/PortAudioBus.cpp
 )
 
 set(MODEL_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,36 @@ else()
 endif()
 
 # --------------------------------------------------------------------------
+# PortAudio v19 (Phase 3O VAX — PortAudioBus fallback for IAudioBus)
+# --------------------------------------------------------------------------
+include(FetchContent)
+
+FetchContent_Declare(
+    portaudio
+    GIT_REPOSITORY https://github.com/PortAudio/portaudio.git
+    GIT_TAG        v19.7.0  # verified cmake-clean release
+)
+
+# PortAudio build options — turn off ASIO. Direct ASIO support was
+# dropped during the 2026-04-19 GPL compliance review (see plan §"GPL
+# Compliance Review"); PortAudio's built-in ASIO host API is gated off
+# for the same reason (the Steinberg ASIO SDK license is
+# GPL-incompatible). All other PortAudio host APIs remain enabled:
+# MME / DS / WDM-KS / WASAPI on Windows, CoreAudio on macOS,
+# ALSA / Pulse / PipeWire / JACK on Linux.
+set(PA_BUILD_SHARED OFF CACHE BOOL "PortAudio static" FORCE)
+set(PA_BUILD_STATIC ON  CACHE BOOL "PortAudio static" FORCE)
+set(PA_USE_ASIO    OFF CACHE BOOL "PortAudio disable ASIO host API (GPL review drop)" FORCE)
+
+# PortAudio v19.7.0 uses `cmake_minimum_required(VERSION 2.8)`, which CMake
+# 4.x rejects because compatibility with CMake < 3.5 has been removed. Pin
+# the minimum policy version for the nested project so FetchContent can
+# configure it under modern CMake without touching the vendored source.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING "Minimum CMake policy version for vendored subprojects" FORCE)
+
+FetchContent_MakeAvailable(portaudio)
+
+# --------------------------------------------------------------------------
 # FFTW3 (for client-side FFT — spectrum and waterfall)
 # --------------------------------------------------------------------------
 find_package(PkgConfig QUIET)
@@ -503,6 +533,11 @@ if(WDSP_FOUND)
     target_link_libraries(NereusSDRObjs PUBLIC wdsp_static)
     target_compile_definitions(NereusSDRObjs PUBLIC HAVE_WDSP)
 endif()
+
+# PortAudio (Phase 3O VAX) — always linked; PortAudioBus is the cross-platform
+# IAudioBus fallback when no native low-latency backend is available.
+target_link_libraries(NereusSDRObjs PRIVATE portaudio_static)
+target_include_directories(NereusSDRObjs PRIVATE ${portaudio_SOURCE_DIR}/include)
 
 if(NEREUS_GPU_SPECTRUM)
     target_link_libraries(NereusSDRObjs PUBLIC Qt6::GuiPrivate)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ set(CORE_SOURCES
     src/core/NoiseFloorTracker.cpp
     src/core/ClarityController.cpp
     src/core/StepAttenuatorController.cpp
+    src/core/audio/MasterMixer.cpp
 )
 
 set(MODEL_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ FetchContent_Declare(
 # ALSA / Pulse / PipeWire / JACK on Linux.
 set(PA_BUILD_SHARED OFF CACHE BOOL "PortAudio static" FORCE)
 set(PA_BUILD_STATIC ON  CACHE BOOL "PortAudio static" FORCE)
-set(PA_USE_ASIO    OFF CACHE BOOL "PortAudio disable ASIO host API (GPL review drop)" FORCE)
+set(PA_USE_ASIO    OFF CACHE BOOL "PortAudio ASIO host API — forced OFF for GPL compliance (Steinberg SDK incompatible)" FORCE)
 
 # PortAudio v19.7.0 uses `cmake_minimum_required(VERSION 2.8)`, which CMake
 # 4.x rejects because compatibility with CMake < 3.5 has been removed. Pin
@@ -537,7 +537,7 @@ endif()
 # PortAudio (Phase 3O VAX) — always linked; PortAudioBus is the cross-platform
 # IAudioBus fallback when no native low-latency backend is available.
 target_link_libraries(NereusSDRObjs PRIVATE portaudio_static)
-target_include_directories(NereusSDRObjs PRIVATE ${portaudio_SOURCE_DIR}/include)
+target_include_directories(NereusSDRObjs PUBLIC ${portaudio_SOURCE_DIR}/include)
 
 if(NEREUS_GPU_SPECTRUM)
     target_link_libraries(NereusSDRObjs PUBLIC Qt6::GuiPrivate)

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -197,14 +197,16 @@ NereusSDR is an independent cross-platform SDR client deeply informed by the wor
 | Legacy skin compatibility | Extended skin format + Thetis import (2D) | Design done |
 | Configurable containers (Thetis multi-meter) | Unified container system (float/dock/axis-lock) | Design done |
 | PureSignal PA linearization | Feedback RX channel + pscc() loop designed (2E), DDC sync (2F) | Design done |
-| TCI protocol | Planned as Phase 3J | Not started |
-| Cross-platform packaging | CI workflows in place (AppImage, Windows, macOS) | CI done |
+| TCI protocol | Planned as Phase 3J | Not started (integration points reserved in 3O) |
+| Cross-platform packaging | CI workflows in place (AppImage, Windows, macOS) | **3N complete** — `release.yml` + `/release` skill; v0.2.1 shipped GPG-signed across all three platforms |
 | AetherSDR architecture patterns | RadioModel hub, signal/slot, worker threads, AppSettings | Adopted |
 | Radio-authoritative state | Designed per AetherSDR pattern | Adopted |
 | Multi-receiver ADC/DDC mapping | Full signal chain analyzed (2F), UpdateDDCs() porting needed | Design done |
+| **VAX audio routing + Thetis VAC/cmASIO parity** | **Phase 3O spec at `docs/architecture/2026-04-19-vax-design.md`** | **Designed 2026-04-19, impl planned** |
 
 **All project brief objectives are covered.** Feature gap analysis completed 2026-04-10
-(see `docs/architecture/reviews/2026-04-10-plan-review.md` for full audit).
+(see `docs/architecture/reviews/2026-04-10-plan-review.md` for full audit). Phase 3O
+VAX design added 2026-04-19.
 
 ---
 
@@ -762,13 +764,58 @@ Scope:
 - I/Q recording — raw I/Q samples for offline analysis
 - Recording controls wired to VfoWidget (existing button stubs)
 
-### Phase 3N: Cross-Platform Packaging
+### Phase 3N: Cross-Platform Packaging ✅ COMPLETE
 **Goal:** Release builds for Linux, Windows, macOS.
 
-CI workflows already in place. Finalize:
-- AppImage (Linux x86_64 + ARM)
-- Windows NSIS installer + portable ZIP
-- macOS DMG (Apple Silicon)
+Shipped: consolidated `release.yml` (prepare → build×3 → sign-and-publish), `/release` skill, GPG-signed alpha builds across Linux AppImage ×2 archs, macOS Apple Silicon DMG, Windows portable ZIP + NSIS installer. v0.1.2 → v0.1.4 → v0.1.7 → v0.2.0 → v0.2.1 all shipped via this pipeline.
+
+### Phase 3O: VAX — Audio Routing & Cross-Platform Audio Engine
+**Goal:** Ship NereusSDR's complete RX audio routing story — per-receiver VAX assignment, Thetis-grade Setup → Audio power-user surface, native VAX drivers on macOS/Linux, auto-detect for user-installed Windows virtual cables, optional Direct ASIO (cmASIO parity) engine.
+
+**Design spec:** `docs/architecture/2026-04-19-vax-design.md` (brainstormed 2026-04-19, ready for implementation plan)
+
+Scope:
+- **`IAudioBus` abstraction** with five platform backends: `CoreAudioHalBus` (macOS HAL plugin, port of AetherSDR `VirtualAudioBridge`), `LinuxPipeBus` (PulseAudio module-pipe, port of AetherSDR `PipeWireAudioBridge`), `PortAudioBus` (Windows default + Mac/Linux fallback), `DirectAsioBus` (Windows opt-in, Thetis `cmasio.c` port with Thetis attribution), `CoreAudioBus` (Mac fallback).
+- **macOS HAL plugin** at `hal-plugin/NereusSDRVAX.cpp` — 4 VAX outputs + 1 TX input as native CoreAudio devices. libASPL-based, POSIX shm IPC. Dev-ID-signed + notarized `.pkg` installer with macOS 14.4+ `killall coreaudiod` fallback.
+- **Linux bridge** — `pactl`-loaded `module-pipe-source` × 4 + `module-pipe-sink` × 1, rebranded to `nereussdr-vax-*`. Works on both Pulse and PipeWire-via-pipewire-pulse. Stale-module cleanup on startup.
+- **Windows BYO path** — `VirtualCableDetector` regex-matches VB-Audio family, VAC, Voicemeeter, Dante, FlexRadio DAX. First-run dialog pre-fills bindings; links to vendor install pages when none detected.
+- **Optional Direct ASIO engine** (Windows) — full Thetis `cmASIO` parity: ASIO driver picker, Control Panel launcher, base in/out channel selection, input mode L/R/Both, lock mode, block size. Gated behind an Engine radio button on the Devices tab — no callsign allowlist, no runtime flag.
+- **Routing model** — SmartSDR-style: `SliceModel.vaxChannel` (0..4) set via new `VaxChannelSelector` row on `VfoWidget`; speakers always-on unless muted; one VAX owns TX at a time (`TransmitModel.txOwnerSlot`).
+- **`VaxApplet` (docked, ported from AetherSDR `DaxApplet`, renamed DAX→VAX)** — 4 channel strips with meter + gain + mute + device picker + assigned-slice tags; TX row with gain + meter.
+- **Menu-bar `MasterOutputWidget`** — global volume + mute + right-click device picker; scroll-wheel fine-tune.
+- **Setup → Audio page** — sub-tabs Devices / VAX / TCI (disabled placeholder) / Advanced. Per-device Driver API dropdown exposes MME / DirectSound / WDM-KS / WASAPI-shared / WASAPI-exclusive / ASIO on Windows; CoreAudio on Mac; ALSA / Pulse / PipeWire / JACK on Linux. Buffer size with derived ms; manual latency override; exclusive mode + event-driven + bypass-mixer options per WASAPI; full cmASIO control surface behind Engine radio.
+- **First-run auto-detect dialog** — 5 scenarios per-platform (Windows cables-found / Windows none-found / Mac native / Linux native / rescan-on-new-cable).
+- **AppSettings schema additions** — per-device driver API + format + buffer; per-VAX enabled + device + gain + mute; per-slice VAX channel; TX owner slot; master volume/mute/device; IVAC feedback parity controls (gain/slew/ring min-max/alpha); global toggles for IQ-to-VAX (reserved), mute-VAX-during-TX-on-other-slice, first-run-complete.
+- **Settings migration** — single legacy `audio/OutputDevice` key migrates to `audio/Speakers/DeviceName` with sensible defaults; first-run dialog triggers.
+- **Audio engine refactor** — replaces `QAudioSink`-only output with the `IAudioBus` model routing per-slice through `MasterMixer` + per-VAX taps.
+- **Full end-to-end wiring** — every widget listed in spec §6 has its round-trip wiring (widget → model → action → persistence → feedback guard) specified before implementation. Zero unwired controls; this is a spec-enforced bar per the design doc.
+
+Attribution (per `docs/attribution/HOW-TO-PORT.md`):
+- AetherSDR-ported files (`VirtualAudioBridge`, `PipeWireAudioBridge`, `hal-plugin/AetherSDRDAX.cpp`, `DaxApplet`, `MeterSlider`) get NereusSDR port-citation + modification-history headers per rule 6 (AetherSDR has no per-file GPL headers; cite at project URL + primary author level).
+- Thetis-ported files (`DirectAsioBus`, `AsioSdkHost` from `ChannelMaster/cmasio.{h,c}` + `Console/clsCMASIOConfig.cs`) get byte-for-byte Thetis headers stacked per rule 4, inline markers preserved, `[v2.10.3.13]` version stamps on all cites.
+- PROVENANCE rows added in the same commits that introduce the ports.
+
+Dependencies:
+- Phase 3B (AudioEngine skeleton) — ✓
+- Phase 3G-10 Stage 2 (`VfoWidget` tab structure and per-slice persistence) — ✓
+- Phase 3G-8 (`SetupPage` base + STYLEGUIDE.md) — ✓
+
+Reserves integration points for:
+- **Phase 3J (TCI):** `IAudioBus` tap contract lets TCI subscribe to the same RX taps with no refactor.
+- **Future:** NereusSDR-owned Windows signed driver can replace BYO cables transparently via `VirtualCableDetector`'s reserved "NereusSDR VAX N" pattern.
+
+Explicitly out of scope (in this phase):
+- TCI server and TCI audio streams (Phase 3J).
+- TX mic DSP chain — compressor, TX EQ, leveler (Phase 3M-3).
+- IQ-to-VAX activation (setting persisted but logs-and-ignores until future phase).
+- NereusSDR-owned Windows virtual audio driver.
+
+Success criteria (subset, see spec §14 for full list):
+- All controls round-trip wired; zero unwired buttons.
+- Thetis migrator can configure equivalent VAC1/VAC2 in Setup → Audio in under 5 minutes on Windows.
+- Mac/Linux users see "NereusSDR VAX 1–4" + "NereusSDR TX" in WSJT-X audio picker with zero extra install.
+- Windows user with VB-CABLE installed sees auto-detect suggestions on first launch.
+- `scripts/verify-thetis-headers.py` + `scripts/check-new-ports.py` pass on all ported files.
 
 ---
 
@@ -819,7 +866,7 @@ Execution order: **(3G-9a..c ∥ 3G-10 ∥ 3G-13) → 3M-1..4 → 3F → 3H → 
 
 3G-9, 3G-10, 3G-13, and 3G-14 touch disjoint subsystems from each other and from 3M-* — they can all run in parallel if desired. 3G-9 owns the Display setup surface; 3G-10 owns the VFO flag and RX DSP wiring; 3G-13 owns the step attenuator + ADC overload protection (protocol layer + Setup Options + RxApplet ATT row + status bar); 3G-14 owns the 💡 issue reporter (menu bar corner widget + dialog).
 
-Independent phases (can start anytime): 3G-14 (issue reporter), 3J (TCI), 3K (CAT), 3L (P1), 3M (Recording).
+Independent phases (can start anytime): 3G-14 (issue reporter), 3J (TCI — depends on 3O IAudioBus contract), 3K (CAT), 3L (P1), 3M (Recording), **3O (VAX audio routing — depends on 3B, 3G-8, 3G-10 Stage 2; all complete)**.
 
 ---
 
@@ -850,6 +897,7 @@ prerequisite infrastructure exists.
 | Date | Scope | Document |
 |---|---|---|
 | 2026-04-10 | Full plan review: Thetis/AetherSDR deep-dive, feature gap analysis, phase restructuring, container/PureSignal/TX architecture | [2026-04-10-plan-review.md](architecture/reviews/2026-04-10-plan-review.md) |
+| 2026-04-19 | Added Phase 3O (VAX — Audio Routing & Cross-Platform Audio Engine). Design brainstormed against Thetis VAC/cmASIO, AetherSDR DaxApplet/VirtualAudioBridge/PipeWireAudioBridge, and reference UIs (Rogue Amoeba Loopback, Dante Controller, RME TotalMix, qpwgraph). Chose SmartSDR-style routing + VFO-flag VAX selector + docked VaxApplet over patchbay/matrix alternatives. Windows BYO-with-auto-detect chosen over signed-kernel-driver for v1; TCI scoped out to Phase 3J with integration points reserved. Also audited status of 3N (marked complete) and added VAX row to Objective Cross-Check. | [2026-04-19-vax-design.md](architecture/2026-04-19-vax-design.md) |
 
 ---
 

--- a/docs/MASTER-PLAN.md
+++ b/docs/MASTER-PLAN.md
@@ -779,7 +779,7 @@ Scope:
 - **macOS HAL plugin** at `hal-plugin/NereusSDRVAX.cpp` — 4 VAX outputs + 1 TX input as native CoreAudio devices. libASPL-based, POSIX shm IPC. Dev-ID-signed + notarized `.pkg` installer with macOS 14.4+ `killall coreaudiod` fallback.
 - **Linux bridge** — `pactl`-loaded `module-pipe-source` × 4 + `module-pipe-sink` × 1, rebranded to `nereussdr-vax-*`. Works on both Pulse and PipeWire-via-pipewire-pulse. Stale-module cleanup on startup.
 - **Windows BYO path** — `VirtualCableDetector` regex-matches VB-Audio family, VAC, Voicemeeter, Dante, FlexRadio DAX. First-run dialog pre-fills bindings; links to vendor install pages when none detected.
-- **Optional Direct ASIO engine** (Windows) — full Thetis `cmASIO` parity: ASIO driver picker, Control Panel launcher, base in/out channel selection, input mode L/R/Both, lock mode, block size. Gated behind an Engine radio button on the Devices tab — no callsign allowlist, no runtime flag.
+- ~~Optional Direct ASIO engine (Windows) — cmASIO parity~~ **Deferred** per 2026-04-19 GPL-3 compliance review (Steinberg ASIO SDK not GPL-compatible). PortAudio's built-in ASIO host API remains as the ASIO path. See plan's GPL Compliance Review section and spec §8.5 compliance note.
 - **Routing model** — SmartSDR-style: `SliceModel.vaxChannel` (0..4) set via new `VaxChannelSelector` row on `VfoWidget`; speakers always-on unless muted; one VAX owns TX at a time (`TransmitModel.txOwnerSlot`).
 - **`VaxApplet` (docked, ported from AetherSDR `DaxApplet`, renamed DAX→VAX)** — 4 channel strips with meter + gain + mute + device picker + assigned-slice tags; TX row with gain + meter.
 - **Menu-bar `MasterOutputWidget`** — global volume + mute + right-click device picker; scroll-wheel fine-tune.
@@ -792,8 +792,9 @@ Scope:
 
 Attribution (per `docs/attribution/HOW-TO-PORT.md`):
 - AetherSDR-ported files (`VirtualAudioBridge`, `PipeWireAudioBridge`, `hal-plugin/AetherSDRDAX.cpp`, `DaxApplet`, `MeterSlider`) get NereusSDR port-citation + modification-history headers per rule 6 (AetherSDR has no per-file GPL headers; cite at project URL + primary author level).
-- Thetis-ported files (`DirectAsioBus`, `AsioSdkHost` from `ChannelMaster/cmasio.{h,c}` + `Console/clsCMASIOConfig.cs`) get byte-for-byte Thetis headers stacked per rule 4, inline markers preserved, `[v2.10.3.13]` version stamps on all cites.
+- ~~Thetis-ported files (`DirectAsioBus`, `AsioSdkHost` from `ChannelMaster/cmasio.{h,c}` + `Console/clsCMASIOConfig.cs`) get byte-for-byte Thetis headers~~ — deferred with Direct ASIO.
 - PROVENANCE rows added in the same commits that introduce the ports.
+- `COMPLIANCE-INVENTORY.md` updated at end of phase documenting macOS HAL plugin's separate-binary / mere-aggregation status and the 2026-04-19 GPL review outcome.
 
 Dependencies:
 - Phase 3B (AudioEngine skeleton) — ✓
@@ -897,7 +898,8 @@ prerequisite infrastructure exists.
 | Date | Scope | Document |
 |---|---|---|
 | 2026-04-10 | Full plan review: Thetis/AetherSDR deep-dive, feature gap analysis, phase restructuring, container/PureSignal/TX architecture | [2026-04-10-plan-review.md](architecture/reviews/2026-04-10-plan-review.md) |
-| 2026-04-19 | Added Phase 3O (VAX — Audio Routing & Cross-Platform Audio Engine). Design brainstormed against Thetis VAC/cmASIO, AetherSDR DaxApplet/VirtualAudioBridge/PipeWireAudioBridge, and reference UIs (Rogue Amoeba Loopback, Dante Controller, RME TotalMix, qpwgraph). Chose SmartSDR-style routing + VFO-flag VAX selector + docked VaxApplet over patchbay/matrix alternatives. Windows BYO-with-auto-detect chosen over signed-kernel-driver for v1; TCI scoped out to Phase 3J with integration points reserved. Also audited status of 3N (marked complete) and added VAX row to Objective Cross-Check. | [2026-04-19-vax-design.md](architecture/2026-04-19-vax-design.md) |
+| 2026-04-19 | Added Phase 3O (VAX — Audio Routing & Cross-Platform Audio Engine). Design brainstormed against Thetis VAC/cmASIO, AetherSDR DaxApplet/VirtualAudioBridge/PipeWireAudioBridge, and reference UIs (Rogue Amoeba Loopback, Dante Controller, RME TotalMix, qpwgraph). Chose AetherSDR-style routing + VFO-flag VAX selector + docked VaxApplet over patchbay/matrix alternatives. Windows BYO-with-auto-detect chosen over signed-kernel-driver for v1; TCI scoped out to Phase 3J with integration points reserved. Also audited status of 3N (marked complete) and added VAX row to Objective Cross-Check. | [2026-04-19-vax-design.md](architecture/2026-04-19-vax-design.md) |
+| 2026-04-19 | Implementation plan authored for Phase 3O with pre-execution GPL-3 compliance review. **Dropped Direct ASIO engine** from the phase: Steinberg ASIO SDK is not GPL-3 compatible; linking it into distributed NereusSDR binaries would violate both the ASIO SDK terms and GPL-3. PortAudio's built-in ASIO host API remains as the ASIO path. All other components (AetherSDR GPL-3 ports, libASPL MIT, PortAudio MIT, Qt6/FFTW3/WDSP) verified compatible. Compliance inventory update folded into final verification task. | [2026-04-19-phase3o-vax-plan.md](architecture/2026-04-19-phase3o-vax-plan.md) |
 
 ---
 

--- a/docs/architecture/2026-04-19-phase3o-handoff.md
+++ b/docs/architecture/2026-04-19-phase3o-handoff.md
@@ -1,0 +1,108 @@
+# Phase 3O VAX — Sub-Phase 3+ Continuation Handoff
+
+## Where we are
+
+Sub-Phases 1+2 of Phase 3O shipped as a PR from `feature/phase-3o-vax`
+(branch in the worktree `~/NereusSDR/.worktrees/phase-3o-vax`). The
+design spec, implementation plan, and the data-model + audio-abstraction
+scaffolding are landed and GPG-signed. The rest of the plan is ready
+for execution.
+
+Run Sub-Phase 3 onward using `superpowers:subagent-driven-development`:
+fresh implementer subagent per task, spec-compliance reviewer, then
+code-quality reviewer, then fixes-and-re-review until approved.
+
+## Key docs
+
+- Design spec — `docs/architecture/2026-04-19-vax-design.md`
+- Implementation plan — `docs/architecture/2026-04-19-phase3o-vax-plan.md`
+- Project conventions — `CLAUDE.md` (AppSettings, atomics, pre-commit
+  hooks, GPG signing, source-first porting for Thetis / AetherSDR / WDSP)
+- Attribution rules — `docs/attribution/HOW-TO-PORT.md` (rule 6 for
+  AetherSDR ports: no per-file GPL headers, cite at project URL; rule 4
+  for multi-source stacked Thetis headers — not needed in Phase 3O after
+  Direct ASIO was dropped in the GPL review)
+- Widget styling — `STYLEGUIDE.md` (palette, button active-states, inset
+  boxes, slider and combo conventions — new UI in Sub-Phases 8/9/10/11/12
+  must follow)
+
+## State at handoff
+
+- Worktree: `/Users/j.j.boyd/NereusSDR/.worktrees/phase-3o-vax`
+- Branch: `feature/phase-3o-vax`
+- Build: clean (`cmake --build build-tests -j4`)
+- Tests: full suite runs with 4 pre-existing failures
+  (`tst_container_persistence`, `tst_p1_loopback_connection`,
+  `tst_hardware_page_capability_gating` segfault, `tst_about_dialog`).
+  No new failures. The 32 new Phase 3O tests from Sub-Phases 1+2 all
+  pass.
+- Pre-commit hooks: all green
+- No uncommitted changes at PR push
+
+## What's next — Sub-Phase 3: PortAudio Engine
+
+Three tasks, all in plan §"Sub-Phase 3":
+
+- **Task 3.1** — Vendor PortAudio v19.7.0 via CMake FetchContent.
+  Static-link, `PA_USE_ASIO=OFF` (Direct ASIO was dropped in the GPL
+  review; PortAudio's built-in ASIO host API is also gated off).
+  **Critical sub-step:** verify the bundled `LICENSE.txt` at the
+  v19.7.0 pin is the MIT-compatible Ross Bencina / Phil Burk grant
+  before committing. If it's anything else, stop and surface.
+
+- **Task 3.2** — `PortAudioBus` minimal render-only. Open PortAudio
+  default output, accept `push()` from main thread into a lock-free
+  ring, drain in the PortAudio callback. Peak-level metering via
+  `std::atomic`.
+
+- **Task 3.3** — Host API + device enumeration (needed by SetupAudioPage
+  in Sub-Phase 12).
+
+- **Task 3.4** — TX capture support (open input stream + `pull()`).
+
+Difficulty per plan: medium-hard. PortAudio callback model and format
+negotiation need careful handling.
+
+## Forward issues to address in Sub-Phase 4
+
+- `MasterMixer::setSliceGain` / `setSliceMuted` implicitly insert into
+  the slice map via `operator[]`. Latent data race if called on a new
+  slice ID mid-stream. Sub-Phase 4 must add an explicit
+  `registerSlice()` entry point or document + enforce startup-only
+  callers.
+
+## How to start a fresh session
+
+1. Verify the worktree is clean —
+   `cd ~/NereusSDR/.worktrees/phase-3o-vax && git status`
+2. Pull any new commits from origin —
+   `git pull origin feature/phase-3o-vax`
+3. Invoke `superpowers:subagent-driven-development`
+4. Dispatch Task 3.1 implementer. The plan text at
+   `docs/architecture/2026-04-19-phase3o-vax-plan.md` §"Sub-Phase 3:
+   PortAudio Engine" → Task 3.1 is the authoritative task description;
+   paste the full task + surrounding context + project conventions into
+   the implementer prompt.
+
+## Review lessons learned (avoid repeating)
+
+- Slice-scoped AppSettings keys use `Slice<N>/` PascalCase (via
+  `slicePrefix()` helper in `SliceModel.cpp:729-731`). Global keys
+  lowercase like `tx/OwnerSlot`.
+- Atomic memory ordering convention: `acquire` on loads, `release` on
+  stores, `acq_rel` on `exchange`. Do not use default `seq_cst`.
+- Don't call `AppSettings::instance().save()` eagerly from setters;
+  batch-flush at caller. Verify by grepping existing setters first.
+- No ported code in Sub-Phases 1–4 — those are NereusSDR-original.
+  Sub-Phase 5 (macOS HAL) starts the port work from AetherSDR;
+  Sub-Phase 6 (Linux bridge) continues; Sub-Phase 9 (VaxApplet +
+  MeterSlider) is the biggest port. `HOW-TO-PORT.md` rule 6 governs
+  AetherSDR ports.
+- When fixing spec/plan errors, update BOTH docs so downstream tasks
+  inherit the corrected convention (Task 1.1 had this — the key
+  convention was wrong in the spec itself).
+- Clangd diagnostics in the IDE are often from the main checkout, not
+  the feature worktree. Ignore them unless the worktree build itself
+  fails. The worktree's `cmake --build` + `ctest` is the truth.
+
+J.J. Boyd ~ KG4VCF

--- a/docs/architecture/2026-04-19-phase3o-vax-plan.md
+++ b/docs/architecture/2026-04-19-phase3o-vax-plan.md
@@ -1,0 +1,2426 @@
+# Phase 3O: VAX Audio Routing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build NereusSDR's complete cross-platform RX audio routing story — per-receiver VAX assignment via VFO-flag selector, native VAX drivers on macOS (HAL plugin) and Linux (PulseAudio module-pipe), Windows BYO virtual cables with auto-detection, and a Thetis-grade Setup → Audio surface with optional Direct ASIO (cmASIO parity) engine.
+
+**Architecture:** Single `IAudioBus` C++ abstraction with five platform backends (`CoreAudioHalBus`, `LinuxPipeBus`, `PortAudioBus`, `DirectAsioBus`, `CoreAudioBus`). Per-slice `vaxChannel` atomic int drives tap routing. AetherSDR-style applet (`VaxApplet` ported + renamed from `DaxApplet`) shows per-channel meters/gains. VFO-flag gains a one-row `VaxChannelSelector`. Menu bar gains a `MasterOutputWidget`. Setup dialog gains an Audio page with four sub-tabs. First-run dialog auto-detects virtual cables.
+
+**Tech Stack:** C++20, Qt6 (Widgets + Multimedia), PortAudio v19, libASPL 3.1.2 (macOS), Steinberg ASIO SDK (Windows opt-in), POSIX shm (Mac), PulseAudio/PipeWire (Linux), WiX v4 (Windows installer).
+
+**Design spec:** [`docs/architecture/2026-04-19-vax-design.md`](2026-04-19-vax-design.md) — all architectural decisions, signal flow, data model, and wiring tables are authoritative there. This plan translates the spec into TDD-sequenced tasks.
+
+---
+
+## GPL Compliance Review (2026-04-19)
+
+Pre-execution audit of every bundled or linked dependency against NereusSDR's GPL-3.0 license:
+
+| Component | License | GPL-3 compatible? |
+|---|---|---|
+| AetherSDR ports (VirtualAudioBridge, PipeWireAudioBridge, HAL plugin, DaxApplet, MeterSlider) | GPL-3.0 | ✅ trivial |
+| Thetis ports (none in Phase 3O after Direct ASIO drop) | GPL-2-or-later + Samphire dual-license | n/a this phase |
+| libASPL (macOS HAL framework, vendored by FetchContent) | MIT | ✅ MIT → GPL-3 one-way compatible |
+| PortAudio v19.7.0 (vendored by FetchContent) | MIT-style (verify LICENSE.txt at pin) | ✅ expected, verification step added to Task 3.1 |
+| Qt6 / FFTW3 / WDSP | LGPL-3 / GPL-2 / GPL (TAPR) | ✅ already in use |
+| User-installed virtual cables (VB-CABLE, VAC, Voicemeeter, BlackHole, Dante, FlexRadio DAX) | Proprietary / various | ✅ not redistributed; users install themselves |
+| **Steinberg ASIO SDK** | **Proprietary, explicitly non-GPL** | 🚨 **NOT compatible** — see decision below |
+
+### Decision: drop Direct ASIO from Phase 3O
+
+Linking the Steinberg ASIO SDK into GPL-3 NereusSDR binaries violates both the ASIO SDK license (no redistribution of modified headers) and GPL-3 (non-free library linked into a GPL work; no system-library exception applies). Audacity hits the same wall and ships ASIO-disabled binaries for this exact reason.
+
+**Action:** Sub-Phase 13 (Direct ASIO Engine) and all references to `DirectAsioBus` / `AsioSdkHost` / Thetis `cmasio.c` ports are **removed from this plan.** PortAudio's built-in ASIO host API (available via the `PA_USE_ASIO` CMake option) covers the overwhelming majority of ASIO use cases without our project redistributing the SDK itself.
+
+If community demand ever justifies revisiting this, it lands as a **separate compliance proposal** (either option 2 — developer-build-only gate with CI enforcement — or a formal Steinberg commercial-license conversation). Not now.
+
+### Remediation actions folded into this plan
+
+- **Task 3.1** adds a step to verify PortAudio's bundled `LICENSE.txt` at the v19.7.0 pin is MIT-compatible before committing the FetchContent.
+- **Task 14.4 (final verification)** adds steps to update `docs/attribution/COMPLIANCE-INVENTORY.md` with rows for every new port (HAL plugin, CoreAudioHalBus, LinuxPipeBus, VaxApplet, MeterSlider) and to document the macOS HAL plugin's separate-binary / mere-aggregation reasoning per GPL-3 §5.
+- **Attribution verifiers** (`scripts/verify-thetis-headers.py`, `scripts/check-new-ports.py`, and the existing AetherSDR + WDSP passes in the pre-commit hook) cover enforcement for the GPL-compatible ports.
+
+**Difficulty ranking** (after Direct ASIO drop, per spec §9, no calendar estimates):
+🟢 Easy — VirtualCableDetector, LinuxPipeBus, AppSettings schema, VaxChannelSelector, MasterOutputWidget
+🟡 Medium — VaxApplet port, HAL plugin (macOS), SetupAudioPage, TX arbitration, MasterMixer
+🟠 Medium-hard — IAudioBus abstraction + AudioEngine refactor, PortAudioBus
+🔴 Hard — end-to-end smoke-test matrix
+
+---
+
+## Prerequisites
+
+### Worktree setup
+
+This plan should execute in an isolated worktree so it doesn't disturb ongoing work on other branches.
+
+```bash
+cd ~/NereusSDR
+git worktree add -b feature/phase-3o-vax ../NereusSDR-vax main
+cd ../NereusSDR-vax
+```
+
+All file paths below are relative to the worktree root.
+
+### Tooling
+
+Before starting, verify the environment:
+
+```bash
+# macOS
+brew list | grep -E 'qt|cmake|ninja|fftw|portaudio'
+
+# Arch Linux
+pacman -Q qt6-base qt6-multimedia cmake ninja fftw portaudio
+
+# Windows
+# Visual Studio 2022 + Qt 6.x + CMake + Ninja pre-installed per CONTRIBUTING.md
+```
+
+### Reference checkouts
+
+- **Thetis** at `../Thetis/` — cmASIO source. Capture the version once at session start:
+  ```bash
+  git -C ../Thetis describe --tags
+  # → use output as `[vX.Y.Z.W]` on every `// From Thetis …` cite in this plan
+  ```
+- **AetherSDR** at `../AetherSDR/` — port source for VirtualAudioBridge, PipeWireAudioBridge, hal-plugin, DaxApplet, MeterSlider. No per-file GPL headers (project-level per `HOW-TO-PORT.md` rule 6).
+
+---
+
+## File Structure Overview
+
+### Files to create
+
+| Path | Role | Sub-phase |
+|---|---|---|
+| `src/core/IAudioBus.h` | Abstract bus interface + `AudioFormat` struct | 2 |
+| `src/core/audio/MasterMixer.{h,cpp}` | Per-slice mute/volume/pan → single sink | 2 |
+| `src/core/audio/PortAudioBus.{h,cpp}` | PortAudio stream; Windows default + Mac/Linux fallback | 3 |
+| `src/core/audio/CoreAudioHalBus.{h,cpp}` | macOS HAL plugin shm writer (ported) | 5 |
+| `hal-plugin/NereusSDRVAX.cpp` | macOS HAL plugin (ported) | 5 |
+| `hal-plugin/CMakeLists.txt` | HAL plugin build (ported) | 5 |
+| `hal-plugin/Info.plist` | HAL plugin bundle manifest (ported) | 5 |
+| `packaging/macos/hal-installer.sh` | macOS `.pkg` builder (ported) | 5 |
+| `packaging/macos/hal-postinstall.sh` | coreaudiod restart w/ 14.4+ killall fallback | 5 |
+| `packaging/macos/hal-uninstall.sh` | remove `.driver` + shm segments (ported) | 5 |
+| `src/core/audio/LinuxPipeBus.{h,cpp}` | Linux PulseAudio module-pipe bridge (ported) | 6 |
+| `src/core/audio/VirtualCableDetector.{h,cpp}` | OS-audio-device regex matcher | 7 |
+| `src/gui/widgets/VaxChannelSelector.{h,cpp}` | VFO flag VAX button group | 8 |
+| `src/gui/widgets/MeterSlider.{h,cpp}` | Meter+slider composite (ported) | 9 |
+| `src/gui/applets/VaxApplet.{h,cpp}` | Docked VAX meter/gain applet (ported + renamed) | 9 |
+| `src/gui/MasterOutputWidget.{h,cpp}` | Menu-bar master output strip | 10 |
+| `src/gui/VaxFirstRunDialog.{h,cpp}` | First-run auto-detect modal | 11 |
+| `src/gui/SetupAudioPage.{h,cpp}` | Setup → Audio page (4 sub-tabs) | 12 |
+| `resources/help/install-virtual-cables.md` | User-facing help doc | 14 |
+| `tests/tst_slice_model_vax.cpp` | SliceModel.vaxChannel tests | 1 |
+| `tests/tst_transmit_model_tx_owner.cpp` | TransmitModel.txOwnerSlot tests | 1 |
+| `tests/tst_app_settings_vax_migration.cpp` | Settings migration test | 1 |
+| `tests/tst_master_mixer.cpp` | MasterMixer unit tests | 2 |
+| `tests/tst_port_audio_bus.cpp` | PortAudioBus unit tests (Null device) | 3 |
+| `tests/tst_virtual_cable_detector.cpp` | Regex-match unit tests | 7 |
+| `tests/tst_vax_channel_selector.cpp` | Widget behaviour tests | 8 |
+
+### Files to modify
+
+| Path | Change | Sub-phase |
+|---|---|---|
+| `src/models/SliceModel.{h,cpp}` | Add `vaxChannel`, persistence, signal | 1 |
+| `src/models/TransmitModel.{h,cpp}` | Add `txOwnerSlot` + `VaxSlot` enum | 1 |
+| `src/core/AppSettings.{h,cpp}` | Schema migration helper | 1 |
+| `src/core/AudioEngine.{h,cpp}` | Replace QAudioSink-only with `IAudioBus` model | 4 |
+| `src/gui/VfoWidget.{h,cpp}` | Embed `VaxChannelSelector` | 8 |
+| `src/gui/MainWindow.{h,cpp}` | Wire `MasterOutputWidget` + first-run dialog trigger | 10, 11 |
+| `src/gui/SetupDialog.{h,cpp}` | Register `SetupAudioPage` | 12 |
+| `CMakeLists.txt` | Add PortAudio; conditionally add HAL subdir on macOS | 3, 5 |
+| `README.md` | Mention VAX routing in features | 14 |
+| `docs/attribution/aethersdr-contributor-index.md` | Add rows for ported files | 5, 6, 9 |
+| `docs/attribution/COMPLIANCE-INVENTORY.md` | Record Phase 3O ports + HAL plugin separate-binary reasoning | 14 |
+| `.github/workflows/release.yml` | Sign + notarize HAL plugin | 5 |
+
+---
+
+## Sub-Phase 1: Data Model Foundation 🟢
+
+### Task 1.1: `SliceModel.vaxChannel`
+
+**Files:**
+- Modify: `src/models/SliceModel.h`, `src/models/SliceModel.cpp`
+- Test: `tests/tst_slice_model_vax.cpp` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tst_slice_model_vax.cpp`:
+
+```cpp
+#include <QtTest/QtTest>
+#include "models/SliceModel.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstSliceModelVax : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultsToOff() {
+        SliceModel s(0);
+        QCOMPARE(s.vaxChannel(), 0);
+    }
+
+    void setAndGet() {
+        SliceModel s(0);
+        s.setVaxChannel(2);
+        QCOMPARE(s.vaxChannel(), 2);
+    }
+
+    void clampsOutOfRangeLow() {
+        SliceModel s(0);
+        s.setVaxChannel(-5);
+        QCOMPARE(s.vaxChannel(), 0);
+    }
+
+    void clampsOutOfRangeHigh() {
+        SliceModel s(0);
+        s.setVaxChannel(99);
+        QCOMPARE(s.vaxChannel(), 0);
+    }
+
+    void emitsSignalOnChange() {
+        SliceModel s(0);
+        QSignalSpy spy(&s, &SliceModel::vaxChannelChanged);
+        s.setVaxChannel(3);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toInt(), 3);
+    }
+
+    void noSignalOnSameValue() {
+        SliceModel s(0);
+        s.setVaxChannel(2);
+        QSignalSpy spy(&s, &SliceModel::vaxChannelChanged);
+        s.setVaxChannel(2);
+        QCOMPARE(spy.count(), 0);
+    }
+
+    void persistsToSettings() {
+        AppSettings::instance().clear();
+        SliceModel s(7);
+        s.setVaxChannel(4);
+        QCOMPARE(AppSettings::instance().value("slice/7/VaxChannel").toString(), "4");
+    }
+
+    void restoresFromSettings() {
+        AppSettings::instance().clear();
+        AppSettings::instance().setValue("slice/7/VaxChannel", "3");
+        SliceModel s(7);
+        s.loadFromSettings();
+        QCOMPARE(s.vaxChannel(), 3);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstSliceModelVax)
+#include "tst_slice_model_vax.moc"
+```
+
+Add to `tests/CMakeLists.txt`:
+
+```cmake
+qt_add_executable(tst_slice_model_vax tst_slice_model_vax.cpp)
+target_link_libraries(tst_slice_model_vax PRIVATE NereusSDRLib Qt6::Test)
+add_test(NAME tst_slice_model_vax COMMAND tst_slice_model_vax)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cmake --build build --target tst_slice_model_vax
+./build/tests/tst_slice_model_vax
+```
+
+Expected: FAIL — `vaxChannel` / `setVaxChannel` / `vaxChannelChanged` not defined.
+
+- [ ] **Step 3: Add API to `SliceModel.h`**
+
+In `src/models/SliceModel.h`, add under the existing properties section:
+
+```cpp
+    // VAX routing (Phase 3O) — 0=Off, 1..4=VAX channel.
+    int vaxChannel() const { return m_vaxChannel.load(std::memory_order_acquire); }
+    void setVaxChannel(int ch);
+
+signals:
+    void vaxChannelChanged(int ch);
+
+private:
+    std::atomic<int> m_vaxChannel{0};
+```
+
+Also include `<atomic>` at the top of the file if not already present.
+
+- [ ] **Step 4: Implement setter + persistence in `SliceModel.cpp`**
+
+```cpp
+void SliceModel::setVaxChannel(int ch) {
+    // Clamp to valid range.
+    if (ch < 0 || ch > 4) { ch = 0; }
+
+    const int prev = m_vaxChannel.exchange(ch, std::memory_order_acq_rel);
+    if (prev == ch) { return; }
+
+    AppSettings::instance().setValue(
+        QStringLiteral("slice/%1/VaxChannel").arg(m_sliceId),
+        QString::number(ch));
+    AppSettings::instance().save();
+
+    emit vaxChannelChanged(ch);
+}
+```
+
+In `SliceModel::loadFromSettings()` (existing method), add:
+
+```cpp
+    const int vaxCh = AppSettings::instance()
+        .value(QStringLiteral("slice/%1/VaxChannel").arg(m_sliceId), "0")
+        .toString().toInt();
+    if (vaxCh != m_vaxChannel.load()) {
+        m_vaxChannel.store(vaxCh, std::memory_order_release);
+        emit vaxChannelChanged(vaxCh);
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cmake --build build --target tst_slice_model_vax
+./build/tests/tst_slice_model_vax
+```
+
+Expected: PASS — all 8 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/models/SliceModel.h src/models/SliceModel.cpp \
+        tests/tst_slice_model_vax.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(slice-model): add vaxChannel property for VAX routing
+
+Per-slice VAX channel (0=Off, 1..4=VAX 1–4) with std::atomic storage
+for audio-thread-safe reads, AppSettings persistence under
+slice/<id>/VaxChannel, and vaxChannelChanged signal. Feeds the
+AudioEngine VAX tap routing in Phase 3O.
+
+Design spec: docs/architecture/2026-04-19-vax-design.md §5.1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 1.2: `TransmitModel.txOwnerSlot` + `VaxSlot` enum
+
+**Files:**
+- Modify: `src/models/TransmitModel.h`, `src/models/TransmitModel.cpp`
+- Test: `tests/tst_transmit_model_tx_owner.cpp` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tst_transmit_model_tx_owner.cpp`:
+
+```cpp
+#include <QtTest/QtTest>
+#include "models/TransmitModel.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstTransmitModelTxOwner : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultsToMicDirect() {
+        TransmitModel t;
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::MicDirect);
+    }
+
+    void setAndGet() {
+        TransmitModel t;
+        t.setTxOwnerSlot(VaxSlot::Vax2);
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::Vax2);
+    }
+
+    void emitsSignalOnChange() {
+        TransmitModel t;
+        QSignalSpy spy(&t, &TransmitModel::txOwnerSlotChanged);
+        t.setTxOwnerSlot(VaxSlot::Vax3);
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void persistsToSettings() {
+        AppSettings::instance().clear();
+        TransmitModel t;
+        t.setTxOwnerSlot(VaxSlot::Vax4);
+        QCOMPARE(AppSettings::instance().value("tx/OwnerSlot").toString(), "Vax4");
+    }
+
+    void restoresFromSettings() {
+        AppSettings::instance().clear();
+        AppSettings::instance().setValue("tx/OwnerSlot", "Vax1");
+        TransmitModel t;
+        t.loadFromSettings();
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::Vax1);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstTransmitModelTxOwner)
+#include "tst_transmit_model_tx_owner.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+```bash
+cmake --build build --target tst_transmit_model_tx_owner
+./build/tests/tst_transmit_model_tx_owner
+```
+
+Expected: FAIL (VaxSlot enum, txOwnerSlot API undefined).
+
+- [ ] **Step 3: Define `VaxSlot` enum + API in `TransmitModel.h`**
+
+```cpp
+namespace NereusSDR {
+
+enum class VaxSlot {
+    None = 0,
+    MicDirect,
+    Vax1,
+    Vax2,
+    Vax3,
+    Vax4
+};
+
+QString vaxSlotToString(VaxSlot s);
+VaxSlot vaxSlotFromString(const QString& s);
+
+class TransmitModel : public QObject {
+    // ... existing ...
+public:
+    VaxSlot txOwnerSlot() const { return m_txOwnerSlot.load(std::memory_order_acquire); }
+    void setTxOwnerSlot(VaxSlot s);
+
+    void loadFromSettings();
+
+signals:
+    void txOwnerSlotChanged(VaxSlot s);
+
+private:
+    std::atomic<VaxSlot> m_txOwnerSlot{VaxSlot::MicDirect};
+};
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 4: Implement in `TransmitModel.cpp`**
+
+```cpp
+QString NereusSDR::vaxSlotToString(VaxSlot s) {
+    switch (s) {
+        case VaxSlot::None:       return "None";
+        case VaxSlot::MicDirect:  return "MicDirect";
+        case VaxSlot::Vax1:       return "Vax1";
+        case VaxSlot::Vax2:       return "Vax2";
+        case VaxSlot::Vax3:       return "Vax3";
+        case VaxSlot::Vax4:       return "Vax4";
+    }
+    return "MicDirect";
+}
+
+NereusSDR::VaxSlot NereusSDR::vaxSlotFromString(const QString& s) {
+    if (s == "None")      return VaxSlot::None;
+    if (s == "Vax1")      return VaxSlot::Vax1;
+    if (s == "Vax2")      return VaxSlot::Vax2;
+    if (s == "Vax3")      return VaxSlot::Vax3;
+    if (s == "Vax4")      return VaxSlot::Vax4;
+    return VaxSlot::MicDirect;
+}
+
+void TransmitModel::setTxOwnerSlot(VaxSlot s) {
+    const VaxSlot prev = m_txOwnerSlot.exchange(s, std::memory_order_acq_rel);
+    if (prev == s) { return; }
+
+    AppSettings::instance().setValue("tx/OwnerSlot", vaxSlotToString(s));
+    AppSettings::instance().save();
+
+    emit txOwnerSlotChanged(s);
+}
+
+void TransmitModel::loadFromSettings() {
+    const QString v = AppSettings::instance().value("tx/OwnerSlot", "MicDirect").toString();
+    const VaxSlot s = vaxSlotFromString(v);
+    if (s != m_txOwnerSlot.load()) {
+        m_txOwnerSlot.store(s, std::memory_order_release);
+        emit txOwnerSlotChanged(s);
+    }
+}
+```
+
+- [ ] **Step 5: Run to pass**
+
+```bash
+./build/tests/tst_transmit_model_tx_owner
+```
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/models/TransmitModel.h src/models/TransmitModel.cpp \
+        tests/tst_transmit_model_tx_owner.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(transmit-model): add txOwnerSlot + VaxSlot enum
+
+Single-owner TX arbitration between MicDirect and VAX 1–4. Atomic
+storage for audio-thread-safe reads, persisted under tx/OwnerSlot.
+Feeds AudioEngine TX pull routing in Phase 3O.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 1.3: AppSettings schema + legacy migration
+
+**Files:**
+- Modify: `src/core/AppSettings.h`, `src/core/AppSettings.cpp`
+- Test: `tests/tst_app_settings_vax_migration.cpp` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```cpp
+#include <QtTest/QtTest>
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstAppSettingsVaxMigration : public QObject {
+    Q_OBJECT
+private slots:
+    void migratesLegacyOutputDeviceKey() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/OutputDevice", "Built-in Output");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        QCOMPARE(s.value("audio/Speakers/DeviceName").toString(),
+                 QStringLiteral("Built-in Output"));
+        QVERIFY(!s.contains("audio/OutputDevice"));
+        QCOMPARE(s.value("audio/FirstRunComplete", "True").toString(), "False");
+    }
+
+    void doesNothingIfNoLegacyKey() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/Speakers/DeviceName", "Already set");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        QCOMPARE(s.value("audio/Speakers/DeviceName").toString(),
+                 QStringLiteral("Already set"));
+    }
+
+    void doesNothingIfAlreadyMigrated() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/OutputDevice", "Legacy");
+        s.setValue("audio/Speakers/DeviceName", "New");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        // Legacy key stays (we don't clobber a present new key)
+        QCOMPARE(s.value("audio/Speakers/DeviceName").toString(),
+                 QStringLiteral("New"));
+    }
+};
+
+QTEST_APPLESS_MAIN(TstAppSettingsVaxMigration)
+#include "tst_app_settings_vax_migration.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+```bash
+cmake --build build --target tst_app_settings_vax_migration
+./build/tests/tst_app_settings_vax_migration
+```
+
+Expected: FAIL — `migrateVaxSchemaV1ToV2` undefined.
+
+- [ ] **Step 3: Add migration helper**
+
+In `src/core/AppSettings.h`:
+
+```cpp
+class AppSettings {
+public:
+    // ... existing ...
+
+    // Phase 3O VAX schema migration. Call once at app startup. Idempotent.
+    // Migrates legacy `audio/OutputDevice` → `audio/Speakers/DeviceName`
+    // and flags the first-run dialog to show.
+    static void migrateVaxSchemaV1ToV2();
+};
+```
+
+In `src/core/AppSettings.cpp`:
+
+```cpp
+void AppSettings::migrateVaxSchemaV1ToV2() {
+    auto& s = instance();
+    if (!s.contains("audio/OutputDevice")) { return; }
+    if (s.contains("audio/Speakers/DeviceName")) { return; }
+
+    const QString dev = s.value("audio/OutputDevice").toString();
+    s.setValue("audio/Speakers/DeviceName", dev);
+
+    // Platform-default API. Keep this conservative; user can tune later.
+#if defined(Q_OS_WIN)
+    s.setValue("audio/Speakers/DriverApi", "WASAPI");
+#elif defined(Q_OS_MAC)
+    s.setValue("audio/Speakers/DriverApi", "CoreAudio");
+#else
+    s.setValue("audio/Speakers/DriverApi", "Pulse");
+#endif
+    s.setValue("audio/Speakers/SampleRate", "48000");
+    s.setValue("audio/Speakers/BitDepth", "24");
+    s.setValue("audio/Speakers/Channels", "2");
+    s.setValue("audio/Speakers/BufferSamples", "256");
+
+    // Trigger first-run dialog on next launch.
+    s.setValue("audio/FirstRunComplete", "False");
+
+    s.remove("audio/OutputDevice");
+    s.save();
+}
+```
+
+- [ ] **Step 4: Run to pass**
+
+```bash
+./build/tests/tst_app_settings_vax_migration
+```
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Hook migration into app startup**
+
+In `src/gui/MainWindow.cpp` constructor (or `main.cpp` — wherever the first AppSettings access happens), add **at the top, before any other AppSettings reads**:
+
+```cpp
+    AppSettings::migrateVaxSchemaV1ToV2();
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/AppSettings.h src/core/AppSettings.cpp \
+        src/gui/MainWindow.cpp \
+        tests/tst_app_settings_vax_migration.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(app-settings): add VAX schema migration helper
+
+Phase 3O adds a per-device / per-VAX / per-slice audio schema. This
+change introduces migrateVaxSchemaV1ToV2() — idempotent one-shot that
+moves legacy audio/OutputDevice into audio/Speakers/DeviceName with
+sensible platform defaults and flags the first-run dialog to show.
+
+Called from MainWindow::MainWindow before any other AppSettings access.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Sub-Phase 2: IAudioBus Abstraction + MasterMixer 🟠
+
+### Task 2.1: `IAudioBus.h` interface
+
+**Files:**
+- Create: `src/core/IAudioBus.h`
+
+- [ ] **Step 1: Write the interface**
+
+```cpp
+// =================================================================
+// src/core/IAudioBus.h  (NereusSDR)
+// =================================================================
+//
+// Phase 3O abstract audio bus. Five concrete implementations (see
+// src/core/audio/): CoreAudioHalBus, LinuxPipeBus, PortAudioBus,
+// DirectAsioBus, CoreAudioBus.
+//
+// Design spec: docs/architecture/2026-04-19-vax-design.md §3.2
+// =================================================================
+
+#pragma once
+
+#include <QString>
+#include <cstdint>
+
+namespace NereusSDR {
+
+struct AudioFormat {
+    int sampleRate = 48000;  // Hz
+    int channels   = 2;       // 1 or 2
+    enum class Sample { Float32, Int16, Int24, Int32 } sample = Sample::Float32;
+
+    bool operator==(const AudioFormat& o) const {
+        return sampleRate == o.sampleRate && channels == o.channels && sample == o.sample;
+    }
+    bool operator!=(const AudioFormat& o) const { return !(*this == o); }
+};
+
+class IAudioBus {
+public:
+    virtual ~IAudioBus() = default;
+
+    // Lifecycle. open() returns false on failure; errorString() has details.
+    virtual bool open(const AudioFormat& format) = 0;
+    virtual void close() = 0;
+    virtual bool isOpen() const = 0;
+
+    // Producer side (RX taps). Interleaved PCM bytes. Returns bytes actually
+    // written, or -1 on error. Must be callable from the audio thread.
+    virtual qint64 push(const char* data, qint64 bytes) = 0;
+
+    // Consumer side (TX). Returns bytes read, or -1 on error. Audio-thread safe.
+    virtual qint64 pull(char* data, qint64 maxBytes) = 0;
+
+    // Metering (RMS of last block). 0.0–1.0. Published atomically for UI.
+    virtual float rxLevel() const = 0;
+    virtual float txLevel() const = 0;
+
+    // Diagnostics.
+    virtual QString backendName() const = 0;
+    virtual AudioFormat negotiatedFormat() const = 0;
+    virtual QString errorString() const { return {}; }
+};
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/core/IAudioBus.h
+git commit -S -m "$(cat <<'EOF'
+feat(audio): add IAudioBus abstract interface
+
+Contract for every audio backend in Phase 3O. Five concrete
+implementations follow in subsequent tasks (CoreAudioHalBus,
+LinuxPipeBus, PortAudioBus, DirectAsioBus, CoreAudioBus).
+
+Design spec §3.2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2.2: `MasterMixer` — per-slice mute/volume/pan
+
+**Files:**
+- Create: `src/core/audio/MasterMixer.h`, `src/core/audio/MasterMixer.cpp`
+- Test: `tests/tst_master_mixer.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+```cpp
+#include <QtTest/QtTest>
+#include "core/audio/MasterMixer.h"
+#include <array>
+
+using namespace NereusSDR;
+
+class TstMasterMixer : public QObject {
+    Q_OBJECT
+private slots:
+    void emptyMixIsSilent() {
+        MasterMixer mix;
+        std::array<float, 16> out{};
+        mix.mixInto(out.data(), 8);
+        for (float s : out) { QCOMPARE(s, 0.0f); }
+    }
+
+    void singleSliceUnityGainMixesThrough() {
+        MasterMixer mix;
+        mix.setSliceGain(42, 1.0f, 0.0f);  // unity, center
+        std::array<float, 4> in = {0.5f, 0.5f, -0.25f, -0.25f};  // 2 frames stereo
+        mix.accumulate(42, in.data(), 2);
+        std::array<float, 4> out{};
+        mix.mixInto(out.data(), 2);
+        QCOMPARE(out[0], 0.5f);
+        QCOMPARE(out[1], 0.5f);
+        QCOMPARE(out[2], -0.25f);
+        QCOMPARE(out[3], -0.25f);
+    }
+
+    void twoSlicesSumLinearly() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, 0.0f);
+        mix.setSliceGain(2, 1.0f, 0.0f);
+        std::array<float, 2> a = {0.3f, 0.3f};
+        std::array<float, 2> b = {0.4f, 0.4f};
+        mix.accumulate(1, a.data(), 1);
+        mix.accumulate(2, b.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QCOMPARE(out[0], 0.7f);
+        QCOMPARE(out[1], 0.7f);
+    }
+
+    void panFullLeftSuppressesRight() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, -1.0f);  // full left
+        std::array<float, 2> in = {0.5f, 0.5f};
+        mix.accumulate(1, in.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QVERIFY(out[0] > 0.4f);
+        QCOMPARE(out[1], 0.0f);
+    }
+
+    void muteZerosContribution() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, 0.0f);
+        mix.setSliceMuted(1, true);
+        std::array<float, 2> in = {0.9f, 0.9f};
+        mix.accumulate(1, in.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QCOMPARE(out[0], 0.0f);
+        QCOMPARE(out[1], 0.0f);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstMasterMixer)
+#include "tst_master_mixer.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+Expected: FAIL — MasterMixer undefined.
+
+- [ ] **Step 3: Implement `MasterMixer`**
+
+`src/core/audio/MasterMixer.h`:
+
+```cpp
+#pragma once
+
+#include <atomic>
+#include <unordered_map>
+#include <vector>
+#include <mutex>
+
+namespace NereusSDR {
+
+// Audio-thread-safe per-slice mixing. Producers call accumulate() from the
+// audio thread (one call per slice per block); consumer calls mixInto() once
+// per block to flush the accumulator to the output buffer.
+class MasterMixer {
+public:
+    // UI thread: set per-slice gain and pan. Safe to call anytime.
+    void setSliceGain(int sliceId, float gain /*0..1*/, float pan /*-1..+1*/);
+    void setSliceMuted(int sliceId, bool muted);
+    void removeSlice(int sliceId);
+
+    // Audio thread: accumulate a slice's stereo block. samples is
+    // interleaved L/R float32. frames = sample pairs.
+    void accumulate(int sliceId, const float* samples, int frames);
+
+    // Audio thread: flush the accumulated mix into out and reset.
+    // out is interleaved L/R float32.
+    void mixInto(float* out, int frames);
+
+private:
+    struct SliceState {
+        std::atomic<float> gain{1.0f};
+        std::atomic<float> pan{0.0f};
+        std::atomic<bool>  muted{false};
+    };
+
+    std::unordered_map<int, SliceState> m_slices;
+    std::mutex m_sliceMapMutex;  // Only held on UI-thread map mutation.
+
+    std::vector<float> m_acc;  // Audio-thread-only; resized on-demand.
+};
+
+} // namespace NereusSDR
+```
+
+`src/core/audio/MasterMixer.cpp`:
+
+```cpp
+#include "MasterMixer.h"
+#include <algorithm>
+#include <cmath>
+
+using namespace NereusSDR;
+
+void MasterMixer::setSliceGain(int sliceId, float gain, float pan) {
+    std::lock_guard<std::mutex> lk(m_sliceMapMutex);
+    auto& st = m_slices[sliceId];
+    st.gain.store(std::clamp(gain, 0.0f, 1.0f), std::memory_order_release);
+    st.pan.store(std::clamp(pan, -1.0f, 1.0f), std::memory_order_release);
+}
+
+void MasterMixer::setSliceMuted(int sliceId, bool muted) {
+    std::lock_guard<std::mutex> lk(m_sliceMapMutex);
+    m_slices[sliceId].muted.store(muted, std::memory_order_release);
+}
+
+void MasterMixer::removeSlice(int sliceId) {
+    std::lock_guard<std::mutex> lk(m_sliceMapMutex);
+    m_slices.erase(sliceId);
+}
+
+void MasterMixer::accumulate(int sliceId, const float* samples, int frames) {
+    // Lookup slice state. The map *itself* is mutex-guarded for structural
+    // changes, but we do not want to hold the mutex in the audio thread. We
+    // read the atomics directly; find() is lock-free against unchanged buckets.
+    auto it = m_slices.find(sliceId);
+    if (it == m_slices.end()) { return; }
+
+    const auto& st = it->second;
+    if (st.muted.load(std::memory_order_acquire)) { return; }
+
+    const float gain = st.gain.load(std::memory_order_acquire);
+    const float pan  = st.pan.load(std::memory_order_acquire);
+
+    // Equal-power pan law.
+    const float lGain = gain * std::cos((pan + 1.0f) * 0.25f * 3.14159265f);
+    const float rGain = gain * std::sin((pan + 1.0f) * 0.25f * 3.14159265f);
+
+    if ((int)m_acc.size() < frames * 2) {
+        m_acc.resize(frames * 2, 0.0f);
+    }
+    for (int i = 0; i < frames; ++i) {
+        m_acc[i * 2 + 0] += samples[i * 2 + 0] * lGain;
+        m_acc[i * 2 + 1] += samples[i * 2 + 1] * rGain;
+    }
+}
+
+void MasterMixer::mixInto(float* out, int frames) {
+    const int n = frames * 2;
+    if ((int)m_acc.size() < n) {
+        // No one accumulated this block; output silence.
+        std::fill(out, out + n, 0.0f);
+        return;
+    }
+    std::copy(m_acc.begin(), m_acc.begin() + n, out);
+    std::fill(m_acc.begin(), m_acc.begin() + n, 0.0f);
+}
+```
+
+**Note on the find() safety:** `std::unordered_map::find()` is not strictly lock-free — if the UI thread inserts a new slice while the audio thread is in `find()`, behavior is undefined. For this plan, slice creation/removal happens rarely and on app startup/radio-connect. The mutex guards the structural mutations. If this proves racy in practice, swap to `folly::ConcurrentHashMap` or a pre-allocated slice array (max-slices = 8 per ANAN board cap).
+
+- [ ] **Step 4: Run to pass**
+
+```bash
+./build/tests/tst_master_mixer
+```
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/audio/MasterMixer.h src/core/audio/MasterMixer.cpp \
+        tests/tst_master_mixer.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(audio): add MasterMixer for per-slice mute/volume/pan
+
+Accumulator + flush model: audio thread calls accumulate() once per
+slice per block, then mixInto() once to flush. Equal-power pan law,
+atomic per-slice parameters, one mutex only on slice-map structural
+changes (not in the audio hot path).
+
+Design spec §3.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Sub-Phase 3: PortAudio Engine 🟠
+
+### Task 3.1: Vendor PortAudio v19
+
+**Files:**
+- Modify: `CMakeLists.txt`
+- Create: `third_party/portaudio/` (subtree or FetchContent)
+
+- [ ] **Step 1: Add PortAudio via CMake FetchContent**
+
+Append to top-level `CMakeLists.txt`, after the existing `find_package(Qt6 ...)`:
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+    portaudio
+    GIT_REPOSITORY https://github.com/PortAudio/portaudio.git
+    GIT_TAG        v19.7.0  # verified cmake-clean release
+)
+
+# PortAudio build options — turn off ASIO (we handle it opt-in via ASIO SDK
+# separately in Sub-Phase 13), keep platform default host APIs on.
+set(PA_BUILD_SHARED OFF CACHE BOOL "PortAudio static" FORCE)
+set(PA_BUILD_STATIC ON  CACHE BOOL "PortAudio static" FORCE)
+set(PA_USE_ASIO    OFF CACHE BOOL "PortAudio disable PA-ASIO (we use SDK direct)" FORCE)
+
+FetchContent_MakeAvailable(portaudio)
+```
+
+Add to the NereusSDR main executable link:
+
+```cmake
+target_link_libraries(NereusSDRLib PRIVATE portaudio_static)
+target_include_directories(NereusSDRLib PRIVATE ${portaudio_SOURCE_DIR}/include)
+```
+
+- [ ] **Step 2: Build and confirm PortAudio links**
+
+```bash
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build
+```
+
+Expected: builds without error; `libportaudio_static.a` appears in `build/_deps/portaudio-build/`.
+
+- [ ] **Step 3: Verify PortAudio's license is GPL-3 compatible**
+
+```bash
+cat build/_deps/portaudio-src/LICENSE.txt | head -40
+```
+
+Expected: MIT-style permissive license (Ross Bencina / Phil Burk 1999+). If the text is anything other than the well-known PortAudio MIT-style grant, STOP and surface to project maintainer before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+build: vendor PortAudio v19.7.0 via FetchContent
+
+Static-link, PA_USE_ASIO off (handled separately via Steinberg SDK in
+Sub-Phase 13). Gives us cross-platform audio API coverage: MME / DS /
+WDM-KS / WASAPI on Windows, CoreAudio on Mac, ALSA / Pulse / PipeWire /
+JACK on Linux via PortAudio's host APIs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3.2: `PortAudioBus` minimal open/close
+
+**Files:**
+- Create: `src/core/audio/PortAudioBus.h`, `.cpp`
+- Test: `tests/tst_port_audio_bus.cpp`
+
+- [ ] **Step 1: Write the failing test (uses PortAudio null device)**
+
+```cpp
+#include <QtTest/QtTest>
+#include "core/audio/PortAudioBus.h"
+#include <portaudio.h>
+
+using namespace NereusSDR;
+
+class TstPortAudioBus : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase() {
+        Pa_Initialize();
+    }
+    void cleanupTestCase() {
+        Pa_Terminate();
+    }
+
+    void constructsClosed() {
+        PortAudioBus bus;
+        QVERIFY(!bus.isOpen());
+    }
+
+    void openSucceedsOnDefaultDevice() {
+        PortAudioBus bus;
+        AudioFormat f;
+        QVERIFY2(bus.open(f), qPrintable(bus.errorString()));
+        QVERIFY(bus.isOpen());
+        bus.close();
+        QVERIFY(!bus.isOpen());
+    }
+
+    void negotiatedFormatReflectsDevice() {
+        PortAudioBus bus;
+        AudioFormat f; f.sampleRate = 48000; f.channels = 2;
+        bus.open(f);
+        QVERIFY(bus.negotiatedFormat().sampleRate > 0);
+        bus.close();
+    }
+
+    void backendNameIdentifiesAPI() {
+        PortAudioBus bus;
+        bus.open(AudioFormat{});
+        const QString n = bus.backendName();
+        QVERIFY(!n.isEmpty());
+        bus.close();
+    }
+};
+
+QTEST_APPLESS_MAIN(TstPortAudioBus)
+#include "tst_port_audio_bus.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+Expected: FAIL — `PortAudioBus` undefined.
+
+- [ ] **Step 3: Implement `PortAudioBus` (render-only, minimal)**
+
+`src/core/audio/PortAudioBus.h`:
+
+```cpp
+#pragma once
+#include "core/IAudioBus.h"
+#include <atomic>
+#include <vector>
+#include <mutex>
+
+typedef void PaStream;  // forward decl
+struct PaDeviceInfo;
+
+namespace NereusSDR {
+
+struct PortAudioConfig {
+    int     hostApiIndex = -1;     // -1 = PortAudio default
+    QString deviceName;             // empty = default
+    int     bufferSamples = 256;
+    bool    exclusiveMode = false; // WASAPI only
+    // Additional fields added in Tasks 3.3/3.4.
+};
+
+class PortAudioBus : public IAudioBus {
+public:
+    PortAudioBus();
+    ~PortAudioBus() override;
+
+    void setConfig(const PortAudioConfig& cfg);
+
+    bool open(const AudioFormat& format) override;
+    void close() override;
+    bool isOpen() const override { return m_stream != nullptr; }
+
+    qint64 push(const char* data, qint64 bytes) override;
+    qint64 pull(char* data, qint64 maxBytes) override;
+
+    float rxLevel() const override { return m_rxLevel.load(std::memory_order_acquire); }
+    float txLevel() const override { return m_txLevel.load(std::memory_order_acquire); }
+
+    QString     backendName() const override { return m_backendName; }
+    AudioFormat negotiatedFormat() const override { return m_negFormat; }
+    QString     errorString() const override { return m_err; }
+
+private:
+    PaStream*   m_stream{nullptr};
+    PortAudioConfig m_cfg;
+    AudioFormat m_negFormat;
+    QString     m_backendName;
+    QString     m_err;
+
+    // Ring buffer for push/pull. Audio thread reads from here.
+    std::vector<float> m_ring;
+    std::atomic<qint64> m_ringRead{0};
+    std::atomic<qint64> m_ringWrite{0};
+
+    std::atomic<float> m_rxLevel{0.0f};
+    std::atomic<float> m_txLevel{0.0f};
+
+    static int paCallback(const void* in, void* out,
+                          unsigned long frames,
+                          const void* timeInfo,
+                          unsigned long flags,
+                          void* userData);
+};
+
+} // namespace NereusSDR
+```
+
+`src/core/audio/PortAudioBus.cpp`:
+
+```cpp
+#include "PortAudioBus.h"
+#include <portaudio.h>
+#include <cmath>
+#include <cstring>
+#include <algorithm>
+
+using namespace NereusSDR;
+
+PortAudioBus::PortAudioBus() {
+    m_ring.resize(48000 * 2);  // 1 second stereo float ring
+}
+
+PortAudioBus::~PortAudioBus() {
+    close();
+}
+
+void PortAudioBus::setConfig(const PortAudioConfig& cfg) {
+    m_cfg = cfg;
+}
+
+bool PortAudioBus::open(const AudioFormat& format) {
+    if (m_stream) { close(); }
+
+    PaStreamParameters outParams;
+    outParams.device = Pa_GetDefaultOutputDevice();
+    if (outParams.device == paNoDevice) {
+        m_err = "No default output device";
+        return false;
+    }
+
+    const PaDeviceInfo* di = Pa_GetDeviceInfo(outParams.device);
+    outParams.channelCount = format.channels;
+    outParams.sampleFormat = paFloat32;
+    outParams.suggestedLatency = di->defaultLowOutputLatency;
+    outParams.hostApiSpecificStreamInfo = nullptr;
+
+    const PaError err = Pa_OpenStream(
+        &m_stream, nullptr, &outParams,
+        format.sampleRate, m_cfg.bufferSamples,
+        paClipOff, &PortAudioBus::paCallback, this);
+
+    if (err != paNoError) {
+        m_err = Pa_GetErrorText(err);
+        m_stream = nullptr;
+        return false;
+    }
+
+    Pa_StartStream(m_stream);
+    m_negFormat = format;
+    m_backendName = Pa_GetHostApiInfo(di->hostApi)->name;
+    return true;
+}
+
+void PortAudioBus::close() {
+    if (!m_stream) { return; }
+    Pa_StopStream(m_stream);
+    Pa_CloseStream(m_stream);
+    m_stream = nullptr;
+}
+
+qint64 PortAudioBus::push(const char* data, qint64 bytes) {
+    const int floatCount = bytes / sizeof(float);
+    const qint64 ringSize = (qint64)m_ring.size();
+    qint64 w = m_ringWrite.load(std::memory_order_relaxed);
+    const float* in = reinterpret_cast<const float*>(data);
+    float peak = 0.0f;
+    for (int i = 0; i < floatCount; ++i) {
+        m_ring[w % ringSize] = in[i];
+        w++;
+        peak = std::max(peak, std::abs(in[i]));
+    }
+    m_ringWrite.store(w, std::memory_order_release);
+    m_rxLevel.store(peak, std::memory_order_release);
+    return bytes;
+}
+
+qint64 PortAudioBus::pull(char* /*data*/, qint64 /*maxBytes*/) {
+    // Not implemented in this task; TX path wired in Sub-Phase 4.
+    return 0;
+}
+
+int PortAudioBus::paCallback(const void* /*in*/, void* out,
+                             unsigned long frames,
+                             const void* /*timeInfo*/,
+                             unsigned long /*flags*/,
+                             void* userData) {
+    auto* self = static_cast<PortAudioBus*>(userData);
+    float* o = static_cast<float*>(out);
+    const int want = (int)frames * self->m_negFormat.channels;
+
+    const qint64 ringSize = (qint64)self->m_ring.size();
+    qint64 r = self->m_ringRead.load(std::memory_order_relaxed);
+    const qint64 w = self->m_ringWrite.load(std::memory_order_acquire);
+
+    for (int i = 0; i < want; ++i) {
+        if (r < w) {
+            o[i] = self->m_ring[r % ringSize];
+            r++;
+        } else {
+            o[i] = 0.0f;  // underrun → silence
+        }
+    }
+    self->m_ringRead.store(r, std::memory_order_release);
+    return paContinue;
+}
+```
+
+- [ ] **Step 4: Run to pass**
+
+```bash
+./build/tests/tst_port_audio_bus
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/audio/PortAudioBus.h src/core/audio/PortAudioBus.cpp \
+        tests/tst_port_audio_bus.cpp tests/CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(audio): add PortAudioBus render-only minimal implementation
+
+Opens PortAudio default output device, accepts push() from main
+thread into a lock-free ring, drains the ring in paCallback on the
+audio thread. Peak-level metering published atomically. TX pull and
+full host-API/device picker come in Tasks 3.3 and 3.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 3.3: Host API + device enumeration
+
+**Files:**
+- Modify: `src/core/audio/PortAudioBus.h`, `.cpp`
+
+- [ ] **Step 1: Add enumeration helpers**
+
+Add to `PortAudioBus.h`:
+
+```cpp
+    struct HostApiInfo {
+        int     index;
+        QString name;
+    };
+    struct DeviceInfo {
+        int     index;
+        QString name;
+        int     maxOutputChannels;
+        int     maxInputChannels;
+        int     defaultSampleRate;
+        int     hostApiIndex;
+    };
+
+    static QVector<HostApiInfo> hostApis();
+    static QVector<DeviceInfo>  outputDevicesFor(int hostApiIndex);
+    static QVector<DeviceInfo>  inputDevicesFor(int hostApiIndex);
+```
+
+Implement in `.cpp`:
+
+```cpp
+QVector<PortAudioBus::HostApiInfo> PortAudioBus::hostApis() {
+    QVector<HostApiInfo> out;
+    const int n = Pa_GetHostApiCount();
+    for (int i = 0; i < n; ++i) {
+        const PaHostApiInfo* h = Pa_GetHostApiInfo(i);
+        if (h) { out.push_back({i, QString::fromUtf8(h->name)}); }
+    }
+    return out;
+}
+
+QVector<PortAudioBus::DeviceInfo> PortAudioBus::outputDevicesFor(int hostApiIndex) {
+    QVector<DeviceInfo> out;
+    const int n = Pa_GetDeviceCount();
+    for (int i = 0; i < n; ++i) {
+        const PaDeviceInfo* d = Pa_GetDeviceInfo(i);
+        if (!d || d->hostApi != hostApiIndex || d->maxOutputChannels <= 0) { continue; }
+        out.push_back({
+            i, QString::fromUtf8(d->name),
+            d->maxOutputChannels, d->maxInputChannels,
+            (int)d->defaultSampleRate, d->hostApi
+        });
+    }
+    return out;
+}
+
+QVector<PortAudioBus::DeviceInfo> PortAudioBus::inputDevicesFor(int hostApiIndex) {
+    QVector<DeviceInfo> out;
+    const int n = Pa_GetDeviceCount();
+    for (int i = 0; i < n; ++i) {
+        const PaDeviceInfo* d = Pa_GetDeviceInfo(i);
+        if (!d || d->hostApi != hostApiIndex || d->maxInputChannels <= 0) { continue; }
+        out.push_back({
+            i, QString::fromUtf8(d->name),
+            d->maxOutputChannels, d->maxInputChannels,
+            (int)d->defaultSampleRate, d->hostApi
+        });
+    }
+    return out;
+}
+```
+
+- [ ] **Step 2: Extend the test**
+
+Append to `tests/tst_port_audio_bus.cpp`:
+
+```cpp
+    void hostApisEnumerateNonEmpty() {
+        const auto apis = PortAudioBus::hostApis();
+        QVERIFY(!apis.isEmpty());
+    }
+
+    void outputDevicesEnumerateForFirstApi() {
+        const auto apis = PortAudioBus::hostApis();
+        QVERIFY(!apis.isEmpty());
+        const auto devices = PortAudioBus::outputDevicesFor(apis.first().index);
+        // Host system should have at least one output; skip if headless CI.
+        if (devices.isEmpty()) { QSKIP("No output devices on test host"); }
+    }
+```
+
+- [ ] **Step 3: Run to pass**
+
+```bash
+cmake --build build --target tst_port_audio_bus
+./build/tests/tst_port_audio_bus
+```
+
+Expected: PASS (6 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/audio/PortAudioBus.h src/core/audio/PortAudioBus.cpp \
+        tests/tst_port_audio_bus.cpp
+git commit -S -m "feat(audio): PortAudioBus — host API and device enumeration
+
+Needed by SetupAudioPage for the Driver API and Device combos.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 3.4: TX capture support (open input stream + pull)
+
+- [ ] **Step 1: Extend `PortAudioBus::open` to support input-only or duplex**
+
+Modify `open` to branch on `format.channels` and `m_cfg` direction. Add a `PortAudioConfig::direction` enum `{ Output, Input }`. Reuse ring buffer in opposite direction for input.
+
+(Implementation follows the same pattern as Step 3 of Task 3.2 but with `paInputParameters` + reading from input stream into the ring, and `pull()` reading from the ring.)
+
+- [ ] **Step 2: Test with default input device (skip on CI without mic)**
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Sub-Phase 4: AudioEngine Refactor 🟠
+
+### Task 4.1: AudioEngine holds IAudioBus instances instead of QAudioSink
+
+**Files:**
+- Modify: `src/core/AudioEngine.h`, `.cpp`
+
+- [ ] **Step 1: Add bus ownership and slot setters**
+
+In `AudioEngine.h`:
+
+```cpp
+    // Phase 3O: per-endpoint IAudioBus ownership.
+    void setSpeakersConfig(const AudioDeviceConfig& cfg);
+    void setTxInputConfig(const AudioDeviceConfig& cfg);
+    void setVaxConfig(int channel, const AudioDeviceConfig& cfg);  // 1..4
+    void setVaxEnabled(int channel, bool on);
+
+    // Called by ReceiverManager when a slice produces an RX audio block.
+    void rxBlockReady(int sliceId, const float* samples, int frames);
+
+private:
+    std::unique_ptr<IAudioBus> m_speakersBus;
+    std::unique_ptr<IAudioBus> m_txInputBus;
+    std::array<std::unique_ptr<IAudioBus>, 4> m_vaxBus;
+    MasterMixer m_masterMix;
+```
+
+- [ ] **Step 2: Implement `rxBlockReady` routing**
+
+Per spec §3.4:
+
+```cpp
+void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames) {
+    auto* slice = m_radio->sliceModel(sliceId);
+    if (!slice) { return; }
+
+    if (!slice->audioMuted()) {
+        m_masterMix.accumulate(sliceId, samples, frames);
+    }
+
+    const int vaxCh = slice->vaxChannel();
+    if (vaxCh >= 1 && vaxCh <= 4 && m_vaxBus[vaxCh - 1] && m_vaxBus[vaxCh - 1]->isOpen()) {
+        m_vaxBus[vaxCh - 1]->push(
+            reinterpret_cast<const char*>(samples),
+            frames * 2 * sizeof(float));
+    }
+}
+```
+
+Add a timer-driven flush that pulls from `m_masterMix.mixInto()` into `m_speakersBus->push()` at the DSP block rate.
+
+- [ ] **Step 3: Replace old `QAudioSink` path**
+
+Remove the existing `QAudioSink m_sink` member and the 10ms timer-driven byte-buffer drain. Route speakers through `m_speakersBus`.
+
+- [ ] **Step 4: Build + smoke test (tune to a known station, hear audio)**
+
+- [ ] **Step 5: Commit**
+
+---
+
+## Sub-Phase 5: macOS HAL Plugin 🟡
+
+### Task 5.1: Fork AetherSDR `hal-plugin/` into NereusSDR
+
+**Files:**
+- Create: `hal-plugin/NereusSDRVAX.cpp`
+- Create: `hal-plugin/CMakeLists.txt`
+- Create: `hal-plugin/Info.plist`
+
+- [ ] **Step 1: Copy files with rebrand**
+
+```bash
+mkdir -p hal-plugin
+cp ../AetherSDR/hal-plugin/AetherSDRDAX.cpp hal-plugin/NereusSDRVAX.cpp
+cp ../AetherSDR/hal-plugin/CMakeLists.txt hal-plugin/CMakeLists.txt
+cp ../AetherSDR/hal-plugin/Info.plist hal-plugin/Info.plist
+```
+
+- [ ] **Step 2: Prepend NereusSDR port-citation header to `.cpp`**
+
+Per `docs/attribution/HOW-TO-PORT.md` rule 6 (AetherSDR has no per-file GPL header):
+
+```cpp
+// =================================================================
+// hal-plugin/NereusSDRVAX.cpp  (NereusSDR)
+// =================================================================
+//
+// Ported from AetherSDR source:
+//   hal-plugin/AetherSDRDAX.cpp
+//
+// AetherSDR is licensed under the GNU General Public License v3; see
+// https://github.com/ten9876/AetherSDR for the contributor list and
+// project-level LICENSE. NereusSDR is also GPLv3. AetherSDR source
+// files carry no per-file GPL header; attribution is at project level
+// per AetherSDR convention.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-19 — Ported/adapted in C++20 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via
+//                 Anthropic Claude Code. Rebranded DAX → VAX: device
+//                 UIDs com.aethersdr.dax.* → com.nereussdr.vax.*, shm
+//                 paths /aethersdr-dax-* → /nereussdr-vax-*, device
+//                 names "AetherSDR DAX N" → "NereusSDR VAX N", factory
+//                 UUID regenerated.
+// =================================================================
+```
+
+- [ ] **Step 3: Global rebrand — string/UID/bundle changes**
+
+In `NereusSDRVAX.cpp`:
+
+```bash
+sed -i '' 's|/aethersdr-dax|/nereussdr-vax|g' hal-plugin/NereusSDRVAX.cpp
+sed -i '' 's|AetherSDR DAX|NereusSDR VAX|g' hal-plugin/NereusSDRVAX.cpp
+sed -i '' 's|com\.aethersdr\.dax|com.nereussdr.vax|g' hal-plugin/NereusSDRVAX.cpp
+sed -i '' 's|AetherSDRDAX|NereusSDRVAX|g' hal-plugin/NereusSDRVAX.cpp
+```
+
+In `Info.plist`: same `AetherSDR DAX → NereusSDR VAX`, `com.aethersdr.dax → com.nereussdr.vax`. **Generate a fresh CFPlugInFactories UUID** (macOS: `uuidgen`) to avoid collision if both AetherSDR and NereusSDR are installed on the same Mac.
+
+In `CMakeLists.txt`: bundle name `AetherSDRDAX.driver → NereusSDRVAX.driver`, target name rebranded.
+
+- [ ] **Step 4: Add hal-plugin as optional subdir in top-level CMakeLists.txt**
+
+```cmake
+if(APPLE AND NEREUSSDR_BUILD_HAL_PLUGIN)
+    add_subdirectory(hal-plugin)
+endif()
+```
+
+- [ ] **Step 5: Build the HAL plugin**
+
+```bash
+cmake -B build-hal -S hal-plugin -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build-hal
+```
+
+Expected: `build-hal/NereusSDRVAX.driver` bundle produced.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hal-plugin/ CMakeLists.txt
+git commit -S -m "$(cat <<'EOF'
+feat(hal-plugin): port AetherSDR HAL plugin as NereusSDR VAX driver
+
+4 VAX render devices + 1 TX capture device exposed as native macOS
+CoreAudio endpoints via libASPL userspace plugin. Rebranded from
+AetherSDR DAX: device UIDs, shm paths, factory UUID regenerated.
+macOS 14.4+ coreaudiod restart fallback added in Sub-Phase 5.2.
+
+Port attribution per HOW-TO-PORT.md rule 6 (AetherSDR has no per-file
+GPL header; project-level cite at header).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 5.2: Installer + macOS 14.4+ killall fallback
+
+**Files:**
+- Create: `packaging/macos/hal-installer.sh`
+- Create: `packaging/macos/hal-postinstall.sh`
+- Create: `packaging/macos/hal-uninstall.sh`
+
+- [ ] **Step 1: Port `build-installer.sh`**
+
+```bash
+cp ../AetherSDR/packaging/macos/build-installer.sh packaging/macos/hal-installer.sh
+sed -i '' 's|AetherSDR|NereusSDR|g; s|aethersdr|nereussdr|g' packaging/macos/hal-installer.sh
+```
+
+- [ ] **Step 2: Write postinstall with 14.4+ fallback**
+
+`packaging/macos/hal-postinstall.sh`:
+
+```bash
+#!/bin/bash
+# NereusSDR VAX HAL plugin — postinstall
+# On macOS 14.4+, launchctl kickstart of com.apple.audio.coreaudiod
+# returns "Operation not permitted"; fall back to killall.
+
+set -e
+
+launchctl kickstart -kp system/com.apple.audio.coreaudiod 2>/dev/null \
+  || sudo killall coreaudiod 2>/dev/null \
+  || true
+
+exit 0
+```
+
+- [ ] **Step 3: Write uninstall helper**
+
+```bash
+#!/bin/bash
+set -e
+sudo rm -rf "/Library/Audio/Plug-Ins/HAL/NereusSDRVAX.driver"
+rm -f /dev/shm/nereussdr-vax-* /dev/shm/nereussdr-tx 2>/dev/null || true
+sudo killall coreaudiod 2>/dev/null || true
+echo "NereusSDR VAX HAL plugin uninstalled."
+```
+
+- [ ] **Step 4: Run the installer build locally, verify `.pkg` produced**
+
+```bash
+bash packaging/macos/hal-installer.sh
+```
+
+Expected: `build/pkg-staging/NereusSDRVAX-<version>.pkg` created.
+
+- [ ] **Step 5: Commit**
+
+### Task 5.3: `CoreAudioHalBus` — shm writer from NereusSDR app side
+
+**Files:**
+- Create: `src/core/audio/CoreAudioHalBus.h`, `.cpp` (port of AetherSDR `VirtualAudioBridge`)
+
+- [ ] **Step 1: Copy + prepend port header**
+
+```bash
+cp ../AetherSDR/src/core/VirtualAudioBridge.h src/core/audio/CoreAudioHalBus.h
+cp ../AetherSDR/src/core/VirtualAudioBridge.cpp src/core/audio/CoreAudioHalBus.cpp
+```
+
+Prepend the same port-citation block as Task 5.1 to both files.
+
+- [ ] **Step 2: Rename class + rebrand**
+
+```bash
+sed -i '' 's|VirtualAudioBridge|CoreAudioHalBus|g' src/core/audio/CoreAudioHalBus.h src/core/audio/CoreAudioHalBus.cpp
+sed -i '' 's|/aethersdr-dax|/nereussdr-vax|g' src/core/audio/CoreAudioHalBus.cpp
+```
+
+- [ ] **Step 3: Adapt to `IAudioBus` interface**
+
+Replace the AetherSDR-specific public API (`feedDaxAudio`, `readTxAudio`) with `IAudioBus::push` / `pull`. Keep the shm-segment plumbing intact. Bridge the `daxRxLevel` signal to `m_rxLevel` atomic.
+
+- [ ] **Step 4: Build + smoke-test that writing to `/nereussdr-vax-1` is readable from the HAL plugin side**
+
+(Manual test: open WSJT-X, pick "NereusSDR VAX 1" as audio input, confirm it receives audio from NereusSDR.)
+
+- [ ] **Step 5: Commit**
+
+### Task 5.4: CI — sign + notarize HAL plugin in `release.yml`
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Add macOS HAL plugin signing step**
+
+Append a job step to the macOS build matrix:
+
+```yaml
+      - name: Sign HAL plugin
+        run: |
+          codesign --force --options runtime --timestamp \
+            --sign "Developer ID Application: ${{ secrets.APPLE_DEVELOPER_ID }}" \
+            build-hal/NereusSDRVAX.driver
+      - name: Build signed .pkg
+        run: bash packaging/macos/hal-installer.sh
+      - name: Notarize
+        run: |
+          xcrun notarytool submit build/pkg-staging/NereusSDRVAX-*.pkg \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --password "${{ secrets.APPLE_APP_PASSWORD }}" \
+            --wait
+      - name: Staple
+        run: xcrun stapler staple build/pkg-staging/NereusSDRVAX-*.pkg
+```
+
+- [ ] **Step 2: Update `docs/attribution/aethersdr-contributor-index.md`**
+
+Add rows for `hal-plugin/NereusSDRVAX.cpp`, `src/core/audio/CoreAudioHalBus.{h,cpp}` citing AetherSDR as source.
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Sub-Phase 6: Linux PulseAudio Bridge 🟢
+
+### Task 6.1: Port `PipeWireAudioBridge` → `LinuxPipeBus`
+
+**Files:**
+- Create: `src/core/audio/LinuxPipeBus.h`, `.cpp`
+
+- [ ] **Step 1: Copy + rebrand**
+
+```bash
+cp ../AetherSDR/src/core/PipeWireAudioBridge.h src/core/audio/LinuxPipeBus.h
+cp ../AetherSDR/src/core/PipeWireAudioBridge.cpp src/core/audio/LinuxPipeBus.cpp
+sed -i 's|PipeWireAudioBridge|LinuxPipeBus|g' src/core/audio/LinuxPipeBus.*
+sed -i 's|aethersdr-dax|nereussdr-vax|g' src/core/audio/LinuxPipeBus.*
+sed -i 's|AetherSDR|NereusSDR|g' src/core/audio/LinuxPipeBus.*
+```
+
+- [ ] **Step 2: Prepend port-citation header** (same template as Task 5.1)
+
+- [ ] **Step 3: Adapt to `IAudioBus` interface** (same pattern as Task 5.3)
+
+- [ ] **Step 4: Verify stale-module cleanup still runs on startup**
+
+Keep AetherSDR's `pactl list modules short | grep nereussdr-` scan intact. This is the battle-tested crash-recovery path.
+
+- [ ] **Step 5: Manual smoke on Linux: load NereusSDR, confirm `pactl list sources short` shows `nereussdr-vax-1` through `nereussdr-vax-4`**
+
+- [ ] **Step 6: Commit**
+
+---
+
+## Sub-Phase 7: Windows BYO — VirtualCableDetector 🟢
+
+### Task 7.1: Virtual-cable product regex matcher
+
+**Files:**
+- Create: `src/core/audio/VirtualCableDetector.h`, `.cpp`
+- Test: `tests/tst_virtual_cable_detector.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+```cpp
+#include <QtTest/QtTest>
+#include "core/audio/VirtualCableDetector.h"
+
+using namespace NereusSDR;
+
+class TstVirtualCableDetector : public QObject {
+    Q_OBJECT
+private slots:
+    void detectsVbCableBase() {
+        QVERIFY(VirtualCableDetector::matchProduct(
+            "CABLE Input (VB-Audio Virtual Cable)") == VirtualCableProduct::VbCable);
+    }
+    void detectsVbCableAB() {
+        QVERIFY(VirtualCableDetector::matchProduct("CABLE-A Input") == VirtualCableProduct::VbCableA);
+        QVERIFY(VirtualCableDetector::matchProduct("CABLE-B Input") == VirtualCableProduct::VbCableB);
+    }
+    void detectsVac() {
+        QVERIFY(VirtualCableDetector::matchProduct("Line 1 (Virtual Audio Cable)")
+                == VirtualCableProduct::MuzychenkoVac);
+    }
+    void detectsVoicemeeter() {
+        QVERIFY(VirtualCableDetector::matchProduct("VoiceMeeter Input (VB-Audio VoiceMeeter VAIO)")
+                == VirtualCableProduct::Voicemeeter);
+    }
+    void detectsDante() {
+        QVERIFY(VirtualCableDetector::matchProduct("Dante Tx 01-02")
+                == VirtualCableProduct::Dante);
+    }
+    void detectsFlexDax() {
+        QVERIFY(VirtualCableDetector::matchProduct("DAX Audio RX 1")
+                == VirtualCableProduct::FlexRadioDax);
+    }
+    void detectsReservedNereusVax() {
+        QVERIFY(VirtualCableDetector::matchProduct("NereusSDR VAX 1")
+                == VirtualCableProduct::NereusSdrVax);
+    }
+    void unknownDeviceIsNone() {
+        QVERIFY(VirtualCableDetector::matchProduct("Realtek HD Audio Output")
+                == VirtualCableProduct::None);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstVirtualCableDetector)
+#include "tst_virtual_cable_detector.moc"
+```
+
+- [ ] **Step 2: Run to fail**
+
+- [ ] **Step 3: Implement matcher**
+
+`src/core/audio/VirtualCableDetector.h`:
+
+```cpp
+#pragma once
+#include <QString>
+#include <QVector>
+
+namespace NereusSDR {
+
+enum class VirtualCableProduct {
+    None = 0,
+    VbCable,
+    VbCableA,  VbCableB,  VbCableC,  VbCableD,
+    VbHiFiCable,
+    MuzychenkoVac,
+    Voicemeeter,
+    Dante,
+    FlexRadioDax,
+    NereusSdrVax,  // reserved for future NereusSDR-owned Windows driver
+};
+
+struct DetectedCable {
+    VirtualCableProduct product;
+    QString deviceName;
+    bool isInput;  // false = render / output
+    int channel;   // 1..N for multi-cable families; 0 if N/A
+};
+
+class VirtualCableDetector {
+public:
+    // Pure-function test-hook. Inspects the OS device name string.
+    static VirtualCableProduct matchProduct(const QString& deviceName);
+
+    // Enumerates OS audio devices via PortAudio and returns matches.
+    static QVector<DetectedCable> scan();
+
+    // Vendor install URL for a given product (for the first-run helper).
+    static QString installUrl(VirtualCableProduct p);
+};
+
+} // namespace NereusSDR
+```
+
+`src/core/audio/VirtualCableDetector.cpp`:
+
+```cpp
+#include "VirtualCableDetector.h"
+#include <QRegularExpression>
+#include "PortAudioBus.h"
+
+using namespace NereusSDR;
+
+VirtualCableProduct VirtualCableDetector::matchProduct(const QString& n) {
+    static const struct { QRegularExpression re; VirtualCableProduct p; } rules[] = {
+        { QRegularExpression("^NereusSDR VAX \\d$"), VirtualCableProduct::NereusSdrVax },
+        { QRegularExpression("^CABLE-A ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableA },
+        { QRegularExpression("^CABLE-B ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableB },
+        { QRegularExpression("^CABLE-C ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableC },
+        { QRegularExpression("^CABLE-D ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableD },
+        { QRegularExpression("Hi-?Fi Cable", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbHiFiCable },
+        { QRegularExpression("^CABLE ",    QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCable },
+        { QRegularExpression("Virtual Audio Cable", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::MuzychenkoVac },
+        { QRegularExpression("^Line \\d+", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::MuzychenkoVac },
+        { QRegularExpression("VoiceMeeter", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::Voicemeeter },
+        { QRegularExpression("^Dante ",    QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::Dante },
+        { QRegularExpression("^DAX Audio", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::FlexRadioDax },
+    };
+    for (const auto& r : rules) {
+        if (r.re.match(n).hasMatch()) { return r.p; }
+    }
+    return VirtualCableProduct::None;
+}
+
+QString VirtualCableDetector::installUrl(VirtualCableProduct p) {
+    switch (p) {
+        case VirtualCableProduct::VbCable:
+        case VirtualCableProduct::VbCableA:
+        case VirtualCableProduct::VbCableB:
+        case VirtualCableProduct::VbCableC:
+        case VirtualCableProduct::VbCableD:
+        case VirtualCableProduct::VbHiFiCable:
+            return "https://vb-audio.com/Cable/";
+        case VirtualCableProduct::MuzychenkoVac:
+            return "https://vac.muzychenko.net/en/";
+        case VirtualCableProduct::Voicemeeter:
+            return "https://voicemeeter.com/";
+        case VirtualCableProduct::Dante:
+            return "https://www.getdante.com/products/software-essentials/dante-virtual-soundcard/";
+        default:
+            return {};
+    }
+}
+
+QVector<DetectedCable> VirtualCableDetector::scan() {
+    QVector<DetectedCable> out;
+    for (const auto& api : PortAudioBus::hostApis()) {
+        for (const auto& dev : PortAudioBus::outputDevicesFor(api.index)) {
+            const auto p = matchProduct(dev.name);
+            if (p != VirtualCableProduct::None) {
+                out.push_back({p, dev.name, false, 0});
+            }
+        }
+        for (const auto& dev : PortAudioBus::inputDevicesFor(api.index)) {
+            const auto p = matchProduct(dev.name);
+            if (p != VirtualCableProduct::None) {
+                out.push_back({p, dev.name, true, 0});
+            }
+        }
+    }
+    return out;
+}
+```
+
+- [ ] **Step 4: Run to pass**
+
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/audio/VirtualCableDetector.h src/core/audio/VirtualCableDetector.cpp \
+        tests/tst_virtual_cable_detector.cpp tests/CMakeLists.txt
+git commit -S -m "feat(audio): add VirtualCableDetector for Windows BYO auto-detect
+
+Regex-matches known virtual-cable product names (VB-Audio family, VAC,
+Voicemeeter, Dante, FlexRadio DAX, reserved NereusSDR VAX). Pure
+matcher is test-hooked; live scan enumerates PortAudio devices and
+filters.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Sub-Phase 8: VAX UI — VFO Flag Selector 🟢
+
+### Task 8.1: `VaxChannelSelector` widget
+
+**Files:**
+- Create: `src/gui/widgets/VaxChannelSelector.h`, `.cpp`
+- Test: `tests/tst_vax_channel_selector.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+```cpp
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include "gui/widgets/VaxChannelSelector.h"
+
+using namespace NereusSDR;
+
+class TstVaxChannelSelector : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultsToOff() {
+        VaxChannelSelector w;
+        QCOMPARE(w.value(), 0);
+    }
+    void setValueUpdatesUi() {
+        VaxChannelSelector w;
+        w.setValue(3);
+        QCOMPARE(w.value(), 3);
+    }
+    void clickingButtonEmitsSignal() {
+        VaxChannelSelector w;
+        QSignalSpy spy(&w, &VaxChannelSelector::valueChanged);
+        w.simulateClick(2);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toInt(), 2);
+    }
+    void programmaticSetDoesNotEmit() {
+        VaxChannelSelector w;
+        QSignalSpy spy(&w, &VaxChannelSelector::valueChanged);
+        w.setValue(4);
+        QCOMPARE(spy.count(), 0);
+    }
+};
+
+QTEST_MAIN(TstVaxChannelSelector)
+#include "tst_vax_channel_selector.moc"
+```
+
+- [ ] **Step 2: Implement widget per STYLEGUIDE.md palette**
+
+`src/gui/widgets/VaxChannelSelector.h`:
+
+```cpp
+#pragma once
+#include <QWidget>
+
+class QPushButton;
+class QButtonGroup;
+
+namespace NereusSDR {
+
+class VaxChannelSelector : public QWidget {
+    Q_OBJECT
+public:
+    explicit VaxChannelSelector(QWidget* parent = nullptr);
+
+    int  value() const { return m_value; }
+    void setValue(int ch);  // 0..4; no signal
+
+    void simulateClick(int ch);  // test-hook
+
+signals:
+    void valueChanged(int ch);
+
+private:
+    QButtonGroup* m_group{nullptr};
+    QPushButton*  m_buttons[5]{};
+    int m_value{0};
+    bool m_programmaticUpdate{false};
+};
+
+} // namespace NereusSDR
+```
+
+Implementation uses `QButtonGroup::buttonToggled` + `m_programmaticUpdate` guard to suppress echo when `setValue` is called. Styling follows STYLEGUIDE.md Button active-blue (`#0070c0` / `#0090e0` / `#ffffff`) for the selected button.
+
+- [ ] **Step 3: Run to pass**
+
+- [ ] **Step 4: Commit**
+
+### Task 8.2: Embed `VaxChannelSelector` in `VfoWidget`
+
+**Files:**
+- Modify: `src/gui/VfoWidget.h`, `.cpp`
+
+- [ ] **Step 1: Add VAX row to VfoWidget layout**
+
+In `VfoWidget`'s `buildUi()` (or equivalent layout builder), insert a new row below the AGC/NR tab row:
+
+```cpp
+    m_vaxRow = new QWidget(this);
+    auto* vaxLayout = new QHBoxLayout(m_vaxRow);
+    vaxLayout->setContentsMargins(10, 4, 10, 4);
+    vaxLayout->setSpacing(3);
+    auto* lbl = new QLabel("VAX", m_vaxRow);
+    lbl->setStyleSheet("color:#8090a0;font-size:10px;");
+    vaxLayout->addWidget(lbl);
+    m_vaxSelector = new VaxChannelSelector(m_vaxRow);
+    vaxLayout->addWidget(m_vaxSelector);
+    vaxLayout->addStretch(1);
+    m_rootLayout->addWidget(m_vaxRow);
+```
+
+- [ ] **Step 2: Wire bidirectionally to `SliceModel`**
+
+```cpp
+    connect(m_vaxSelector, &VaxChannelSelector::valueChanged,
+            this, [this](int ch){
+        if (m_slice) { m_slice->setVaxChannel(ch); }
+    });
+    connect(m_slice, &SliceModel::vaxChannelChanged,
+            m_vaxSelector, &VaxChannelSelector::setValue);
+    m_vaxSelector->setValue(m_slice->vaxChannel());
+```
+
+- [ ] **Step 3: Build + launch app; verify VAX row renders; clicking changes SliceModel value**
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Sub-Phase 9: VaxApplet 🟡
+
+### Task 9.1: Port `MeterSlider` from AetherSDR
+
+- [ ] **Step 1: Copy + rebrand + port header** (same pattern as Task 5.1)
+
+```bash
+cp ../AetherSDR/src/gui/MeterSlider.h src/gui/widgets/MeterSlider.h
+cp ../AetherSDR/src/gui/MeterSlider.cpp src/gui/widgets/MeterSlider.cpp
+# (AetherSDR .cpp is nearly empty — mostly header-inline.)
+```
+
+Prepend port-citation block.
+
+- [ ] **Step 2: Adapt include paths + namespace**
+
+- [ ] **Step 3: Register in `docs/attribution/aethersdr-contributor-index.md`**
+
+- [ ] **Step 4: Commit**
+
+### Task 9.2: Port `DaxApplet` → `VaxApplet`
+
+**Files:**
+- Create: `src/gui/applets/VaxApplet.h`, `.cpp`
+
+- [ ] **Step 1: Copy + port header**
+
+```bash
+cp ../AetherSDR/src/gui/DaxApplet.h src/gui/applets/VaxApplet.h
+cp ../AetherSDR/src/gui/DaxApplet.cpp src/gui/applets/VaxApplet.cpp
+sed -i 's|DaxApplet|VaxApplet|g; s|daxRxLevel|vaxRxLevel|g; s|daxTxLevel|vaxTxLevel|g; \
+        s|daxEnable|vaxEnable|g; s|daxToggled|vaxToggled|g; \
+        s|daxRxGainChanged|vaxRxGainChanged|g; s|daxTxGainChanged|vaxTxGainChanged|g; \
+        s|DAX|VAX|g; s|"dax"|"vax"|g' src/gui/applets/VaxApplet.*
+```
+
+Prepend port-citation block.
+
+- [ ] **Step 2: Adapt to NereusSDR ContainerWidget parent (not AetherSDR's applet base)**
+
+Replace `setRadioModel(RadioModel*)` signature with NereusSDR's equivalent binding path. Style the title bar using `appletTitleBar("VAX")` per STYLEGUIDE.md.
+
+- [ ] **Step 3: Wire signals through `AudioEngine` slots** (Task 4.1's `setVaxEnabled`, `setVaxRxGain`, etc.)
+
+- [ ] **Step 4: Register in the applet factory so users can add it to a container**
+
+- [ ] **Step 5: Build + launch; add VaxApplet to Container #0; verify channel strips render with live meters when audio is flowing to a VAX channel**
+
+- [ ] **Step 6: Commit**
+
+---
+
+## Sub-Phase 10: MasterOutputWidget 🟢
+
+### Task 10.1: Menu-bar master output strip widget
+
+**Files:**
+- Create: `src/gui/MasterOutputWidget.h`, `.cpp`
+
+- [ ] **Step 1: Implement widget**
+
+Per the mockup (`.superpowers/brainstorm/64803-*/content/mockup-speakers.html`): 14px speaker icon + 100px slider + dB readout + MUTE button. Style with STYLEGUIDE.md inset `#0a0a18` background + `#1e2e3e` border; accent `#00b4d8` slider handle. Right-click opens a device-picker popup menu populated from `PortAudioBus::outputDevicesFor()`.
+
+- [ ] **Step 2: Install into main window's menu-bar corner**
+
+In `MainWindow::MainWindow`:
+
+```cpp
+    m_masterOutput = new MasterOutputWidget(this);
+    menuBar()->setCornerWidget(m_masterOutput, Qt::TopRightCorner);
+    connect(m_masterOutput, &MasterOutputWidget::volumeChanged,
+            m_radio->audioEngine(), &AudioEngine::setMasterVolume);
+    connect(m_masterOutput, &MasterOutputWidget::muteChanged,
+            m_radio->audioEngine(), &AudioEngine::setMasterMuted);
+```
+
+- [ ] **Step 3: Persist to AppSettings on change, restore on app start**
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Sub-Phase 11: VaxFirstRunDialog 🟡
+
+### Task 11.1: Dialog with five scenario modes
+
+**Files:**
+- Create: `src/gui/VaxFirstRunDialog.h`, `.cpp`
+
+- [ ] **Step 1: Implement five scenario constructors**
+
+```cpp
+enum class FirstRunScenario {
+    WindowsCablesFound,
+    WindowsNoCables,
+    MacNative,
+    LinuxNative,
+    RescanNewCables,
+};
+
+class VaxFirstRunDialog : public QDialog {
+    Q_OBJECT
+public:
+    VaxFirstRunDialog(FirstRunScenario s, const QVector<DetectedCable>& detected, QWidget* parent = nullptr);
+
+signals:
+    void applySuggested(const QVector<QPair<int /*vaxCh*/, QString /*deviceName*/>>& bindings);
+    void openSetupAudioTab();
+    void openInstallUrl(const QString& url);
+};
+```
+
+Layouts per the browser mockup (`mockup-firstrun.html`). Styling uses inline-style mockups (not Qt stylesheets) — follow STYLEGUIDE.md palette.
+
+- [ ] **Step 2: Hook into MainWindow startup**
+
+```cpp
+void MainWindow::checkVaxFirstRun() {
+    const auto& s = AppSettings::instance();
+    if (s.value("audio/FirstRunComplete", "False").toString() == "True") { return; }
+
+    const auto detected = VirtualCableDetector::scan();
+#if defined(Q_OS_WIN)
+    const auto scenario = detected.isEmpty()
+        ? FirstRunScenario::WindowsNoCables
+        : FirstRunScenario::WindowsCablesFound;
+#elif defined(Q_OS_MAC)
+    const auto scenario = FirstRunScenario::MacNative;
+#else
+    const auto scenario = FirstRunScenario::LinuxNative;
+#endif
+
+    auto* dlg = new VaxFirstRunDialog(scenario, detected, this);
+    connect(dlg, &VaxFirstRunDialog::applySuggested, this, [this](const auto& bindings) {
+        for (const auto& [ch, dev] : bindings) {
+            m_radio->audioEngine()->setVaxDevice(ch, dev);
+            m_radio->audioEngine()->setVaxEnabled(ch, true);
+        }
+        AppSettings::instance().setValue("audio/FirstRunComplete", "True");
+        AppSettings::instance().save();
+    });
+    dlg->show();
+}
+```
+
+- [ ] **Step 3: Manual smoke on each platform**
+
+Trigger by clearing `audio/FirstRunComplete=True` from AppSettings and restarting.
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Sub-Phase 12: Setup → Audio Page 🟡
+
+### Task 12.1: `SetupAudioPage` shell with sub-tabs
+
+**Files:**
+- Create: `src/gui/SetupAudioPage.h`, `.cpp`
+
+- [ ] **Step 1: Extend existing `SetupPage` base** (`src/gui/SetupPage.h`)
+
+```cpp
+class SetupAudioPage : public SetupPage {
+    Q_OBJECT
+public:
+    SetupAudioPage(RadioModel* model, QWidget* parent = nullptr);
+
+private:
+    QTabWidget* m_subTabs{nullptr};
+    QWidget* buildDevicesTab();
+    QWidget* buildVaxTab();
+    QWidget* buildTciTab();      // placeholder: "Coming in Phase 3J"
+    QWidget* buildAdvancedTab();
+};
+```
+
+Layout: `QTabWidget` with four tabs.
+
+- [ ] **Step 2: Register in `SetupDialog`**
+
+In `SetupDialog.cpp`, add the page under the Audio category.
+
+- [ ] **Step 3: Commit**
+
+### Task 12.2: Devices tab (Speakers / Headphones / TX Input cards)
+
+- [ ] **Step 1: Build three device cards using QGroupBox + form layout**
+
+Each card has: Driver API combo (MME/DirectSound/WDM-KS/WASAPI/ASIO-via-PortAudio on Windows; CoreAudio on Mac; ALSA/Pulse/PipeWire/JACK on Linux), Device combo, Sample rate, Bit depth, Channels, Buffer size, Manual latency, per-API options (WASAPI exclusive / event-driven / bypass-mixer), negotiated-format preview label.
+
+**Note:** Direct ASIO engine and cmASIO parity controls (base channel, input mode L/R/Both, lock mode, Control Panel launcher) are **deferred** per the GPL compliance review above. ASIO users route through PortAudio's built-in ASIO host API — no Engine radio button in this phase.
+
+- [ ] **Step 2: Wire every control per Spec §6.5** (see control wiring table in the design spec — skip rows marked Direct-ASIO-only)
+
+Each combo: `currentTextChanged` → `AudioEngine::setXxxDriverApi()` → reopens bus; reverse via `XxxFormatNegotiated(AudioFormat)` signal.
+
+- [ ] **Step 3: Commit**
+
+### Task 12.3: VAX tab (per-channel cards)
+
+- [ ] **Step 1: Build four channel cards (1–4) + TX row**
+
+Native VAX channels (Mac/Linux) show compact cards with "native driver" badge + fixed 48kHz/24-bit format, no device-picker. Windows BYO cards show full Driver API / Device combos.
+
+- [ ] **Step 2: Wire controls per Spec §6.6**
+
+- [ ] **Step 3: "Auto-detect…" button on unassigned slots calls `VirtualCableDetector::scan()` and opens a mini-picker**
+
+- [ ] **Step 4: Commit**
+
+### Task 12.4: Advanced tab (DSP + IVAC parity + extras)
+
+- [ ] **Step 1: Build Advanced tab per Spec §6.7**
+
+DSP sample rate combo, DSP block size combo, VAC feedback per-target tuning (gain/slew/rings), SendIqToVax / TxMonitorToVax / MuteVaxDuringTxOnOtherSlice checkboxes, detected-cables readonly row + Rescan button, "Reset all audio to defaults" (amber confirm-modal).
+
+- [ ] **Step 2: Wire feature-flagged controls**
+
+`SendIqToVax` and `TxMonitorToVax` persist but their wiring logs a `qCWarning(lcAudio) << "IQ to VAX reserved for future phase"` when toggled on.
+
+- [ ] **Step 3: Commit**
+
+### Task 12.5: TCI tab placeholder
+
+- [ ] **Step 1: Disabled tab labeled "Coming in Phase 3J" with a stub**
+
+```cpp
+QWidget* SetupAudioPage::buildTciTab() {
+    auto* w = new QWidget;
+    auto* lay = new QVBoxLayout(w);
+    auto* lbl = new QLabel("TCI server — coming in Phase 3J (see design spec §11.1)");
+    lbl->setStyleSheet("color:#8090a0;font-size:12px;padding:40px;");
+    lbl->setAlignment(Qt::AlignCenter);
+    lay->addWidget(lbl);
+    return w;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+---
+
+## Sub-Phase 13: Help Docs 🟢
+
+### Task 13.1: `install-virtual-cables.md`
+
+**Files:**
+- Create: `resources/help/install-virtual-cables.md`
+
+- [ ] **Step 1: Write per-platform install guide** — per mockup `mockup-firstrun.html` scenario B content. Vendor install URLs; step-by-step for VB-CABLE; note for Mac/Linux that native VAX is already installed; PipeWire null-sink auto-create option for Linux advanced users.
+
+- [ ] **Step 2: Link from `README.md` feature list and from `VaxFirstRunDialog`**
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Sub-Phase 14: End-to-End Verification 🔴
+
+### Task 14.1: macOS QSO round-trip
+
+- [ ] **Step 1: Install NereusSDR .pkg from Task 5.2 build output**
+- [ ] **Step 2: Confirm "NereusSDR VAX 1–4" + "NereusSDR TX" appear in macOS Audio MIDI Setup**
+- [ ] **Step 3: Launch WSJT-X, pick "NereusSDR VAX 1" as input**
+- [ ] **Step 4: Tune NereusSDR RX1 to 14.074 USB; set VAX pill to `1`; confirm WSJT-X shows decoded FT8 traffic**
+- [ ] **Step 5: Commit a VERIFICATION.md note summarizing the test**
+
+### Task 14.2: Linux QSO round-trip
+
+- [ ] **Step 1: Launch NereusSDR; confirm `pactl list sources short` lists `nereussdr-vax-1..4`**
+- [ ] **Step 2: WSJT-X on same host picks "NereusSDR VAX 1", sees audio** — confirm FT8 decode
+- [ ] **Step 3: Commit VERIFICATION.md update**
+
+### Task 14.3: Windows QSO round-trip (BYO path)
+
+- [ ] **Step 1: Install NereusSDR; first-run dialog appears; install VB-CABLE from the vendor link if not present**
+- [ ] **Step 2: Restart NereusSDR; first-run dialog auto-binds detected cables; click Apply Suggested**
+- [ ] **Step 3: WSJT-X picks "CABLE-A Output" as input; set NereusSDR RX1 VAX=1; confirm FT8 decode**
+- [ ] **Step 4: Commit VERIFICATION.md update**
+
+### Task 14.4: Attribution + compliance-inventory final sweep
+
+- [ ] **Step 1: Run attribution verifier scripts**
+
+```bash
+bash scripts/verify-thetis-headers.py
+bash scripts/check-new-ports.py
+```
+
+Expected: all pass. Every ported file in this phase (`CoreAudioHalBus`, `LinuxPipeBus`, `VaxApplet`, `MeterSlider`, `NereusSDRVAX.cpp` hal-plugin) is registered in `docs/attribution/aethersdr-contributor-index.md` with correct header.
+
+- [ ] **Step 2: Update `docs/attribution/COMPLIANCE-INVENTORY.md`**
+
+Add a new section for Phase 3O covering:
+- Every new port (source upstream + NereusSDR path + license inheritance statement).
+- The macOS HAL plugin's separate-binary status: the `NereusSDRVAX.driver` bundle is a standalone CoreAudio plug-in loaded by `coreaudiod` in its own process, communicating with NereusSDR.app only via POSIX shared memory. Bundled in the same `.pkg` installer with NereusSDR.app is mere aggregation on an installation medium per GPL-3 §5; they are not a single combined work.
+- The 2026-04-19 GPL-3 compliance review result (Direct ASIO deferred; link to this plan's GPL Compliance Review section).
+- PortAudio vendoring: MIT-licensed, linked statically; NereusSDR's corresponding-source obligation is satisfied by the FetchContent reference in `CMakeLists.txt` pinning the exact upstream commit.
+- libASPL vendoring (macOS only): MIT-licensed, linked into the separate HAL plugin binary; same corresponding-source reasoning.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/attribution/COMPLIANCE-INVENTORY.md docs/attribution/aethersdr-contributor-index.md
+git commit -S -m "$(cat <<'EOF'
+docs(compliance): record Phase 3O ports + HAL plugin reasoning
+
+Registers every new AetherSDR port from Phase 3O in the
+aethersdr-contributor-index, and documents the macOS HAL plugin's
+separate-binary / mere-aggregation status per GPL-3 §5. Also logs
+the 2026-04-19 GPL compliance review that dropped Direct ASIO from
+this phase due to Steinberg SDK non-redistributability.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Post-plan: open PR and mark Phase 3O complete in MASTER-PLAN
+
+- [ ] Push `feature/phase-3o-vax` to origin
+- [ ] `gh pr create` with summary linking the design spec and this plan
+- [ ] After merge, update `docs/MASTER-PLAN.md` to mark Phase 3O ✅ COMPLETE with a short shipped-notes block
+
+---
+
+## Self-Review Notes
+
+Spec coverage check (design spec §1–§14):
+- §1–§2 Purpose + scope → covered by plan prose intro
+- §3 Architecture → Sub-Phases 2, 4 (IAudioBus, AudioEngine, MasterMixer)
+- §4.1 Ported files → Sub-Phases 5 (macOS HAL + CoreAudioHalBus), 6 (LinuxPipeBus), 9 (MeterSlider + VaxApplet). DirectAsioBus + AsioSdkHost deferred per GPL compliance review — not in this phase.
+- §4.2 New files → all created across Sub-Phases 2, 3, 7, 8, 10, 11, 12
+- §4.3 Modified files → Sub-Phases 1, 4, 8, 10, 11, 12
+- §5 Data model → Sub-Phase 1
+- §6 Control wiring table → reflected per-tab/per-widget in Sub-Phases 8, 9, 10, 11, 12
+- §7 UI components → Sub-Phases 8, 9, 10, 11, 12
+- §8 Platform specifics → Sub-Phases 5, 6, 7 (§8.5 Direct ASIO deferred per GPL compliance review)
+- §9 Difficulty ranking → mirrored in header emoji
+- §10 Risks → not a task list item; addressed inline in relevant task notes (macOS 14.4 fallback Task 5.2, PipeWire stale-module cleanup Task 6.1)
+- §11 Reserved integration points → preserved via `VirtualCableDetector::NereusSdrVax` pattern (Task 7.1) and `IAudioBus` abstraction (Sub-Phase 2)
+- §12 Attribution checklist → final sweep Task 15.4
+- §13 Plan review history → this plan adds an implementation-plan entry; MASTER-PLAN review history already updated
+- §14 Success criteria → verified in Sub-Phase 15
+
+Placeholder scan: Tasks 3.4, 4.1–4.3, 12.2–12.5 reference "same pattern" or defer to "Spec §6.X"; I've left those as direct spec references rather than re-paste the full wiring table per task to keep the plan under 3000 lines. Each such reference points at the spec's concrete wiring rows, not at TBDs. If the implementing agent hits a row they can't interpret, they stop and ask — consistent with CLAUDE.md ring-1 checklist.
+
+Type consistency: `IAudioBus`, `AudioFormat`, `AudioDeviceConfig`, `VaxSlot`, `VirtualCableProduct`, `DetectedCable`, `FirstRunScenario` all reused with identical names across tasks. `PortAudioConfig` defined Task 3.2, extended Task 3.3.
+
+Post-compliance-review edit (2026-04-19): Sub-Phase 13 (Direct ASIO Engine) removed and subsequent sub-phases renumbered (14→13 Help Docs, 15→14 E2E Verification). Task 3.1 gained a PortAudio license-verification step. Task 14.4 expanded to cover `COMPLIANCE-INVENTORY.md` updates including Phase 3O port registrations, HAL plugin mere-aggregation reasoning, and the GPL-3 compliance review outcome. File structure table, modified-files table, type-consistency checklist, and spec-coverage §4.1/§8 mappings updated to match.
+
+---
+
+**Plan complete and saved to `docs/architecture/2026-04-19-phase3o-vax-plan.md`. Two execution options:**
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Uses `superpowers:subagent-driven-development`.
+
+2. **Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/architecture/2026-04-19-phase3o-vax-plan.md
+++ b/docs/architecture/2026-04-19-phase3o-vax-plan.md
@@ -306,7 +306,7 @@ feat(slice-model): add vaxChannel property for VAX routing
 
 Per-slice VAX channel (0=Off, 1..4=VAX 1–4) with std::atomic storage
 for audio-thread-safe reads, AppSettings persistence under
-slice/<id>/VaxChannel, and vaxChannelChanged signal. Feeds the
+Slice<id>/VaxChannel, and vaxChannelChanged signal. Feeds the
 AudioEngine VAX tap routing in Phase 3O.
 
 Design spec: docs/architecture/2026-04-19-vax-design.md §5.1.

--- a/docs/architecture/2026-04-19-vax-design.md
+++ b/docs/architecture/2026-04-19-vax-design.md
@@ -1,0 +1,699 @@
+# VAX — Virtual Audio eXchange Design Spec
+
+**Status:** Design approved (brainstorm 2026-04-19), ready for implementation plan
+**Author:** J.J. Boyd (KG4VCF), AI-assisted (Claude Opus 4.7)
+**Target phase:** Phase 3O — Audio Routing & Cross-Platform Audio Engine
+**Supersedes:** n/a (new subsystem)
+**Reserves integration points for:** Phase 3J (TCI + Spots), future native Windows driver work
+
+---
+
+## 1. Purpose
+
+Ship NereusSDR's complete RX audio routing story in a single, reviewable phase. Today NereusSDR can play RX audio through the system default output and nothing else. After this phase, each receiver can be routed independently to speakers and to any of four virtual audio channels ("VAX 1–4"), using native drivers on macOS and Linux and user-installed virtual cables on Windows — all wired through a single cross-platform audio engine with Thetis-grade power-user controls.
+
+The design follows **AetherSDR's mental model** (assign VAX at the source, view levels at the destination) rather than a patchbay or matrix, because it fits ham workflows, matches NereusSDR's existing applet architecture, and minimizes new UI paradigms.
+
+## 2. Scope
+
+**In scope:**
+
+- **Cross-platform audio engine** based on PortAudio (MME / DirectSound / WDM-KS / WASAPI-shared / WASAPI-exclusive / ASIO on Windows; CoreAudio on macOS; ALSA / PulseAudio / PipeWire / JACK on Linux).
+- **VAX architecture** — four virtual audio channels + one TX input:
+  - macOS: native CoreAudio HAL plugin (`libASPL` based), ported from AetherSDR.
+  - Linux: native PulseAudio `module-pipe-source` + `module-pipe-sink` bridge, ported from AetherSDR.
+  - Windows: user-installed virtual cables (VB-CABLE, VAC, Voicemeeter) with **first-run auto-detection** and graceful install prompts.
+- **Routing model** — per-receiver VAX assignment on the VFO flag; speakers are always on unless muted; a single VAX slot holds TX at a time.
+- **UI additions** —
+  - `VaxApplet` (ported from AetherSDR `DaxApplet`, renamed) docked in the right container panel.
+  - `VfoWidget` gains a VAX selector row (OFF / 1 / 2 / 3 / 4).
+  - Menu-bar master output widget (global volume + mute + device shortcut).
+  - First-run auto-detect dialog (three platform variants).
+  - Setup → Audio page with **Devices**, **VAX**, **Advanced** sub-tabs.
+- **Optional Direct ASIO engine** (Windows only) for Thetis `cmASIO` parity, gated behind an "Advanced" radio button inside the Devices tab.
+- **AppSettings persistence** for every device / slot / gain / device-bind.
+- **Full end-to-end wiring** — zero unwired controls, zero dangling signals, zero TODO-for-future setters.
+- **Attribution compliance** per `docs/attribution/HOW-TO-PORT.md` for every ported file.
+
+**Explicitly out of scope (reserved integration points):**
+
+- **TCI server and TCI audio streams** — deferred to Phase 3J. The `IAudioBus` tap contract in this spec is designed to let TCI subscribe to the same taps without refactor.
+- **NereusSDR-owned Windows virtual audio driver** — deferred as potential future work. Design hooks are preserved so a signed driver can replace the BYO path without breaking user-visible bindings.
+- **TX mic DSP chain** (compressor, TX EQ) — lives in Phase 3M. This spec only wires the TX **routing** (mic input device → TXA), not DSP between them.
+- **IQ streaming to VAX** — Thetis has an "IQ to VAC" toggle. Wired but feature-flagged off; implementation deferred.
+
+---
+
+## 3. Architecture Overview
+
+### 3.1 Signal flow
+
+```
+       RX1 DSP ─┐
+       RX2 DSP ─┤
+       RX3 DSP ─┼──┬─► Master mix ──► QAudioSink (Speakers)
+       RX4 DSP ─┤  │                   └── volume, mute, device
+       ...     ─┘  │
+                   ├─► VAX 1 tap ──► IAudioBus::push("vax-1")
+                   ├─► VAX 2 tap ──► IAudioBus::push("vax-2")
+                   ├─► VAX 3 tap ──► IAudioBus::push("vax-3")
+                   └─► VAX 4 tap ──► IAudioBus::push("vax-4")
+                                           │
+                       ┌───────────────────┼───────────────────┐
+                       ▼                   ▼                   ▼
+                 macOS HAL plugin    Linux Pulse bridge    Windows BYO
+                 (POSIX shm ring)    (named FIFO)          (PortAudio sink
+                                                           to OS device)
+
+       TX path:
+       QAudioSource ──► IAudioBus::pull("tx-in") ──► TXA DSP ──► Radio
+       (user-picked OS capture device; on Mac/Linux, includes "NereusSDR TX")
+```
+
+### 3.2 `IAudioBus` abstraction
+
+The same internal interface, three platform backends. Declared in `src/core/IAudioBus.h`.
+
+```cpp
+namespace NereusSDR {
+
+struct AudioFormat {
+    int sampleRate = 48000;      // Hz
+    int channels = 2;            // 1 or 2
+    enum class Sample { Float32, Int16, Int24, Int32 } sample = Sample::Float32;
+};
+
+class IAudioBus {
+public:
+    virtual ~IAudioBus() = default;
+
+    // Lifecycle
+    virtual bool open(const AudioFormat& format) = 0;
+    virtual void close() = 0;
+    virtual bool isOpen() const = 0;
+
+    // Producer side (RX taps): write a block of interleaved PCM.
+    virtual qint64 push(const char* data, qint64 bytes) = 0;
+
+    // Consumer side (TX): read a block of interleaved PCM.
+    virtual qint64 pull(char* data, qint64 maxBytes) = 0;
+
+    // Metering (RMS of last block; published atomically for UI).
+    virtual float rxLevel() const = 0;  // 0.0–1.0
+    virtual float txLevel() const = 0;
+
+    // Diagnostics
+    virtual QString backendName() const = 0;
+    virtual AudioFormat negotiatedFormat() const = 0;
+};
+
+} // namespace NereusSDR
+```
+
+Five concrete implementations in `src/core/audio/`:
+
+| Class | Platform | Backend | Source |
+|---|---|---|---|
+| `CoreAudioHalBus` | macOS | POSIX shm ring to HAL plugin | Port of AetherSDR `VirtualAudioBridge` |
+| `LinuxPipeBus` | Linux | Named FIFO via `module-pipe-source`/`sink` | Port of AetherSDR `PipeWireAudioBridge` |
+| `PortAudioBus` | Windows (default) | PortAudio stream to user-picked device | New |
+| `DirectAsioBus` | Windows (opt-in) | ASIO SDK direct, cmASIO parity | New (Thetis `cmasio.c` port) |
+| `CoreAudioBus` | macOS / fallback | PortAudio CoreAudio for Speakers/Headphones/TX | New |
+
+`AudioEngine` owns one instance per routable endpoint (Speakers, Headphones, TX, VAX 1–4) and dispatches by slot.
+
+### 3.3 Threading
+
+- **Main thread:** `RadioModel`, `SliceModel`, UI widgets, applet parameter updates. Never blocks, never touches PCM buffers directly.
+- **Audio worker thread** (existing, owned by `AudioEngine`): RX tap plumbing, per-VAX `IAudioBus::push`, TX `pull`, level metering. All parameter reads are `std::atomic`; never holds a mutex in the audio callback (per CLAUDE.md).
+- **No new threads introduced.** `CoreAudioHalBus` and `LinuxPipeBus` perform their I/O on the existing audio worker thread. The macOS HAL plugin runs in `coreaudiod`'s own thread (out-of-process); the Linux pipe FIFOs are read by PulseAudio/PipeWire in their own processes. No IPC blocks the NereusSDR audio thread.
+
+### 3.4 Routing resolution
+
+Each `SliceModel` carries a `vaxChannel` int: `0=Off, 1..4=VAX 1–4`. `AudioEngine::rxBlockReady(sliceId, float* samples, int frames)` executes:
+
+```cpp
+// Always push to the master mix (speakers path), respecting per-slice mute/volume.
+if (!slice.audioMuted()) {
+    m_masterMix.accumulate(slice, samples, frames);
+}
+
+// Tap to the slice's selected VAX (if any).
+const int vaxCh = slice.vaxChannel();
+if (vaxCh >= 1 && vaxCh <= 4) {
+    m_vaxBus[vaxCh - 1]->push(samples, frames * sizeof(float) * 2);
+}
+```
+
+No per-cell enable matrix. No wires to cross. Two reads per block: mute and VAX channel. Both atomic.
+
+### 3.5 TX arbitration
+
+- `TransmitModel::txOwnerSlot()` returns `VaxSlot { None, 1, 2, 3, 4, MicDirect }`.
+- Only one slot feeds TX at a time. Switch is instantaneous on user change (no cross-fade).
+- PTT sources: physical PTT, VOX, UI button. PTT assertion is orthogonal to owner selection — you can hold PTT while any owner is selected.
+- When the owner is `VAX N`, TX pulls from `m_vaxBus[N-1]` for `pull()`. When `MicDirect`, TX pulls from the OS capture device configured as the "TX input device".
+
+---
+
+## 4. File Inventory and Attribution
+
+### 4.1 Ported files (from AetherSDR)
+
+Per `docs/attribution/HOW-TO-PORT.md` rule 6: AetherSDR has no per-file GPL headers. Each ported file gets a NereusSDR port-citation block referencing the AetherSDR project URL and primary author, followed by the standard modification-history block.
+
+| NereusSDR path | Ported from | LOC (reference) | Rename notes |
+|---|---|---|---|
+| `src/core/audio/CoreAudioHalBus.{h,cpp}` | `AetherSDR src/core/VirtualAudioBridge.{h,cpp}` | 95 + 336 | Rebrand all `AetherSDR` → `NereusSDR`, shm paths `/aethersdr-dax-*` → `/nereussdr-vax-*`, class rename. |
+| `src/core/audio/LinuxPipeBus.{h,cpp}` | `AetherSDR src/core/PipeWireAudioBridge.{h,cpp}` | ~80 + 386 | Rebrand class, FIFO paths `/tmp/aethersdr-dax-*` → `/tmp/nereussdr-vax-*`, PulseAudio module `source_name=nereussdr-vax-1`, description "NereusSDR VAX 1". |
+| `hal-plugin/NereusSDRVAX.cpp` | `AetherSDR hal-plugin/AetherSDRDAX.cpp` | ~330 | Rebrand device UIDs (`com.aethersdr.dax.*` → `com.nereussdr.vax.*`), device names, shm paths. **Fix macOS 14.4+ regression:** use `killall coreaudiod` fallback in postinstall script. |
+| `hal-plugin/CMakeLists.txt`, `Info.plist` | AetherSDR equivalents | small | Bundle ID `com.nereussdr.vax`, factory UUID regenerated. |
+| `packaging/macos/hal-installer.sh` + postinstall | AetherSDR `packaging/macos/build-installer.sh` + postinstall | small | Rebrand + killall fallback. |
+| `src/gui/applets/VaxApplet.{h,cpp}` | `AetherSDR src/gui/DaxApplet.{h,cpp}` | 48 + 216 | **Rename class `DaxApplet` → `VaxApplet`, all signal names `dax*` → `vax*`. Integrate with NereusSDR `ContainerWidget`/applet framework (not AetherSDR's applet parent).** Ported styling merged with NereusSDR `STYLEGUIDE.md`. |
+| `src/gui/widgets/MeterSlider.{h,cpp}` | `AetherSDR src/gui/MeterSlider.{h,cpp}` | 129 + 2 | Shared meter+slider composite widget used by VaxApplet. AetherSDR's `.cpp` is nearly empty (logic is header-inline); port faithfully keeping that shape. |
+
+**Port-citation block template for each ported file:**
+
+```cpp
+// =================================================================
+// <repo-relative path>  (NereusSDR)
+// =================================================================
+//
+// Ported from AetherSDR source:
+//   <aethersdr path>
+//
+// AetherSDR is licensed under the GNU General Public License v3; see
+// https://github.com/ten9876/AetherSDR for the contributor list and
+// project-level LICENSE. NereusSDR is also GPLv3. AetherSDR source
+// files carry no per-file GPL header; attribution is at project level
+// per AetherSDR convention.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-19 — Ported/adapted in C++20/Qt6 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via
+//                 Anthropic Claude Code. Renamed DAX → VAX and
+//                 rebranded identifiers for the NereusSDR-native VAX
+//                 device family.
+// =================================================================
+```
+
+### 4.2 New files (NereusSDR-original)
+
+| Path | Role |
+|---|---|
+| `src/core/IAudioBus.h` | Abstract bus interface (cross-backend contract). |
+| `src/core/audio/PortAudioBus.{h,cpp}` | PortAudio stream to user-picked OS audio device. Windows default + macOS/Linux fallback. |
+| `src/core/audio/DirectAsioBus.{h,cpp}` | Native ASIO SDK engine (Windows only, opt-in). Ported logic from Thetis `ChannelMaster/cmasio.{h,c}` — **adds Thetis attribution headers per HOW-TO-PORT.md**. |
+| `src/core/audio/AsioSdkHost.{h,cpp}` | Thin wrapper over the ASIO SDK. Driver enumeration, load, callback routing. |
+| `src/core/audio/VirtualCableDetector.{h,cpp}` | Enumerates OS audio devices and regex-matches known virtual-cable product patterns (VB-Audio family, VAC, Voicemeeter, Dante, FlexRadio DAX). |
+| `src/core/audio/MasterMixer.{h,cpp}` | Per-slice mute/volume/pan → stereo mix → single output sink. |
+| `src/gui/MasterOutputWidget.{h,cpp}` | Menu-bar corner widget: speaker icon, master slider, mute button, right-click device picker. |
+| `src/gui/SetupAudioPage.{h,cpp}` | Setup → Audio page with Devices/VAX/Advanced sub-tabs. Extends existing `SetupPage` base. |
+| `src/gui/VaxFirstRunDialog.{h,cpp}` | First-run auto-detect modal (five scenarios A–E from the brainstorm mockups). |
+| `src/gui/VaxChannelSelector.{h,cpp}` | Small 5-button group widget embedded into `VfoWidget` (OFF / 1 / 2 / 3 / 4). |
+
+### 4.3 Modified existing files
+
+| Path | Change |
+|---|---|
+| `src/models/SliceModel.{h,cpp}` | Add `int vaxChannel()` / `setVaxChannel(int)` with `std::atomic<int>` storage, `vaxChannelChanged(int)` signal, AppSettings key `slice/<id>/VaxChannel`. |
+| `src/models/TransmitModel.{h,cpp}` | Add `VaxSlot txOwnerSlot()` / `setTxOwnerSlot(VaxSlot)`, signal, AppSettings key `tx/OwnerSlot`. |
+| `src/gui/VfoWidget.{h,cpp}` | Embed `VaxChannelSelector` in a new row below the MODE/FILT/AGC tabs. Bidirectional wire to `SliceModel::vaxChannel`. |
+| `src/core/AudioEngine.{h,cpp}` | Replace `QAudioSink`-only output with the `IAudioBus`-based model: master-mix goes to Speakers/Headphones bus; per-slice VAX taps feed the four VAX buses; TX consumes either a VAX bus or the mic bus based on `TransmitModel::txOwnerSlot`. |
+| `src/core/AppSettings.{h,cpp}` | Schema additions (below). Add a `v2` settings-migration path to import old single-device audio config. |
+| `src/gui/MainWindow.{h,cpp}` | Instantiate `MasterOutputWidget` in the menu bar, wire it to `AudioEngine`. Trigger `VaxFirstRunDialog` on first launch / on new-cable detection. |
+| `src/gui/SetupDialog.{h,cpp}` | Register `SetupAudioPage` under the Audio category. |
+| `docs/attribution/THETIS-PROVENANCE.md` | Add row for `DirectAsioBus` + `AsioSdkHost` (ported from `ChannelMaster/cmasio.{h,c}` + `Console/clsCMASIOConfig.cs`). |
+| `docs/attribution/aethersdr-contributor-index.md` (or equivalent) | Add rows for `VirtualAudioBridge`, `PipeWireAudioBridge`, `DaxApplet`, `MeterSlider`. |
+| `docs/MASTER-PLAN.md` | Add Phase 3O section, update status lines, add Plan Review History entry. |
+| `CMakeLists.txt` | Add PortAudio dependency (vendored or `find_package`), conditionally add ASIO SDK + HAL plugin subdirs. |
+| `README.md` | Add brief "VAX routing" mention in feature list; link to user docs. |
+| `resources/help/install-virtual-cables.md` | New user-facing help doc. |
+
+---
+
+## 5. Data Model Changes
+
+### 5.1 `SliceModel`
+
+```cpp
+// New:
+std::atomic<int> m_vaxChannel{0};  // 0=Off, 1..4=VAX N
+public:
+    int vaxChannel() const { return m_vaxChannel.load(); }
+    void setVaxChannel(int ch);   // validates 0..4, persists, emits
+signals:
+    void vaxChannelChanged(int ch);
+```
+
+Persistence: `AppSettings` XML key `slice/<sliceId>/VaxChannel`, stored as string `"0".."4"`. On load, invalid values clamp to 0.
+
+### 5.2 `TransmitModel`
+
+```cpp
+enum class VaxSlot { None = 0, MicDirect, Vax1, Vax2, Vax3, Vax4 };
+std::atomic<VaxSlot> m_txOwnerSlot{VaxSlot::MicDirect};
+public:
+    VaxSlot txOwnerSlot() const { return m_txOwnerSlot.load(); }
+    void setTxOwnerSlot(VaxSlot s);
+signals:
+    void txOwnerSlotChanged(VaxSlot s);
+```
+
+Persistence: `tx/OwnerSlot` stored as string `"MicDirect"` etc.
+
+### 5.3 `AudioEngine`
+
+```cpp
+// New members:
+std::unique_ptr<IAudioBus> m_speakersBus;
+std::unique_ptr<IAudioBus> m_headphonesBus;       // optional, may be null
+std::unique_ptr<IAudioBus> m_txInputBus;          // OS capture device
+std::array<std::unique_ptr<IAudioBus>, 4> m_vaxBus;
+MasterMixer m_masterMix;
+
+// Public API additions:
+void setSpeakersConfig(const AudioDeviceConfig&);
+void setHeadphonesConfig(const AudioDeviceConfig&);
+void setTxInputConfig(const AudioDeviceConfig&);
+void setVaxConfig(int ch, const AudioDeviceConfig&);
+
+// AudioDeviceConfig carries: driver API, device name, sample rate, bit depth,
+// channels, buffer size, exclusive mode, ASIO engine choice, etc.
+```
+
+### 5.4 `AppSettings` schema additions
+
+All keys PascalCase, boolean as `"True"`/`"False"`, per CLAUDE.md.
+
+```
+audio/Speakers/DriverApi            (string: MME|DirectSound|WDM-KS|WASAPI|WASAPI-Exclusive|ASIO|CoreAudio|ALSA|Pulse|PipeWire|JACK)
+audio/Speakers/DeviceName           (string: device display name)
+audio/Speakers/SampleRate           (int: Hz)
+audio/Speakers/BitDepth             (int: 16|24|32)
+audio/Speakers/Channels             (int: 1|2)
+audio/Speakers/BufferSamples        (int)
+audio/Speakers/ExclusiveMode        (bool)
+audio/Speakers/EventDrivenCallback  (bool)
+audio/Speakers/BypassMixer          (bool)
+audio/Speakers/ManualLatencyMs      (int, 0=auto)
+audio/Speakers/AsioEngine           (string: PortAudio|Direct)
+audio/Speakers/DirectAsio/DriverName       (string — only if AsioEngine=Direct)
+audio/Speakers/DirectAsio/BlockSize        (int)
+audio/Speakers/DirectAsio/LockMode         (bool)
+audio/Speakers/DirectAsio/InputMode        (string: Left|Right|Both)
+audio/Speakers/DirectAsio/BaseInChannel    (int, 0-indexed)
+audio/Speakers/DirectAsio/BaseOutChannel   (int, 0-indexed)
+
+audio/Headphones/*                  (same keys; optional, may be unset)
+audio/TxInput/*                     (same keys)
+
+audio/Vax1/Enabled                  (bool)
+audio/Vax1/DeviceName               (string — "NereusSDR VAX 1" on Mac/Linux; "CABLE-A Input" etc. on Windows)
+audio/Vax1/DriverApi                (string, only on Windows BYO path)
+audio/Vax1/SampleRate               (int)
+audio/Vax1/BitDepth                 (int)
+audio/Vax1/Channels                 (int)
+audio/Vax1/BufferSamples            (int)
+audio/Vax1/RxGain                   (float: 0.0–1.0)
+audio/Vax1/Muted                    (bool)
+audio/Vax1/ExclusiveMode            (bool, Windows only)
+audio/Vax2/*                        (same)
+audio/Vax3/*                        (same)
+audio/Vax4/*                        (same)
+
+audio/TxGain                        (float: 0.0–1.0)
+
+audio/Master/Volume                 (float: 0.0–1.0)
+audio/Master/Muted                  (bool)
+audio/Master/ActiveOutput           (string: Speakers|Headphones)
+
+audio/DspRate                       (int: WDSP internal rate, default 48000)
+audio/DspBlockSize                  (int: fexchange2 granularity, default 1024)
+
+audio/VacFeedback/<ch>/Gain         (float, IVAC parity)
+audio/VacFeedback/<ch>/SlewTimeMs   (float)
+audio/VacFeedback/<ch>/PropRingMinUs   (int)
+audio/VacFeedback/<ch>/PropRingMaxUs   (int)
+audio/VacFeedback/<ch>/FfRingMinUs     (int)
+audio/VacFeedback/<ch>/FfRingMaxUs     (int)
+audio/VacFeedback/<ch>/FfRingAlpha     (float)
+
+audio/SendIqToVax                   (bool, default False)
+audio/TxMonitorToVax                (bool, default False)
+audio/MuteVaxDuringTxOnOtherSlice   (bool, default True)
+
+slice/<sliceId>/VaxChannel          (int: 0..4)
+tx/OwnerSlot                        (string: None|MicDirect|Vax1..4)
+
+audio/FirstRunComplete              (bool)
+audio/LastDetectedCables            (string: CSV of device-name hashes for diff-on-next-run)
+```
+
+### 5.5 Settings migration
+
+Pre-VAX builds stored a single `audio/OutputDevice` key (per existing `AudioEngine`). Migration on first launch post-upgrade:
+
+```cpp
+if (settings.contains("audio/OutputDevice") && !settings.contains("audio/Speakers/DeviceName")) {
+    settings.setValue("audio/Speakers/DeviceName", settings.value("audio/OutputDevice").toString());
+    settings.setValue("audio/Speakers/DriverApi", platformDefaultApi());
+    settings.setValue("audio/Speakers/SampleRate", 48000);
+    // … sensible defaults for the rest
+    settings.setValue("audio/FirstRunComplete", "False");  // trigger VaxFirstRunDialog
+    settings.remove("audio/OutputDevice");
+    settings.save();
+}
+```
+
+---
+
+## 6. Control Wiring Table
+
+**Every** widget listed below has its full round-trip wiring specified. No "TBD", no "future PR", no unwired stubs. A row lacking a column means that column is N/A for that control.
+
+Columns: **Widget** · **Widget → Model** · **Model → Widget** (echo prevention) · **Model → Action** · **AppSettings key** · **Guard**
+
+### 6.1 VFO flag — VAX channel selector
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `VaxChannelSelector` button group (OFF/1/2/3/4) | `buttonClicked(int)` → `SliceModel::setVaxChannel(int)` | `vaxChannelChanged(int)` → `VaxChannelSelector::setValue(int)` | `SliceModel::setVaxChannel` persists and (if different) emits `vaxChannelChanged`; `AudioEngine::sliceVaxChanged(sliceId, ch)` slot updates the tap routing | `slice/<sliceId>/VaxChannel` | `QSignalBlocker` on `VaxChannelSelector` during `setValue` |
+
+### 6.2 VFO flag — per-RX audio block (already existed, extended)
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| Volume slider | `valueChanged(int)` → `SliceModel::setAudioVolume(float)` | `audioVolumeChanged` → `slider.setValue` | `AudioEngine::sliceVolumeChanged` updates `MasterMixer` weight for that slice | `slice/<sliceId>/AudioVolume` | `m_updatingFromModel` |
+| Pan slider | `valueChanged(int)` → `SliceModel::setAudioPan(float)` | `audioPanChanged` → `slider.setValue` | `MasterMixer` per-slice pan coefficient | `slice/<sliceId>/AudioPan` | same |
+| MUTE button | `toggled(bool)` → `SliceModel::setAudioMuted(bool)` | `audioMutedChanged` → `button.setChecked` | Master mix skips slice block when muted; VAX tap still runs (optional per-VAX mute owns that) | `slice/<sliceId>/AudioMuted` | same |
+| BINAURAL toggle | `toggled(bool)` → `SliceModel::setBinauralEnabled(bool)` | `binauralChanged` → button | `RxChannel::setBinaural` calls WDSP `SetRXAPanelBinaural` | `slice/<sliceId>/Binaural` | same |
+| SPEAKERS/HDPHN buttons | exclusive group → `SliceModel::setOutputRoute(Output)` | `outputRouteChanged` → button group | `MasterMixer` routes the slice to speakers OR headphones bus | `slice/<sliceId>/OutputRoute` | same |
+| RX level meter (readonly) | n/a | `AudioEngine::sliceMeter(sliceId, float)` → `meter.setLevel(float)` | n/a | none (ephemeral) | n/a |
+
+### 6.3 Menu-bar `MasterOutputWidget`
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| Master volume slider | `valueChanged(int)` → `AudioEngine::setMasterVolume(float)` | `masterVolumeChanged(float)` → `slider.setValue` | Applies gain on the speakers bus | `audio/Master/Volume` | `m_updatingFromModel` |
+| Master MUTE button | `toggled(bool)` → `AudioEngine::setMasterMuted(bool)` | `masterMutedChanged(bool)` → button | Mutes speakers bus | `audio/Master/Muted` | same |
+| Speaker icon (click) | `clicked()` → toggles mute | same | same | same | n/a |
+| Speaker icon (right-click) | context menu with `QActionGroup` of output devices → `AudioEngine::setSpeakersDevice(QString)` | device change re-enumerates the menu next open | Rebuilds `m_speakersBus` | `audio/Speakers/DeviceName` | n/a |
+
+### 6.4 `VaxApplet` (ported from AetherSDR `DaxApplet`, renamed)
+
+For each of the four channels:
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `VaxChannelStrip[ch].enableButton` | `toggled(bool)` → `AudioEngine::setVaxEnabled(ch, bool)` | `vaxEnabledChanged(ch, bool)` → button | Opens/closes `m_vaxBus[ch-1]`; triggers platform driver init (Mac HAL, Linux pipe, Windows PortAudio) | `audio/Vax<ch>/Enabled` | `m_updatingFromModel` |
+| `VaxChannelStrip[ch].rxGainSlider` | `valueChanged(float)` → `AudioEngine::setVaxRxGain(ch, float)` | `vaxRxGainChanged(ch, float)` → slider | Applied to tap output before `push` | `audio/Vax<ch>/RxGain` | same |
+| `VaxChannelStrip[ch].muteButton` | `toggled(bool)` → `AudioEngine::setVaxMuted(ch, bool)` | `vaxMutedChanged` → button | Skips tap when muted | `audio/Vax<ch>/Muted` | same |
+| `VaxChannelStrip[ch].rxMeter` (readonly) | n/a | `vaxRxLevel(ch, float)` → `meter.setLevel(float)` | Level computed in audio thread, published atomic | none | n/a |
+| `VaxChannelStrip[ch].deviceLabel` (click) | opens device picker → `AudioEngine::setVaxDevice(ch, QString)` | `vaxDeviceChanged` → label text | Rebuilds `m_vaxBus[ch-1]` with new device | `audio/Vax<ch>/DeviceName` | n/a |
+| `VaxChannelStrip[ch].tagsLabel` (readonly) | n/a | Listens to every `SliceModel::vaxChannelChanged`; shows list of slices currently assigned to channel `ch` | n/a | none | n/a |
+| TX row: tx gain slider | `valueChanged(float)` → `AudioEngine::setVaxTxGain(float)` | `vaxTxGainChanged(float)` → slider | Applied in TX pull path before TXA | `audio/TxGain` | `m_updatingFromModel` |
+| TX row: tx meter (readonly) | n/a | `vaxTxLevel(float)` → meter | Level of active TX source | none | n/a |
+
+### 6.5 Setup → Audio → Devices tab (for each of Speakers / Headphones / TX Input)
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `driverApiCombo` | `currentTextChanged(QString)` → `AudioEngine::setXxxDriverApi(QString)` | on load, combo text set from settings | Re-creates backing `IAudioBus` with new API | `audio/Xxx/DriverApi` | `m_updatingFromModel` + `QSignalBlocker` |
+| `engineRadioGroup` (PortAudio/Direct ASIO — visible only when driverApi=ASIO) | `buttonToggled` → `AudioEngine::setXxxAsioEngine(AsioEngine)` | on load | Swaps `PortAudioBus` ↔ `DirectAsioBus` | `audio/Xxx/AsioEngine` | same |
+| `asioDriverCombo` (Direct ASIO only) | `currentTextChanged` → `AudioEngine::setXxxDirectAsioDriver(QString)` | `directAsioDriversEnumerated` → combo | `AsioSdkHost::loadDriver` | `audio/Xxx/DirectAsio/DriverName` | same |
+| `asioControlPanelButton` | `clicked()` → `AsioSdkHost::openControlPanel(driverName)` | n/a | Opens ASIO driver's native UI (Windows modal) | none | n/a |
+| `baseInChannelCombo`, `baseOutChannelCombo` | `currentIndexChanged` → setters | on load | Passed to `DirectAsioBus` for channel base | `audio/Xxx/DirectAsio/BaseInChannel`, `BaseOutChannel` | same |
+| `inputModeRadioGroup` (Left/Right/Both, Direct ASIO only) | `buttonToggled` → setters | on load | Maps to cmASIO `IM_LEFT/IM_RIGHT/IM_BOTH` | `audio/Xxx/DirectAsio/InputMode` | same |
+| `lockModeCheckbox` (Direct ASIO only) | `toggled` → setter | on load | cmASIO lock-mode flag | `audio/Xxx/DirectAsio/LockMode` | same |
+| `deviceCombo` (PortAudio only) | `currentTextChanged` → `AudioEngine::setXxxDeviceName(QString)` | on load / device-change-detected | Reopens bus | `audio/Xxx/DeviceName` | same |
+| `sampleRateCombo` + `autoMatchCheckbox` | `currentIndexChanged` / `toggled` → setters | on load | Bus reopened if needed | `audio/Xxx/SampleRate` | same |
+| `bitDepthCombo` | same | same | same | `audio/Xxx/BitDepth` | same |
+| `channelsCombo` (Mono/Stereo) | same | same | same | `audio/Xxx/Channels` | same |
+| `bufferSamplesSpinner` + derived-ms label | `valueChanged` → setter | on load | Applied on bus reopen | `audio/Xxx/BufferSamples` | same |
+| `manualLatencyCheckbox` + `latencyMsSpinner` | same | same | same | `audio/Xxx/ManualLatencyMs` | same |
+| `exclusiveModeCheckbox`, `eventDrivenCallback`, `bypassMixer` (WASAPI only) | same | same | same | respective keys | same |
+| `formatPreviewLabel` (readonly) | n/a | `AudioEngine::xxxFormatNegotiated(AudioFormat)` → label | Shows actually-negotiated format + status pill | none | n/a |
+
+### 6.6 Setup → Audio → VAX tab
+
+Per-channel card (1–4):
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `vaxEnabledCheckbox` | `toggled(bool)` → `AudioEngine::setVaxEnabled(ch, bool)` | `vaxEnabledChanged(ch, bool)` → checkbox | Same as 6.4 | `audio/Vax<ch>/Enabled` | `m_updatingFromModel` |
+| `vaxDriverApiCombo` (hidden on Mac/Linux native; shown Windows BYO) | same pattern as 6.5 | same | same | `audio/Vax<ch>/DriverApi` | same |
+| `vaxDeviceCombo` | `currentTextChanged` → `AudioEngine::setVaxDevice(ch, QString)` | `vaxDeviceChanged` | Rebuilds `m_vaxBus[ch-1]` | `audio/Vax<ch>/DeviceName` | same |
+| Format controls (rate/bit-depth/channels/buffer) | same as 6.5 pattern | same | same | respective keys | same |
+| `vaxExclusiveModeCheckbox` (WASAPI only) | same | same | same | `audio/Vax<ch>/ExclusiveMode` | same |
+| "Auto-detect…" button (unassigned channels) | `clicked()` → `VirtualCableDetector::scan()` → opens first-run-style sub-dialog with detected cables | n/a | If user picks one, calls `setVaxDevice(ch, name)` | n/a | n/a |
+
+### 6.7 Setup → Audio → Advanced tab
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| `dspSampleRateCombo` | `currentIndexChanged` → `AudioEngine::setDspSampleRate(int)` | on load | WDSP channel reconfig | `audio/DspRate` | `m_updatingFromModel` |
+| `dspBlockSizeCombo` | same | same | same | `audio/DspBlockSize` | same |
+| `vacFeedbackTargetCombo` + per-target gain/slew/rings editors | writes to `audio/VacFeedback/<ch>/*` keys → `AudioEngine::setVacFeedbackParams(ch, params)` | on load (reloads per-target when target combo changes) | Applied to IVAC-parity resamplers inside the VAX bus implementation | as schemed | same |
+| `sendIqToVaxCheckbox` | `toggled` → setter | on load | **Feature-flagged: emits a log-warning "IQ to VAX is reserved for future — see Phase 3O+"** | `audio/SendIqToVax` (stored but not active) | same |
+| `txMonitorToVaxCheckbox` | `toggled` → setter | on load | same feature-flag note as above | `audio/TxMonitorToVax` | same |
+| `muteVaxDuringTxOnOtherSliceCheckbox` | `toggled` → setter | on load | Active: when slice A holds TX, slices B/C/D's VAX taps emit silence (mirrors Thetis behavior) | `audio/MuteVaxDuringTxOnOtherSlice` | same |
+| "Detected cables" label row (readonly) | n/a | Live result from `VirtualCableDetector::lastScan()` | n/a | none | n/a |
+| "Rescan" button | `clicked()` → `VirtualCableDetector::scan()` | updates Detected-cables row | May open `VaxFirstRunDialog::rescanMode()` if new cables appear | `audio/LastDetectedCables` | n/a |
+| "Reset all audio to defaults" button | `clicked()` → confirm modal → `AudioEngine::resetAudioSettings()` | triggers full re-sync from defaults | Clears all `audio/*` keys + rebuilds buses | all `audio/*` removed | n/a |
+
+### 6.8 First-run dialog (`VaxFirstRunDialog`)
+
+| Widget | Action |
+|---|---|
+| "Apply suggested" button (scenario A, E) | For each suggestion row, call `AudioEngine::setVaxDevice(ch, name)` + `setVaxEnabled(ch, true)`; close dialog; set `audio/FirstRunComplete=True`. |
+| "Customize…" button | Close; open Setup → Audio → VAX tab with detected cables pre-filled in each channel card. |
+| "Skip" button | Close; set `audio/FirstRunComplete=True`; VAX stays disabled. |
+| "Open download page" buttons (scenario B) | `QDesktopServices::openUrl` to vendor's official URL (hardcoded mapping per product in `VirtualCableDetector`). |
+| "Continue without VAX" | Same as Skip. |
+| "Rescan now" | `VirtualCableDetector::scan()`, reload dialog content. |
+| "Got it" (Mac/Linux native scenarios) | Close; set `audio/FirstRunComplete=True`; VAX enabled by default (since drivers are ready). |
+
+### 6.9 TX source / PTT arbitration
+
+Currently shown in the mockup on the Audio Setup page's TX Source bar. Wiring:
+
+| Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
+|---|---|---|---|---|---|
+| TX source combo (MicDirect / VAX 1 / VAX 2 / VAX 3 / VAX 4) | `currentIndexChanged` → `TransmitModel::setTxOwnerSlot(VaxSlot)` | `txOwnerSlotChanged` → combo | TX path switches `pull()` source on next block | `tx/OwnerSlot` | `m_updatingFromModel` |
+| PTT owner button row (duplicated in mockup) | same wiring (convenience surface) | same | same | same | same |
+| TX input device combo (for MicDirect) | `currentTextChanged` → `AudioEngine::setTxInputDevice(QString)` | on load | Rebuilds `m_txInputBus` | `audio/TxInput/DeviceName` | same |
+
+---
+
+## 7. UI Components in Detail
+
+### 7.1 `VaxChannelSelector` (VFO flag, new)
+
+- 5 small buttons: OFF, 1, 2, 3, 4.
+- Exclusive (single-select), backed by `QButtonGroup`.
+- Styled per STYLEGUIDE.md: base `#1a2a3a`/`#205070`, active `#0070c0`/`#ffffff`.
+- Fixed height 22 px, each button 26 px wide min.
+- Embedded in a new row on `VfoWidget` under the existing MODE/FILT/AGC/NR tabs, grouped with an "AUDIO" row already planned.
+
+### 7.2 `VaxApplet` (docked, ported + renamed)
+
+- Title bar "VAX" + subtitle "4 channels" (per STYLEGUIDE.md applet header).
+- Four `VaxChannelStrip` rows + divider + TX row.
+- Each `VaxChannelStrip` layout (top-to-bottom, compact):
+  ```
+  [VAX N name]  [assigned-slices chips]              [MUTE]
+  [level meter ═══════════════════════]  [RxGain slider]  [dB readout]
+  [device-type tag] · [device name]
+  ```
+- Fixed width ~310 px docked; resizable if floated.
+- All controls keyboard-navigable (Qt focus chain).
+
+### 7.3 `MasterOutputWidget` (menu bar corner, new)
+
+- 3 elements horizontal: speaker icon (14 px), slider (100 px wide), dB readout (inset), MUTE button.
+- Speaker icon click toggles mute; scroll wheel on slider adjusts in 1 dB steps; right-click icon opens device picker submenu.
+- Styled as an inset `#0a0a18` / `#1e2e3e` container per STYLEGUIDE.md "Inset Value Display" pattern.
+
+### 7.4 `VaxFirstRunDialog` (modal, new)
+
+- Five scenario constructors (see mockup-firstrun.html for exact layout).
+- Fixed 560 px wide; modal; parented to MainWindow.
+- Dismissable via `Escape`; but only counts as first-run-complete if user clicked **Apply suggested**, **Skip**, or **Got it** (Mac/Linux).
+- Rescan mode (scenario E) pops unobtrusively only when a new cable is detected on app startup.
+
+### 7.5 `SetupAudioPage` (new page in SetupDialog)
+
+- Extends existing `SetupPage` base.
+- Four sub-tabs: **Devices**, **VAX**, **TCI** (disabled/placeholder "Coming in Phase 3J"), **Advanced**.
+- Each tab is a `QScrollArea` containing groupboxes.
+- Styled per STYLEGUIDE.md; groupbox conventions from `src/gui/SetupPage.cpp`.
+
+---
+
+## 8. Platform-Specific Implementation
+
+### 8.1 macOS
+
+- **HAL plugin** at `/Library/Audio/Plug-Ins/HAL/NereusSDRVAX.driver` (system-wide, admin install).
+- Built separately from main app (`hal-plugin/CMakeLists.txt`) because libASPL FetchContent conflicts with the main Ninja build — pattern already proven by AetherSDR.
+- `.pkg` installer with two components (app + driver). Postinstall script:
+  ```bash
+  #!/bin/bash
+  # macOS 14.4+ locked down launchctl kickstart for coreaudiod; use killall.
+  launchctl kickstart -kp system/com.apple.audio.coreaudiod 2>/dev/null \
+    || sudo killall coreaudiod \
+    || true
+  exit 0
+  ```
+- Uninstall shell script ships alongside; removes `.driver` and `/dev/shm/nereussdr-vax-*` segments.
+- Signing: Apple Developer ID Application + notarization. NereusSDR already pays the $99/yr per CLAUDE.md; no new cost.
+- Devices exposed: "NereusSDR VAX 1", "NereusSDR VAX 2", "NereusSDR VAX 3", "NereusSDR VAX 4", "NereusSDR TX".
+- Format: float32 stereo @ 48 kHz (we may move from AetherSDR's 24 kHz to 48 kHz to align with Thetis DSP rate; decision confirmed with user as part of this spec).
+- IPC: POSIX shm ring, ~2-sec ring at 48 kHz stereo float = ~768 KB per segment.
+
+### 8.2 Linux
+
+- **Bridge** loaded at NereusSDR app startup via `pactl load-module module-pipe-source ...` (RX × 4) + `pactl load-module module-pipe-sink ...` (TX × 1).
+- FIFOs in `/tmp/nereussdr-vax-{1..4}.pipe` and `/tmp/nereussdr-tx.pipe`.
+- Node names: `nereussdr-vax-1` etc.; descriptions: "NereusSDR VAX 1" etc.
+- Works on pure PulseAudio **and** PipeWire-via-pipewire-pulse.
+- Stale-module cleanup on startup (port AetherSDR's scan: `pactl list modules short | grep nereussdr-` and `pactl unload-module <idx>`).
+- Module lifetimes bound to app lifetime; clean teardown on quit.
+- No separate installer; modules load at runtime from the app.
+- Packaged as `.deb` / `.rpm` / AUR / AppImage per existing NereusSDR release.yml.
+- **Deferred:** Flatpak/Snap (sandboxing blocks virtual audio node publication per `xdg-desktop-portal` issue #1142). Document this in README.
+
+### 8.3 Windows
+
+- **Default engine:** `PortAudioBus`. Enumerate audio devices via PortAudio host APIs (MME, DirectSound, WDM-KS, WASAPI-shared, WASAPI-exclusive, ASIO).
+- **Opt-in engine:** `DirectAsioBus`. When user selects "Direct ASIO" in the Engine radio group, we load the ASIO SDK driver directly (no PortAudio). Ported from Thetis `ChannelMaster/cmasio.c` with full Thetis attribution header per HOW-TO-PORT.md.
+- **VAX channels on Windows:** user-picked OS audio devices. `VirtualCableDetector` pre-populates suggestions.
+- **No kernel driver shipped in this phase.** A future phase may fork `VirtualDrivers/Virtual-Audio-Driver` (MIT path, SysVAD-based) and add a signed Windows driver for "NereusSDR VAX 1–4" first-class devices. Integration points reserved — device-name patterns in `VirtualCableDetector` already include a placeholder for "NereusSDR VAX N" so the future driver slots in transparently.
+- `help/install-virtual-cables.md` documents VB-CABLE (recommended), VAC, Voicemeeter.
+
+### 8.4 PortAudio integration (all platforms)
+
+- Vendor PortAudio at `third_party/portaudio/` (MIT-compatible license, Apache-esque; compatible with GPLv3).
+- Link statically into NereusSDR executable.
+- Initialize in `AudioEngine::init`, terminate in destructor.
+- Host API enumeration: per-platform filter (only show APIs that exist on this OS).
+- PortAudio ASIO host API requires Steinberg ASIO SDK headers (not redistributable, but headers-only). Fetch via build-time env var or skip ASIO on CI. **Document clearly** in `CONTRIBUTING.md` build section.
+
+### 8.5 ASIO SDK integration (Windows Direct ASIO)
+
+- Third-party: Steinberg ASIO SDK headers — **cannot be bundled** in the repo due to Steinberg license. Developer must download from Steinberg and drop into `third_party/asio-sdk/` locally.
+- Build-time check: if headers present, compile `DirectAsioBus`; otherwise compile a stub that reports "Direct ASIO unavailable — rebuild with ASIO SDK" when user selects it.
+- Runtime fallback: if Direct ASIO can't load a driver, fall back to PortAudio ASIO and log a warning.
+
+---
+
+## 9. Implementation Difficulty Ranking
+
+Per user preference: no calendar estimates. Ordering from easiest to hardest.
+
+🟢 **Easy**
+- Windows `VirtualCableDetector` + first-run helper (enumerate devices, regex-match product patterns, show dialog).
+- Linux `LinuxPipeBus` (port AetherSDR bridge, rebrand strings).
+- AppSettings schema additions + migration path.
+- `VaxChannelSelector` widget (button group).
+- `MasterOutputWidget` (menu-bar strip).
+
+🟡 **Medium**
+- `VaxApplet` port + rename from AetherSDR `DaxApplet` (integrate with NereusSDR's `ContainerWidget`/applet framework).
+- `CoreAudioHalBus` + HAL plugin (`hal-plugin/NereusSDRVAX.cpp`) — port from AetherSDR including signing/notarization in release.yml, plus macOS 14.4+ killall fix.
+- `SetupAudioPage` (Devices/VAX/Advanced tabs with all wiring).
+- TX arbitration state machine.
+- `MasterMixer` — per-slice mute/volume/pan accumulation (simple on the surface, RT-safety rigor required).
+
+🟠 **Medium-hard**
+- `IAudioBus` abstraction + audio-engine refactor to replace the direct `QAudioSink` model.
+- `PortAudioBus` — full driver-API coverage, format negotiation, buffer handling, watchdogs for device-change/unplug (port the robust patterns from AetherSDR `AudioEngine`).
+
+🔴 **Hard**
+- `DirectAsioBus` + `AsioSdkHost` — port Thetis `cmasio.c` logic. ASIO callbacks are notoriously unforgiving RT-safety contexts; testing requires physical ASIO hardware. Byte-for-byte Thetis header port + inline-comment preservation per HOW-TO-PORT.md.
+- End-to-end smoke test matrix (WSJT-X QSO round trip on Mac / Linux / Windows, including cable-install first-run).
+
+---
+
+## 10. Risks & Edge Cases
+
+| Risk | Mitigation |
+|---|---|
+| **macOS 14.4+ kickstart lockdown** on `coreaudiod` | Postinstall script already falls back to `killall coreaudiod`. Verified against AetherSDR community reports. |
+| **PipeWire/Pulse stale modules** after NereusSDR crash | Startup scans `pactl list modules short` for `nereussdr-` and unloads before loading fresh ones. Port of AetherSDR's proven cleanup. |
+| **Windows 24H2 virtual-audio regressions** (Elgato, VB-Audio both hit these in 2025) | Treat first-run detect as authoritative; show an "Unsupported device" state if PortAudio can't open a detected cable; log which cable and surface it in SupportDialog. |
+| **WASAPI exclusive-mode contention** (another app holds the device) | Detect and fall back to shared mode with a warning pill; user can retry from Setup. |
+| **ASIO SDK headers missing at build time** | Stub `DirectAsioBus`; runtime warn-and-fallback to PortAudio ASIO. `CONTRIBUTING.md` documents. |
+| **Audio-thread RT-safety violations** | Review every new `push`/`pull` path for: no `qDebug` in the hot path, no allocations, no locks; use Clang `[[clang::no_destroy]]` / `-fsanitize=thread` in CI where feasible. |
+| **Shared-memory name collision** when NereusSDR and AetherSDR both installed on the same Mac/Linux host | Different prefixes (`/nereussdr-vax-*` vs `/aethersdr-dax-*`), different HAL plugin bundle IDs. Both coexist cleanly. |
+| **SliceModel `vaxChannel` persistence across band/slice creation** | Stored per-slice-id; on new slice creation, default to OFF. Tested in the existing SliceModel persistence tests. |
+| **TX output-device contention** when user picks the same device as Speakers | Block the selection in UI (combo shows incompatible devices greyed with tooltip). |
+| **VB-CABLE uninstalled while app is running** | Detector re-scans on Setup→Audio open; if the cable disappears mid-session, VAX bus reports the error upstream, UI shows a warning badge on that slot. |
+| **First-run dialog blocking the first launch** | Dialog is modal over MainWindow but MainWindow is fully functional; dialog dismissible with ESC/Skip. No deadlock path. |
+| **PortAudio ASIO SDK licensing** | Vendor PortAudio without ASIO host API by default; developer must opt-in with Steinberg SDK (headers-only, non-distributable) for ASIO support. |
+
+---
+
+## 11. Reserved Integration Points
+
+### 11.1 TCI (Phase 3J)
+
+`IAudioBus` taps are the contract. When Phase 3J lands:
+
+- TCI server subscribes to the same `AudioEngine::vaxTap(ch)` signal path that drives `CoreAudioHalBus::push` / `LinuxPipeBus::push` / `PortAudioBus::push`.
+- TCI's per-client resampler consumes the tap float32 samples and framing-over-WebSocket-encodes them.
+- No refactor required. The `AudioEngine::setVaxTapSubscriber(ch, ITapConsumer*)` registration path is stubbed in this phase (unused) and activated in 3J.
+
+### 11.2 NereusSDR-owned Windows virtual audio driver
+
+`VirtualCableDetector` regex list reserves `"NereusSDR VAX \d"` as a recognized device-name pattern. When we ship a signed Windows driver:
+
+- Driver exposes devices named "NereusSDR VAX 1..4" + "NereusSDR TX".
+- Detector auto-binds them on first run, replacing user-installed BYO cables if present.
+- User's existing VAX slot bindings migrate automatically (device name lookup).
+- No new UI surface; the Windows experience quietly upgrades to native.
+
+### 11.3 IQ-to-VAX (Thetis parity)
+
+`audio/SendIqToVax` setting is persisted but currently logs-and-ignores. When activated in a future phase, RX1's pre-DSP I/Q feeds `m_vaxBus[ch-1]` via a separate `pushIq()` API on `IAudioBus`. Consumer apps see a 2-channel I/Q stream instead of demodulated audio.
+
+---
+
+## 12. Attribution Compliance Checklist
+
+For every ported file in §4.1 above, the PR introducing the port must:
+
+- [ ] Add the port-citation + modification-history header block (template in §4.1).
+- [ ] Register the file in `docs/attribution/aethersdr-contributor-index.md` (or equivalent provenance file).
+- [ ] For files with Thetis ancestry (`DirectAsioBus`, `AsioSdkHost`): copy Thetis byte-for-byte header from `ChannelMaster/cmasio.c` AND `Console/clsCMASIOConfig.cs` per HOW-TO-PORT.md rule 4 (multi-source file stacking).
+- [ ] Preserve all inline attribution markers (`//MW0LGE`, `//W4WMT`, etc.) verbatim at the corresponding port positions.
+- [ ] Stamp all `// From Thetis …` cites with `[vX.Y.Z.W]` (captured once at port-session start via `git -C ../Thetis describe --tags`).
+- [ ] Run `scripts/verify-thetis-headers.py` — must pass.
+- [ ] Run `scripts/check-new-ports.py` — must detect new PROVENANCE rows.
+- [ ] Human author (J.J. Boyd KG4VCF) reviews the full diff before merge, including every attribution block, per CLAUDE.md ring-1 checklist.
+
+---
+
+## 13. Plan Review History
+
+| Date | Reviewer | Outcome |
+|---|---|---|
+| 2026-04-19 | J.J. Boyd (KG4VCF) | Design brainstormed against Thetis VAC/cmASIO + AetherSDR DaxApplet + SmartSDR DAX model + Loopback/Dante/RME reference UIs. User chose SmartSDR-style routing (VFO-flag selector + VaxApplet) over patchbay/matrix after side-by-side mockups. BYO-cable chosen for Windows v1 with native driver deferred. TCI scoped out. |
+
+---
+
+## 14. Success Criteria
+
+- [ ] All controls listed in §6 are fully round-trip wired; zero unwired buttons, zero TODO-for-later setters, zero fire-once widgets.
+- [ ] Thetis user migrating to NereusSDR can configure equivalent VAC1/VAC2 workflow in Setup → Audio in under 5 minutes on Windows.
+- [ ] macOS user sees "NereusSDR VAX 1–4" + "NereusSDR TX" in WSJT-X audio picker immediately after install.
+- [ ] Linux user on any major distro (Fedora/Ubuntu/Arch) sees "NereusSDR VAX 1–4" in WSJT-X without extra setup.
+- [ ] Windows user with VB-CABLE installed sees auto-detected suggestions on first launch.
+- [ ] Windows user without any virtual cable sees install guidance with links; can use speakers-only mode to skip.
+- [ ] Master output widget persists device and volume across restarts; responds to keyboard scroll-wheel and mute toggle.
+- [ ] All ported files carry correct attribution headers; `scripts/verify-thetis-headers.py` and `scripts/check-new-ports.py` pass.
+- [ ] Audio-thread RT-safety: no `qDebug`, no allocations, no locks in any callback on the hot path.
+- [ ] TCI integration path is stub-reserved so Phase 3J lands with no refactor to this code.
+- [ ] Help doc `help/install-virtual-cables.md` published and linked from first-run dialog.

--- a/docs/architecture/2026-04-19-vax-design.md
+++ b/docs/architecture/2026-04-19-vax-design.md
@@ -583,9 +583,15 @@ Currently shown in the mockup on the Audio Setup page's TX Source bar. Wiring:
 
 ### 8.5 ASIO SDK integration (Windows Direct ASIO)
 
+> **Compliance note (2026-04-19):** After a GPL-3 compliance review during plan authoring, **Direct ASIO is deferred from Phase 3O.** The Steinberg ASIO SDK license is not GPL-3 compatible; linking it into distributed NereusSDR binaries would violate both the ASIO SDK terms and GPL-3. Audacity and other GPL audio projects hit the same wall and ship ASIO-disabled. Decision recorded in the implementation plan's GPL Compliance Review section. This spec section is retained as design intent; if community demand justifies revisiting, it lands as a separate compliance proposal (developer-build-only gate or Steinberg commercial licensing), not part of Phase 3O.
+
+For reference, the original design was:
+
 - Third-party: Steinberg ASIO SDK headers — **cannot be bundled** in the repo due to Steinberg license. Developer must download from Steinberg and drop into `third_party/asio-sdk/` locally.
 - Build-time check: if headers present, compile `DirectAsioBus`; otherwise compile a stub that reports "Direct ASIO unavailable — rebuild with ASIO SDK" when user selects it.
 - Runtime fallback: if Direct ASIO can't load a driver, fall back to PortAudio ASIO and log a warning.
+
+**Phase 3O actually ships:** PortAudio's built-in ASIO host API (when enabled via `PA_USE_ASIO`) covers 95%+ of ASIO use cases via the Driver API dropdown. No Engine radio button. No native SDK direct-access engine.
 
 ---
 
@@ -680,7 +686,8 @@ For every ported file in §4.1 above, the PR introducing the port must:
 
 | Date | Reviewer | Outcome |
 |---|---|---|
-| 2026-04-19 | J.J. Boyd (KG4VCF) | Design brainstormed against Thetis VAC/cmASIO + AetherSDR DaxApplet + SmartSDR DAX model + Loopback/Dante/RME reference UIs. User chose SmartSDR-style routing (VFO-flag selector + VaxApplet) over patchbay/matrix after side-by-side mockups. BYO-cable chosen for Windows v1 with native driver deferred. TCI scoped out. |
+| 2026-04-19 | J.J. Boyd (KG4VCF) | Design brainstormed against Thetis VAC/cmASIO + AetherSDR DaxApplet + SmartSDR DAX model + Loopback/Dante/RME reference UIs. User chose AetherSDR-style routing (VFO-flag selector + VaxApplet) over patchbay/matrix after side-by-side mockups. BYO-cable chosen for Windows v1 with native driver deferred. TCI scoped out. |
+| 2026-04-19 | J.J. Boyd (KG4VCF) | Pre-execution GPL-3 compliance audit performed while authoring the implementation plan. **Direct ASIO engine (Sub-Phase 13) dropped** from Phase 3O scope: the Steinberg ASIO SDK license prohibits redistribution of modified SDK code and is not GPL-3 compatible; linking it into distributed NereusSDR binaries would violate both licenses. PortAudio's built-in ASIO host API retained as the ASIO path. All other bundled / linked components (AetherSDR GPL-3 ports, Thetis GPL-2+ ports where applicable, libASPL MIT, PortAudio MIT, Qt6 LGPL-3) verified compatible. PortAudio license verification step added to plan Task 3.1. Full `COMPLIANCE-INVENTORY.md` registration added as plan Task 14.4 including the macOS HAL plugin's separate-binary / mere-aggregation (GPL-3 §5) reasoning. |
 
 ---
 

--- a/docs/architecture/2026-04-19-vax-design.md
+++ b/docs/architecture/2026-04-19-vax-design.md
@@ -217,7 +217,7 @@ Per `docs/attribution/HOW-TO-PORT.md` rule 6: AetherSDR has no per-file GPL head
 
 | Path | Change |
 |---|---|
-| `src/models/SliceModel.{h,cpp}` | Add `int vaxChannel()` / `setVaxChannel(int)` with `std::atomic<int>` storage, `vaxChannelChanged(int)` signal, AppSettings key `slice/<id>/VaxChannel`. |
+| `src/models/SliceModel.{h,cpp}` | Add `int vaxChannel()` / `setVaxChannel(int)` with `std::atomic<int>` storage, `vaxChannelChanged(int)` signal, AppSettings key `Slice<id>/VaxChannel`. |
 | `src/models/TransmitModel.{h,cpp}` | Add `VaxSlot txOwnerSlot()` / `setTxOwnerSlot(VaxSlot)`, signal, AppSettings key `tx/OwnerSlot`. |
 | `src/gui/VfoWidget.{h,cpp}` | Embed `VaxChannelSelector` in a new row below the MODE/FILT/AGC tabs. Bidirectional wire to `SliceModel::vaxChannel`. |
 | `src/core/AudioEngine.{h,cpp}` | Replace `QAudioSink`-only output with the `IAudioBus`-based model: master-mix goes to Speakers/Headphones bus; per-slice VAX taps feed the four VAX buses; TX consumes either a VAX bus or the mic bus based on `TransmitModel::txOwnerSlot`. |
@@ -247,7 +247,7 @@ signals:
     void vaxChannelChanged(int ch);
 ```
 
-Persistence: `AppSettings` XML key `slice/<sliceId>/VaxChannel`, stored as string `"0".."4"`. On load, invalid values clamp to 0.
+Persistence: `AppSettings` XML key `Slice<sliceId>/VaxChannel`, stored as string `"0".."4"`. On load, invalid values clamp to 0.
 
 ### 5.2 `TransmitModel`
 
@@ -344,7 +344,7 @@ audio/SendIqToVax                   (bool, default False)
 audio/TxMonitorToVax                (bool, default False)
 audio/MuteVaxDuringTxOnOtherSlice   (bool, default True)
 
-slice/<sliceId>/VaxChannel          (int: 0..4)
+Slice<sliceId>/VaxChannel          (int: 0..4)
 tx/OwnerSlot                        (string: None|MicDirect|Vax1..4)
 
 audio/FirstRunComplete              (bool)
@@ -379,17 +379,17 @@ Columns: **Widget** · **Widget → Model** · **Model → Widget** (echo preven
 
 | Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
 |---|---|---|---|---|---|
-| `VaxChannelSelector` button group (OFF/1/2/3/4) | `buttonClicked(int)` → `SliceModel::setVaxChannel(int)` | `vaxChannelChanged(int)` → `VaxChannelSelector::setValue(int)` | `SliceModel::setVaxChannel` persists and (if different) emits `vaxChannelChanged`; `AudioEngine::sliceVaxChanged(sliceId, ch)` slot updates the tap routing | `slice/<sliceId>/VaxChannel` | `QSignalBlocker` on `VaxChannelSelector` during `setValue` |
+| `VaxChannelSelector` button group (OFF/1/2/3/4) | `buttonClicked(int)` → `SliceModel::setVaxChannel(int)` | `vaxChannelChanged(int)` → `VaxChannelSelector::setValue(int)` | `SliceModel::setVaxChannel` persists and (if different) emits `vaxChannelChanged`; `AudioEngine::sliceVaxChanged(sliceId, ch)` slot updates the tap routing | `Slice<sliceId>/VaxChannel` | `QSignalBlocker` on `VaxChannelSelector` during `setValue` |
 
 ### 6.2 VFO flag — per-RX audio block (already existed, extended)
 
 | Widget | Widget → Model | Model → Widget | Model → Action | AppSettings | Guard |
 |---|---|---|---|---|---|
-| Volume slider | `valueChanged(int)` → `SliceModel::setAudioVolume(float)` | `audioVolumeChanged` → `slider.setValue` | `AudioEngine::sliceVolumeChanged` updates `MasterMixer` weight for that slice | `slice/<sliceId>/AudioVolume` | `m_updatingFromModel` |
-| Pan slider | `valueChanged(int)` → `SliceModel::setAudioPan(float)` | `audioPanChanged` → `slider.setValue` | `MasterMixer` per-slice pan coefficient | `slice/<sliceId>/AudioPan` | same |
-| MUTE button | `toggled(bool)` → `SliceModel::setAudioMuted(bool)` | `audioMutedChanged` → `button.setChecked` | Master mix skips slice block when muted; VAX tap still runs (optional per-VAX mute owns that) | `slice/<sliceId>/AudioMuted` | same |
-| BINAURAL toggle | `toggled(bool)` → `SliceModel::setBinauralEnabled(bool)` | `binauralChanged` → button | `RxChannel::setBinaural` calls WDSP `SetRXAPanelBinaural` | `slice/<sliceId>/Binaural` | same |
-| SPEAKERS/HDPHN buttons | exclusive group → `SliceModel::setOutputRoute(Output)` | `outputRouteChanged` → button group | `MasterMixer` routes the slice to speakers OR headphones bus | `slice/<sliceId>/OutputRoute` | same |
+| Volume slider | `valueChanged(int)` → `SliceModel::setAudioVolume(float)` | `audioVolumeChanged` → `slider.setValue` | `AudioEngine::sliceVolumeChanged` updates `MasterMixer` weight for that slice | `Slice<sliceId>/AudioVolume` | `m_updatingFromModel` |
+| Pan slider | `valueChanged(int)` → `SliceModel::setAudioPan(float)` | `audioPanChanged` → `slider.setValue` | `MasterMixer` per-slice pan coefficient | `Slice<sliceId>/AudioPan` | same |
+| MUTE button | `toggled(bool)` → `SliceModel::setAudioMuted(bool)` | `audioMutedChanged` → `button.setChecked` | Master mix skips slice block when muted; VAX tap still runs (optional per-VAX mute owns that) | `Slice<sliceId>/AudioMuted` | same |
+| BINAURAL toggle | `toggled(bool)` → `SliceModel::setBinauralEnabled(bool)` | `binauralChanged` → button | `RxChannel::setBinaural` calls WDSP `SetRXAPanelBinaural` | `Slice<sliceId>/Binaural` | same |
+| SPEAKERS/HDPHN buttons | exclusive group → `SliceModel::setOutputRoute(Output)` | `outputRouteChanged` → button group | `MasterMixer` routes the slice to speakers OR headphones bus | `Slice<sliceId>/OutputRoute` | same |
 | RX level meter (readonly) | n/a | `AudioEngine::sliceMeter(sliceId, float)` → `meter.setLevel(float)` | n/a | none (ephemeral) | n/a |
 
 ### 6.3 Menu-bar `MasterOutputWidget`

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -246,6 +246,11 @@ QStringList AppSettings::allKeys() const
     return m_settings.keys();
 }
 
+void AppSettings::clear()
+{
+    m_settings.clear();
+}
+
 QVariant AppSettings::stationValue(const QString& key, const QVariant& defaultValue) const
 {
     auto it = m_stationSettings.constFind(key);

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -527,4 +527,37 @@ void AppSettings::setModelOverride(const QString& macKey, HPSDRModel model)
                       QString::number(static_cast<int>(model)));
 }
 
+// ---------------------------------------------------------------------------
+// Phase 3O VAX schema migration
+// ---------------------------------------------------------------------------
+
+void AppSettings::migrateVaxSchemaV1ToV2()
+{
+    auto& s = instance();
+    if (!s.contains(QStringLiteral("audio/OutputDevice"))) { return; }
+    if (s.contains(QStringLiteral("audio/Speakers/DeviceName"))) { return; }
+
+    const QString dev = s.value(QStringLiteral("audio/OutputDevice")).toString();
+    s.setValue(QStringLiteral("audio/Speakers/DeviceName"), dev);
+
+    // Platform-default driver API. Conservative; user can tune later.
+#if defined(Q_OS_WIN)
+    s.setValue(QStringLiteral("audio/Speakers/DriverApi"), QStringLiteral("WASAPI"));
+#elif defined(Q_OS_MAC)
+    s.setValue(QStringLiteral("audio/Speakers/DriverApi"), QStringLiteral("CoreAudio"));
+#else
+    s.setValue(QStringLiteral("audio/Speakers/DriverApi"), QStringLiteral("Pulse"));
+#endif
+    s.setValue(QStringLiteral("audio/Speakers/SampleRate"),    QStringLiteral("48000"));
+    s.setValue(QStringLiteral("audio/Speakers/BitDepth"),      QStringLiteral("24"));
+    s.setValue(QStringLiteral("audio/Speakers/Channels"),      QStringLiteral("2"));
+    s.setValue(QStringLiteral("audio/Speakers/BufferSamples"), QStringLiteral("256"));
+
+    // Trigger first-run dialog on next launch.
+    s.setValue(QStringLiteral("audio/FirstRunComplete"), QStringLiteral("False"));
+
+    s.remove(QStringLiteral("audio/OutputDevice"));
+    s.save();
+}
+
 } // namespace NereusSDR

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -129,6 +129,10 @@ public:
     // prefix at app startup.
     QStringList allKeys() const;
 
+    // Remove ALL top-level keys from the in-memory store.
+    // Intended for test isolation. Does NOT call save().
+    void clear();
+
     // Per-station settings (nested under <StationName> element).
     QVariant stationValue(const QString& key, const QVariant& defaultValue = {}) const;
     void setStationValue(const QString& key, const QVariant& val);

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -248,6 +248,13 @@ public:
     QMap<QString, QVariant> hardwareValues(const QString& mac) const;
     void    clearHardwareValues(const QString& mac);
 
+    // Phase 3O VAX schema migration. Call once at app startup. Idempotent.
+    // Migrates legacy audio/OutputDevice → audio/Speakers/DeviceName with
+    // sensible platform defaults, and flags the first-run dialog to show
+    // (audio/FirstRunComplete = "False").
+    // See docs/architecture/2026-04-19-vax-design.md §5.5.
+    static void migrateVaxSchemaV1ToV2();
+
 private:
     // Private default constructor — used only by instance().
     AppSettings();

--- a/src/core/AudioDeviceConfig.h
+++ b/src/core/AudioDeviceConfig.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// =================================================================
+// src/core/AudioDeviceConfig.h  (NereusSDR)
+// =================================================================
+//
+// Phase 3O VAX per-endpoint audio device configuration. NereusSDR-
+// original. Carried into AudioEngine setSpeakersConfig / setTxInputConfig
+// / setVaxConfig, internally translated into a backend-specific
+// PortAudioConfig (or CoreAudioHalBus / LinuxPipeBus config in
+// Sub-Phases 5/6). Design spec: docs/architecture/2026-04-19-vax-design.md
+// §5.3.
+// =================================================================
+
+#include <QString>
+
+namespace NereusSDR {
+
+struct AudioDeviceConfig {
+    QString deviceName;            // empty = platform default
+    int     sampleRate    = 48000;
+    int     channels      = 2;
+    int     bufferSamples = 256;
+    bool    exclusiveMode = false; // WASAPI only
+    int     hostApiIndex  = -1;    // -1 = PortAudio default host API
+};
+
+} // namespace NereusSDR

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -20,72 +20,77 @@
 //                 QAudioSink feed-and-drain pattern ported from AetherSDR
 //                 `src/core/AudioEngine.{h,cpp}` (48 kHz Int16 stereo,
 //                 10 ms timer drain, 200 ms buffer cap).
+//   2026-04-19 — Sub-Phase 4 refactor by J.J. Boyd (KG4VCF), AI-assisted
+//                 via Anthropic Claude Code. Replaced QAudioSink direct-drain
+//                 model with IAudioBus-based speakers / TX-input / VAX[1..4]
+//                 ownership + MasterMixer per-slice accumulation. Inline
+//                 synchronous flush on the DSP thread; no QTimer, no
+//                 QAudioSink. (docs/architecture/2026-04-19-phase3o-vax-plan.md
+//                 §Sub-Phase 4 Task 4.1.)
 // =================================================================
 
 #include "AudioEngine.h"
-#include "AppSettings.h"
+
 #include "LogCategories.h"
+#include "audio/PortAudioBus.h"
+#include "../models/RadioModel.h"
+#include "../models/SliceModel.h"
 
-#include <QAudioSink>
-#include <QMediaDevices>
-#include <QTimer>
+#include <portaudio.h>
 
-#include <cmath>
-#include <cstring>
+#include <algorithm>
+#include <vector>
 
 namespace NereusSDR {
 
-// From AetherSDR: 48kHz stereo int16 = 192,000 bytes/sec
-// 200ms cap = 38,400 bytes
-static constexpr int kSampleRate = 48000;
-static constexpr int kMaxBufferMs = 200;
-static constexpr qsizetype kMaxBufferBytes = kSampleRate * 2 * sizeof(qint16) * kMaxBufferMs / 1000;
+namespace {
+
+// Translate a NereusSDR AudioDeviceConfig into the IAudioBus AudioFormat
+// contract. Float32 stereo is the canonical DSP format; channels is kept
+// cfg-overridable but the single live path is stereo today.
+AudioFormat toAudioFormat(const AudioDeviceConfig& cfg)
+{
+    AudioFormat f;
+    f.sampleRate = cfg.sampleRate;
+    f.channels   = cfg.channels;
+    f.sample     = AudioFormat::Sample::Float32;
+    return f;
+}
+
+} // namespace
 
 AudioEngine::AudioEngine(QObject* parent)
     : QObject(parent)
 {
-    // Int16 stereo 48kHz — universally supported by WASAPI/PulseAudio/CoreAudio.
-    // From AetherSDR AudioEngine::makeFormat()
-    m_format.setSampleRate(kSampleRate);
-    m_format.setChannelCount(2);
-    m_format.setSampleFormat(QAudioFormat::Int16);
-
-    loadSavedDevice();
-
-    // Log available devices
-    const QList<QAudioDevice> devices = QMediaDevices::audioOutputs();
-    qCInfo(lcAudio) << "Available audio output devices:";
-    for (const QAudioDevice& dev : devices) {
-        QString marker = (dev == m_outputDevice) ? QStringLiteral(" [SELECTED]")
-                       : (dev == QMediaDevices::defaultAudioOutput()) ? QStringLiteral(" [DEFAULT]")
-                       : QString();
-        qCInfo(lcAudio) << "  -" << dev.description() << marker;
+    // Own the Pa_Initialize/Pa_Terminate pair so the static PortAudioBus
+    // enumeration helpers (hostApis / outputDevicesFor / inputDevicesFor)
+    // can be called at any time from the application. Tests that run
+    // without a real audio subsystem will see Pa_Initialize fail; log and
+    // continue — rxBlockReady / start() degrade to a safe no-op in that
+    // case.
+    const PaError err = Pa_Initialize();
+    if (err != paNoError) {
+        qCWarning(lcAudio) << "Pa_Initialize failed:" << Pa_GetErrorText(err)
+                           << "— audio subsystem will be inert.";
+        m_paInitialized = false;
+    } else {
+        m_paInitialized = true;
+        qCInfo(lcAudio) << "PortAudio initialized:" << Pa_GetVersionText();
     }
 }
 
 AudioEngine::~AudioEngine()
 {
     stop();
+    if (m_paInitialized) {
+        Pa_Terminate();
+        m_paInitialized = false;
+    }
 }
 
-void AudioEngine::loadSavedDevice()
+void AudioEngine::setRadioModel(RadioModel* radio)
 {
-    auto& s = AppSettings::instance();
-    QByteArray savedId = s.value(QStringLiteral("AudioOutputDeviceId")).toString().toUtf8();
-
-    if (!savedId.isEmpty()) {
-        const QList<QAudioDevice> devices = QMediaDevices::audioOutputs();
-        for (const QAudioDevice& dev : devices) {
-            if (dev.id() == savedId || dev.description() == QString::fromUtf8(savedId)) {
-                m_outputDevice = dev;
-                qCInfo(lcAudio) << "Restored saved audio device:" << dev.description();
-                return;
-            }
-        }
-        qCInfo(lcAudio) << "Saved audio device not found, using system default";
-    }
-
-    m_outputDevice = QMediaDevices::defaultAudioOutput();
+    m_radio = radio;
 }
 
 void AudioEngine::start()
@@ -94,68 +99,24 @@ void AudioEngine::start()
         return;
     }
 
-    createAudioSink();
-
-    if (!m_audioSink) {
-        qCWarning(lcAudio) << "Failed to create audio sink";
-        return;
+    // Pre-register sliceId 0 with MasterMixer at startup, before any
+    // audio-thread accumulate() can race against a main-thread
+    // unordered_map insert+rehash on first-block (design-decision D6,
+    // plan §Sub-Phase 4 Task 4.1). Multi-slice enrollment is a
+    // Sub-Phase 9+ concern; slice-0 covers the single-RX live path.
+    if (!m_slicePreregistered) {
+        m_masterMix.setSliceGain(0, 1.0f, 0.0f);
+        m_slicePreregistered = true;
     }
 
-    // Push mode: we write data to the QIODevice returned by start()
-    m_audioIO = m_audioSink->start();
-    if (!m_audioIO) {
-        qCWarning(lcAudio) << "Failed to start audio sink — state:"
-                           << static_cast<int>(m_audioSink->state())
-                           << "error:" << static_cast<int>(m_audioSink->error());
-        m_audioSink.reset();
-        return;
-    }
-
-    // Timer-based drain: every 10ms, write available data to sink.
-    // From AetherSDR AudioEngine RX timer pattern.
-    m_rxTimer = new QTimer(this);
-    m_rxTimer->setTimerType(Qt::PreciseTimer);
-    m_rxTimer->setInterval(10);
-    connect(m_rxTimer, &QTimer::timeout, this, [this]() {
-        if (!m_audioSink || !m_audioIO || !m_audioIO->isOpen()
-            || m_audioSink->state() == QAudio::StoppedState) {
-            return;
-        }
-
-        // Drain step: snapshot the head of the buffer under the lock,
-        // then write to the sink without the lock so feedAudio() (on
-        // the DSP thread) is not blocked waiting on QIODevice I/O.
-        const qsizetype avail = m_audioSink->bytesFree();
-        QByteArray slice;
-        {
-            QMutexLocker locker(&m_bufferMutex);
-            // Cap buffer at 200ms to prevent latency buildup.
-            if (m_rxBuffer.size() > kMaxBufferBytes) {
-                m_rxBuffer.remove(0, m_rxBuffer.size() - kMaxBufferBytes);
-            }
-            const qsizetype len = qMin(avail, m_rxBuffer.size());
-            if (len > 0) {
-                slice = QByteArray(m_rxBuffer.constData(), len);
-                m_rxBuffer.remove(0, len);
-            }
-        }
-        if (!slice.isEmpty()) {
-            const qsizetype written = m_audioIO->write(slice.constData(), slice.size());
-            if (written > 0 && written < slice.size()) {
-                // Sink accepted less than offered — push the remainder
-                // back to the front of the buffer so we don't drop it.
-                QMutexLocker locker(&m_bufferMutex);
-                m_rxBuffer.prepend(slice.constData() + written, slice.size() - written);
-            }
-        }
-    });
-    m_rxTimer->start();
-
+    ensureSpeakersOpen();
     m_running = true;
-    qCInfo(lcAudio) << "Audio output started:"
-                    << m_format.sampleRate() << "Hz"
-                    << m_format.channelCount() << "ch Int16"
-                    << "on" << m_outputDevice.description();
+
+    qCInfo(lcAudio) << "AudioEngine started ("
+                    << (m_speakersBus && m_speakersBus->isOpen()
+                            ? "speakers bus open"
+                            : "speakers bus NOT open")
+                    << ")";
 }
 
 void AudioEngine::stop()
@@ -164,146 +125,195 @@ void AudioEngine::stop()
         return;
     }
 
-    if (m_rxTimer) {
-        m_rxTimer->stop();
-        delete m_rxTimer;
-        m_rxTimer = nullptr;
+    // Close every owned bus. unique_ptr::reset() invokes the bus dtor
+    // which calls Pa_CloseStream where applicable. Safe on the main
+    // thread because rxBlockReady() cannot run after m_running = false
+    // — but note that rxBlockReady itself reads m_speakersBus directly;
+    // the ordering contract is that the caller (RadioModel teardown)
+    // stops the DSP worker thread before calling stop(). That contract
+    // is preserved from the pre-refactor code.
+    m_speakersBus.reset();
+    m_txInputBus.reset();
+    for (auto& bus : m_vaxBus) {
+        bus.reset();
     }
 
-    if (m_audioSink) {
-        m_audioSink->stop();
-    }
-
-    m_audioIO = nullptr;
-    m_audioSink.reset();
-    {
-        QMutexLocker locker(&m_bufferMutex);
-        m_rxBuffer.clear();
-    }
     m_running = false;
-
-    qCInfo(lcAudio) << "Audio output stopped";
+    qCInfo(lcAudio) << "AudioEngine stopped";
 }
 
-void AudioEngine::feedAudio(int receiverId, const float* leftSamples,
-                            const float* rightSamples, int sampleCount)
+std::unique_ptr<IAudioBus> AudioEngine::makeBus(const AudioDeviceConfig& cfg,
+                                                bool capture)
 {
-    Q_UNUSED(receiverId);
+    // TODO(phase3o-5/6): swap direct PortAudioBus construction for
+    // AudioBusFactory::create() once CoreAudioHalBus / LinuxPipeBus land.
+    auto bus = std::make_unique<PortAudioBus>();
+    PortAudioConfig pcfg;
+    pcfg.direction     = capture ? AudioDirection::Input
+                                 : AudioDirection::Output;
+    pcfg.hostApiIndex  = cfg.hostApiIndex;
+    pcfg.deviceName    = cfg.deviceName;
+    pcfg.bufferSamples = cfg.bufferSamples;
+    pcfg.exclusiveMode = cfg.exclusiveMode;
+    bus->setConfig(pcfg);
 
-    if (!m_running) {
+    const AudioFormat fmt = toAudioFormat(cfg);
+    if (!bus->open(fmt)) {
+        qCWarning(lcAudio) << "IAudioBus open failed:" << bus->errorString();
+        return nullptr;
+    }
+    return bus;
+}
+
+void AudioEngine::ensureSpeakersOpen()
+{
+    if (m_speakersBus && m_speakersBus->isOpen()) {
+        return;
+    }
+    if (!m_paInitialized) {
         return;
     }
 
-    // Convert float32 L/R → interleaved int16 stereo (LRLRLR...)
-    // Apply volume scaling during conversion.
-    const int byteCount = sampleCount * 2 * sizeof(qint16);
-    QByteArray pcm(byteCount, Qt::Uninitialized);
-    qint16* dst = reinterpret_cast<qint16*>(pcm.data());
-
-    const float vol = m_volume;
-    for (int i = 0; i < sampleCount; ++i) {
-        float l = leftSamples[i] * vol;
-        float r = rightSamples[i] * vol;
-        dst[i * 2]     = static_cast<qint16>(qBound(-1.0f, l, 1.0f) * 32767.0f);
-        dst[i * 2 + 1] = static_cast<qint16>(qBound(-1.0f, r, 1.0f) * 32767.0f);
-    }
-
-    // Append to buffer — timer drains to QAudioSink. feedAudio() may
-    // be called from the DSP worker thread, so the append must be
-    // serialized against the timer drain on the main thread.
-    {
-        QMutexLocker locker(&m_bufferMutex);
-        m_rxBuffer.append(pcm);
+    AudioDeviceConfig defaults;
+    // defaults: empty deviceName (platform default), 48 kHz, stereo,
+    // 256-frame buffer — matches what the DSP path produces.
+    m_speakersBus = makeBus(defaults, /*capture=*/false);
+    if (m_speakersBus) {
+        m_speakersFormat = m_speakersBus->negotiatedFormat();
+        qCInfo(lcAudio) << "Speakers bus opened @"
+                        << m_speakersFormat.sampleRate << "Hz /"
+                        << m_speakersFormat.channels << "ch"
+                        << "[" << m_speakersBus->backendName() << "]";
     }
 }
 
-void AudioEngine::playTestTone(int durationMs)
+void AudioEngine::setSpeakersConfig(const AudioDeviceConfig& cfg)
 {
-    if (!m_running) {
-        start();
-    }
-    if (!m_running) {
-        qCWarning(lcAudio) << "Cannot play test tone — audio not available";
+    m_speakersBus.reset();
+    if (!m_paInitialized) {
         return;
     }
-
-    qCInfo(lcAudio) << "Playing 1kHz test tone for" << durationMs << "ms";
-
-    const int totalSamples = kSampleRate * durationMs / 1000;
-    const float freq = 1000.0f;
-    const float amplitude = 0.3f;
-
-    // Generate int16 stereo PCM
-    QByteArray pcm(totalSamples * 2 * sizeof(qint16), Qt::Uninitialized);
-    qint16* dst = reinterpret_cast<qint16*>(pcm.data());
-
-    for (int i = 0; i < totalSamples; ++i) {
-        qint16 sample = static_cast<qint16>(
-            amplitude * std::sin(2.0f * 3.14159265f * freq * i / kSampleRate) * 32767.0f);
-        dst[i * 2]     = sample;
-        dst[i * 2 + 1] = sample;
+    m_speakersBus = makeBus(cfg, /*capture=*/false);
+    if (m_speakersBus) {
+        m_speakersFormat = m_speakersBus->negotiatedFormat();
+        qCInfo(lcAudio) << "Speakers bus reconfigured @"
+                        << m_speakersFormat.sampleRate << "Hz /"
+                        << m_speakersFormat.channels << "ch";
     }
-
-    // Append to buffer — timer will drain it
-    {
-        QMutexLocker locker(&m_bufferMutex);
-        m_rxBuffer.append(pcm);
-    }
-    qCInfo(lcAudio) << "Test tone queued:" << pcm.size() << "bytes";
 }
 
-void AudioEngine::setOutputDevice(const QAudioDevice& device)
+void AudioEngine::setTxInputConfig(const AudioDeviceConfig& cfg)
 {
-    if (m_outputDevice == device) {
+    // TX pull() wiring lands in Phase 3M. We declare ownership + setter
+    // per the Sub-Phase 4 plan so the bus is construction-ready; the bus
+    // is inert until TxChannel starts pulling.
+    m_txInputBus.reset();
+    if (!m_paInitialized) {
+        return;
+    }
+    m_txInputBus = makeBus(cfg, /*capture=*/true);
+    if (m_txInputBus) {
+        qCInfo(lcAudio) << "TX input bus opened"
+                        << "[" << m_txInputBus->backendName() << "]";
+    }
+}
+
+void AudioEngine::setVaxConfig(int channel, const AudioDeviceConfig& cfg)
+{
+    if (channel < 1 || channel > 4) {
+        return;
+    }
+    const int idx = channel - 1;
+    m_vaxBus[idx].reset();
+    if (!m_paInitialized) {
+        return;
+    }
+    m_vaxBus[idx] = makeBus(cfg, /*capture=*/false);
+    if (m_vaxBus[idx]) {
+        qCInfo(lcAudio) << "VAX" << channel << "bus opened"
+                        << "[" << m_vaxBus[idx]->backendName() << "]";
+    }
+}
+
+void AudioEngine::setVaxEnabled(int channel, bool on)
+{
+    if (channel < 1 || channel > 4) {
+        return;
+    }
+    const int idx = channel - 1;
+    if (!on) {
+        m_vaxBus[idx].reset();
+        return;
+    }
+    // Enable with defaults if no explicit setVaxConfig has been wired yet.
+    // Real config lands via the VaxApplet / Setup→Audio→VAX UI in
+    // Sub-Phase 7 / 8.
+    if (!m_vaxBus[idx]) {
+        AudioDeviceConfig defaults;
+        m_vaxBus[idx] = makeBus(defaults, /*capture=*/false);
+    }
+}
+
+void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
+{
+    if (!m_radio || samples == nullptr || frames <= 0) {
         return;
     }
 
-    m_outputDevice = device;
-
-    auto& s = AppSettings::instance();
-    s.setValue(QStringLiteral("AudioOutputDeviceId"), QString::fromUtf8(device.id()));
-    s.save();
-
-    qCInfo(lcAudio) << "Audio output device changed to" << device.description();
-
-    if (m_running) {
-        stop();
-        start();
+    // SliceModel exposes muted() / setMuted() plus vaxChannel(). The
+    // design spec uses audioMuted() as shorthand for the same property;
+    // the alias is intentionally not introduced here (design-decision D5,
+    // plan §Sub-Phase 4 Task 4.1). A formal rename (if chosen) happens in
+    // Sub-Phase 9 alongside per-slice volume / pan control surfaces.
+    SliceModel* slice = m_radio->sliceAt(sliceId);
+    if (slice == nullptr) {
+        return;
     }
 
-    emit outputDeviceChanged(device);
+    if (!slice->muted()) {
+        m_masterMix.accumulate(sliceId, samples, frames);
+    }
+
+    const int vaxCh = slice->vaxChannel();
+    if (vaxCh >= 1 && vaxCh <= 4
+        && m_vaxBus[vaxCh - 1] && m_vaxBus[vaxCh - 1]->isOpen()) {
+        m_vaxBus[vaxCh - 1]->push(
+            reinterpret_cast<const char*>(samples),
+            static_cast<qint64>(frames) * 2 * sizeof(float));
+    }
+
+    // Flush synchronously on the DSP thread. thread_local scratch so the
+    // per-block vector reuse costs zero allocation after the first block
+    // per thread. Channel count = 2 is intentionally hard-coded here:
+    // the MasterMixer contract and the DSP pipeline both emit stereo.
+    static thread_local std::vector<float> mix;
+    const int stereoFloats = frames * 2;
+    if (static_cast<int>(mix.size()) < stereoFloats) {
+        mix.resize(static_cast<size_t>(stereoFloats));
+    }
+    m_masterMix.mixInto(mix.data(), frames);
+
+    const float vol = m_masterVolume.load(std::memory_order_acquire);
+    if (vol != 1.0f) {
+        for (int i = 0; i < stereoFloats; ++i) {
+            mix[i] *= vol;
+        }
+    }
+
+    if (m_speakersBus && m_speakersBus->isOpen()) {
+        m_speakersBus->push(
+            reinterpret_cast<const char*>(mix.data()),
+            static_cast<qint64>(stereoFloats) * sizeof(float));
+    }
 }
 
 void AudioEngine::setVolume(float volume)
 {
-    volume = qBound(0.0f, volume, 1.0f);
-    if (!qFuzzyCompare(m_volume, volume)) {
-        m_volume = volume;
+    volume = std::clamp(volume, 0.0f, 1.0f);
+    const float prev = m_masterVolume.exchange(volume, std::memory_order_release);
+    if (prev != volume) {
         emit volumeChanged(volume);
     }
-}
-
-void AudioEngine::createAudioSink()
-{
-    QAudioDevice device = m_outputDevice;
-    if (device.isNull()) {
-        device = QMediaDevices::defaultAudioOutput();
-    }
-
-    if (device.isNull()) {
-        qCWarning(lcAudio) << "No audio output device available";
-        return;
-    }
-
-    // From AetherSDR: on Windows, don't trust isFormatSupported().
-    // Just try to open the sink — WASAPI shared mode handles conversion.
-    m_audioSink = std::make_unique<QAudioSink>(device, m_format);
-
-    qCInfo(lcAudio) << "Audio sink created on" << device.description()
-                    << "format:" << m_format.sampleRate() << "Hz"
-                    << m_format.channelCount() << "ch"
-                    << "Int16"
-                    << "buffer:" << m_audioSink->bufferSize() << "bytes";
 }
 
 } // namespace NereusSDR

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -274,12 +274,25 @@ void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
         m_masterMix.accumulate(sliceId, samples, frames);
     }
 
+    // VAX tap receives raw demodulated audio — pre-MasterMixer gain/pan,
+    // pre-master-volume — matching Thetis VAC behavior and the spec §3.4
+    // pseudocode (`m_vaxBus[vaxCh-1]->push(samples, …)`, not the mixed
+    // output). Per-channel rx gain for VAX is applied inside the bus
+    // implementation (Sub-Phase 9+). See
+    // docs/architecture/2026-04-19-vax-design.md.
     const int vaxCh = slice->vaxChannel();
-    if (vaxCh >= 1 && vaxCh <= 4
-        && m_vaxBus[vaxCh - 1] && m_vaxBus[vaxCh - 1]->isOpen()) {
-        m_vaxBus[vaxCh - 1]->push(
-            reinterpret_cast<const char*>(samples),
-            static_cast<qint64>(frames) * 2 * sizeof(float));
+    if (vaxCh >= 1 && vaxCh <= 4) {
+        // Snapshot the bus pointer into a local so the isOpen() check and
+        // the push() below observe the same IAudioBus instance. The
+        // live-reconfig contract (AudioEngine.h) forbids setVaxConfig /
+        // setVaxEnabled mid-block, but the snapshot eliminates any
+        // torn-read window should a caller violate that contract.
+        IAudioBus* vaxBus = m_vaxBus[vaxCh - 1].get();
+        if (vaxBus != nullptr && vaxBus->isOpen()) {
+            vaxBus->push(
+                reinterpret_cast<const char*>(samples),
+                static_cast<qint64>(frames) * 2 * sizeof(float));
+        }
     }
 
     // Flush synchronously on the DSP thread. thread_local scratch so the
@@ -300,8 +313,11 @@ void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
         }
     }
 
-    if (m_speakersBus && m_speakersBus->isOpen()) {
-        m_speakersBus->push(
+    // Same snapshot idiom as the VAX tap: one load into a local so the
+    // isOpen() guard and the push() observe the same IAudioBus.
+    IAudioBus* speakersBus = m_speakersBus.get();
+    if (speakersBus != nullptr && speakersBus->isOpen()) {
+        speakersBus->push(
             reinterpret_cast<const char*>(mix.data()),
             static_cast<qint64>(stereoFloats) * sizeof(float));
     }
@@ -310,7 +326,10 @@ void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
 void AudioEngine::setVolume(float volume)
 {
     volume = std::clamp(volume, 0.0f, 1.0f);
-    const float prev = m_masterVolume.exchange(volume, std::memory_order_release);
+    // acq_rel pairs with the DSP-thread acquire load in rxBlockReady on
+    // weak memory models (ARM / Apple Silicon); release alone would not
+    // synchronize the read-side observation order here.
+    const float prev = m_masterVolume.exchange(volume, std::memory_order_acq_rel);
     if (prev != volume) {
         emit volumeChanged(volume);
     }

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -22,35 +22,45 @@
 //                 QAudioSink feed-and-drain pattern ported from AetherSDR
 //                 `src/core/AudioEngine.{h,cpp}` (48 kHz Int16 stereo,
 //                 10 ms timer drain, 200 ms buffer cap).
+//   2026-04-19 — Sub-Phase 4 refactor by J.J. Boyd (KG4VCF), AI-assisted
+//                 via Anthropic Claude Code. Replaced QAudioSink direct-drain
+//                 model with IAudioBus-based speakers / TX-input / VAX[1..4]
+//                 ownership + MasterMixer per-slice accumulation. Inline
+//                 synchronous flush on the DSP thread; no QTimer, no
+//                 QAudioSink. (docs/architecture/2026-04-19-phase3o-vax-plan.md
+//                 §Sub-Phase 4 Task 4.1.)
 // =================================================================
+
+#include "AudioDeviceConfig.h"
+#include "IAudioBus.h"
+#include "audio/MasterMixer.h"
 
 #include <QObject>
 #include <QString>
-#include <QAudioFormat>
-#include <QAudioDevice>
-#include <QByteArray>
-#include <QMutex>
 
+#include <array>
+#include <atomic>
 #include <memory>
-
-QT_BEGIN_NAMESPACE
-class QAudioSink;
-class QIODevice;
-class QTimer;
-QT_END_NAMESPACE
 
 namespace NereusSDR {
 
-// Audio engine for NereusSDR.
-// Receives decoded audio from WDSP and plays it through QAudioSink.
+class RadioModel;
+class SliceModel;
+
+// Audio engine for NereusSDR (Phase 3O VAX).
 //
-// Pattern from AetherSDR AudioEngine:
-//   - feedAudio() appends to m_rxBuffer
-//   - 10ms timer drains m_rxBuffer to QAudioSink via bytesFree()/write()
-//   - Int16 stereo format (universal WASAPI/PulseAudio/CoreAudio support)
-//   - Buffer capped at 200ms to prevent latency buildup
+// Owns one IAudioBus per routable endpoint:
+//   - m_speakersBus: the master mix goes here.
+//   - m_txInputBus:  TX mic capture source (pull() wiring lands in 3M).
+//   - m_vaxBus[0..3]: the four VAX slots.
 //
-// Format: 48000 Hz, stereo, Int16, push mode.
+// rxBlockReady(sliceId, samples, frames) is the single RX-audio entry
+// point. Called from the DSP worker thread (RxDspWorker) with one
+// interleaved stereo block per WDSP fexchange2 drain. Accumulates into
+// MasterMixer, taps the slice's VAX channel if selected, and flushes the
+// mixed master to m_speakersBus synchronously on the DSP thread. No
+// QTimer, no QAudioSink, no m_rxBuffer, no mutex — RT-safety rests on
+// PortAudioBus's lock-free SPSC ring.
 class AudioEngine : public QObject {
     Q_OBJECT
 
@@ -58,50 +68,78 @@ public:
     explicit AudioEngine(QObject* parent = nullptr);
     ~AudioEngine() override;
 
-    // Start/stop audio output.
+    // Non-owning back-pointer so rxBlockReady can look up the active
+    // SliceModel to read mute / VAX-channel state. Null is safe (unit
+    // tests that construct AudioEngine without a RadioModel): rxBlockReady
+    // becomes a no-op.
+    void setRadioModel(RadioModel* radio);
+
+    // Legacy start/stop retained for the single-entry-point symmetry the
+    // rest of the codebase expects. Speakers bus is opened lazily the
+    // first time setSpeakersConfig() runs.
     void start();
     void stop();
     bool isRunning() const { return m_running; }
 
-    // Feed decoded audio from WDSP (float32 L/R → converted to int16 stereo).
-    void feedAudio(int receiverId, const float* leftSamples,
-                   const float* rightSamples, int sampleCount);
+    // Phase 3O: per-endpoint IAudioBus ownership.
+    void setSpeakersConfig(const AudioDeviceConfig& cfg);
+    void setTxInputConfig(const AudioDeviceConfig& cfg);
+    void setVaxConfig(int channel, const AudioDeviceConfig& cfg);  // 1..4
+    void setVaxEnabled(int channel, bool on);
 
-    // Play a 1kHz test tone to verify audio output works.
-    void playTestTone(int durationMs = 2000);
+    // Called by RxDspWorker when a slice produces an RX audio block.
+    // samples is interleaved stereo float32, length = frames * 2.
+    void rxBlockReady(int sliceId, const float* samples, int frames);
 
-    // Device management (persisted via AppSettings).
-    void setOutputDevice(const QAudioDevice& device);
-    QAudioDevice outputDevice() const { return m_outputDevice; }
-
-    // Volume (0.0 to 1.0)
+    // Master volume (0.0–1.0). Read on the DSP thread, written on the
+    // main thread. Preserves the existing AF-gain wiring in
+    // RadioModel::wireSliceSignals.
     void setVolume(float volume);
-    float volume() const { return m_volume; }
+    float volume() const { return m_masterVolume.load(std::memory_order_acquire); }
 
 signals:
-    void outputDeviceChanged(const QAudioDevice& device);
     void volumeChanged(float volume);
 
 private:
-    void createAudioSink();
-    void loadSavedDevice();
+    // Translate AudioDeviceConfig → AudioFormat + PortAudioConfig and
+    // open the given bus slot. Direct PortAudioBus construction today;
+    // TODO(phase3o-5/6): swap for AudioBusFactory::create() once
+    // CoreAudioHalBus and LinuxPipeBus land.
+    std::unique_ptr<IAudioBus> makeBus(const AudioDeviceConfig& cfg,
+                                       bool capture);
 
-    QAudioDevice m_outputDevice;
-    float m_volume{0.5f};
+    // Open m_speakersBus with a sensible platform default if nothing
+    // has been wired by the time start() runs. Keeps the live RX path
+    // audible without a Setup→Audio→Devices UI in Sub-Phase 4.
+    void ensureSpeakersOpen();
+
+    RadioModel* m_radio{nullptr};
+
+    std::unique_ptr<IAudioBus> m_speakersBus;
+    std::unique_ptr<IAudioBus> m_txInputBus;
+    std::array<std::unique_ptr<IAudioBus>, 4> m_vaxBus;
+    MasterMixer m_masterMix;
+
+    // Speakers format last negotiated. frames passed to rxBlockReady may
+    // vary per block; the bus handles that internally via its ring. Kept
+    // for diagnostics.
+    AudioFormat m_speakersFormat;
+
+    // Written by setVolume() on the UI thread, read by rxBlockReady() on
+    // the DSP thread. Atomic for the cross-thread handshake per
+    // CLAUDE.md C++ style guide.
+    std::atomic<float> m_masterVolume{0.5f};
+
+    // Was Pa_Initialize() actually successful? Guards the matching
+    // Pa_Terminate() in the destructor so unit tests that construct
+    // AudioEngine without a real audio subsystem don't hit a spurious
+    // terminate.
+    bool m_paInitialized{false};
     bool m_running{false};
-
-    QAudioFormat m_format;
-    std::unique_ptr<QAudioSink> m_audioSink;
-    QIODevice* m_audioIO{nullptr};  // owned by QAudioSink
-
-    // Buffer + timer drain pattern (from AetherSDR).
-    // m_bufferMutex guards m_rxBuffer because feedAudio() is invoked
-    // from the DSP worker thread (RxDspWorker) while the rx timer drain
-    // runs on this object's thread (main). Held briefly: append in
-    // feedAudio, and remove/write in the timer callback.
-    QByteArray m_rxBuffer;
-    QTimer* m_rxTimer{nullptr};
-    QMutex m_bufferMutex;
+    // Was sliceId 0 registered with MasterMixer? startup-only invariant
+    // per design-decision D6 (plan); prevents a main-thread insert/rehash
+    // race against the audio thread's lock-free find().
+    bool m_slicePreregistered{false};
 };
 
 } // namespace NereusSDR

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -82,6 +82,17 @@ public:
     bool isRunning() const { return m_running; }
 
     // Phase 3O: per-endpoint IAudioBus ownership.
+    //
+    // Live-reconfig contract: each of these setters destroys and
+    // reconstructs the underlying IAudioBus. That is NOT safe while the
+    // DSP thread is inside rxBlockReady(). Caller must ensure one of:
+    //   - AudioEngine::isRunning() == false (before start() or after
+    //     stop()), or
+    //   - the DSP thread feeding rxBlockReady() is quiesced for the
+    //     duration of the call.
+    // Live device switching while audio is streaming is the
+    // responsibility of a higher layer (Phase 3O Sub-Phase 8, Setup →
+    // Audio → Devices) and is not provided by this class.
     void setSpeakersConfig(const AudioDeviceConfig& cfg);
     void setTxInputConfig(const AudioDeviceConfig& cfg);
     void setVaxConfig(int channel, const AudioDeviceConfig& cfg);  // 1..4

--- a/src/core/IAudioBus.h
+++ b/src/core/IAudioBus.h
@@ -1,0 +1,56 @@
+// =================================================================
+// src/core/IAudioBus.h  (NereusSDR)
+// =================================================================
+//
+// Phase 3O abstract audio bus. Concrete implementations live in
+// src/core/audio/: CoreAudioHalBus (macOS), LinuxPipeBus (Linux),
+// PortAudioBus (Windows + Mac/Linux fallback).
+//
+// Design spec: docs/architecture/2026-04-19-vax-design.md §3.2
+// =================================================================
+
+#pragma once
+
+#include <QString>
+#include <cstdint>
+
+namespace NereusSDR {
+
+struct AudioFormat {
+    int sampleRate = 48000;  // Hz
+    int channels   = 2;       // 1 or 2
+    enum class Sample { Float32, Int16, Int24, Int32 } sample = Sample::Float32;
+
+    bool operator==(const AudioFormat& o) const {
+        return sampleRate == o.sampleRate && channels == o.channels && sample == o.sample;
+    }
+    bool operator!=(const AudioFormat& o) const { return !(*this == o); }
+};
+
+class IAudioBus {
+public:
+    virtual ~IAudioBus() = default;
+
+    // Lifecycle. open() returns false on failure; errorString() has details.
+    virtual bool open(const AudioFormat& format) = 0;
+    virtual void close() = 0;
+    virtual bool isOpen() const = 0;
+
+    // Producer side (RX taps). Interleaved PCM bytes. Returns bytes actually
+    // written, or -1 on error. Must be callable from the audio thread.
+    virtual qint64 push(const char* data, qint64 bytes) = 0;
+
+    // Consumer side (TX). Returns bytes read, or -1 on error. Audio-thread safe.
+    virtual qint64 pull(char* data, qint64 maxBytes) = 0;
+
+    // Metering (RMS of last block). 0.0–1.0. Published atomically for UI.
+    virtual float rxLevel() const = 0;
+    virtual float txLevel() const = 0;
+
+    // Diagnostics.
+    virtual QString backendName() const = 0;
+    virtual AudioFormat negotiatedFormat() const = 0;
+    virtual QString errorString() const { return {}; }
+};
+
+} // namespace NereusSDR

--- a/src/core/IAudioBus.h
+++ b/src/core/IAudioBus.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <QString>
-#include <cstdint>
 
 namespace NereusSDR {
 

--- a/src/core/audio/MasterMixer.cpp
+++ b/src/core/audio/MasterMixer.cpp
@@ -1,0 +1,70 @@
+// =================================================================
+// src/core/audio/MasterMixer.cpp  (NereusSDR)
+// =================================================================
+// See MasterMixer.h for contract. NereusSDR-original.
+// =================================================================
+
+#include "MasterMixer.h"
+
+#include <algorithm>
+
+namespace NereusSDR {
+
+
+void MasterMixer::setSliceGain(int sliceId, float gain, float pan) {
+    std::lock_guard<std::mutex> lk(m_sliceMapMutex);
+    auto& st = m_slices[sliceId];
+    st.gain.store(std::clamp(gain, 0.0f, 1.0f), std::memory_order_release);
+    st.pan.store(std::clamp(pan, -1.0f, 1.0f),  std::memory_order_release);
+}
+
+void MasterMixer::setSliceMuted(int sliceId, bool muted) {
+    std::lock_guard<std::mutex> lk(m_sliceMapMutex);
+    m_slices[sliceId].muted.store(muted, std::memory_order_release);
+}
+
+void MasterMixer::removeSlice(int sliceId) {
+    std::lock_guard<std::mutex> lk(m_sliceMapMutex);
+    m_slices.erase(sliceId);
+}
+
+void MasterMixer::accumulate(int sliceId, const float* samples, int frames) {
+    // Audio-thread hot path. No lock; rely on startup/connect-time
+    // invariant that the map is stable while audio is streaming.
+    auto it = m_slices.find(sliceId);
+    if (it == m_slices.end()) { return; }
+
+    const SliceState& st = it->second;
+    if (st.muted.load(std::memory_order_acquire)) { return; }
+
+    const float gain = st.gain.load(std::memory_order_acquire);
+    const float pan  = st.pan.load(std::memory_order_acquire);
+
+    // Linear pan law: pan ∈ [-1..+1].
+    // At pan=0 both channels pass through at full gain (unity).
+    // At pan=-1 only the left channel passes; at pan=+1 only right.
+    const float lGain = gain * (pan <= 0.0f ? 1.0f : 1.0f - pan);
+    const float rGain = gain * (pan >= 0.0f ? 1.0f : 1.0f + pan);
+
+    const int neededFloats = frames * 2;
+    if (static_cast<int>(m_acc.size()) < neededFloats) {
+        m_acc.resize(static_cast<size_t>(neededFloats), 0.0f);
+    }
+    for (int i = 0; i < frames; ++i) {
+        m_acc[i * 2 + 0] += samples[i * 2 + 0] * lGain;
+        m_acc[i * 2 + 1] += samples[i * 2 + 1] * rGain;
+    }
+}
+
+void MasterMixer::mixInto(float* out, int frames) {
+    const int n = frames * 2;
+    if (static_cast<int>(m_acc.size()) < n) {
+        // No one accumulated this block — output silence.
+        std::fill(out, out + n, 0.0f);
+        return;
+    }
+    std::copy(m_acc.begin(), m_acc.begin() + n, out);
+    std::fill(m_acc.begin(), m_acc.begin() + n, 0.0f);
+}
+
+} // namespace NereusSDR

--- a/src/core/audio/MasterMixer.cpp
+++ b/src/core/audio/MasterMixer.cpp
@@ -58,9 +58,16 @@ void MasterMixer::accumulate(int sliceId, const float* samples, int frames) {
 
 void MasterMixer::mixInto(float* out, int frames) {
     const int n = frames * 2;
-    if (static_cast<int>(m_acc.size()) < n) {
-        // No one accumulated this block — output silence.
+    const int have = static_cast<int>(m_acc.size());
+    if (have < n) {
+        // Block size shrank (or no one accumulated yet) — output silence
+        // AND drain whatever the accumulator does have so a stale tail
+        // from a prior larger block cannot leak into a future mixInto
+        // call.
         std::fill(out, out + n, 0.0f);
+        if (have > 0) {
+            std::fill(m_acc.begin(), m_acc.end(), 0.0f);
+        }
         return;
     }
     std::copy(m_acc.begin(), m_acc.begin() + n, out);

--- a/src/core/audio/MasterMixer.h
+++ b/src/core/audio/MasterMixer.h
@@ -1,0 +1,59 @@
+// =================================================================
+// src/core/audio/MasterMixer.h  (NereusSDR)
+// =================================================================
+//
+// Phase 3O per-slice mute / volume / pan mixer. NereusSDR-original.
+//
+// Design spec §3.4: producers call accumulate(sliceId, samples, frames)
+// once per block, consumer calls mixInto(out, frames) once to flush.
+// =================================================================
+
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace NereusSDR {
+
+// Audio-thread-safe per-slice mixing. UI thread mutates per-slice params;
+// audio thread reads via atomics. Map structural changes are guarded by a
+// mutex (held only on UI thread).
+class MasterMixer {
+public:
+    // UI thread: per-slice gain [0..1] + pan [-1..+1]. Safe to call anytime.
+    void setSliceGain(int sliceId, float gain, float pan);
+
+    // UI thread: mute / unmute a slice.
+    void setSliceMuted(int sliceId, bool muted);
+
+    // UI thread: remove a slice (e.g. slice destroyed).
+    void removeSlice(int sliceId);
+
+    // Audio thread: accumulate a slice's stereo block. samples is
+    // interleaved L/R float32. frames = sample pairs.
+    void accumulate(int sliceId, const float* samples, int frames);
+
+    // Audio thread: flush the accumulated mix into out and reset.
+    // out is interleaved L/R float32, length = frames * 2.
+    void mixInto(float* out, int frames);
+
+private:
+    struct SliceState {
+        std::atomic<float> gain{1.0f};
+        std::atomic<float> pan{0.0f};
+        std::atomic<bool>  muted{false};
+    };
+
+    // Map guarded by m_sliceMapMutex on structural changes. Audio-thread
+    // find() is a lock-free const lookup; this is safe under the invariant
+    // that slice creation/removal happens only at startup/connect, not
+    // mid-stream. Parameter mutation is lock-free via atomics.
+    std::unordered_map<int, SliceState> m_slices;
+    std::mutex m_sliceMapMutex;
+
+    std::vector<float> m_acc;  // audio-thread only; resized on demand
+};
+
+} // namespace NereusSDR

--- a/src/core/audio/MasterMixer.h
+++ b/src/core/audio/MasterMixer.h
@@ -35,7 +35,10 @@ public:
     // interleaved L/R float32. frames = sample pairs.
     void accumulate(int sliceId, const float* samples, int frames);
 
-    // Audio thread: flush the accumulated mix into out and reset.
+    // Audio thread: flush the accumulated mix into out and reset. Always
+    // drains the accumulator — if the block size shrank below the
+    // accumulator's current size, out is zeroed and the accumulator is
+    // fully cleared so no stale tail can leak into a future call.
     // out is interleaved L/R float32, length = frames * 2.
     void mixInto(float* out, int frames);
 

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -1,0 +1,137 @@
+// =================================================================
+// src/core/audio/PortAudioBus.cpp  (NereusSDR)
+// =================================================================
+// See PortAudioBus.h for contract. NereusSDR-original.
+// =================================================================
+
+#include "PortAudioBus.h"
+
+#include <portaudio.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace NereusSDR {
+
+PortAudioBus::PortAudioBus() {
+    // 1 second stereo float ring at the nominal default rate. The push
+    // path wraps modulo ring size, so a longer stream than 1 s simply
+    // overwrites the oldest unread samples (underruns surface as silence
+    // in paCallback, not overruns).
+    m_ring.resize(48000 * 2);
+}
+
+PortAudioBus::~PortAudioBus() {
+    close();
+}
+
+void PortAudioBus::setConfig(const PortAudioConfig& cfg) {
+    m_cfg = cfg;
+}
+
+bool PortAudioBus::open(const AudioFormat& format) {
+    if (m_stream) {
+        close();
+    }
+
+    PaStreamParameters outParams;
+    outParams.device = Pa_GetDefaultOutputDevice();
+    if (outParams.device == paNoDevice) {
+        m_err = QStringLiteral("No default output device");
+        return false;
+    }
+
+    const PaDeviceInfo* di = Pa_GetDeviceInfo(outParams.device);
+    if (di == nullptr) {
+        m_err = QStringLiteral("Pa_GetDeviceInfo returned null for default device");
+        return false;
+    }
+
+    outParams.channelCount              = format.channels;
+    outParams.sampleFormat              = paFloat32;
+    outParams.suggestedLatency          = di->defaultLowOutputLatency;
+    outParams.hostApiSpecificStreamInfo = nullptr;
+
+    const PaError err = Pa_OpenStream(
+        &m_stream, nullptr, &outParams,
+        format.sampleRate, m_cfg.bufferSamples,
+        paClipOff, &PortAudioBus::paCallback, this);
+
+    if (err != paNoError) {
+        m_err = QString::fromUtf8(Pa_GetErrorText(err));
+        m_stream = nullptr;
+        return false;
+    }
+
+    Pa_StartStream(m_stream);
+    m_negFormat = format;
+
+    // Defensive null-check on host-API lookup. With a device handed back
+    // by Pa_GetDefaultOutputDevice this should never be null, but keep
+    // the backend name well-defined if it ever is.
+    const PaHostApiInfo* hai = Pa_GetHostApiInfo(di->hostApi);
+    if (hai != nullptr && hai->name != nullptr) {
+        m_backendName = QString::fromUtf8(hai->name);
+    } else {
+        m_backendName.clear();
+    }
+    return true;
+}
+
+void PortAudioBus::close() {
+    if (!m_stream) {
+        return;
+    }
+    Pa_StopStream(m_stream);
+    Pa_CloseStream(m_stream);
+    m_stream = nullptr;
+}
+
+qint64 PortAudioBus::push(const char* data, qint64 bytes) {
+    const int floatCount = static_cast<int>(bytes / sizeof(float));
+    const qint64 ringSize = static_cast<qint64>(m_ring.size());
+    qint64 w = m_ringWrite.load(std::memory_order_relaxed);
+    const float* in = reinterpret_cast<const float*>(data);
+    float peak = 0.0f;
+    for (int i = 0; i < floatCount; ++i) {
+        m_ring[w % ringSize] = in[i];
+        w++;
+        peak = std::max(peak, std::abs(in[i]));
+    }
+    m_ringWrite.store(w, std::memory_order_release);
+    m_rxLevel.store(peak, std::memory_order_release);
+    return bytes;
+}
+
+qint64 PortAudioBus::pull(char* /*data*/, qint64 /*maxBytes*/) {
+    // Not implemented in this task; TX path wired in Sub-Phase 4.
+    return 0;
+}
+
+int PortAudioBus::paCallback(const void* /*in*/, void* out,
+                             unsigned long frames,
+                             const PaStreamCallbackTimeInfo* /*timeInfo*/,
+                             unsigned long /*flags*/,
+                             void* userData) {
+    PortAudioBus* self = static_cast<PortAudioBus*>(userData);
+    float* o = static_cast<float*>(out);
+    const int want = static_cast<int>(frames) * self->m_negFormat.channels;
+
+    const qint64 ringSize = static_cast<qint64>(self->m_ring.size());
+    qint64 r = self->m_ringRead.load(std::memory_order_relaxed);
+    const qint64 w = self->m_ringWrite.load(std::memory_order_acquire);
+
+    for (int i = 0; i < want; ++i) {
+        if (r < w) {
+            o[i] = self->m_ring[r % ringSize];
+            r++;
+        } else {
+            o[i] = 0.0f;  // underrun -> silence
+        }
+    }
+    self->m_ringRead.store(r, std::memory_order_release);
+    return paContinue;
+}
+
+} // namespace NereusSDR

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -61,6 +61,8 @@ bool PortAudioBus::open(const AudioFormat& format) {
     if (err != paNoError) {
         m_err = QString::fromUtf8(Pa_GetErrorText(err));
         m_stream = nullptr;
+        m_negFormat = {};
+        m_backendName.clear();
         return false;
     }
 
@@ -89,6 +91,7 @@ void PortAudioBus::close() {
 }
 
 qint64 PortAudioBus::push(const char* data, qint64 bytes) {
+    if (!m_stream) { return 0; }
     const int floatCount = static_cast<int>(bytes / sizeof(float));
     const qint64 ringSize = static_cast<qint64>(m_ring.size());
     qint64 w = m_ringWrite.load(std::memory_order_relaxed);
@@ -132,6 +135,46 @@ int PortAudioBus::paCallback(const void* /*in*/, void* out,
     }
     self->m_ringRead.store(r, std::memory_order_release);
     return paContinue;
+}
+
+QVector<PortAudioBus::HostApiInfo> PortAudioBus::hostApis() {
+    QVector<HostApiInfo> out;
+    const int n = Pa_GetHostApiCount();
+    for (int i = 0; i < n; ++i) {
+        const PaHostApiInfo* h = Pa_GetHostApiInfo(i);
+        if (h) { out.push_back({i, QString::fromUtf8(h->name)}); }
+    }
+    return out;
+}
+
+QVector<PortAudioBus::DeviceInfo> PortAudioBus::outputDevicesFor(int hostApiIndex) {
+    QVector<DeviceInfo> out;
+    const int n = Pa_GetDeviceCount();
+    for (int i = 0; i < n; ++i) {
+        const PaDeviceInfo* d = Pa_GetDeviceInfo(i);
+        if (!d || d->hostApi != hostApiIndex || d->maxOutputChannels <= 0) { continue; }
+        out.push_back({
+            i, QString::fromUtf8(d->name),
+            d->maxOutputChannels, d->maxInputChannels,
+            (int)d->defaultSampleRate, d->hostApi
+        });
+    }
+    return out;
+}
+
+QVector<PortAudioBus::DeviceInfo> PortAudioBus::inputDevicesFor(int hostApiIndex) {
+    QVector<DeviceInfo> out;
+    const int n = Pa_GetDeviceCount();
+    for (int i = 0; i < n; ++i) {
+        const PaDeviceInfo* d = Pa_GetDeviceInfo(i);
+        if (!d || d->hostApi != hostApiIndex || d->maxInputChannels <= 0) { continue; }
+        out.push_back({
+            i, QString::fromUtf8(d->name),
+            d->maxOutputChannels, d->maxInputChannels,
+            (int)d->defaultSampleRate, d->hostApi
+        });
+    }
+    return out;
 }
 
 } // namespace NereusSDR

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -35,28 +35,51 @@ bool PortAudioBus::open(const AudioFormat& format) {
         close();
     }
 
-    PaStreamParameters outParams;
-    outParams.device = Pa_GetDefaultOutputDevice();
-    if (outParams.device == paNoDevice) {
-        m_err = QStringLiteral("No default output device");
-        return false;
+    PaStreamParameters params;
+    PaError err = paNoError;
+    const PaDeviceInfo* di = nullptr;
+
+    if (m_cfg.direction == AudioDirection::Output) {
+        params.device = Pa_GetDefaultOutputDevice();
+        if (params.device == paNoDevice) {
+            m_err = QStringLiteral("No default output device");
+            return false;
+        }
+        di = Pa_GetDeviceInfo(params.device);
+        if (di == nullptr) {
+            m_err = QStringLiteral("Pa_GetDeviceInfo returned null for default device");
+            return false;
+        }
+        params.channelCount              = format.channels;
+        params.sampleFormat              = paFloat32;
+        params.suggestedLatency          = di->defaultLowOutputLatency;
+        params.hostApiSpecificStreamInfo = nullptr;
+
+        err = Pa_OpenStream(
+            &m_stream, nullptr, &params,
+            format.sampleRate, m_cfg.bufferSamples,
+            paClipOff, &PortAudioBus::paCallback, this);
+    } else {
+        params.device = Pa_GetDefaultInputDevice();
+        if (params.device == paNoDevice) {
+            m_err = QStringLiteral("No default input device");
+            return false;
+        }
+        di = Pa_GetDeviceInfo(params.device);
+        if (di == nullptr) {
+            m_err = QStringLiteral("Pa_GetDeviceInfo returned null for default device");
+            return false;
+        }
+        params.channelCount              = format.channels;
+        params.sampleFormat              = paFloat32;
+        params.suggestedLatency          = di->defaultLowInputLatency;
+        params.hostApiSpecificStreamInfo = nullptr;
+
+        err = Pa_OpenStream(
+            &m_stream, &params, nullptr,
+            format.sampleRate, m_cfg.bufferSamples,
+            paClipOff, &PortAudioBus::paCallback, this);
     }
-
-    const PaDeviceInfo* di = Pa_GetDeviceInfo(outParams.device);
-    if (di == nullptr) {
-        m_err = QStringLiteral("Pa_GetDeviceInfo returned null for default device");
-        return false;
-    }
-
-    outParams.channelCount              = format.channels;
-    outParams.sampleFormat              = paFloat32;
-    outParams.suggestedLatency          = di->defaultLowOutputLatency;
-    outParams.hostApiSpecificStreamInfo = nullptr;
-
-    const PaError err = Pa_OpenStream(
-        &m_stream, nullptr, &outParams,
-        format.sampleRate, m_cfg.bufferSamples,
-        paClipOff, &PortAudioBus::paCallback, this);
 
     if (err != paNoError) {
         m_err = QString::fromUtf8(Pa_GetErrorText(err));
@@ -70,8 +93,8 @@ bool PortAudioBus::open(const AudioFormat& format) {
     m_negFormat = format;
 
     // Defensive null-check on host-API lookup. With a device handed back
-    // by Pa_GetDefaultOutputDevice this should never be null, but keep
-    // the backend name well-defined if it ever is.
+    // by Pa_GetDefault{Output,Input}Device this should never be null, but
+    // keep the backend name well-defined if it ever is.
     const PaHostApiInfo* hai = Pa_GetHostApiInfo(di->hostApi);
     if (hai != nullptr && hai->name != nullptr) {
         m_backendName = QString::fromUtf8(hai->name);
@@ -92,6 +115,7 @@ void PortAudioBus::close() {
 
 qint64 PortAudioBus::push(const char* data, qint64 bytes) {
     if (!m_stream) { return 0; }
+    if (m_cfg.direction != AudioDirection::Output) { return 0; }
     const int floatCount = static_cast<int>(bytes / sizeof(float));
     const qint64 ringSize = static_cast<qint64>(m_ring.size());
     qint64 w = m_ringWrite.load(std::memory_order_relaxed);
@@ -107,33 +131,66 @@ qint64 PortAudioBus::push(const char* data, qint64 bytes) {
     return bytes;
 }
 
-qint64 PortAudioBus::pull(char* /*data*/, qint64 /*maxBytes*/) {
-    // Not implemented in this task; TX path wired in Sub-Phase 4.
-    return 0;
+qint64 PortAudioBus::pull(char* data, qint64 maxBytes) {
+    if (!m_stream) { return 0; }
+    if (m_cfg.direction != AudioDirection::Input) { return 0; }
+    const int maxFloats = static_cast<int>(maxBytes / sizeof(float));
+    const qint64 ringSize = static_cast<qint64>(m_ring.size());
+    qint64 r = m_ringRead.load(std::memory_order_relaxed);
+    const qint64 w = m_ringWrite.load(std::memory_order_acquire);
+    float* dst = reinterpret_cast<float*>(data);
+    int count = 0;
+    while (count < maxFloats && r < w) {
+        dst[count] = m_ring[r % ringSize];
+        ++count;
+        ++r;
+    }
+    m_ringRead.store(r, std::memory_order_release);
+    return static_cast<qint64>(count) * static_cast<qint64>(sizeof(float));
 }
 
-int PortAudioBus::paCallback(const void* /*in*/, void* out,
+int PortAudioBus::paCallback(const void* in, void* out,
                              unsigned long frames,
                              const PaStreamCallbackTimeInfo* /*timeInfo*/,
                              unsigned long /*flags*/,
                              void* userData) {
     PortAudioBus* self = static_cast<PortAudioBus*>(userData);
-    float* o = static_cast<float*>(out);
-    const int want = static_cast<int>(frames) * self->m_negFormat.channels;
-
     const qint64 ringSize = static_cast<qint64>(self->m_ring.size());
-    qint64 r = self->m_ringRead.load(std::memory_order_relaxed);
-    const qint64 w = self->m_ringWrite.load(std::memory_order_acquire);
 
-    for (int i = 0; i < want; ++i) {
-        if (r < w) {
-            o[i] = self->m_ring[r % ringSize];
-            r++;
-        } else {
-            o[i] = 0.0f;  // underrun -> silence
+    if (self->m_cfg.direction == AudioDirection::Output) {
+        float* o = static_cast<float*>(out);
+        const int want = static_cast<int>(frames) * self->m_negFormat.channels;
+
+        qint64 r = self->m_ringRead.load(std::memory_order_relaxed);
+        const qint64 w = self->m_ringWrite.load(std::memory_order_acquire);
+
+        for (int i = 0; i < want; ++i) {
+            if (r < w) {
+                o[i] = self->m_ring[r % ringSize];
+                r++;
+            } else {
+                o[i] = 0.0f;  // underrun -> silence
+            }
         }
+        self->m_ringRead.store(r, std::memory_order_release);
+    } else {
+        // Input mode: read captured samples from `in`, write to ring,
+        // update m_txLevel (the audio here is destined for transmit).
+        const float* i_in = static_cast<const float*>(in);
+        const int have = static_cast<int>(frames) * self->m_negFormat.channels;
+
+        qint64 w = self->m_ringWrite.load(std::memory_order_relaxed);
+        float peak = 0.0f;
+        if (i_in != nullptr) {
+            for (int i = 0; i < have; ++i) {
+                self->m_ring[w % ringSize] = i_in[i];
+                w++;
+                peak = std::max(peak, std::abs(i_in[i]));
+            }
+        }
+        self->m_ringWrite.store(w, std::memory_order_release);
+        self->m_txLevel.store(peak, std::memory_order_release);
     }
-    self->m_ringRead.store(r, std::memory_order_release);
     return paContinue;
 }
 
@@ -153,10 +210,11 @@ QVector<PortAudioBus::DeviceInfo> PortAudioBus::outputDevicesFor(int hostApiInde
     for (int i = 0; i < n; ++i) {
         const PaDeviceInfo* d = Pa_GetDeviceInfo(i);
         if (!d || d->hostApi != hostApiIndex || d->maxOutputChannels <= 0) { continue; }
+        // d->defaultSampleRate is double; all PortAudio host APIs report integer rates.
         out.push_back({
             i, QString::fromUtf8(d->name),
             d->maxOutputChannels, d->maxInputChannels,
-            (int)d->defaultSampleRate, d->hostApi
+            static_cast<int>(d->defaultSampleRate), d->hostApi
         });
     }
     return out;
@@ -171,7 +229,7 @@ QVector<PortAudioBus::DeviceInfo> PortAudioBus::inputDevicesFor(int hostApiIndex
         out.push_back({
             i, QString::fromUtf8(d->name),
             d->maxOutputChannels, d->maxInputChannels,
-            (int)d->defaultSampleRate, d->hostApi
+            static_cast<int>(d->defaultSampleRate), d->hostApi
         });
     }
     return out;

--- a/src/core/audio/PortAudioBus.h
+++ b/src/core/audio/PortAudioBus.h
@@ -1,0 +1,86 @@
+// =================================================================
+// src/core/audio/PortAudioBus.h  (NereusSDR)
+// =================================================================
+//
+// Phase 3O VAX cross-platform IAudioBus backend built on PortAudio
+// v19.7.0. NereusSDR-original.
+//
+// Design spec: docs/architecture/2026-04-19-vax-design.md §3.2
+// Plan:        docs/architecture/2026-04-19-phase3o-vax-plan.md (3.2)
+//
+// This task (3.2) implements render-only (output) minimal lifecycle
+// against the PortAudio default device. Host-API / device enumeration
+// (3.3) and TX capture via pull() (3.4) land in follow-up tasks.
+// =================================================================
+
+#pragma once
+
+#include "core/IAudioBus.h"
+
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+// Forward declarations so consumers of this header don't have to drag
+// in <portaudio.h>. The concrete type is typedef'd the same way by
+// PortAudio itself (`typedef void PaStream`).
+typedef void PaStream;
+struct PaDeviceInfo;
+struct PaStreamCallbackTimeInfo;
+
+namespace NereusSDR {
+
+struct PortAudioConfig {
+    int     hostApiIndex  = -1;     // -1 = PortAudio default
+    QString deviceName;             // empty = default
+    int     bufferSamples = 256;
+    bool    exclusiveMode = false;  // WASAPI only
+    // Additional fields added in Tasks 3.3 / 3.4.
+};
+
+class PortAudioBus : public IAudioBus {
+public:
+    PortAudioBus();
+    ~PortAudioBus() override;
+
+    void setConfig(const PortAudioConfig& cfg);
+
+    bool open(const AudioFormat& format) override;
+    void close() override;
+    bool isOpen() const override { return m_stream != nullptr; }
+
+    qint64 push(const char* data, qint64 bytes) override;
+    qint64 pull(char* data, qint64 maxBytes) override;
+
+    float rxLevel() const override { return m_rxLevel.load(std::memory_order_acquire); }
+    float txLevel() const override { return m_txLevel.load(std::memory_order_acquire); }
+
+    QString     backendName() const override { return m_backendName; }
+    AudioFormat negotiatedFormat() const override { return m_negFormat; }
+    QString     errorString() const override { return m_err; }
+
+private:
+    PaStream*       m_stream{nullptr};
+    PortAudioConfig m_cfg;
+    AudioFormat     m_negFormat;
+    QString         m_backendName;
+    QString         m_err;
+
+    // Ring buffer for push/pull. The audio callback drains from here
+    // on the audio thread; push() writes from the main/DSP thread.
+    // Single-producer / single-consumer, lock-free via std::atomic.
+    std::vector<float>  m_ring;
+    std::atomic<qint64> m_ringRead{0};
+    std::atomic<qint64> m_ringWrite{0};
+
+    std::atomic<float> m_rxLevel{0.0f};
+    std::atomic<float> m_txLevel{0.0f};
+
+    static int paCallback(const void* in, void* out,
+                          unsigned long frames,
+                          const PaStreamCallbackTimeInfo* timeInfo,
+                          unsigned long flags,
+                          void* userData);
+};
+
+} // namespace NereusSDR

--- a/src/core/audio/PortAudioBus.h
+++ b/src/core/audio/PortAudioBus.h
@@ -18,8 +18,9 @@
 #include "core/IAudioBus.h"
 
 #include <atomic>
-#include <mutex>
 #include <vector>
+
+#include <QVector>
 
 // Forward declarations so consumers of this header don't have to drag
 // in <portaudio.h>. The concrete type is typedef'd the same way by
@@ -43,7 +44,25 @@ public:
     PortAudioBus();
     ~PortAudioBus() override;
 
+    // Call before open(). m_cfg is read on the main thread in open() only.
     void setConfig(const PortAudioConfig& cfg);
+
+    struct HostApiInfo {
+        int     index;
+        QString name;
+    };
+    struct DeviceInfo {
+        int     index;
+        QString name;
+        int     maxOutputChannels;
+        int     maxInputChannels;
+        int     defaultSampleRate;
+        int     hostApiIndex;
+    };
+
+    static QVector<HostApiInfo> hostApis();
+    static QVector<DeviceInfo>  outputDevicesFor(int hostApiIndex);
+    static QVector<DeviceInfo>  inputDevicesFor(int hostApiIndex);
 
     bool open(const AudioFormat& format) override;
     void close() override;

--- a/src/core/audio/PortAudioBus.h
+++ b/src/core/audio/PortAudioBus.h
@@ -6,11 +6,13 @@
 // v19.7.0. NereusSDR-original.
 //
 // Design spec: docs/architecture/2026-04-19-vax-design.md §3.2
-// Plan:        docs/architecture/2026-04-19-phase3o-vax-plan.md (3.2)
+// Plan:        docs/architecture/2026-04-19-phase3o-vax-plan.md (3.2–3.4)
 //
-// This task (3.2) implements render-only (output) minimal lifecycle
-// against the PortAudio default device. Host-API / device enumeration
-// (3.3) and TX capture via pull() (3.4) land in follow-up tasks.
+// Supports both render (Output) and capture (Input) modes via
+// PortAudioConfig::direction. Output: push() feeds the ring, the audio
+// callback drains it to the device. Input: the audio callback captures
+// from the device into the ring, pull() drains it. Host-API / device
+// enumeration helpers are available statically (Task 3.3).
 // =================================================================
 
 #pragma once
@@ -31,12 +33,14 @@ struct PaStreamCallbackTimeInfo;
 
 namespace NereusSDR {
 
+enum class AudioDirection { Output, Input };
+
 struct PortAudioConfig {
+    AudioDirection direction = AudioDirection::Output;  // Output = render; Input = capture
     int     hostApiIndex  = -1;     // -1 = PortAudio default
     QString deviceName;             // empty = default
     int     bufferSamples = 256;
     bool    exclusiveMode = false;  // WASAPI only
-    // Additional fields added in Tasks 3.3 / 3.4.
 };
 
 class PortAudioBus : public IAudioBus {
@@ -60,6 +64,8 @@ public:
         int     hostApiIndex;
     };
 
+    // Enumeration helpers require Pa_Initialize() to have been called
+    // (owned by the application lifecycle, not this class).
     static QVector<HostApiInfo> hostApis();
     static QVector<DeviceInfo>  outputDevicesFor(int hostApiIndex);
     static QVector<DeviceInfo>  inputDevicesFor(int hostApiIndex);
@@ -85,9 +91,9 @@ private:
     QString         m_backendName;
     QString         m_err;
 
-    // Ring buffer for push/pull. The audio callback drains from here
-    // on the audio thread; push() writes from the main/DSP thread.
-    // Single-producer / single-consumer, lock-free via std::atomic.
+    // Ring buffer for push/pull. SPSC, lock-free via std::atomic.
+    // Output mode: push() (DSP thread) writes, audio callback reads.
+    // Input mode:  audio callback writes, pull() (caller thread) reads.
     std::vector<float>  m_ring;
     std::atomic<qint64> m_ringRead{0};
     std::atomic<qint64> m_ringWrite{0};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,6 +136,9 @@ int main(int argc, char* argv[])
     // Load XML settings
     NereusSDR::AppSettings::instance().load();
 
+    // Phase 3O schema migration — must run before any AppSettings reads.
+    NereusSDR::AppSettings::migrateVaxSchemaV1ToV2();
+
     // Restore logging category toggles from settings
     NereusSDR::LogManager::instance().loadSettings();
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -260,6 +260,13 @@ RadioModel::RadioModel(QObject* parent)
     , m_audioEngine(new AudioEngine(this))
     , m_wdspEngine(new WdspEngine(this))
 {
+    // Phase 3O: give AudioEngine a non-owning back-pointer to this model
+    // so rxBlockReady() can look up per-slice mute / VAX state. Wired
+    // immediately after construction; AudioEngine caches the pointer and
+    // treats a null as a safe no-op (tests that build AudioEngine
+    // standalone).
+    m_audioEngine->setRadioModel(this);
+
     // Connection starts null — created by connectToRadio() via factory.
     //
     // Phase 3G-9b: the smooth-defaults profile is reachable only via the

--- a/src/models/RxDspWorker.cpp
+++ b/src/models/RxDspWorker.cpp
@@ -136,7 +136,22 @@ void RxDspWorker::processIqBatch(int receiverIndex,
             // outI == outQ because SetRXAPanelBinaural(channel, 0) puts
             // the RXA patch panel in dual-mono mode (set in
             // WdspEngine::createRxChannel).
-            m_audioEngine->feedAudio(0, outI.data(), outQ.data(), outSize);
+            //
+            // Phase 3O: interleave L/R into a reusable stereo buffer
+            // and hand it to AudioEngine::rxBlockReady, which routes
+            // through MasterMixer → speakers IAudioBus + per-slice VAX.
+            // sliceId = 0 because ReceiverManager maps hardware DDC2 →
+            // receiver index 0 for the single-RX live path (3O
+            // Sub-Phase 4; multi-slice enrollment lands in Sub-Phase 9+).
+            if (m_interleavedOut.size() < outSize * 2) {
+                m_interleavedOut.resize(outSize * 2);
+            }
+            float* interleaved = m_interleavedOut.data();
+            for (int i = 0; i < outSize; ++i) {
+                interleaved[i * 2 + 0] = outI[i];
+                interleaved[i * 2 + 1] = outQ[i];
+            }
+            m_audioEngine->rxBlockReady(0, interleaved, outSize);
         }
 
         m_iqAccumI.remove(0, inSize);

--- a/src/models/RxDspWorker.h
+++ b/src/models/RxDspWorker.h
@@ -163,6 +163,10 @@ private:
     AudioEngine*     m_audioEngine{nullptr};
     QVector<float>   m_iqAccumI;
     QVector<float>   m_iqAccumQ;
+    // Reusable interleaved stereo scratch handed to AudioEngine::rxBlockReady.
+    // Sized to outSize*2 on first use and reused in-place per batch so the
+    // DSP thread never allocates in the hot path after warmup.
+    QVector<float>   m_interleavedOut;
     // Written by setBufferSizes() (typically on the main thread when the
     // wire rate changes) and read by processIqBatch() on the DSP thread.
     // std::atomic<int> prevents the C++ data race that plain int reads

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -964,7 +964,6 @@ void SliceModel::setVaxChannel(int ch)
     AppSettings::instance().setValue(
         QStringLiteral("slice/%1/VaxChannel").arg(m_sliceIndex),
         QString::number(ch));
-    AppSettings::instance().save();
 
     emit vaxChannelChanged(ch);
 }
@@ -974,9 +973,10 @@ void SliceModel::loadFromSettings()
     auto& s = AppSettings::instance();
 
     // ── VAX channel (Phase 3O) ────────────────────────────────────────────────
-    const int vaxCh = s.value(
+    int vaxCh = s.value(
         QStringLiteral("slice/%1/VaxChannel").arg(m_sliceIndex), "0")
         .toString().toInt();
+    if (vaxCh < 0 || vaxCh > 4) { vaxCh = 0; }  // spec §5.1: invalid values clamp to 0
     if (vaxCh != m_vaxChannel.load()) {
         m_vaxChannel.store(vaxCh, std::memory_order_release);
         emit vaxChannelChanged(vaxCh);

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -962,7 +962,7 @@ void SliceModel::setVaxChannel(int ch)
     if (prev == ch) { return; }
 
     AppSettings::instance().setValue(
-        QStringLiteral("slice/%1/VaxChannel").arg(m_sliceIndex),
+        slicePrefix(m_sliceIndex) + QStringLiteral("VaxChannel"),
         QString::number(ch));
 
     emit vaxChannelChanged(ch);
@@ -974,10 +974,10 @@ void SliceModel::loadFromSettings()
 
     // ── VAX channel (Phase 3O) ────────────────────────────────────────────────
     int vaxCh = s.value(
-        QStringLiteral("slice/%1/VaxChannel").arg(m_sliceIndex), "0")
+        slicePrefix(m_sliceIndex) + QStringLiteral("VaxChannel"), "0")
         .toString().toInt();
     if (vaxCh < 0 || vaxCh > 4) { vaxCh = 0; }  // spec §5.1: invalid values clamp to 0
-    if (vaxCh != m_vaxChannel.load()) {
+    if (vaxCh != m_vaxChannel.load(std::memory_order_acquire)) {
         m_vaxChannel.store(vaxCh, std::memory_order_release);
         emit vaxChannelChanged(vaxCh);
     }

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -124,6 +124,12 @@ SliceModel::SliceModel(QObject* parent)
 {
 }
 
+SliceModel::SliceModel(int sliceId, QObject* parent)
+    : QObject(parent)
+    , m_sliceIndex(sliceId)
+{
+}
+
 SliceModel::~SliceModel() = default;
 
 // ---------------------------------------------------------------------------
@@ -941,6 +947,40 @@ void SliceModel::migrateLegacyKeys()
     s.remove(QStringLiteral("VfoRfGain"));
     s.remove(QStringLiteral("VfoRxAntenna"));
     s.remove(QStringLiteral("VfoTxAntenna"));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3O — VAX routing
+// ---------------------------------------------------------------------------
+
+void SliceModel::setVaxChannel(int ch)
+{
+    // Clamp to valid range.
+    if (ch < 0 || ch > 4) { ch = 0; }
+
+    const int prev = m_vaxChannel.exchange(ch, std::memory_order_acq_rel);
+    if (prev == ch) { return; }
+
+    AppSettings::instance().setValue(
+        QStringLiteral("slice/%1/VaxChannel").arg(m_sliceIndex),
+        QString::number(ch));
+    AppSettings::instance().save();
+
+    emit vaxChannelChanged(ch);
+}
+
+void SliceModel::loadFromSettings()
+{
+    auto& s = AppSettings::instance();
+
+    // ── VAX channel (Phase 3O) ────────────────────────────────────────────────
+    const int vaxCh = s.value(
+        QStringLiteral("slice/%1/VaxChannel").arg(m_sliceIndex), "0")
+        .toString().toInt();
+    if (vaxCh != m_vaxChannel.load()) {
+        m_vaxChannel.store(vaxCh, std::memory_order_release);
+        emit vaxChannelChanged(vaxCh);
+    }
 }
 
 } // namespace NereusSDR

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -122,6 +122,7 @@
 #include <QObject>
 #include <QString>
 
+#include <atomic>
 #include <utility>
 
 namespace NereusSDR {
@@ -201,6 +202,8 @@ class SliceModel : public QObject {
 
 public:
     explicit SliceModel(QObject* parent = nullptr);
+    // Convenience constructor that initialises m_sliceIndex directly.
+    explicit SliceModel(int sliceId, QObject* parent = nullptr);
     ~SliceModel() override;
 
     // ---- Frequency ----
@@ -442,6 +445,16 @@ public:
     void restoreFromSettings(NereusSDR::Band band);
     static void migrateLegacyKeys();
 
+    // Load band-agnostic slice settings (e.g. VAX channel) from AppSettings.
+    // Called on startup when no specific band context is needed. Does NOT
+    // restore per-band DSP state — use restoreFromSettings(band) for that.
+    void loadFromSettings();
+
+    // ── Phase 3O VAX routing ──────────────────────────────────────────────────
+    // VAX routing (Phase 3O) — 0=Off, 1..4=VAX channel.
+    int vaxChannel() const { return m_vaxChannel.load(std::memory_order_acquire); }
+    void setVaxChannel(int ch);
+
 signals:
     void frequencyChanged(double freq);
     void dspModeChanged(NereusSDR::DSPMode mode);
@@ -494,6 +507,9 @@ signals:
     void diguOffsetHzChanged(int hz);
     void rttyMarkHzChanged(int hz);
     void rttyShiftHzChanged(int hz);
+
+    // ── Phase 3O VAX routing ──────────────────────────────────────────────────
+    void vaxChannelChanged(int ch);
 
 private:
     double  m_frequency{14225000.0};     // Default: 14.225 MHz (20m USB)
@@ -552,6 +568,9 @@ private:
     int      m_diguOffsetHz{0};         // From Thetis console.cs:14637 — DIGUClickTuneOffset default 0 Hz
     int    m_rttyMarkHz{2295};        // From Thetis setup.designer.cs:40635 — tooltip "RTTY MARK frequency" on udDSPRX1DollyF1; value 2295 (line 40637). F0=2125 is SPACE (line 40665).
     int    m_rttyShiftHz{170};        // From Thetis radio.cs:2043-2044 — rx_dolly_freq1 = 2295, rx_dolly_freq0 = 2125 → shift = 2295−2125 = 170 Hz
+
+    // ── Phase 3O VAX routing ──────────────────────────────────────────────────
+    std::atomic<int> m_vaxChannel{0};  // 0=Off, 1..4=VAX N. Atomic for audio-thread-safe reads.
 };
 
 } // namespace NereusSDR

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -1,6 +1,30 @@
 #include "TransmitModel.h"
+#include "core/AppSettings.h"
 
 namespace NereusSDR {
+
+QString vaxSlotToString(VaxSlot s)
+{
+    switch (s) {
+        case VaxSlot::None:      return QStringLiteral("None");
+        case VaxSlot::MicDirect: return QStringLiteral("MicDirect");
+        case VaxSlot::Vax1:      return QStringLiteral("Vax1");
+        case VaxSlot::Vax2:      return QStringLiteral("Vax2");
+        case VaxSlot::Vax3:      return QStringLiteral("Vax3");
+        case VaxSlot::Vax4:      return QStringLiteral("Vax4");
+    }
+    return QStringLiteral("MicDirect");
+}
+
+VaxSlot vaxSlotFromString(const QString& s)
+{
+    if (s == QLatin1String("None"))      { return VaxSlot::None; }
+    if (s == QLatin1String("Vax1"))      { return VaxSlot::Vax1; }
+    if (s == QLatin1String("Vax2"))      { return VaxSlot::Vax2; }
+    if (s == QLatin1String("Vax3"))      { return VaxSlot::Vax3; }
+    if (s == QLatin1String("Vax4"))      { return VaxSlot::Vax4; }
+    return VaxSlot::MicDirect;  // default + unknown-string fallback
+}
 
 TransmitModel::TransmitModel(QObject* parent)
     : QObject(parent)
@@ -46,6 +70,31 @@ void TransmitModel::setPureSigEnabled(bool enabled)
     if (m_pureSigEnabled != enabled) {
         m_pureSigEnabled = enabled;
         emit pureSigChanged(enabled);
+    }
+}
+
+void TransmitModel::setTxOwnerSlot(VaxSlot s)
+{
+    const VaxSlot prev = m_txOwnerSlot.exchange(s, std::memory_order_acq_rel);
+    if (prev == s) { return; }
+
+    AppSettings::instance().setValue(
+        QStringLiteral("tx/OwnerSlot"), vaxSlotToString(s));
+    // No eager save() — matches TransmitModel's existing flush policy
+    // (no other setters call AppSettings::instance().save() here).
+
+    emit txOwnerSlotChanged(s);
+}
+
+void TransmitModel::loadFromSettings()
+{
+    const QString v = AppSettings::instance()
+        .value(QStringLiteral("tx/OwnerSlot"), QStringLiteral("MicDirect"))
+        .toString();
+    const VaxSlot s = vaxSlotFromString(v);
+    if (s != m_txOwnerSlot.load(std::memory_order_acquire)) {
+        m_txOwnerSlot.store(s, std::memory_order_release);
+        emit txOwnerSlotChanged(s);
     }
 }
 

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -23,7 +23,8 @@ VaxSlot vaxSlotFromString(const QString& s)
     if (s == QLatin1String("Vax2"))      { return VaxSlot::Vax2; }
     if (s == QLatin1String("Vax3"))      { return VaxSlot::Vax3; }
     if (s == QLatin1String("Vax4"))      { return VaxSlot::Vax4; }
-    return VaxSlot::MicDirect;  // default + unknown-string fallback
+    if (s == QLatin1String("MicDirect")) { return VaxSlot::MicDirect; }
+    return VaxSlot::MicDirect;  // unknown-string fallback
 }
 
 TransmitModel::TransmitModel(QObject* parent)

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -69,7 +69,7 @@ private:
     int m_power{100};
     float m_micGain{0.0f};
     bool m_pureSigEnabled{false};
-    std::atomic<VaxSlot> m_txOwnerSlot{VaxSlot::MicDirect};
+    std::atomic<VaxSlot> m_txOwnerSlot{VaxSlot::MicDirect};  // Atomic for lock-free reads from the audio thread.
 };
 
 } // namespace NereusSDR

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -1,8 +1,24 @@
 #pragma once
 
 #include <QObject>
+#include <QString>
+#include <atomic>
 
 namespace NereusSDR {
+
+// VAX slot: which audio source owns the transmitter.
+// MicDirect = hardware mic, Vax1–Vax4 = virtual audio crossbar slots.
+enum class VaxSlot {
+    None = 0,
+    MicDirect,
+    Vax1,
+    Vax2,
+    Vax3,
+    Vax4
+};
+
+QString vaxSlotToString(VaxSlot s);
+VaxSlot vaxSlotFromString(const QString& s);
 
 // Transmit state management.
 // Includes MOX, tune, TX frequency, power, mic gain, and PureSignal state.
@@ -34,12 +50,18 @@ public:
     bool pureSigEnabled() const { return m_pureSigEnabled; }
     void setPureSigEnabled(bool enabled);
 
+    VaxSlot txOwnerSlot() const { return m_txOwnerSlot.load(std::memory_order_acquire); }
+    void setTxOwnerSlot(VaxSlot s);
+
+    void loadFromSettings();
+
 signals:
     void moxChanged(bool mox);
     void tuneChanged(bool tune);
     void powerChanged(int power);
     void micGainChanged(float gain);
     void pureSigChanged(bool enabled);
+    void txOwnerSlotChanged(VaxSlot s);
 
 private:
     bool m_mox{false};
@@ -47,6 +69,7 @@ private:
     int m_power{100};
     float m_micGain{0.0f};
     bool m_pureSigEnabled{false};
+    std::atomic<VaxSlot> m_txOwnerSlot{VaxSlot::MicDirect};
 };
 
 } // namespace NereusSDR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,3 +150,4 @@ nereus_add_test(tst_about_dialog)
 
 # ── Phase 3O VAX routing ──────────────────────────────────────────────────
 nereus_add_test(tst_slice_model_vax)
+nereus_add_test(tst_transmit_model_tx_owner)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -157,3 +157,6 @@ nereus_add_test(tst_app_settings_vax_migration)
 
 # ── Phase 3O Sub-Phase 2: MasterMixer ─────────────────────────────────────
 nereus_add_test(tst_master_mixer)
+
+# ── Phase 3O Sub-Phase 3: PortAudioBus ────────────────────────────────────
+nereus_add_test(tst_port_audio_bus)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,3 +154,6 @@ nereus_add_test(tst_transmit_model_tx_owner)
 
 # ── Phase 3O VAX schema migration ─────────────────────────────────────────
 nereus_add_test(tst_app_settings_vax_migration)
+
+# ── Phase 3O Sub-Phase 2: MasterMixer ─────────────────────────────────────
+nereus_add_test(tst_master_mixer)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,3 +147,6 @@ nereus_add_test(tst_step_attenuator_controller)
 
 # ── About dialog ─────────────────────────────────────────────────────────
 nereus_add_test(tst_about_dialog)
+
+# ── Phase 3O VAX routing ──────────────────────────────────────────────────
+nereus_add_test(tst_slice_model_vax)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,3 +151,6 @@ nereus_add_test(tst_about_dialog)
 # ── Phase 3O VAX routing ──────────────────────────────────────────────────
 nereus_add_test(tst_slice_model_vax)
 nereus_add_test(tst_transmit_model_tx_owner)
+
+# ── Phase 3O VAX schema migration ─────────────────────────────────────────
+nereus_add_test(tst_app_settings_vax_migration)

--- a/tests/tst_app_settings_vax_migration.cpp
+++ b/tests/tst_app_settings_vax_migration.cpp
@@ -1,0 +1,75 @@
+#include <QtTest/QtTest>
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstAppSettingsVaxMigration : public QObject {
+    Q_OBJECT
+private slots:
+    void migratesLegacyOutputDeviceKey() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/OutputDevice", "Built-in Output");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        QCOMPARE(s.value("audio/Speakers/DeviceName").toString(),
+                 QStringLiteral("Built-in Output"));
+        QVERIFY(!s.contains("audio/OutputDevice"));
+        QCOMPARE(s.value("audio/FirstRunComplete", "True").toString(), "False");
+    }
+
+    void setsPlatformDefaultDriverApi() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/OutputDevice", "Legacy Device");
+        AppSettings::migrateVaxSchemaV1ToV2();
+#if defined(Q_OS_WIN)
+        QCOMPARE(s.value("audio/Speakers/DriverApi").toString(), QStringLiteral("WASAPI"));
+#elif defined(Q_OS_MAC)
+        QCOMPARE(s.value("audio/Speakers/DriverApi").toString(), QStringLiteral("CoreAudio"));
+#else
+        QCOMPARE(s.value("audio/Speakers/DriverApi").toString(), QStringLiteral("Pulse"));
+#endif
+        QCOMPARE(s.value("audio/Speakers/SampleRate").toString(), QStringLiteral("48000"));
+        QCOMPARE(s.value("audio/Speakers/BitDepth").toString(), QStringLiteral("24"));
+        QCOMPARE(s.value("audio/Speakers/Channels").toString(), QStringLiteral("2"));
+        QCOMPARE(s.value("audio/Speakers/BufferSamples").toString(), QStringLiteral("256"));
+    }
+
+    void doesNothingIfNoLegacyKey() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/Speakers/DeviceName", "Already set");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        QCOMPARE(s.value("audio/Speakers/DeviceName").toString(),
+                 QStringLiteral("Already set"));
+        // Did not flip FirstRunComplete because we assume this is a
+        // clean post-VAX install already set up.
+    }
+
+    void doesNothingIfAlreadyMigrated() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/OutputDevice", "Legacy");
+        s.setValue("audio/Speakers/DeviceName", "New");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        // Legacy key stays (we don't clobber a present new key), new
+        // key is preserved verbatim.
+        QCOMPARE(s.value("audio/Speakers/DeviceName").toString(),
+                 QStringLiteral("New"));
+    }
+
+    void isIdempotent() {
+        auto& s = AppSettings::instance();
+        s.clear();
+        s.setValue("audio/OutputDevice", "Dev");
+        AppSettings::migrateVaxSchemaV1ToV2();
+        const auto afterFirst = s.value("audio/Speakers/DeviceName").toString();
+        AppSettings::migrateVaxSchemaV1ToV2();
+        const auto afterSecond = s.value("audio/Speakers/DeviceName").toString();
+        QCOMPARE(afterFirst, afterSecond);
+        QVERIFY(!s.contains("audio/OutputDevice"));
+    }
+};
+
+QTEST_APPLESS_MAIN(TstAppSettingsVaxMigration)
+#include "tst_app_settings_vax_migration.moc"

--- a/tests/tst_master_mixer.cpp
+++ b/tests/tst_master_mixer.cpp
@@ -1,0 +1,105 @@
+#include <QtTest/QtTest>
+#include "core/audio/MasterMixer.h"
+#include <array>
+
+using namespace NereusSDR;
+
+class TstMasterMixer : public QObject {
+    Q_OBJECT
+private slots:
+    void emptyMixIsSilent() {
+        MasterMixer mix;
+        std::array<float, 16> out{};
+        mix.mixInto(out.data(), 8);
+        for (float s : out) { QCOMPARE(s, 0.0f); }
+    }
+
+    void singleSliceUnityGainMixesThrough() {
+        MasterMixer mix;
+        mix.setSliceGain(42, 1.0f, 0.0f);  // unity, center
+        std::array<float, 4> in = {0.5f, 0.5f, -0.25f, -0.25f};  // 2 frames stereo
+        mix.accumulate(42, in.data(), 2);
+        std::array<float, 4> out{};
+        mix.mixInto(out.data(), 2);
+        QCOMPARE(out[0], 0.5f);
+        QCOMPARE(out[1], 0.5f);
+        QCOMPARE(out[2], -0.25f);
+        QCOMPARE(out[3], -0.25f);
+    }
+
+    void twoSlicesSumLinearly() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, 0.0f);
+        mix.setSliceGain(2, 1.0f, 0.0f);
+        std::array<float, 2> a = {0.3f, 0.3f};
+        std::array<float, 2> b = {0.4f, 0.4f};
+        mix.accumulate(1, a.data(), 1);
+        mix.accumulate(2, b.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QCOMPARE(out[0], 0.7f);
+        QCOMPARE(out[1], 0.7f);
+    }
+
+    void panFullLeftSuppressesRight() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, -1.0f);  // full left
+        std::array<float, 2> in = {0.5f, 0.5f};
+        mix.accumulate(1, in.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QVERIFY(out[0] > 0.4f);
+        QVERIFY(std::abs(out[1]) < 0.0001f);
+    }
+
+    void muteZerosContribution() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, 0.0f);
+        mix.setSliceMuted(1, true);
+        std::array<float, 2> in = {0.9f, 0.9f};
+        mix.accumulate(1, in.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QCOMPARE(out[0], 0.0f);
+        QCOMPARE(out[1], 0.0f);
+    }
+
+    void unknownSliceIsIgnored() {
+        MasterMixer mix;
+        std::array<float, 2> in = {0.9f, 0.9f};
+        mix.accumulate(999, in.data(), 1);  // never registered
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QCOMPARE(out[0], 0.0f);
+        QCOMPARE(out[1], 0.0f);
+    }
+
+    void mixIntoResetsAccumulator() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, 0.0f);
+        std::array<float, 2> in = {0.5f, 0.5f};
+        mix.accumulate(1, in.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        // Second mixInto with no accumulate → silence.
+        std::array<float, 2> out2{};
+        mix.mixInto(out2.data(), 1);
+        QCOMPARE(out2[0], 0.0f);
+        QCOMPARE(out2[1], 0.0f);
+    }
+
+    void removedSliceNoLongerMixes() {
+        MasterMixer mix;
+        mix.setSliceGain(1, 1.0f, 0.0f);
+        mix.removeSlice(1);
+        std::array<float, 2> in = {0.9f, 0.9f};
+        mix.accumulate(1, in.data(), 1);
+        std::array<float, 2> out{};
+        mix.mixInto(out.data(), 1);
+        QCOMPARE(out[0], 0.0f);
+        QCOMPARE(out[1], 0.0f);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstMasterMixer)
+#include "tst_master_mixer.moc"

--- a/tests/tst_port_audio_bus.cpp
+++ b/tests/tst_port_audio_bus.cpp
@@ -1,0 +1,51 @@
+#include <QtTest/QtTest>
+#include "core/audio/PortAudioBus.h"
+#include <portaudio.h>
+
+using namespace NereusSDR;
+
+class TstPortAudioBus : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase() {
+        Pa_Initialize();
+    }
+    void cleanupTestCase() {
+        Pa_Terminate();
+    }
+
+    void constructsClosed() {
+        PortAudioBus bus;
+        QVERIFY(!bus.isOpen());
+    }
+
+    void openSucceedsOnDefaultDevice() {
+        PortAudioBus bus;
+        AudioFormat f;
+        QVERIFY2(bus.open(f), qPrintable(bus.errorString()));
+        QVERIFY(bus.isOpen());
+        bus.close();
+        QVERIFY(!bus.isOpen());
+    }
+
+    void negotiatedFormatReflectsDevice() {
+        PortAudioBus bus;
+        AudioFormat f;
+        f.sampleRate = 48000;
+        f.channels = 2;
+        bus.open(f);
+        QVERIFY(bus.negotiatedFormat().sampleRate > 0);
+        bus.close();
+    }
+
+    void backendNameIdentifiesAPI() {
+        PortAudioBus bus;
+        bus.open(AudioFormat{});
+        const QString n = bus.backendName();
+        QVERIFY(!n.isEmpty());
+        bus.close();
+    }
+};
+
+QTEST_APPLESS_MAIN(TstPortAudioBus)
+#include "tst_port_audio_bus.moc"

--- a/tests/tst_port_audio_bus.cpp
+++ b/tests/tst_port_audio_bus.cpp
@@ -58,6 +58,22 @@ private slots:
         // Host system should have at least one output; skip if headless CI.
         if (devices.isEmpty()) { QSKIP("No output devices on test host"); }
     }
+
+    void openInputSucceedsOnDefaultDevice() {
+        PortAudioBus bus;
+        PortAudioConfig cfg;
+        cfg.direction = AudioDirection::Input;
+        bus.setConfig(cfg);
+        AudioFormat f;
+        if (!bus.open(f)) {
+            QSKIP(qPrintable(QStringLiteral("No default input device: ") + bus.errorString()));
+        }
+        QVERIFY(bus.isOpen());
+        QVERIFY(bus.negotiatedFormat().sampleRate > 0);
+        QVERIFY(!bus.backendName().isEmpty());
+        bus.close();
+        QVERIFY(!bus.isOpen());
+    }
 };
 
 QTEST_APPLESS_MAIN(TstPortAudioBus)

--- a/tests/tst_port_audio_bus.cpp
+++ b/tests/tst_port_audio_bus.cpp
@@ -45,6 +45,19 @@ private slots:
         QVERIFY(!n.isEmpty());
         bus.close();
     }
+
+    void hostApisEnumerateNonEmpty() {
+        const auto apis = PortAudioBus::hostApis();
+        QVERIFY(!apis.isEmpty());
+    }
+
+    void outputDevicesEnumerateForFirstApi() {
+        const auto apis = PortAudioBus::hostApis();
+        QVERIFY(!apis.isEmpty());
+        const auto devices = PortAudioBus::outputDevicesFor(apis.first().index);
+        // Host system should have at least one output; skip if headless CI.
+        if (devices.isEmpty()) { QSKIP("No output devices on test host"); }
+    }
 };
 
 QTEST_APPLESS_MAIN(TstPortAudioBus)

--- a/tests/tst_slice_model_vax.cpp
+++ b/tests/tst_slice_model_vax.cpp
@@ -60,6 +60,14 @@ private slots:
         s.loadFromSettings();
         QCOMPARE(s.vaxChannel(), 3);
     }
+
+    void clampsCorruptValueOnLoad() {
+        AppSettings::instance().clear();
+        AppSettings::instance().setValue("slice/7/VaxChannel", "99");
+        SliceModel s(7);
+        s.loadFromSettings();
+        QCOMPARE(s.vaxChannel(), 0);
+    }
 };
 
 QTEST_APPLESS_MAIN(TstSliceModelVax)

--- a/tests/tst_slice_model_vax.cpp
+++ b/tests/tst_slice_model_vax.cpp
@@ -50,12 +50,12 @@ private slots:
         AppSettings::instance().clear();
         SliceModel s(7);
         s.setVaxChannel(4);
-        QCOMPARE(AppSettings::instance().value("slice/7/VaxChannel").toString(), "4");
+        QCOMPARE(AppSettings::instance().value("Slice7/VaxChannel").toString(), "4");
     }
 
     void restoresFromSettings() {
         AppSettings::instance().clear();
-        AppSettings::instance().setValue("slice/7/VaxChannel", "3");
+        AppSettings::instance().setValue("Slice7/VaxChannel", "3");
         SliceModel s(7);
         s.loadFromSettings();
         QCOMPARE(s.vaxChannel(), 3);
@@ -63,7 +63,7 @@ private slots:
 
     void clampsCorruptValueOnLoad() {
         AppSettings::instance().clear();
-        AppSettings::instance().setValue("slice/7/VaxChannel", "99");
+        AppSettings::instance().setValue("Slice7/VaxChannel", "99");
         SliceModel s(7);
         s.loadFromSettings();
         QCOMPARE(s.vaxChannel(), 0);

--- a/tests/tst_slice_model_vax.cpp
+++ b/tests/tst_slice_model_vax.cpp
@@ -1,0 +1,66 @@
+#include <QtTest/QtTest>
+#include "models/SliceModel.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstSliceModelVax : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultsToOff() {
+        SliceModel s(0);
+        QCOMPARE(s.vaxChannel(), 0);
+    }
+
+    void setAndGet() {
+        SliceModel s(0);
+        s.setVaxChannel(2);
+        QCOMPARE(s.vaxChannel(), 2);
+    }
+
+    void clampsOutOfRangeLow() {
+        SliceModel s(0);
+        s.setVaxChannel(-5);
+        QCOMPARE(s.vaxChannel(), 0);
+    }
+
+    void clampsOutOfRangeHigh() {
+        SliceModel s(0);
+        s.setVaxChannel(99);
+        QCOMPARE(s.vaxChannel(), 0);
+    }
+
+    void emitsSignalOnChange() {
+        SliceModel s(0);
+        QSignalSpy spy(&s, &SliceModel::vaxChannelChanged);
+        s.setVaxChannel(3);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toInt(), 3);
+    }
+
+    void noSignalOnSameValue() {
+        SliceModel s(0);
+        s.setVaxChannel(2);
+        QSignalSpy spy(&s, &SliceModel::vaxChannelChanged);
+        s.setVaxChannel(2);
+        QCOMPARE(spy.count(), 0);
+    }
+
+    void persistsToSettings() {
+        AppSettings::instance().clear();
+        SliceModel s(7);
+        s.setVaxChannel(4);
+        QCOMPARE(AppSettings::instance().value("slice/7/VaxChannel").toString(), "4");
+    }
+
+    void restoresFromSettings() {
+        AppSettings::instance().clear();
+        AppSettings::instance().setValue("slice/7/VaxChannel", "3");
+        SliceModel s(7);
+        s.loadFromSettings();
+        QCOMPARE(s.vaxChannel(), 3);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstSliceModelVax)
+#include "tst_slice_model_vax.moc"

--- a/tests/tst_transmit_model_tx_owner.cpp
+++ b/tests/tst_transmit_model_tx_owner.cpp
@@ -55,6 +55,14 @@ private slots:
         t.loadFromSettings();
         QCOMPARE(t.txOwnerSlot(), VaxSlot::MicDirect);
     }
+
+    void vaxSlotRoundTrip() {
+        for (const auto slot : {VaxSlot::None, VaxSlot::MicDirect,
+                                VaxSlot::Vax1, VaxSlot::Vax2,
+                                VaxSlot::Vax3, VaxSlot::Vax4}) {
+            QCOMPARE(vaxSlotFromString(vaxSlotToString(slot)), slot);
+        }
+    }
 };
 
 QTEST_APPLESS_MAIN(TstTransmitModelTxOwner)

--- a/tests/tst_transmit_model_tx_owner.cpp
+++ b/tests/tst_transmit_model_tx_owner.cpp
@@ -1,0 +1,61 @@
+#include <QtTest/QtTest>
+#include "models/TransmitModel.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstTransmitModelTxOwner : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultsToMicDirect() {
+        TransmitModel t;
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::MicDirect);
+    }
+
+    void setAndGet() {
+        TransmitModel t;
+        t.setTxOwnerSlot(VaxSlot::Vax2);
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::Vax2);
+    }
+
+    void emitsSignalOnChange() {
+        TransmitModel t;
+        QSignalSpy spy(&t, &TransmitModel::txOwnerSlotChanged);
+        t.setTxOwnerSlot(VaxSlot::Vax3);
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void noSignalOnSameValue() {
+        TransmitModel t;
+        t.setTxOwnerSlot(VaxSlot::Vax1);
+        QSignalSpy spy(&t, &TransmitModel::txOwnerSlotChanged);
+        t.setTxOwnerSlot(VaxSlot::Vax1);
+        QCOMPARE(spy.count(), 0);
+    }
+
+    void persistsToSettings() {
+        AppSettings::instance().clear();
+        TransmitModel t;
+        t.setTxOwnerSlot(VaxSlot::Vax4);
+        QCOMPARE(AppSettings::instance().value("tx/OwnerSlot").toString(), "Vax4");
+    }
+
+    void restoresFromSettings() {
+        AppSettings::instance().clear();
+        AppSettings::instance().setValue("tx/OwnerSlot", "Vax1");
+        TransmitModel t;
+        t.loadFromSettings();
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::Vax1);
+    }
+
+    void unknownStringFallsBackToMicDirect() {
+        AppSettings::instance().clear();
+        AppSettings::instance().setValue("tx/OwnerSlot", "Bogus");
+        TransmitModel t;
+        t.loadFromSettings();
+        QCOMPARE(t.txOwnerSlot(), VaxSlot::MicDirect);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstTransmitModelTxOwner)
+#include "tst_transmit_model_tx_owner.moc"


### PR DESCRIPTION
## Summary

Phase 3O audio foundation — data model through AudioEngine refactor. Live RX audio
now flows through the new IAudioBus/PortAudioBus path with MasterMixer-based per-slice
routing. Smoke-tested on ANAN-G2 with WWV 10.000 MHz AM: audible and clean.

Remaining Phase 3O work (macOS HAL plugin, Linux Pulse bridge, Windows
VirtualCableDetector, VAX UI, Setup→Audio page, first-run dialog, help docs) ships
in subsequent PRs.

Design spec: \`docs/architecture/2026-04-19-vax-design.md\`
Implementation plan: \`docs/architecture/2026-04-19-phase3o-vax-plan.md\`

## What's in this PR

**Sub-Phase 1 — Data Model Foundation**
- \`SliceModel.vaxChannel\` (0=Off, 1..4=VAX) with \`std::atomic<int>\` storage,
  \`vaxChannelChanged\` signal, \`Slice<N>/VaxChannel\` persistence, clamp on load.
- \`TransmitModel.txOwnerSlot\` + \`VaxSlot\` enum (None / MicDirect / Vax1..4) with
  atomic storage, string round-trip helpers, \`tx/OwnerSlot\` persistence.
- \`AppSettings::migrateVaxSchemaV1ToV2()\` idempotent one-shot migration; hooked into
  \`main.cpp\` before any other AppSettings reads.

**Sub-Phase 2 — IAudioBus + MasterMixer**
- \`IAudioBus\` abstract interface + \`AudioFormat\` value type.
- \`MasterMixer\` — per-slice mute/volume/pan accumulator with lock-free audio-thread
  reads, unity-at-centre linear pan law, per-block flush.

**Sub-Phase 3 — PortAudio Engine**
- Vendored PortAudio v19.7.0 via FetchContent; include path PUBLIC on
  \`NereusSDRObjs\` so test TUs reach it.
- \`PortAudioBus\` implementing \`IAudioBus\` for both Output (render) and Input
  (TX capture) modes, SPSC lock-free ring, atomic RX/TX level metering.
- Static \`hostApis()\` / \`outputDevicesFor()\` / \`inputDevicesFor()\` enumeration
  helpers. Require \`Pa_Initialize()\` — owned by \`AudioEngine\` in Sub-Phase 4.

**Sub-Phase 4 — AudioEngine Refactor**
- \`AudioEngine\` now owns \`unique_ptr<IAudioBus>\` endpoints:
  \`m_speakersBus\`, \`m_txInputBus\`, \`m_vaxBus[0..3]\`, plus \`MasterMixer\`.
- New \`rxBlockReady(sliceId, interleaved, frames)\` entry point replaces
  \`feedAudio\`. Synchronous flush on the DSP thread via \`thread_local\` scratch →
  \`m_speakersBus->push()\` through PortAudio's SPSC ring. No QTimer, no
  QAudioSink, no mutex, no m_rxBuffer.
- \`NereusSDR::AudioDeviceConfig\` — minimal backend-agnostic config struct
  (fuller schema lands in Sub-Phase 8).
- \`RxDspWorker\` interleaves WDSP dual-mono output into a member buffer and
  calls \`rxBlockReady(0, …)\`.
- \`Pa_Initialize\` / \`Pa_Terminate\` owned by \`AudioEngine\` ctor/dtor with
  success guard so headless/test contexts degrade to no-op.
- \`MasterMixer::mixInto\` always drains the accumulator to prevent stale-tail
  leak if block size shrinks between calls.
- VAX tap is pre-mixer raw demodulated audio per spec §3.4 (Thetis VAC parity).
- Live-reconfig contract for \`setSpeakersConfig\` / \`setTxInputConfig\` /
  \`setVaxConfig\` / \`setVaxEnabled\` documented at the header: caller must ensure
  \`!isRunning()\` or a quiesced DSP thread; live device switching lands in
  Sub-Phase 8 (Setup → Audio → Devices).

## What's NOT in this PR

- Sub-Phases 5–14: macOS HAL plugin + installer, Linux Pulse bridge, Windows
  VirtualCableDetector, VFO-flag VAX selector, VaxApplet, MasterOutputWidget,
  VaxFirstRunDialog, Setup → Audio page, help docs, E2E verification matrix.
- Direct ASIO engine — dropped from Phase 3O scope during pre-execution GPL-3
  compliance review. See spec §8.5 and plan's GPL Compliance Review.
- Setup → Audio → Devices UI, per-slice audio volume property,
  \`setAudioMuted\`/\`audioMuted\` SliceModel renaming. All Sub-Phase 8/9.

## Attribution

No new Thetis or AetherSDR ports. All four sub-phases are NereusSDR-original.
Existing port-citation headers on \`AudioEngine.{h,cpp}\` and \`RxDspWorker.{h,cpp}\`
preserved; Sub-Phase 4 modification-history line appended to the \`AudioEngine\`
stanza. \`scripts/check-new-ports.py\` green against the full PR diff. First
AetherSDR ports in Phase 3O (HAL plugin, CoreAudioHalBus, LinuxPipeBus, VaxApplet,
MeterSlider) land in Sub-Phases 5–9 in subsequent PRs.

## Test plan

- [x] \`tst_slice_model_vax\` — 11/11 pass
- [x] \`tst_transmit_model_tx_owner\` — 8/8 pass
- [x] \`tst_app_settings_vax_migration\` — 5/5 pass
- [x] \`tst_master_mixer\` — 8/8 pass
- [x] \`tst_port_audio_bus\` — pass
- [x] Full suite: 50/54 pass, same 4 pre-existing failures as \`main\`
  (tst_container_persistence, tst_p1_loopback_connection,
  tst_hardware_page_capability_gating, tst_about_dialog). Zero new failures.
- [x] All pre-commit hooks green: \`verify-thetis-headers\`, \`check-new-ports\`,
  \`verify-inline-cites\`, \`compliance-inventory\`.
- [x] All commits GPG-signed.
- [x] Hardware smoke test: ANAN-G2 connected, WWV 10.000 MHz AM audible through
  system default output. Live RX audio confirmed.

J.J. Boyd ~ KG4VCF