### PR TITLE
Phase 3O sub-phase 5: macOS CoreAudio HAL plugin + installer + app-side shm bus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,58 @@ jobs:
           codesign --force --deep --sign - build/NereusSDR.app
           codesign --verify --verbose=2 build/NereusSDR.app
 
+      # ── Sub-Phase 5 Task 5.4: HAL plugin build + sign + .pkg + notarize ──
+      # The HAL plugin build and the .pkg build via hal-installer.sh run
+      # unconditionally so alpha / dev release cuts without Apple certs
+      # still produce a working (unsigned) .pkg artifact. The Developer ID
+      # sign, notarize, and staple steps are gated on APPLE_DEVELOPER_ID
+      # being populated.
+      #
+      # Known limitations (tracked for a Sub-Phase 5.5 follow-up):
+      #   * The main app currently gets ad-hoc codesign above, not
+      #     Developer ID. Apple's notarytool requires every component
+      #     inside a submitted .pkg to carry a Developer ID signature,
+      #     so notarization will reject the .pkg until the app's
+      #     codesign step is upgraded to Developer ID when secrets are
+      #     present.
+      #   * The .pkg itself is produced by productbuild without --sign.
+      #     A Developer ID Installer certificate and an extra productsign
+      #     step (or an env-var threading through hal-installer.sh) will
+      #     be needed before notarization can succeed end-to-end.
+      # Until both are addressed, the Notarize step is expected to fail
+      # on real submissions; the Sign HAL plugin / Build signed .pkg
+      # steps do their job standalone and the .pkg upload still lands.
+      - name: Build HAL plugin
+        run: |
+          cmake -B build-hal -S hal-plugin -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          cmake --build build-hal
+
+      - name: Sign HAL plugin
+        if: ${{ secrets.APPLE_DEVELOPER_ID != '' }}
+        run: |
+          codesign --force --options runtime --timestamp \
+            --sign "Developer ID Application: ${{ secrets.APPLE_DEVELOPER_ID }}" \
+            build-hal/NereusSDRVAX.driver
+
+      - name: Build signed .pkg
+        run: bash packaging/macos/hal-installer.sh
+
+      - name: Notarize
+        if: ${{ secrets.APPLE_DEVELOPER_ID != '' }}
+        run: |
+          xcrun notarytool submit \
+            build/NereusSDR-${{ needs.prepare.outputs.version }}-macOS.pkg \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --password "${{ secrets.APPLE_APP_PASSWORD }}" \
+            --wait
+
+      - name: Staple
+        if: ${{ secrets.APPLE_DEVELOPER_ID != '' }}
+        run: |
+          xcrun stapler staple \
+            build/NereusSDR-${{ needs.prepare.outputs.version }}-macOS.pkg
+
       - name: Create DMG
         run: |
           create-dmg \
@@ -321,6 +373,13 @@ jobs:
             "build/NereusSDR.app" \
           || true
           ls -la NereusSDR-*.dmg
+
+      - name: Upload .pkg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-hal-pkg-${{ matrix.arch }}
+          path: build/NereusSDR-*.pkg
+          retention-days: 7
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,7 +340,7 @@ jobs:
             --sign "Developer ID Application: ${{ secrets.APPLE_DEVELOPER_ID }}" \
             build-hal/NereusSDRVAX.driver
 
-      - name: Build signed .pkg
+      - name: Build .pkg
         run: bash packaging/macos/hal-installer.sh
 
       - name: Notarize
@@ -374,6 +374,17 @@ jobs:
           || true
           ls -la NereusSDR-*.dmg
 
+      # NOTE: The .pkg is uploaded as a workflow artifact only — NOT attached
+      # to the GitHub Release. Release attachment is deferred until the two
+      # cascading items land:
+      #   1. Main app codesign upgraded from ad-hoc to Developer ID (required
+      #      for notarization to accept the .pkg).
+      #   2. hal-installer.sh wired for productbuild --sign via
+      #      Developer ID Installer certificate.
+      # Until both are in place, the .pkg is a build-verification artifact
+      # for local smoke-testing, not a distributable installer. The
+      # sign-and-publish job at the bottom of this workflow intentionally
+      # excludes *.pkg from its find glob.
       - name: Upload .pkg artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,8 +326,8 @@ jobs:
       #     step (or an env-var threading through hal-installer.sh) will
       #     be needed before notarization can succeed end-to-end.
       # Until both are addressed, the Notarize step is expected to fail
-      # on real submissions; the Sign HAL plugin / Build signed .pkg
-      # steps do their job standalone and the .pkg upload still lands.
+      # on real submissions; the Sign HAL plugin / Build .pkg steps do
+      # their job standalone and the .pkg upload still lands.
       - name: Build HAL plugin
         run: |
           cmake -B build-hal -S hal-plugin -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,3 +657,19 @@ if(NEREUS_BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
 endif()
+
+# --------------------------------------------------------------------------
+# macOS HAL Audio Server Plug-In (Phase 3O VAX — Sub-Phase 5)
+#
+# Builds NereusSDRVAX.driver, a standalone CoreAudio HAL plugin that
+# exposes 4 virtual RX devices ("NereusSDR VAX 1..4") plus 1 TX device
+# ("NereusSDR TX"). Off by default because the plugin pulls libASPL via
+# FetchContent and its preferred build is a separate cmake tree
+# (`cmake -B build-hal -S hal-plugin`) — see docs/architecture/
+# 2026-04-19-vax-design.md §8.1. Enable here only when you want the
+# driver target wired into the main configure for IDE integration.
+# --------------------------------------------------------------------------
+option(NEREUSSDR_BUILD_HAL_PLUGIN "Build macOS CoreAudio HAL Audio Server plug-in" OFF)
+if(APPLE AND NEREUSSDR_BUILD_HAL_PLUGIN)
+    add_subdirectory(hal-plugin)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,14 @@ set(CORE_SOURCES
     src/core/audio/PortAudioBus.cpp
 )
 
+# CoreAudioHalBus — macOS-only IAudioBus implementation bridging to the
+# NereusSDRVAX HAL plugin via POSIX shared memory. The header is
+# cross-platform-safe (falls through to error stubs off macOS) but the .cpp
+# pulls in <sys/mman.h> / shm_open, so only compile it on Apple targets.
+if(APPLE)
+    list(APPEND CORE_SOURCES src/core/audio/CoreAudioHalBus.cpp)
+endif()
+
 set(MODEL_SOURCES
     src/models/RadioModel.cpp
     src/models/RxDspWorker.cpp

--- a/docs/attribution/aethersdr-contributor-index.md
+++ b/docs/attribution/aethersdr-contributor-index.md
@@ -231,7 +231,10 @@ per-file NereusSDR-side diff).
 | `src/core/ShortcutManager.{h,cpp}` | (none yet) | Keyboard shortcuts. |
 | `src/core/SupportBundle.{h,cpp}` | (none yet — pending 3G-14) | Diagnostic bundle. |
 | `src/core/BandStackSettings.{h,cpp}` | (none direct — NereusSDR has PanadapterModel per-band grid) | |
-| `src/core/PipeWireAudioBridge.{h,cpp}` / `VirtualAudioBridge.{h,cpp}` | (none) | Linux virtual-audio bridging (DAX). |
+| `src/core/PipeWireAudioBridge.{h,cpp}` | (none) | Linux virtual-audio bridging (DAX). |
+| `src/core/VirtualAudioBridge.{h,cpp}` | `src/core/audio/CoreAudioHalBus.{h,cpp}` | macOS CoreAudio HAL bridge. NereusSDR decomposes the monolithic 4-RX + 1-TX bridge into per-endpoint `IAudioBus` instances (Role enum for Vax1..4 / TxInput), drops the QObject/signals layer in favour of atomic metering, defers the silence-fill + TX poll timers to Phase 3M, rebrands shm paths `/aethersdr-dax-*` → `/nereussdr-vax-*`, and lifts the native rate 24 kHz → 48 kHz per spec §8.1. Added Sub-Phase 5 Task 5.3. |
+| `hal-plugin/AetherSDRDAX.cpp` | `hal-plugin/NereusSDRVAX.cpp` | macOS Core Audio HAL Audio Server Plug-In (libASPL-based). NereusSDR rebrands DAX → VAX: device UIDs `com.aethersdr.dax.*` → `com.nereussdr.vax.*`, shm paths `/aethersdr-dax-*` → `/nereussdr-vax-*`, device names `AetherSDR DAX N` → `NereusSDR VAX N`, factory UUID regenerated. Same 48 kHz stereo float32 format. Added Sub-Phase 5 Task 5.1. |
+| `hal-plugin/CMakeLists.txt` / `hal-plugin/Info.plist` | `hal-plugin/CMakeLists.txt` / `hal-plugin/Info.plist` | HAL plugin build + bundle descriptor. Structural templates only — NereusSDR rewrites bundle IDs, display names, and FetchContent pins while keeping the libASPL build shape. |
 | `src/core/PropForecastClient.{h,cpp}` | (none) | hamqsl.com HF forecast. |
 | `src/core/MacMicPermission.{h,mm}` | (none) | macOS TCC mic consent. |
 | `src/core/VersionNumber.h` | (none) | Small version-compare helper. |

--- a/docs/attribution/aethersdr-reconciliation.md
+++ b/docs/attribution/aethersdr-reconciliation.md
@@ -14,7 +14,7 @@ the AetherSDR clone at `/Users/j.j.boyd/AetherSDR/`.
 
 | Bucket | Meaning | Count | 25c action |
 |---|---|---:|---|
-| **A** | Genuine AetherSDR derivation — add project-level attribution | 45 | Insert AetherSDR copyright line + specify source file(s) in mod-history |
+| **A** | Genuine AetherSDR derivation — add project-level attribution | 47 | Insert AetherSDR copyright line + specify source file(s) in mod-history |
 | **B** | False citation (boilerplate "Structural template follows AetherSDR" with no real counterpart) — remove line | 126 | Delete the two "Structural template follows AetherSDR (ten9876/AetherSDR) Qt6 conventions." lines from Modification-History |
 | **C** | Mixed lineage — keep both citations, tighten wording | 12 | Keep Thetis block + AetherSDR line, but say what came from where |
 | **D** | Uncertain — human review | 5 | Flag for human judgement; do not auto-edit |
@@ -64,7 +64,7 @@ claim), or when 25a couldn't positively disprove the claim.
 
 ---
 
-## Bucket A — Genuine AetherSDR derivations (45 files)
+## Bucket A — Genuine AetherSDR derivations (47 files)
 
 25c action for every file below:
 1. Add a project-level attribution line to the Copyright block (after
@@ -148,6 +148,17 @@ claim), or when 25a couldn't positively disprove the claim.
 | `src/gui/StyleConstants.h` | `src/gui/ComboStyle.h` / `HGauge.h` / `SliceColors.h` / misc inline palette | Line 7 "Core Theme (from AetherSDR source + STYLEGUIDE.md)". | "Theme palette imported from AetherSDR `src/gui/ComboStyle.h` / `HGauge.h` / `SliceColors.h` and inline QColor calls in `MainWindow.cpp` / `VfoWidget.cpp`." |
 | `src/core/AudioEngine.h` | `src/core/AudioEngine.{h,cpp}` | Line 23 "Pattern from AetherSDR AudioEngine:" (four specific bullets on feedAudio/drain/Int16 format/buffer cap). Line 73 "Buffer + timer drain pattern (from AetherSDR)". | "QAudioSink feed-and-drain pattern ported from AetherSDR `src/core/AudioEngine.{h,cpp}` (48 kHz Int16 stereo, 10 ms timer drain, 200 ms buffer cap)." |
 | `src/core/AudioEngine.cpp` | Same | Lines 14, 24, 91, 274 inline "From AetherSDR AudioEngine::makeFormat()", "RX timer pattern", "on Windows, don't trust isFormatSupported()". | Same. |
+
+### Phase 3O VAX — CoreAudio HAL bridge
+
+Added 2026-04-19 (Sub-Phase 5 Task 5.3). Both files carry a NereusSDR
+port-citation header (HOW-TO-PORT.md rule 6 form — AetherSDR has no
+per-file GPL header to copy verbatim) naming the upstream source file.
+
+| NereusSDR file | AetherSDR counterpart | Evidence | Specific mod-history wording |
+|---|---|---|---|
+| `src/core/audio/CoreAudioHalBus.h` | `src/core/VirtualAudioBridge.h` | Port-citation header lines 5-6 name `src/core/VirtualAudioBridge.h`. Modification-history lines 18-27 record the decomposition (monolithic → per-endpoint Role), QObject drop, silence-fill/TX-poll-timer deferral, shm-path rebrand, and 24 kHz → 48 kHz rate bump. | "Ported from AetherSDR `src/core/VirtualAudioBridge.{h,cpp}` with the monolithic 4-RX + 1-TX bridge decomposed into per-endpoint IAudioBus instances (Role enum for Vax1..4 / TxInput). QObject/signals dropped in favour of atomic metering; silence-fill and TX-poll timers deferred to Phase 3M. Shm paths rebranded /aethersdr-dax-\* → /nereussdr-vax-\*; native rate lifted 24 kHz → 48 kHz per spec §8.1." |
+| `src/core/audio/CoreAudioHalBus.cpp` | `src/core/VirtualAudioBridge.cpp` | Same header + TX drain loop (`pull()`) is a line-for-line port of `VirtualAudioBridge::readTxAudio` (acquire loads, writer-lapped skip, MAX/TARGET backlog guards, strided RMS meter). | Same. |
 
 ### Setup shared-style
 

--- a/docs/attribution/aethersdr-reconciliation.md
+++ b/docs/attribution/aethersdr-reconciliation.md
@@ -14,7 +14,7 @@ the AetherSDR clone at `/Users/j.j.boyd/AetherSDR/`.
 
 | Bucket | Meaning | Count | 25c action |
 |---|---|---:|---|
-| **A** | Genuine AetherSDR derivation — add project-level attribution | 47 | Insert AetherSDR copyright line + specify source file(s) in mod-history |
+| **A** | Genuine AetherSDR derivation — add project-level attribution | 48 | Insert AetherSDR copyright line + specify source file(s) in mod-history |
 | **B** | False citation (boilerplate "Structural template follows AetherSDR" with no real counterpart) — remove line | 126 | Delete the two "Structural template follows AetherSDR (ten9876/AetherSDR) Qt6 conventions." lines from Modification-History |
 | **C** | Mixed lineage — keep both citations, tighten wording | 12 | Keep Thetis block + AetherSDR line, but say what came from where |
 | **D** | Uncertain — human review | 5 | Flag for human judgement; do not auto-edit |
@@ -64,7 +64,7 @@ claim), or when 25a couldn't positively disprove the claim.
 
 ---
 
-## Bucket A — Genuine AetherSDR derivations (47 files)
+## Bucket A — Genuine AetherSDR derivations (48 files)
 
 25c action for every file below:
 1. Add a project-level attribution line to the Copyright block (after
@@ -151,14 +151,27 @@ claim), or when 25a couldn't positively disprove the claim.
 
 ### Phase 3O VAX — CoreAudio HAL bridge
 
-Added 2026-04-19 (Sub-Phase 5 Task 5.3). Both files carry a NereusSDR
-port-citation header (HOW-TO-PORT.md rule 6 form — AetherSDR has no
-per-file GPL header to copy verbatim) naming the upstream source file.
+Added 2026-04-19 (Sub-Phase 5 Tasks 5.1 / 5.3 / 5.4). All three files
+carry a NereusSDR port-citation header (HOW-TO-PORT.md rule 6 form —
+AetherSDR has no per-file GPL header to copy verbatim) naming the
+upstream source file.
 
 | NereusSDR file | AetherSDR counterpart | Evidence | Specific mod-history wording |
 |---|---|---|---|
 | `src/core/audio/CoreAudioHalBus.h` | `src/core/VirtualAudioBridge.h` | Port-citation header lines 5-6 name `src/core/VirtualAudioBridge.h`. Modification-history lines 18-27 record the decomposition (monolithic → per-endpoint Role), QObject drop, silence-fill/TX-poll-timer deferral, shm-path rebrand, and 24 kHz → 48 kHz rate bump. | "Ported from AetherSDR `src/core/VirtualAudioBridge.{h,cpp}` with the monolithic 4-RX + 1-TX bridge decomposed into per-endpoint IAudioBus instances (Role enum for Vax1..4 / TxInput). QObject/signals dropped in favour of atomic metering; silence-fill and TX-poll timers deferred to Phase 3M. Shm paths rebranded /aethersdr-dax-\* → /nereussdr-vax-\*; native rate lifted 24 kHz → 48 kHz per spec §8.1." |
 | `src/core/audio/CoreAudioHalBus.cpp` | `src/core/VirtualAudioBridge.cpp` | Same header + TX drain loop (`pull()`) is a line-for-line port of `VirtualAudioBridge::readTxAudio` (acquire loads, writer-lapped skip, MAX/TARGET backlog guards, strided RMS meter). | Same. |
+| `hal-plugin/NereusSDRVAX.cpp` | `hal-plugin/AetherSDRDAX.cpp` | Port-citation header lines 5-6 name `hal-plugin/AetherSDRDAX.cpp`. Modification-history lines 15-22 record the DAX → VAX rebrand: device UIDs `com.aethersdr.dax.*` → `com.nereussdr.vax.*`, shm paths `/aethersdr-dax-*` → `/nereussdr-vax-*`, device names `AetherSDR DAX N` → `NereusSDR VAX N`, factory UUID regenerated. 48 kHz stereo float32 format preserved. Shared-memory layout block (lines 57–) mirrored byte-for-byte against `src/core/audio/CoreAudioHalBus.h`. | "Ported from AetherSDR `hal-plugin/AetherSDRDAX.cpp` — libASPL-based Core Audio HAL Audio Server Plug-In creating 4 virtual RX outputs + 1 virtual TX input. DAX → VAX rebrand across device UIDs, shm paths, device names, and factory UUID; wire format (48 kHz stereo float32) and ring-buffer layout preserved." |
+
+> **Classification note (Task 5.4):** `hal-plugin/NereusSDRVAX.cpp` is
+> registered here for provenance completeness, but
+> `scripts/compliance-inventory.py::_aethersdr_bucket_a_paths` currently
+> filters Bucket-A paths to those starting with `src/` or `tests/` (see
+> script line 87). The hal-plugin path therefore still classifies as
+> `nereussdr-original` in the inventory output. Widening that prefix
+> filter is a one-line script change deferred out of Task 5.4's "CI +
+> docs only" scope. The file carries the full AetherSDR-port header
+> block regardless, so the `--fail-on-unclassified` gate passes
+> cleanly either way.
 
 ### Setup shared-style
 

--- a/hal-plugin/CMakeLists.txt
+++ b/hal-plugin/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.20)
+project(NereusSDRVAX LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Fetch libASPL
+include(FetchContent)
+FetchContent_Declare(libASPL
+    GIT_REPOSITORY https://github.com/gavv/libASPL.git
+    GIT_TAG        v3.1.2
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(libASPL)
+
+# Build the plugin as a loadable bundle (.driver)
+add_library(NereusSDRVAX MODULE NereusSDRVAX.cpp)
+target_link_libraries(NereusSDRVAX PRIVATE libASPL)
+
+# NOTE: AetherSDR's hal-plugin/CMakeLists.txt added
+# `target_include_directories(... PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)`
+# so the plugin could pull in a shared shm-layout header from its main tree.
+# NereusSDR keeps the plugin self-contained: VaxShmBlock is defined inline in
+# NereusSDRVAX.cpp. Sub-Phase 5.3's CoreAudioHalBus must agree on the same
+# struct layout but shares no header with the plugin.
+
+set_target_properties(NereusSDRVAX PROPERTIES
+    BUNDLE TRUE
+    BUNDLE_EXTENSION "driver"
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist"
+    # Don't add lib prefix
+    PREFIX ""
+)
+
+# Install to the HAL plug-in directory (requires sudo)
+install(TARGETS NereusSDRVAX
+    DESTINATION "/Library/Audio/Plug-Ins/HAL"
+)

--- a/hal-plugin/CMakeLists.txt
+++ b/hal-plugin/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 project(NereusSDRVAX LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+# NereusSDR project-wide C++20 policy (CLAUDE.md); keep the HAL plugin aligned.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Fetch libASPL

--- a/hal-plugin/Info.plist
+++ b/hal-plugin/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>NereusSDRVAX</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.nereussdr.vax</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>NereusSDR VAX</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>AudioServerPlugIn_BundleResourceID</key>
+    <string>com.nereussdr.vax</string>
+    <key>CFPlugInFactories</key>
+    <dict>
+        <key>F58308D0-1ABD-4D44-845B-F308A64CDA16</key>
+        <string>NereusSDRVAX_Create</string>
+    </dict>
+    <key>CFPlugInTypes</key>
+    <dict>
+        <key>443ABAB8-E7B3-491A-B985-BEB9187030DB</key>
+        <array>
+            <string>F58308D0-1ABD-4D44-845B-F308A64CDA16</string>
+        </array>
+    </dict>
+</dict>
+</plist>

--- a/hal-plugin/NereusSDRVAX.cpp
+++ b/hal-plugin/NereusSDRVAX.cpp
@@ -1,0 +1,352 @@
+// =================================================================
+// hal-plugin/NereusSDRVAX.cpp  (NereusSDR)
+// =================================================================
+//
+// Ported from AetherSDR source:
+//   hal-plugin/AetherSDRDAX.cpp
+//
+// AetherSDR is licensed under the GNU General Public License v3; see
+// https://github.com/ten9876/AetherSDR for the contributor list and
+// project-level LICENSE. NereusSDR is also GPLv3. AetherSDR source
+// files carry no per-file GPL header; attribution is at project level
+// per AetherSDR convention.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-19 — Ported/adapted in C++20 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via
+//                 Anthropic Claude Code. Rebranded DAX → VAX: device
+//                 UIDs com.aethersdr.dax.* → com.nereussdr.vax.*, shm
+//                 paths /aethersdr-dax-* → /nereussdr-vax-*, device
+//                 names "AetherSDR DAX N" → "NereusSDR VAX N", factory
+//                 UUID regenerated.
+// =================================================================
+
+// NereusSDR VAX — Core Audio HAL Audio Server Plug-In
+//
+// Creates 4 virtual audio output devices ("NereusSDR VAX 1" through "NereusSDR VAX 4")
+// for receiving VAX audio from the radio, plus 1 virtual input device ("NereusSDR TX")
+// for sending TX audio to the radio.
+//
+// Each device reads/writes PCM audio via a POSIX shared memory ring buffer shared
+// with NereusSDR's VirtualAudioBridge.
+//
+// Format: stereo float32, 48 kHz. NereusSDR uses 48 kHz (not AetherSDR's 24 kHz)
+// to align with Thetis DSP rate conventions.
+
+#include <aspl/Driver.hpp>
+#include <aspl/DriverRequestHandler.hpp>
+#include <aspl/Plugin.hpp>
+#include <aspl/Device.hpp>
+#include <aspl/Stream.hpp>
+#include <aspl/Context.hpp>
+#include <aspl/Tracer.hpp>
+
+#include <vector>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <cmath>
+
+// ── Shared memory layout — must match VirtualAudioBridge.h ──────────────────
+
+struct VaxShmBlock {
+    std::atomic<uint32_t> writePos;
+    std::atomic<uint32_t> readPos;
+    uint32_t sampleRate;
+    uint32_t channels;
+    uint32_t active;
+    uint32_t reserved[3];
+    static constexpr uint32_t RING_SIZE = 48000 * 2 * 2;  // ~2 sec @ 48kHz stereo
+    float ringBuffer[RING_SIZE];
+};
+
+// ── VAX RX Handler: reads from shared memory → output to apps ───────────────
+
+class VaxRxHandler : public aspl::IORequestHandler {
+public:
+    explicit VaxRxHandler(int channel)
+        : m_channel(channel)
+    {}
+
+    ~VaxRxHandler() override
+    {
+        unmapShm();
+    }
+
+    void OnReadClientInput(const std::shared_ptr<aspl::Client>& client,
+                           const std::shared_ptr<aspl::Stream>& stream,
+                           Float64 zeroTimestamp,
+                           Float64 timestamp,
+                           void* bytes,
+                           UInt32 bytesCount) override
+    {
+        auto* dst = static_cast<float*>(bytes);
+        const UInt32 totalSamples = bytesCount / sizeof(float);
+
+        if (!ensureShm()) {
+            std::memset(dst, 0, bytesCount);
+            return;
+        }
+
+        auto* block = m_shmBlock;
+        if (!block->active) {
+            std::memset(dst, 0, bytesCount);
+            return;
+        }
+
+        uint32_t rp = block->readPos.load(std::memory_order_acquire);
+        uint32_t wp = block->writePos.load(std::memory_order_acquire);
+
+        uint32_t available = wp - rp;
+        uint32_t toRead = std::min(available, totalSamples);
+
+        for (uint32_t i = 0; i < toRead; ++i) {
+            dst[i] = block->ringBuffer[rp % VaxShmBlock::RING_SIZE];
+            ++rp;
+        }
+
+        if (toRead < totalSamples) {
+            std::memset(dst + toRead, 0, (totalSamples - toRead) * sizeof(float));
+        }
+
+        block->readPos.store(rp, std::memory_order_release);
+    }
+
+private:
+    bool ensureShm()
+    {
+        if (m_shmBlock) return true;
+
+        // Retry periodically — NereusSDR may not have created the segment yet.
+        auto now = std::chrono::steady_clock::now();
+        if (now - m_lastRetry < std::chrono::seconds(1)) return false;
+        m_lastRetry = now;
+
+        char name[64];
+        snprintf(name, sizeof(name), "/nereussdr-vax-%d", m_channel);
+
+        int fd = shm_open(name, O_RDWR, 0666);
+        if (fd < 0) return false;
+
+        void* ptr = mmap(nullptr, sizeof(VaxShmBlock), PROT_READ | PROT_WRITE,
+                         MAP_SHARED, fd, 0);
+        ::close(fd);
+
+        if (ptr == MAP_FAILED) return false;
+
+        m_shmBlock = static_cast<VaxShmBlock*>(ptr);
+        return true;
+    }
+
+    void unmapShm()
+    {
+        if (m_shmBlock) {
+            munmap(m_shmBlock, sizeof(VaxShmBlock));
+            m_shmBlock = nullptr;
+        }
+    }
+
+    int m_channel{1};
+    VaxShmBlock* m_shmBlock{nullptr};
+    std::chrono::steady_clock::time_point m_lastRetry{};
+};
+
+// ── VAX TX Handler: receives audio from apps → writes to shared memory ──────
+
+class VaxTxHandler : public aspl::IORequestHandler {
+public:
+    VaxTxHandler() = default;
+
+    ~VaxTxHandler() override
+    {
+        unmapShm();
+    }
+
+    void OnWriteMixedOutput(const std::shared_ptr<aspl::Stream>& stream,
+                            Float64 zeroTimestamp,
+                            Float64 timestamp,
+                            const void* bytes,
+                            UInt32 bytesCount) override
+    {
+        if (!ensureShm()) return;
+
+        auto* block = m_shmBlock;
+        const auto* src = static_cast<const float*>(bytes);
+        const UInt32 totalSamples = bytesCount / sizeof(float);
+
+        uint32_t wp = block->writePos.load(std::memory_order_acquire);
+
+        for (uint32_t i = 0; i < totalSamples; ++i) {
+            block->ringBuffer[wp % VaxShmBlock::RING_SIZE] = src[i];
+            ++wp;
+        }
+
+        block->writePos.store(wp, std::memory_order_release);
+        block->active = 1;
+    }
+
+private:
+    bool ensureShm()
+    {
+        if (m_shmBlock) return true;
+
+        auto now = std::chrono::steady_clock::now();
+        if (now - m_lastRetry < std::chrono::seconds(1)) return false;
+        m_lastRetry = now;
+
+        int fd = shm_open("/nereussdr-vax-tx", O_RDWR, 0666);
+        if (fd < 0) return false;
+
+        void* ptr = mmap(nullptr, sizeof(VaxShmBlock), PROT_READ | PROT_WRITE,
+                         MAP_SHARED, fd, 0);
+        ::close(fd);
+
+        if (ptr == MAP_FAILED) return false;
+
+        m_shmBlock = static_cast<VaxShmBlock*>(ptr);
+        return true;
+    }
+
+    void unmapShm()
+    {
+        if (m_shmBlock) {
+            munmap(m_shmBlock, sizeof(VaxShmBlock));
+            m_shmBlock = nullptr;
+        }
+    }
+
+    VaxShmBlock* m_shmBlock{nullptr};
+    std::chrono::steady_clock::time_point m_lastRetry{};
+};
+
+// ── AudioStreamBasicDescription helper ──────────────────────────────────────
+
+static AudioStreamBasicDescription makePCMFormat(Float64 sampleRate, UInt32 channels)
+{
+    AudioStreamBasicDescription fmt{};
+    fmt.mSampleRate       = sampleRate;
+    fmt.mFormatID         = kAudioFormatLinearPCM;
+    fmt.mFormatFlags      = kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked;
+    fmt.mBitsPerChannel   = 32;
+    fmt.mChannelsPerFrame = channels;
+    fmt.mBytesPerFrame    = channels * sizeof(float);
+    fmt.mFramesPerPacket  = 1;
+    fmt.mBytesPerPacket   = fmt.mBytesPerFrame;
+    return fmt;
+}
+
+// ── DriverRequestHandler: defers device creation until host is ready ─────────
+
+class VaxDriverHandler : public aspl::DriverRequestHandler {
+public:
+    VaxDriverHandler(std::shared_ptr<aspl::Context> ctx,
+                     std::shared_ptr<aspl::Plugin> plug)
+        : m_context(std::move(ctx))
+        , m_plugin(std::move(plug))
+    {}
+
+    OSStatus OnInitialize() override
+    {
+        // Called by HAL after driver is fully initialized and host is available.
+        // Safe to add devices here — PropertiesChanged notifications will work.
+
+        // 4 VAX RX input devices (radio → apps receive audio)
+        for (int ch = 1; ch <= 4; ++ch) {
+            char name[64];
+            snprintf(name, sizeof(name), "NereusSDR VAX %d", ch);
+
+            char uid[64];
+            snprintf(uid, sizeof(uid), "com.nereussdr.vax.rx.%d", ch);
+
+            auto handler = std::make_shared<VaxRxHandler>(ch);
+
+            aspl::DeviceParameters devParams;
+            devParams.Name         = name;
+            devParams.Manufacturer = "NereusSDR";
+            devParams.DeviceUID    = uid;
+            devParams.ModelUID     = "com.nereussdr.vax";
+            devParams.SampleRate   = 48000;
+            devParams.ChannelCount = 2;
+            devParams.EnableMixing = true;
+
+            auto device = std::make_shared<aspl::Device>(m_context, devParams);
+            device->SetIOHandler(handler);
+
+            aspl::StreamParameters streamParams;
+            streamParams.Direction = aspl::Direction::Input;
+            streamParams.Format    = makePCMFormat(48000, 2);
+
+            device->AddStreamWithControlsAsync(streamParams);
+            m_plugin->AddDevice(device);
+
+            // Keep shared_ptrs alive
+            m_handlers.push_back(handler);
+            m_devices.push_back(device);
+        }
+
+        // 1 TX output device (apps send audio → radio)
+        {
+            auto txHandler = std::make_shared<VaxTxHandler>();
+
+            aspl::DeviceParameters txParams;
+            txParams.Name         = "NereusSDR TX";
+            txParams.Manufacturer = "NereusSDR";
+            txParams.DeviceUID    = "com.nereussdr.vax.tx";
+            txParams.ModelUID     = "com.nereussdr.vax";
+            txParams.SampleRate   = 48000;
+            txParams.ChannelCount = 2;
+            txParams.EnableMixing = true;
+
+            auto txDevice = std::make_shared<aspl::Device>(m_context, txParams);
+            txDevice->SetIOHandler(txHandler);
+
+            aspl::StreamParameters txStreamParams;
+            txStreamParams.Direction = aspl::Direction::Output;
+            txStreamParams.Format    = makePCMFormat(48000, 2);
+
+            txDevice->AddStreamWithControlsAsync(txStreamParams);
+            m_plugin->AddDevice(txDevice);
+
+            m_handlers.push_back(txHandler);
+            m_devices.push_back(txDevice);
+        }
+
+        return kAudioHardwareNoError;
+    }
+
+private:
+    std::shared_ptr<aspl::Context> m_context;
+    std::shared_ptr<aspl::Plugin> m_plugin;
+    std::vector<std::shared_ptr<aspl::IORequestHandler>> m_handlers;
+    std::vector<std::shared_ptr<aspl::Device>> m_devices;
+};
+
+// ── Driver entry point ──────────────────────────────────────────────────────
+
+extern "C" void* NereusSDRVAX_Create(CFAllocatorRef allocator, CFUUIDRef typeUUID)
+{
+    if (!CFEqual(typeUUID, kAudioServerPlugInTypeUUID)) {
+        return nullptr;
+    }
+
+    auto context = std::make_shared<aspl::Context>(
+        std::make_shared<aspl::Tracer>());
+
+    auto plugin = std::make_shared<aspl::Plugin>(context);
+
+    // Devices are created in OnInitialize() after host is ready
+    auto driverHandler = std::make_shared<VaxDriverHandler>(context, plugin);
+
+    static auto driver = std::make_shared<aspl::Driver>(context, plugin);
+    driver->SetDriverHandler(driverHandler);
+
+    // Keep handler alive
+    static auto handlerRef = driverHandler;
+
+    return driver->GetReference();
+}

--- a/hal-plugin/NereusSDRVAX.cpp
+++ b/hal-plugin/NereusSDRVAX.cpp
@@ -46,24 +46,36 @@
 
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <atomic>
 #include <chrono>
 #include <cstring>
 #include <cmath>
 
-// ── Shared memory layout — must match VirtualAudioBridge.h ──────────────────
+// ── Shared memory layout — must match src/core/audio/CoreAudioHalBus.h
+//    (Sub-Phase 5.3; not yet landed). Any field change here requires the
+//    matching change in CoreAudioHalBus or the shm contract breaks.
 
 struct VaxShmBlock {
     std::atomic<uint32_t> writePos;
     std::atomic<uint32_t> readPos;
-    uint32_t sampleRate;
-    uint32_t channels;
-    uint32_t active;
-    uint32_t reserved[3];
+    uint32_t sampleRate;             // written by producer (CoreAudioHalBus); plugin does not read
+    uint32_t channels;               // written by producer (CoreAudioHalBus); plugin does not read
+    std::atomic<uint32_t> active;
+    uint32_t reserved[3];            // reserved — DO NOT REMOVE; preserves layout alignment with CoreAudioHalBus
     static constexpr uint32_t RING_SIZE = 48000 * 2 * 2;  // ~2 sec @ 48kHz stereo
     float ringBuffer[RING_SIZE];
 };
+
+static_assert(
+    sizeof(VaxShmBlock) ==
+        2 * sizeof(std::atomic<uint32_t>)   // writePos, readPos
+      + 1 * sizeof(std::atomic<uint32_t>)   // active (FIX 1: atomic with acquire/release)
+      + 2 * sizeof(uint32_t)                // sampleRate, channels
+      + 3 * sizeof(uint32_t)                // reserved[3]
+      + VaxShmBlock::RING_SIZE * sizeof(float),
+    "VaxShmBlock layout changed — update CoreAudioHalBus.h to match");
 
 // ── VAX RX Handler: reads from shared memory → output to apps ───────────────
 
@@ -94,7 +106,7 @@ public:
         }
 
         auto* block = m_shmBlock;
-        if (!block->active) {
+        if (!block->active.load(std::memory_order_acquire)) {
             std::memset(dst, 0, bytesCount);
             return;
         }
@@ -132,6 +144,14 @@ private:
 
         int fd = shm_open(name, O_RDWR, 0666);
         if (fd < 0) return false;
+
+        struct stat st;
+        if (fstat(fd, &st) != 0 || static_cast<size_t>(st.st_size) < sizeof(VaxShmBlock)) {
+            // Stale or undersized segment — refuse to mmap past the end.
+            // A SIGBUS here would crash coreaudiod. Try again next retry cycle.
+            ::close(fd);
+            return false;
+        }
 
         void* ptr = mmap(nullptr, sizeof(VaxShmBlock), PROT_READ | PROT_WRITE,
                          MAP_SHARED, fd, 0);
@@ -187,7 +207,7 @@ public:
         }
 
         block->writePos.store(wp, std::memory_order_release);
-        block->active = 1;
+        block->active.store(1, std::memory_order_release);
     }
 
 private:
@@ -201,6 +221,14 @@ private:
 
         int fd = shm_open("/nereussdr-vax-tx", O_RDWR, 0666);
         if (fd < 0) return false;
+
+        struct stat st;
+        if (fstat(fd, &st) != 0 || static_cast<size_t>(st.st_size) < sizeof(VaxShmBlock)) {
+            // Stale or undersized segment — refuse to mmap past the end.
+            // A SIGBUS here would crash coreaudiod. Try again next retry cycle.
+            ::close(fd);
+            return false;
+        }
 
         void* ptr = mmap(nullptr, sizeof(VaxShmBlock), PROT_READ | PROT_WRITE,
                          MAP_SHARED, fd, 0);

--- a/hal-plugin/NereusSDRVAX.cpp
+++ b/hal-plugin/NereusSDRVAX.cpp
@@ -124,6 +124,19 @@ public:
         uint32_t wp = block->writePos.load(std::memory_order_acquire);
 
         uint32_t available = wp - rp;
+
+        // Lap protection: if the app-side producer has written more than
+        // RING_SIZE samples without our reader advancing (e.g. app pushing
+        // VAX audio before any CoreAudio client connected), jump rp forward
+        // to a recent window. Without this, the loop below reads from
+        // already-overwritten ring slots and playback stays permanently
+        // garbled until the client reconnects. Mirrors the pattern in
+        // CoreAudioHalBus::pull().
+        if (available > VaxShmBlock::RING_SIZE) {
+            rp = wp - VaxShmBlock::RING_SIZE / 2;
+            available = wp - rp;
+        }
+
         uint32_t toRead = std::min(available, totalSamples);
 
         for (uint32_t i = 0; i < toRead; ++i) {

--- a/hal-plugin/NereusSDRVAX.cpp
+++ b/hal-plugin/NereusSDRVAX.cpp
@@ -50,6 +50,7 @@
 #include <unistd.h>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstring>
 #include <cmath>
 
@@ -76,6 +77,14 @@ static_assert(
       + 3 * sizeof(uint32_t)                // reserved[3]
       + VaxShmBlock::RING_SIZE * sizeof(float),
     "VaxShmBlock layout changed — update CoreAudioHalBus.h to match");
+
+static_assert(offsetof(VaxShmBlock, writePos)    == 0,  "VaxShmBlock.writePos offset changed");
+static_assert(offsetof(VaxShmBlock, readPos)     == 4,  "VaxShmBlock.readPos offset changed");
+static_assert(offsetof(VaxShmBlock, sampleRate)  == 8,  "VaxShmBlock.sampleRate offset changed");
+static_assert(offsetof(VaxShmBlock, channels)    == 12, "VaxShmBlock.channels offset changed");
+static_assert(offsetof(VaxShmBlock, active)      == 16, "VaxShmBlock.active offset changed");
+static_assert(offsetof(VaxShmBlock, reserved)    == 20, "VaxShmBlock.reserved offset changed");
+static_assert(offsetof(VaxShmBlock, ringBuffer)  == 32, "VaxShmBlock.ringBuffer offset changed");
 
 // ── VAX RX Handler: reads from shared memory → output to apps ───────────────
 

--- a/packaging/macos/hal-installer.sh
+++ b/packaging/macos/hal-installer.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build NereusSDR macOS installer (.pkg)
+# Usage: ./packaging/macos/hal-installer.sh [build-dir]
+#
+# Bundles NereusSDR.app + the NereusSDRVAX HAL plugin into a single
+# productbuild .pkg. The HAL component's postinstall script restarts
+# coreaudiod with a macOS 14.4+ killall fallback (see hal-postinstall.sh).
+# Ported from AetherSDR's packaging/macos/build-installer.sh.
+
+BUILD_DIR="${1:-build}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PKG_DIR="${BUILD_DIR}/pkg-staging"
+VERSION=$(grep 'project(NereusSDR' CMakeLists.txt | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0")
+
+echo "=== Building NereusSDR macOS installer v${VERSION} ==="
+
+# 1. Build app
+cmake -B "${BUILD_DIR}" -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build "${BUILD_DIR}" -j$(sysctl -n hw.ncpu)
+
+# 1b. Build HAL plugin (separate build because libASPL FetchContent conflicts with main Ninja build)
+HAL_BUILD="${BUILD_DIR}-hal"
+if [ -f "hal-plugin/CMakeLists.txt" ]; then
+    echo "--- Building HAL plugin ---"
+    cmake -B "${HAL_BUILD}" -S hal-plugin -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    cmake --build "${HAL_BUILD}" -j$(sysctl -n hw.ncpu)
+fi
+
+# 2. Prepare staging
+rm -rf "${PKG_DIR}"
+mkdir -p "${PKG_DIR}/app" "${PKG_DIR}/hal" "${PKG_DIR}/scripts"
+
+# Copy app bundle
+cp -R "${BUILD_DIR}/NereusSDR.app" "${PKG_DIR}/app/"
+
+# Copy HAL plugin (check both possible build locations)
+if [ -d "${HAL_BUILD}/NereusSDRVAX.driver" ]; then
+    cp -R "${HAL_BUILD}/NereusSDRVAX.driver" "${PKG_DIR}/hal/"
+elif [ -d "${BUILD_DIR}/NereusSDRVAX.driver" ]; then
+    cp -R "${BUILD_DIR}/NereusSDRVAX.driver" "${PKG_DIR}/hal/"
+else
+    echo "WARNING: HAL plugin not found"
+    echo "The installer will only contain the app."
+fi
+
+# 3. Install postinstall script (standalone file; see hal-postinstall.sh)
+cp "${SCRIPT_DIR}/hal-postinstall.sh" "${PKG_DIR}/scripts/postinstall"
+chmod +x "${PKG_DIR}/scripts/postinstall"
+
+# 4. Build component packages
+pkgbuild \
+    --root "${PKG_DIR}/app" \
+    --install-location /Applications \
+    --identifier com.nereussdr.app \
+    --version "${VERSION}" \
+    "${PKG_DIR}/NereusSDR-app.pkg"
+
+if [ -d "${PKG_DIR}/hal/NereusSDRVAX.driver" ]; then
+    pkgbuild \
+        --root "${PKG_DIR}/hal" \
+        --install-location "/Library/Audio/Plug-Ins/HAL" \
+        --identifier com.nereussdr.vax \
+        --version "${VERSION}" \
+        --scripts "${PKG_DIR}/scripts" \
+        "${PKG_DIR}/NereusSDR-vax.pkg"
+fi
+
+# 5. Create distribution XML
+cat > "${PKG_DIR}/Distribution.xml" << DISTXML
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="2">
+    <title>NereusSDR ${VERSION}</title>
+    <welcome file="welcome.html"/>
+    <options customize="allow" require-scripts="false"/>
+
+    <script>
+    function vaxDriverInstalled() {
+        return system.files.fileExistsAtPath('/Library/Audio/Plug-Ins/HAL/NereusSDRVAX.driver');
+    }
+    function vaxDriverNeedsUpdate() {
+        // Always offer update if installed version differs
+        var plist = system.files.plistAtPath('/Library/Audio/Plug-Ins/HAL/NereusSDRVAX.driver/Contents/Info.plist');
+        if (plist) {
+            var installed = plist['CFBundleShortVersionString'] || '0';
+            return (installed !== '${VERSION}');
+        }
+        return true;
+    }
+    </script>
+
+    <choices-outline>
+        <line choice="app"/>
+        <line choice="vax"/>
+    </choices-outline>
+
+    <choice id="app" title="NereusSDR Application"
+            description="OpenHPSDR / Apache Labs SDR client (Thetis port).">
+        <pkg-ref id="com.nereussdr.app"/>
+    </choice>
+
+    <choice id="vax" title="VAX Virtual Audio Driver"
+            description="Virtual audio devices for digital mode apps (WSJT-X, fldigi, etc.). Uncheck if already installed."
+            selected="!vaxDriverInstalled() || vaxDriverNeedsUpdate()"
+            tooltip="Currently installed: will skip unless a newer version is available">
+        <pkg-ref id="com.nereussdr.vax"/>
+    </choice>
+
+    <pkg-ref id="com.nereussdr.app" version="${VERSION}" onConclusion="none">NereusSDR-app.pkg</pkg-ref>
+    <pkg-ref id="com.nereussdr.vax" version="${VERSION}" onConclusion="none">NereusSDR-vax.pkg</pkg-ref>
+</installer-gui-script>
+DISTXML
+
+# 6. Create welcome HTML
+mkdir -p "${PKG_DIR}/resources"
+cat > "${PKG_DIR}/resources/welcome.html" << 'WELCOME'
+<html><body>
+<h1>NereusSDR</h1>
+<p>A native OpenHPSDR / Apache Labs SDR client for macOS.</p>
+<p>This installer includes:</p>
+<ul>
+<li><b>NereusSDR.app</b> &mdash; the main application</li>
+<li><b>VAX Virtual Audio Driver</b> &mdash; creates virtual audio devices for digital mode apps (WSJT-X, fldigi, VARA, etc.)</li>
+</ul>
+<p>After installation, the CoreAudio daemon will restart automatically to register the new audio devices.</p>
+</body></html>
+WELCOME
+
+# 7. Build product archive
+productbuild \
+    --distribution "${PKG_DIR}/Distribution.xml" \
+    --resources "${PKG_DIR}/resources" \
+    --package-path "${PKG_DIR}" \
+    "${BUILD_DIR}/NereusSDR-${VERSION}-macOS.pkg"
+
+echo ""
+echo "=== Installer created: ${BUILD_DIR}/NereusSDR-${VERSION}-macOS.pkg ==="

--- a/packaging/macos/hal-installer.sh
+++ b/packaging/macos/hal-installer.sh
@@ -16,16 +16,24 @@ VERSION=$(grep 'project(NereusSDR' CMakeLists.txt | grep -oE '[0-9]+\.[0-9]+\.[0
 
 echo "=== Building NereusSDR macOS installer v${VERSION} ==="
 
-# 1. Build app
-cmake -B "${BUILD_DIR}" -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
-cmake --build "${BUILD_DIR}" -j$(sysctl -n hw.ncpu)
+# 1. Build app — skip if already built (preserves pre-existing signatures from CI).
+if [ ! -d "${BUILD_DIR}/NereusSDR.app" ]; then
+    cmake -B "${BUILD_DIR}" -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    cmake --build "${BUILD_DIR}" -j$(sysctl -n hw.ncpu)
+else
+    echo "--- Reusing existing ${BUILD_DIR}/NereusSDR.app ---"
+fi
 
-# 1b. Build HAL plugin (separate build because libASPL FetchContent conflicts with main Ninja build)
+# 1b. Build HAL plugin — skip if already built (preserves pre-existing signatures from CI).
 HAL_BUILD="${BUILD_DIR}-hal"
 if [ -f "hal-plugin/CMakeLists.txt" ]; then
-    echo "--- Building HAL plugin ---"
-    cmake -B "${HAL_BUILD}" -S hal-plugin -DCMAKE_BUILD_TYPE=RelWithDebInfo
-    cmake --build "${HAL_BUILD}" -j$(sysctl -n hw.ncpu)
+    if [ ! -d "${HAL_BUILD}/NereusSDRVAX.driver" ]; then
+        echo "--- Building HAL plugin ---"
+        cmake -B "${HAL_BUILD}" -S hal-plugin -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake --build "${HAL_BUILD}" -j$(sysctl -n hw.ncpu)
+    else
+        echo "--- Reusing existing ${HAL_BUILD}/NereusSDRVAX.driver ---"
+    fi
 fi
 
 # 2. Prepare staging

--- a/packaging/macos/hal-installer.sh
+++ b/packaging/macos/hal-installer.sh
@@ -41,8 +41,9 @@ if [ -d "${HAL_BUILD}/NereusSDRVAX.driver" ]; then
 elif [ -d "${BUILD_DIR}/NereusSDRVAX.driver" ]; then
     cp -R "${BUILD_DIR}/NereusSDRVAX.driver" "${PKG_DIR}/hal/"
 else
-    echo "WARNING: HAL plugin not found"
-    echo "The installer will only contain the app."
+    echo "ERROR: HAL plugin not found at ${HAL_BUILD}/NereusSDRVAX.driver" >&2
+    echo "The HAL plugin must be built before packaging. Check that hal-plugin/ exists and builds cleanly." >&2
+    exit 1
 fi
 
 # 3. Install postinstall script (standalone file; see hal-postinstall.sh)

--- a/packaging/macos/hal-postinstall.sh
+++ b/packaging/macos/hal-postinstall.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# NereusSDR VAX HAL plugin — postinstall
+# On macOS 14.4+, launchctl kickstart of com.apple.audio.coreaudiod
+# returns "Operation not permitted"; fall back to killall.
+
+set -e
+
+launchctl kickstart -kp system/com.apple.audio.coreaudiod 2>/dev/null \
+  || sudo killall coreaudiod 2>/dev/null \
+  || true
+
+exit 0

--- a/packaging/macos/hal-uninstall.sh
+++ b/packaging/macos/hal-uninstall.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+sudo rm -rf "/Library/Audio/Plug-Ins/HAL/NereusSDRVAX.driver"
+rm -f /dev/shm/nereussdr-vax-* /dev/shm/nereussdr-tx 2>/dev/null || true
+sudo killall coreaudiod 2>/dev/null || true
+echo "NereusSDR VAX HAL plugin uninstalled."

--- a/src/core/audio/CoreAudioHalBus.cpp
+++ b/src/core/audio/CoreAudioHalBus.cpp
@@ -1,0 +1,308 @@
+// =================================================================
+// src/core/audio/CoreAudioHalBus.cpp  (NereusSDR)
+// =================================================================
+//
+// Ported from AetherSDR source:
+//   src/core/VirtualAudioBridge.cpp
+//
+// AetherSDR is licensed under the GNU General Public License v3; see
+// https://github.com/ten9876/AetherSDR for the contributor list and
+// project-level LICENSE. NereusSDR is also GPLv3. AetherSDR source
+// files carry no per-file GPL header; attribution is at project level
+// per AetherSDR convention.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-19 — Ported/adapted in C++20 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via Anthropic
+//                 Claude Code. Adapted to NereusSDR IAudioBus contract:
+//                 monolithic VirtualAudioBridge decomposed into per-endpoint
+//                 CoreAudioHalBus instances (Role enum for Vax1..4 / TxInput),
+//                 QObject/signals dropped in favor of atomic metering,
+//                 silence-fill + TX poll timers deferred to Phase 3M.
+//                 Shm paths: /aethersdr-dax-* → /nereussdr-vax-*.
+//                 Sample rate: 24 kHz → 48 kHz (spec §8.1).
+// =================================================================
+
+#include "CoreAudioHalBus.h"
+
+#include "core/LogCategories.h"
+
+#include <QLoggingCategory>
+
+#ifdef Q_OS_MAC
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace NereusSDR {
+
+namespace {
+
+// Agreed shm-name table (Task 5.1 D7). Stored as string literals so the .h
+// can hand out a `const char*` without owning a QString or QByteArray.
+constexpr const char* kShmNameVax1   = "/nereussdr-vax-1";
+constexpr const char* kShmNameVax2   = "/nereussdr-vax-2";
+constexpr const char* kShmNameVax3   = "/nereussdr-vax-3";
+constexpr const char* kShmNameVax4   = "/nereussdr-vax-4";
+constexpr const char* kShmNameTxIn   = "/nereussdr-vax-tx";
+
+const char* shmNameForRole(CoreAudioHalBus::Role role) {
+    switch (role) {
+        case CoreAudioHalBus::Role::Vax1:    return kShmNameVax1;
+        case CoreAudioHalBus::Role::Vax2:    return kShmNameVax2;
+        case CoreAudioHalBus::Role::Vax3:    return kShmNameVax3;
+        case CoreAudioHalBus::Role::Vax4:    return kShmNameVax4;
+        case CoreAudioHalBus::Role::TxInput: return kShmNameTxIn;
+    }
+    return kShmNameVax1;
+}
+
+// Backlog guards for the TX drain path — ported verbatim from
+// VirtualAudioBridge::readTxAudio so the TX consumer keeps near-real-time
+// latency when the HAL plugin has written more than we can drain in a tick.
+constexpr uint32_t kTargetBacklogSamples = 256 * 2;  // 256 frames ≈ 5.3 ms @ 48 kHz stereo
+constexpr uint32_t kMaxBacklogSamples    = 768 * 2;  // 768 frames ≈ 16 ms @ 48 kHz stereo
+
+} // namespace
+
+CoreAudioHalBus::CoreAudioHalBus(Role role)
+    : m_role(role)
+    , m_shmName(shmNameForRole(role))
+    , m_backendName(QStringLiteral("CoreAudio HAL (VAX)"))
+{}
+
+CoreAudioHalBus::~CoreAudioHalBus() {
+    close();
+}
+
+bool CoreAudioHalBus::open(const AudioFormat& format) {
+#ifndef Q_OS_MAC
+    (void)format;
+    m_err = QStringLiteral("CoreAudioHalBus is macOS-only");
+    return false;
+#else
+    if (m_open) {
+        return true;
+    }
+
+    // Fixed format — the HAL plugin hard-codes 48 kHz stereo float32, and the
+    // shm ring sizes itself accordingly. Reject anything else cleanly rather
+    // than silently mis-routing samples.
+    if (format.sampleRate != 48000
+     || format.channels   != 2
+     || format.sample     != AudioFormat::Sample::Float32) {
+        m_err = QStringLiteral("CoreAudioHalBus requires 48000 Hz stereo float32 "
+                               "(got %1 Hz, %2 ch, sample=%3)")
+                    .arg(format.sampleRate)
+                    .arg(format.channels)
+                    .arg(static_cast<int>(format.sample));
+        return false;
+    }
+
+    // Try to open an existing segment first — the HAL plugin (coreaudiod) may
+    // already have it mapped. If that fails, create it at the canonical size.
+    int fd = ::shm_open(m_shmName, O_RDWR, 0666);
+    bool created = false;
+    if (fd < 0) {
+        fd = ::shm_open(m_shmName, O_CREAT | O_RDWR, 0666);
+        if (fd < 0) {
+            m_err = QStringLiteral("shm_open(%1) failed: errno=%2")
+                        .arg(QString::fromUtf8(m_shmName)).arg(errno);
+            qCWarning(lcAudio) << "CoreAudioHalBus:" << m_err;
+            return false;
+        }
+        if (::ftruncate(fd, sizeof(VaxShmBlock)) != 0) {
+            m_err = QStringLiteral("ftruncate(%1) failed: errno=%2")
+                        .arg(QString::fromUtf8(m_shmName)).arg(errno);
+            qCWarning(lcAudio) << "CoreAudioHalBus:" << m_err;
+            ::close(fd);
+            return false;
+        }
+        created = true;
+    }
+
+    // fstat guard — mirrors the Task 5.1 plugin-side fix (I3). Refuse to mmap
+    // a stale/undersized segment, otherwise reading past the end raises SIGBUS.
+    struct stat st{};
+    if (::fstat(fd, &st) != 0
+     || static_cast<size_t>(st.st_size) < sizeof(VaxShmBlock)) {
+        m_err = QStringLiteral("shm segment %1 undersized (%2 bytes, need %3)")
+                    .arg(QString::fromUtf8(m_shmName))
+                    .arg(static_cast<qint64>(st.st_size))
+                    .arg(static_cast<qint64>(sizeof(VaxShmBlock)));
+        qCWarning(lcAudio) << "CoreAudioHalBus:" << m_err;
+        ::close(fd);
+        return false;
+    }
+
+    void* ptr = ::mmap(nullptr, sizeof(VaxShmBlock),
+                       PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (ptr == MAP_FAILED) {
+        m_err = QStringLiteral("mmap(%1) failed: errno=%2")
+                    .arg(QString::fromUtf8(m_shmName)).arg(errno);
+        qCWarning(lcAudio) << "CoreAudioHalBus:" << m_err;
+        ::close(fd);
+        return false;
+    }
+
+    m_shmFd = fd;
+    m_block = static_cast<VaxShmBlock*>(ptr);
+
+    // Re-initialize header fields. We own the segment's header while we're
+    // open — the plugin only reads writePos/readPos/active.
+    m_block->writePos.store(0, std::memory_order_relaxed);
+    m_block->readPos.store(0, std::memory_order_relaxed);
+    m_block->sampleRate = 48000;
+    m_block->channels   = 2;
+    std::memset(&m_block->reserved[0], 0, sizeof(m_block->reserved));
+    m_block->active.store(1, std::memory_order_release);
+
+    m_negFormat = format;
+    m_open = true;
+    m_err.clear();
+
+    qCInfo(lcAudio) << "CoreAudioHalBus: opened" << m_shmName
+                    << (created ? "(created)" : "(attached)")
+                    << "role=" << static_cast<int>(m_role);
+    return true;
+#endif
+}
+
+void CoreAudioHalBus::close() {
+#ifdef Q_OS_MAC
+    if (m_block) {
+        // Tell the plugin we're gone so it stops draining stale data.
+        m_block->active.store(0, std::memory_order_release);
+        ::munmap(m_block, sizeof(VaxShmBlock));
+        m_block = nullptr;
+    }
+    if (m_shmFd >= 0) {
+        ::close(m_shmFd);
+        m_shmFd = -1;
+    }
+    // NOTE: intentionally no shm_unlink here. The HAL plugin (coreaudiod)
+    // may still have the segment mapped; unlinking now would orphan its
+    // file descriptor. Matches the AetherSDR VirtualAudioBridge pattern.
+#endif
+    m_open = false;
+    m_rxLevel.store(0.0f, std::memory_order_release);
+    m_txLevel.store(0.0f, std::memory_order_release);
+    m_meterCounter = 0;
+}
+
+qint64 CoreAudioHalBus::push(const char* data, qint64 bytes) {
+    // TODO(phase3m): Re-add TX-driven silence fill so the HAL plugin's ring
+    // keeps advancing during TX state. See AetherSDR VirtualAudioBridge::
+    // setTransmitting() / feedSilenceToAllChannels() for the pattern — a
+    // future TX state source will drive a timer that writes zeros into every
+    // active Vax1..4 segment so WSJT-X/VARA don't see a stalled input.
+    if (!isProducer()) {
+        return -1;
+    }
+    if (!m_open || !m_block || data == nullptr || bytes <= 0) {
+        return 0;
+    }
+
+#ifdef Q_OS_MAC
+    const auto* samples = reinterpret_cast<const float*>(data);
+    const int numSamples = static_cast<int>(bytes / sizeof(float));
+
+    uint32_t wp = m_block->writePos.load(std::memory_order_relaxed);
+    for (int i = 0; i < numSamples; ++i) {
+        m_block->ringBuffer[wp % VaxShmBlock::RING_SIZE] = samples[i];
+        ++wp;
+    }
+    m_block->writePos.store(wp, std::memory_order_release);
+
+    // RMS meter on the left channel (indices 0, 2, 4, …). Strided so the hot
+    // path doesn't walk the full block every call.
+    if (++m_meterCounter % kMeterStride == 0 && numSamples > 0) {
+        float sum = 0.0f;
+        int count = 0;
+        for (int i = 0; i < numSamples; i += 2) {
+            sum += samples[i] * samples[i];
+            ++count;
+        }
+        const float rms = (count > 0) ? std::sqrt(sum / static_cast<float>(count)) : 0.0f;
+        m_rxLevel.store(rms, std::memory_order_release);
+    }
+
+    return bytes;
+#else
+    (void)data;
+    return 0;
+#endif
+}
+
+qint64 CoreAudioHalBus::pull(char* data, qint64 maxBytes) {
+    if (isProducer()) {
+        return -1;
+    }
+    if (!m_open || !m_block || data == nullptr || maxBytes <= 0) {
+        return 0;
+    }
+
+#ifdef Q_OS_MAC
+    // Drain TX audio written by the HAL plugin. Ported verbatim from
+    // VirtualAudioBridge::readTxAudio — acquire loads, wrap-skip if the writer
+    // has lapped the reader, backlog guards to keep near-real-time latency.
+    uint32_t rp = m_block->readPos.load(std::memory_order_acquire);
+    uint32_t wp = m_block->writePos.load(std::memory_order_acquire);
+
+    uint32_t available = wp - rp;
+    if (available == 0) {
+        return 0;
+    }
+
+    // If writer has lapped the reader, skip ahead to avoid stale data.
+    if (available > VaxShmBlock::RING_SIZE) {
+        rp = wp - VaxShmBlock::RING_SIZE / 2;  // jump to recent data
+        available = wp - rp;
+    }
+
+    // Low-latency guard: if backlog grows, skip stale audio and keep only
+    // a small recent window near the writer head.
+    if (available > kMaxBacklogSamples) {
+        rp = wp - kTargetBacklogSamples;
+        available = wp - rp;
+    }
+
+    uint32_t maxFloats = static_cast<uint32_t>(maxBytes / sizeof(float));
+    uint32_t totalSamples = std::min(available, maxFloats);
+
+    auto* dst = reinterpret_cast<float*>(data);
+    for (uint32_t i = 0; i < totalSamples; ++i) {
+        dst[i] = m_block->ringBuffer[rp % VaxShmBlock::RING_SIZE];
+        ++rp;
+    }
+
+    m_block->readPos.store(rp, std::memory_order_release);
+
+    // TX level meter (strided).
+    if (++m_meterCounter % kMeterStride == 0 && totalSamples > 0) {
+        float sum = 0.0f;
+        uint32_t count = 0;
+        for (uint32_t i = 0; i < totalSamples; i += 2) {
+            sum += dst[i] * dst[i];
+            ++count;
+        }
+        const float rms = (count > 0) ? std::sqrt(sum / static_cast<float>(count)) : 0.0f;
+        m_txLevel.store(rms, std::memory_order_release);
+    }
+
+    return static_cast<qint64>(totalSamples) * static_cast<qint64>(sizeof(float));
+#else
+    (void)data;
+    (void)maxBytes;
+    return 0;
+#endif
+}
+
+} // namespace NereusSDR

--- a/src/core/audio/CoreAudioHalBus.cpp
+++ b/src/core/audio/CoreAudioHalBus.cpp
@@ -214,6 +214,10 @@ qint64 CoreAudioHalBus::push(const char* data, qint64 bytes) {
     const auto* samples = reinterpret_cast<const float*>(data);
     const int numSamples = static_cast<int>(bytes / sizeof(float));
 
+    // SPSC invariant: this thread is the sole writer, so a relaxed load of
+    // our own previously-released store is sound (program order provides
+    // the necessary dependency). The release store below is what the plugin's
+    // acquire load synchronizes against.
     uint32_t wp = m_block->writePos.load(std::memory_order_relaxed);
     for (int i = 0; i < numSamples; ++i) {
         m_block->ringBuffer[wp % VaxShmBlock::RING_SIZE] = samples[i];
@@ -261,7 +265,12 @@ qint64 CoreAudioHalBus::pull(char* data, qint64 maxBytes) {
         return 0;
     }
 
-    // If writer has lapped the reader, skip ahead to avoid stale data.
+    // Defense against 32-bit counter wraparound: wp/rp are uint32 and wrap
+    // after ~12 hours of 48 kHz stereo float pushes. If only one side wraps,
+    // the unsigned `wp - rp` subtraction can produce a bogus huge "available"
+    // value. Skip ahead to a recent window. The MAX/TARGET backlog guard
+    // below usually fires first under any realistic timing; this branch is
+    // the belt-and-suspenders against the pathological wrap case.
     if (available > VaxShmBlock::RING_SIZE) {
         rp = wp - VaxShmBlock::RING_SIZE / 2;  // jump to recent data
         available = wp - rp;

--- a/src/core/audio/CoreAudioHalBus.h
+++ b/src/core/audio/CoreAudioHalBus.h
@@ -1,0 +1,156 @@
+// =================================================================
+// src/core/audio/CoreAudioHalBus.h  (NereusSDR)
+// =================================================================
+//
+// Ported from AetherSDR source:
+//   src/core/VirtualAudioBridge.h
+//
+// AetherSDR is licensed under the GNU General Public License v3; see
+// https://github.com/ten9876/AetherSDR for the contributor list and
+// project-level LICENSE. NereusSDR is also GPLv3. AetherSDR source
+// files carry no per-file GPL header; attribution is at project level
+// per AetherSDR convention.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-19 — Ported/adapted in C++20 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via Anthropic
+//                 Claude Code. Adapted to NereusSDR IAudioBus contract:
+//                 monolithic VirtualAudioBridge decomposed into per-endpoint
+//                 CoreAudioHalBus instances (Role enum for Vax1..4 / TxInput),
+//                 QObject/signals dropped in favor of atomic metering,
+//                 silence-fill + TX poll timers deferred to Phase 3M.
+//                 Shm paths: /aethersdr-dax-* → /nereussdr-vax-*.
+//                 Sample rate: 24 kHz → 48 kHz (spec §8.1).
+// =================================================================
+
+#pragma once
+
+#include "core/IAudioBus.h"
+
+#include <atomic>
+#include <cstdint>
+
+namespace NereusSDR {
+
+// ── Shared memory layout — canonical definition ─────────────────────────────
+//
+// MUST match byte-for-byte the mirrored struct in hal-plugin/NereusSDRVAX.cpp.
+// Any change to field order, size, alignment, or ring size here requires the
+// matching change in the HAL plugin or the shm contract breaks. Both sides
+// carry an equivalent static_assert pinning the total size.
+//
+// Field semantics:
+//   writePos — producer monotonic counter (CoreAudioHalBus Vax1..4 / plugin TX).
+//   readPos  — consumer monotonic counter (plugin RX / CoreAudioHalBus TxInput).
+//   active   — producer→consumer liveness flag; 1 while producer is feeding.
+//   sampleRate / channels — producer-written diagnostic fields; consumer does
+//                           not read them (format is fixed at 48 kHz stereo).
+//   reserved[3] — layout padding; DO NOT REMOVE.
+//
+// Ring size: 48000 * 2 * 2 = 192000 floats = ~2 sec @ 48 kHz stereo.
+//
+// sizeof(VaxShmBlock) evaluates to 768032 bytes with natural alignment on all
+// supported platforms; the static_assert below makes a layout drift a compile
+// error rather than a runtime shm-format mismatch.
+
+struct VaxShmBlock {
+    std::atomic<uint32_t> writePos;
+    std::atomic<uint32_t> readPos;
+    std::atomic<uint32_t> active;
+    uint32_t sampleRate;             // producer-written, consumer does not read
+    uint32_t channels;               // producer-written, consumer does not read
+    uint32_t reserved[3];            // reserved — DO NOT REMOVE; preserves layout alignment
+    static constexpr uint32_t RING_SIZE = 48000 * 2 * 2;  // ~2 sec @ 48 kHz stereo
+    float ringBuffer[RING_SIZE];
+};
+
+static_assert(
+    sizeof(VaxShmBlock) ==
+        2 * sizeof(std::atomic<uint32_t>)   // writePos, readPos
+      + 1 * sizeof(std::atomic<uint32_t>)   // active (atomic with acquire/release)
+      + 2 * sizeof(uint32_t)                // sampleRate, channels
+      + 3 * sizeof(uint32_t)                // reserved[3]
+      + VaxShmBlock::RING_SIZE * sizeof(float),
+    "VaxShmBlock layout changed — update hal-plugin/NereusSDRVAX.cpp to match");
+
+// ── CoreAudioHalBus ─────────────────────────────────────────────────────────
+//
+// Per-endpoint IAudioBus implementation bridging NereusSDR's DSP pipeline to
+// the macOS CoreAudio HAL plugin (NereusSDRVAX.driver) via POSIX shared memory.
+// One instance per endpoint; the Role enum selects the shm segment and the
+// direction:
+//
+//   Role::Vax1..4  — producer; push() writes to /nereussdr-vax-{1..4}.
+//                    The HAL plugin exposes these as 4 virtual input devices
+//                    ("NereusSDR VAX 1..4") that apps like WSJT-X open for RX.
+//   Role::TxInput  — consumer; pull() reads from /nereussdr-vax-tx. The HAL
+//                    plugin exposes this as a virtual output device
+//                    ("NereusSDR TX") that apps write TX audio into.
+//
+// Format is fixed at 48 kHz stereo float32 — open() validates and rejects any
+// other format. macOS-only runtime; the header compiles on all platforms so
+// the test build can link against it under an #ifdef Q_OS_MAC guard.
+
+class CoreAudioHalBus : public IAudioBus {
+public:
+    enum class Role {
+        Vax1 = 1,
+        Vax2 = 2,
+        Vax3 = 3,
+        Vax4 = 4,
+        TxInput,
+    };
+
+    explicit CoreAudioHalBus(Role role);
+    ~CoreAudioHalBus() override;
+
+    bool open(const AudioFormat& format) override;
+    void close() override;
+    bool isOpen() const override { return m_open; }
+
+    // Producer side (Role::Vax1..4 only). Returns -1 for TxInput.
+    qint64 push(const char* data, qint64 bytes) override;
+
+    // Consumer side (Role::TxInput only). Returns -1 for Vax1..4.
+    qint64 pull(char* data, qint64 maxBytes) override;
+
+    float rxLevel() const override { return m_rxLevel.load(std::memory_order_acquire); }
+    float txLevel() const override { return m_txLevel.load(std::memory_order_acquire); }
+
+    QString     backendName() const override { return m_backendName; }
+    AudioFormat negotiatedFormat() const override { return m_negFormat; }
+    QString     errorString() const override { return m_err; }
+
+    // Diagnostics — shm path this instance uses (e.g. "/nereussdr-vax-1").
+    // Stable for the lifetime of the object; computed from Role at construction.
+    const char* shmName() const { return m_shmName; }
+    Role        role() const { return m_role; }
+
+private:
+    bool isProducer() const {
+        return m_role == Role::Vax1 || m_role == Role::Vax2
+            || m_role == Role::Vax3 || m_role == Role::Vax4;
+    }
+
+    Role         m_role;
+    const char*  m_shmName;   // pointer into a string-literal table in the .cpp
+
+    bool            m_open{false};
+    int             m_shmFd{-1};
+    VaxShmBlock*    m_block{nullptr};
+
+    AudioFormat  m_negFormat;
+    QString      m_backendName;
+    QString      m_err;
+
+    std::atomic<float> m_rxLevel{0.0f};
+    std::atomic<float> m_txLevel{0.0f};
+
+    // Metering: update RMS every Nth push/pull so the hot path doesn't walk
+    // the whole block on every call.
+    int m_meterCounter{0};
+    static constexpr int kMeterStride = 10;
+};
+
+} // namespace NereusSDR

--- a/src/core/audio/CoreAudioHalBus.h
+++ b/src/core/audio/CoreAudioHalBus.h
@@ -29,6 +29,7 @@
 #include "core/IAudioBus.h"
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 
 namespace NereusSDR {
@@ -55,14 +56,18 @@ namespace NereusSDR {
 // error rather than a runtime shm-format mismatch.
 
 struct VaxShmBlock {
-    std::atomic<uint32_t> writePos;
-    std::atomic<uint32_t> readPos;
-    std::atomic<uint32_t> active;
-    uint32_t sampleRate;             // producer-written, consumer does not read
-    uint32_t channels;               // producer-written, consumer does not read
-    uint32_t reserved[3];            // reserved — DO NOT REMOVE; preserves layout alignment
+    // Field ORDER is the shm wire contract with hal-plugin/NereusSDRVAX.cpp.
+    // Both sides must declare these fields in the same sequence so offsetof
+    // values agree. DO NOT REORDER without updating the plugin in lockstep.
+    // The static_asserts below pin the layout at compile time on both sides.
+    std::atomic<uint32_t> writePos;   // offset 0
+    std::atomic<uint32_t> readPos;    // offset 4
+    uint32_t sampleRate;              // offset 8  — producer-written; consumer does not read
+    uint32_t channels;                // offset 12 — producer-written; consumer does not read
+    std::atomic<uint32_t> active;     // offset 16 — SPSC gate; writer stores release, reader loads acquire
+    uint32_t reserved[3];             // offset 20 — reserved; DO NOT REMOVE (preserves layout)
     static constexpr uint32_t RING_SIZE = 48000 * 2 * 2;  // ~2 sec @ 48 kHz stereo
-    float ringBuffer[RING_SIZE];
+    float ringBuffer[RING_SIZE];      // offset 32
 };
 
 static_assert(
@@ -73,6 +78,14 @@ static_assert(
       + 3 * sizeof(uint32_t)                // reserved[3]
       + VaxShmBlock::RING_SIZE * sizeof(float),
     "VaxShmBlock layout changed — update hal-plugin/NereusSDRVAX.cpp to match");
+
+static_assert(offsetof(VaxShmBlock, writePos)    == 0,  "VaxShmBlock.writePos offset changed");
+static_assert(offsetof(VaxShmBlock, readPos)     == 4,  "VaxShmBlock.readPos offset changed");
+static_assert(offsetof(VaxShmBlock, sampleRate)  == 8,  "VaxShmBlock.sampleRate offset changed");
+static_assert(offsetof(VaxShmBlock, channels)    == 12, "VaxShmBlock.channels offset changed");
+static_assert(offsetof(VaxShmBlock, active)      == 16, "VaxShmBlock.active offset changed");
+static_assert(offsetof(VaxShmBlock, reserved)    == 20, "VaxShmBlock.reserved offset changed");
+static_assert(offsetof(VaxShmBlock, ringBuffer)  == 32, "VaxShmBlock.ringBuffer offset changed");
 
 // ── CoreAudioHalBus ─────────────────────────────────────────────────────────
 //

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,3 +160,12 @@ nereus_add_test(tst_master_mixer)
 
 # ── Phase 3O Sub-Phase 3: PortAudioBus ────────────────────────────────────
 nereus_add_test(tst_port_audio_bus)
+
+# ── Phase 3O Sub-Phase 5.3: CoreAudioHalBus (macOS-only) ──────────────────
+# Exercises shm-segment lifecycle + push/pull round-trip against the shared
+# memory ring the HAL plugin consumes. shm_open / mmap are macOS-specific
+# in the bus impl (Q_OS_MAC guard) — the test executable is only built on
+# Apple targets to match.
+if(APPLE)
+    nereus_add_test(tst_core_audio_hal_bus)
+endif()

--- a/tests/tst_core_audio_hal_bus.cpp
+++ b/tests/tst_core_audio_hal_bus.cpp
@@ -1,0 +1,278 @@
+// =================================================================
+// tests/tst_core_audio_hal_bus.cpp  (NereusSDR)
+// =================================================================
+//
+// Exercises CoreAudioHalBus — Phase 3O VAX Sub-Phase 5.3.
+//
+// Coverage:
+//   1. Lifecycle — open() creates the shm segment, isOpen() transitions,
+//      close() resets state. A second fd opened from the test process
+//      proves the segment is visible to other would-be consumers (i.e.
+//      the HAL plugin's shm_open path).
+//   2. Producer round-trip — push() on a Vax1 instance writes to the ring;
+//      raw mmap from the test side reads back the same bytes.
+//   3. Consumer round-trip — test writes known samples to /nereussdr-vax-tx;
+//      CoreAudioHalBus(TxInput)::pull() returns them.
+//   4. Role policing — push() returns -1 on TxInput; pull() returns -1 on
+//      Vax1..4.
+//   5. Format validation — open() rejects non-48k/non-stereo/non-float32.
+//   6. Metering — rxLevel() updates after push() with non-zero samples.
+//
+// macOS-only (shm_open + mmap + ftruncate); gated at the CMake level with
+// `if(APPLE)` so non-Apple test builds simply skip this binary.
+// =================================================================
+
+#include <QtTest/QtTest>
+
+#include "core/audio/CoreAudioHalBus.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <vector>
+
+using namespace NereusSDR;
+
+namespace {
+
+constexpr const char* kVax1Path    = "/nereussdr-vax-1";
+constexpr const char* kVax2Path    = "/nereussdr-vax-2";
+constexpr const char* kTxInputPath = "/nereussdr-vax-tx";
+
+// Unlink every VAX shm name the tests touch so a previous crash / run
+// doesn't leak stale data into the next one.
+void unlinkAllVaxSegments() {
+    ::shm_unlink(kVax1Path);
+    ::shm_unlink(kVax2Path);
+    ::shm_unlink("/nereussdr-vax-3");
+    ::shm_unlink("/nereussdr-vax-4");
+    ::shm_unlink(kTxInputPath);
+}
+
+} // namespace
+
+class TstCoreAudioHalBus : public QObject {
+    Q_OBJECT
+
+private slots:
+    void init() {
+        unlinkAllVaxSegments();
+    }
+    void cleanup() {
+        unlinkAllVaxSegments();
+    }
+
+    // ── 1. Lifecycle ────────────────────────────────────────────────────────
+
+    void openCreatesSegmentAndIsVisibleToOtherProcesses() {
+        CoreAudioHalBus bus(CoreAudioHalBus::Role::Vax1);
+        QVERIFY(!bus.isOpen());
+
+        AudioFormat fmt;
+        fmt.sampleRate = 48000;
+        fmt.channels   = 2;
+        fmt.sample     = AudioFormat::Sample::Float32;
+
+        QVERIFY2(bus.open(fmt), qPrintable(bus.errorString()));
+        QVERIFY(bus.isOpen());
+
+        // A consumer (the HAL plugin, or a second test fd) should be able
+        // to open the same segment read-only. If this fails, push() could
+        // never reach the plugin.
+        int fd = ::shm_open(kVax1Path, O_RDONLY, 0666);
+        QVERIFY2(fd >= 0, "shm_open after bus.open() should return a valid fd");
+
+        struct stat st{};
+        QCOMPARE(::fstat(fd, &st), 0);
+        QVERIFY2(static_cast<size_t>(st.st_size) >= sizeof(VaxShmBlock),
+                 "shm segment should be sized at least sizeof(VaxShmBlock)");
+        ::close(fd);
+
+        bus.close();
+        QVERIFY(!bus.isOpen());
+    }
+
+    // ── 2. Producer round-trip ──────────────────────────────────────────────
+
+    void pushOnVax1WritesToSharedRing() {
+        CoreAudioHalBus bus(CoreAudioHalBus::Role::Vax1);
+        AudioFormat fmt;
+        QVERIFY2(bus.open(fmt), qPrintable(bus.errorString()));
+
+        // Open the same segment from the test side (simulating the plugin).
+        int fd = ::shm_open(kVax1Path, O_RDWR, 0666);
+        QVERIFY(fd >= 0);
+        void* ptr = ::mmap(nullptr, sizeof(VaxShmBlock),
+                           PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        QVERIFY(ptr != MAP_FAILED);
+        auto* consumerView = static_cast<VaxShmBlock*>(ptr);
+
+        QVERIFY(consumerView->active.load(std::memory_order_acquire) == 1);
+
+        // Write 1024 bytes (256 floats, 128 stereo frames) of a known pattern.
+        constexpr int kFloats = 256;
+        std::vector<float> payload(kFloats);
+        for (int i = 0; i < kFloats; ++i) {
+            payload[i] = static_cast<float>(i) * 0.01f;
+        }
+        const qint64 bytes = static_cast<qint64>(kFloats) * sizeof(float);
+        QCOMPARE(bus.push(reinterpret_cast<const char*>(payload.data()), bytes), bytes);
+
+        // writePos should have advanced by kFloats.
+        const uint32_t wp = consumerView->writePos.load(std::memory_order_acquire);
+        QCOMPARE(wp, static_cast<uint32_t>(kFloats));
+
+        // Bytes at the head of the ring should match our pattern verbatim.
+        for (int i = 0; i < kFloats; ++i) {
+            QCOMPARE(consumerView->ringBuffer[i], payload[i]);
+        }
+
+        ::munmap(consumerView, sizeof(VaxShmBlock));
+        ::close(fd);
+        bus.close();
+    }
+
+    // ── 3. Consumer round-trip ──────────────────────────────────────────────
+
+    void pullOnTxInputReadsFromSharedRing() {
+        CoreAudioHalBus bus(CoreAudioHalBus::Role::TxInput);
+        AudioFormat fmt;
+        QVERIFY2(bus.open(fmt), qPrintable(bus.errorString()));
+
+        // Map the same segment from the test side and write samples into
+        // the ring as if the HAL plugin had done so.
+        int fd = ::shm_open(kTxInputPath, O_RDWR, 0666);
+        QVERIFY(fd >= 0);
+        void* ptr = ::mmap(nullptr, sizeof(VaxShmBlock),
+                           PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        QVERIFY(ptr != MAP_FAILED);
+        auto* pluginView = static_cast<VaxShmBlock*>(ptr);
+
+        constexpr int kFloats = 128;
+        std::vector<float> payload(kFloats);
+        for (int i = 0; i < kFloats; ++i) {
+            payload[i] = 0.25f - static_cast<float>(i) * 0.001f;
+        }
+
+        // Simulate the plugin's TX write path: copy into the ring, bump wp.
+        for (int i = 0; i < kFloats; ++i) {
+            pluginView->ringBuffer[i] = payload[i];
+        }
+        pluginView->writePos.store(kFloats, std::memory_order_release);
+        // Plugin would also set active=1, but the bus sets it at open() time.
+
+        // Bus should drain the samples back out.
+        std::vector<float> drained(kFloats, -999.0f);
+        const qint64 got = bus.pull(
+            reinterpret_cast<char*>(drained.data()),
+            static_cast<qint64>(kFloats) * sizeof(float));
+        QCOMPARE(got, static_cast<qint64>(kFloats) * sizeof(float));
+        for (int i = 0; i < kFloats; ++i) {
+            QCOMPARE(drained[i], payload[i]);
+        }
+
+        // readPos should have advanced.
+        QCOMPARE(pluginView->readPos.load(std::memory_order_acquire),
+                 static_cast<uint32_t>(kFloats));
+
+        ::munmap(pluginView, sizeof(VaxShmBlock));
+        ::close(fd);
+        bus.close();
+    }
+
+    // ── 4. Role policing ────────────────────────────────────────────────────
+
+    void pushOnTxInputReturnsMinusOne() {
+        CoreAudioHalBus bus(CoreAudioHalBus::Role::TxInput);
+        AudioFormat fmt;
+        QVERIFY2(bus.open(fmt), qPrintable(bus.errorString()));
+
+        const float dummy[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+        QCOMPARE(bus.push(reinterpret_cast<const char*>(dummy), sizeof(dummy)),
+                 static_cast<qint64>(-1));
+
+        bus.close();
+    }
+
+    void pullOnVax1ReturnsMinusOne() {
+        CoreAudioHalBus bus(CoreAudioHalBus::Role::Vax1);
+        AudioFormat fmt;
+        QVERIFY2(bus.open(fmt), qPrintable(bus.errorString()));
+
+        float buf[4] = {};
+        QCOMPARE(bus.pull(reinterpret_cast<char*>(buf), sizeof(buf)),
+                 static_cast<qint64>(-1));
+
+        bus.close();
+    }
+
+    // ── 5. Format validation ────────────────────────────────────────────────
+
+    void openRejectsWrongSampleRate() {
+        CoreAudioHalBus bus(CoreAudioHalBus::Role::Vax1);
+        AudioFormat fmt;
+        fmt.sampleRate = 44100;  // HAL plugin is hard-pinned at 48 kHz
+        fmt.channels   = 2;
+        fmt.sample     = AudioFormat::Sample::Float32;
+
+        QVERIFY(!bus.open(fmt));
+        QVERIFY(!bus.isOpen());
+        QVERIFY(!bus.errorString().isEmpty());
+    }
+
+    void openRejectsWrongChannelCount() {
+        CoreAudioHalBus bus(CoreAudioHalBus::Role::Vax2);
+        AudioFormat fmt;
+        fmt.sampleRate = 48000;
+        fmt.channels   = 1;  // mono — HAL plugin is stereo
+        fmt.sample     = AudioFormat::Sample::Float32;
+
+        QVERIFY(!bus.open(fmt));
+        QVERIFY(!bus.isOpen());
+    }
+
+    void openRejectsWrongSampleFormat() {
+        CoreAudioHalBus bus(CoreAudioHalBus::Role::Vax1);
+        AudioFormat fmt;
+        fmt.sampleRate = 48000;
+        fmt.channels   = 2;
+        fmt.sample     = AudioFormat::Sample::Int16;  // HAL plugin is Float32
+
+        QVERIFY(!bus.open(fmt));
+        QVERIFY(!bus.isOpen());
+    }
+
+    // ── 6. Metering ─────────────────────────────────────────────────────────
+
+    void rxLevelUpdatesAfterPush() {
+        CoreAudioHalBus bus(CoreAudioHalBus::Role::Vax1);
+        AudioFormat fmt;
+        QVERIFY2(bus.open(fmt), qPrintable(bus.errorString()));
+
+        QCOMPARE(bus.rxLevel(), 0.0f);
+
+        // push() strides metering at kMeterStride (10) calls — walk a
+        // handful of pushes so we're guaranteed to land on a meter update.
+        std::vector<float> payload(128);
+        for (int i = 0; i < 128; ++i) {
+            payload[i] = 0.5f;  // constant 0.5 → RMS on left channel also 0.5
+        }
+        for (int k = 0; k < 20; ++k) {
+            QCOMPARE(bus.push(reinterpret_cast<const char*>(payload.data()),
+                              static_cast<qint64>(payload.size()) * sizeof(float)),
+                     static_cast<qint64>(payload.size()) * sizeof(float));
+        }
+
+        const float lvl = bus.rxLevel();
+        QVERIFY2(lvl > 0.4f && lvl < 0.6f,
+                 qPrintable(QStringLiteral("rxLevel=%1 expected near 0.5").arg(lvl)));
+
+        bus.close();
+    }
+};
+
+QTEST_APPLESS_MAIN(TstCoreAudioHalBus)
+#include "tst_core_audio_hal_bus.moc"


### PR DESCRIPTION
## Summary

Phase 3O VAX macOS platform — the full native CoreAudio HAL Audio Server
plug-in story, packaged and ready for Apple Developer ID signing when secrets
are populated. Four \`NereusSDR VAX 1..4\` devices + one \`NereusSDR TX\` device
exposed as real macOS audio endpoints via a libASPL-based userspace driver,
plus the app-side \`IAudioBus\` implementation that writes into the shared
memory the plugin reads.

Does NOT yet integrate with the running app's audio path — \`AudioEngine\`
still instantiates \`PortAudioBus\` for all IAudioBus slots. End-to-end WSJT-X
smoke test (Setup → Audio → VAX 1, tune, listen) lands in a follow-up PR
together with the VAX UI (Sub-Phase 9).

Design spec: \`docs/architecture/2026-04-19-vax-design.md\` §8.1
Implementation plan: \`docs/architecture/2026-04-19-phase3o-vax-plan.md\` §Sub-Phase 5

## What's in this PR

**Task 5.1 — HAL plugin bundle**
- \`hal-plugin/NereusSDRVAX.cpp\` — ported from AetherSDR \`hal-plugin/AetherSDRDAX.cpp\`,
  rebranded (UIDs, shm paths, class names), 24 kHz → 48 kHz per spec, fresh
  \`CFPlugInFactories\` UUID for Mac-side coexistence with AetherSDR, C++20.
- \`hal-plugin/CMakeLists.txt\` + \`Info.plist\` — separate CMake build (libASPL
  FetchContent; standalone of main build). Top-level \`option(NEREUSSDR_BUILD_HAL_PLUGIN OFF)\`.
- Fix pass: \`VaxShmBlock::active\` promoted to \`std::atomic<uint32_t>\`, \`fstat\`
  guard on mmap to prevent SIGBUS on stale shm, \`offsetof\` asserts pin the
  wire-layout on both sides.

**Task 5.2 — Installer**
- \`packaging/macos/hal-installer.sh\` — ported from AetherSDR, rebranded + fixed.
  Produces \`build/NereusSDR-<version>-macOS.pkg\` (~10.6 MiB, two-component:
  app + HAL driver). Fail-fast on missing HAL driver (prevents cryptic
  productbuild failures). Existence-guard on app + HAL rebuilds so CI
  Developer ID signatures survive the installer run.
- \`packaging/macos/hal-postinstall.sh\` — macOS 14.4+ \`killall coreaudiod\`
  fallback for the \`launchctl kickstart\` lockdown regression.
- \`packaging/macos/hal-uninstall.sh\` — emergency HAL-plugin uninstaller.

**Task 5.3 — App-side shm writer**
- \`src/core/audio/CoreAudioHalBus.{h,cpp}\` — per-endpoint \`IAudioBus\`
  implementation (one instance per Role: Vax1..4 / TxInput) ported from
  AetherSDR's monolithic \`VirtualAudioBridge\`. No QObject, no signals,
  no silence-fill/TX-poll timers (deferred to Phase 3M). Producer-side
  \`push()\` (Vax1..4) and consumer-side \`pull()\` (TxInput), both RT-safe.
- Canonical \`VaxShmBlock\` struct definition; matching \`offsetof\` asserts
  in plugin + app so field-reorder drift fails compile on both sides.
- \`tests/tst_core_audio_hal_bus.cpp\` — 10 test slots: lifecycle + shm
  visibility, push/pull round-trip, error-path validation (wrong rate /
  channels / format, wrong-direction calls).

**Task 5.4 — CI + provenance**
- \`.github/workflows/release.yml\` macOS job: new HAL plugin build + Developer
  ID sign + \`.pkg\` build + notarize + staple + upload steps. Sign/Notarize/
  Staple gated on \`APPLE_DEVELOPER_ID\` secret presence so alpha releases
  without certs still produce unsigned \`.pkg\`s as build artifacts.
- \`docs/attribution/aethersdr-contributor-index.md\` + \`aethersdr-reconciliation.md\`
  — new rows for the three ported files citing AetherSDR as upstream.

## Known limitations (follow-ups)

1. **Main app still ad-hoc codesigned** — upgrade to Developer ID needed before
   notarization can accept the produced \`.pkg\`. Conditional workflow branching
   documented inline in \`release.yml\`.
2. **\`productbuild\` outer signing deferred** — needs a Developer ID Installer
   cert + \`productsign\` step or env-var threading through hal-installer.sh.
3. **\`scripts/compliance-inventory.py\` path filter** excludes \`hal-plugin/\` —
   \`NereusSDRVAX.cpp\` classified as \`nereussdr-original\` despite carrying an
   AetherSDR port-citation header. Classification is correct per human reading
   of the attribution docs; widening the script's path filter deferred.
4. **No AudioEngine wiring** — CoreAudioHalBus isn't constructed by AudioEngine
   yet; ships alongside Sub-Phase 9 (VAX UI) when the user-facing enable path
   lands.
5. **End-to-end WSJT-X smoke test** — requires Sub-Phase 9 VAX UI to set
   \`SliceModel::vaxChannel\`. Unit test confirms shm round-trip; cross-process
   smoke pending.

## Secrets to populate (repo Settings → Secrets)

Before the next release can sign + notarize:
- \`APPLE_DEVELOPER_ID\` — e.g. \`"J.J. Boyd (TEAMIDXXXX)"\`
- \`APPLE_ID\` — Apple account email
- \`APPLE_TEAM_ID\` — 10-char Apple team ID
- \`APPLE_APP_PASSWORD\` — app-specific password for notarytool

## Attribution

Three new AetherSDR ports under HOW-TO-PORT.md rule 6 (AetherSDR has no
per-file GPL headers; project-level citation at the NereusSDR port-citation
block). \`scripts/check-new-ports.py\` and \`scripts/compliance-inventory.py\`
both green. All commits GPG-signed.

## Test plan

- [x] \`tst_core_audio_hal_bus\` — 10/10 pass (APPLE-gated)
- [x] Full suite: 51/55 pass, same 4 pre-existing failures as \`main\`
  (tst_container_persistence, tst_p1_loopback_connection,
  tst_hardware_page_capability_gating, tst_about_dialog). Zero new failures.
- [x] \`cmake -B build-hal -S hal-plugin && cmake --build build-hal\` produces
  \`build-hal/NereusSDRVAX.driver/Contents/MacOS/NereusSDRVAX\` as Mach-O
  arm64 bundle.
- [x] \`bash packaging/macos/hal-installer.sh\` produces
  \`build/NereusSDR-0.2.1-macOS.pkg\` (~10.6 MiB). Reuse path honored when
  \`build/\` and \`build-hal/\` already populated.
- [x] YAML syntax of \`release.yml\` valid.
- [x] All pre-commit hooks green (\`verify-thetis-headers\`, \`check-new-ports\`,
  \`verify-inline-cites\`, \`compliance-inventory\`).
- [x] All 9 commits GPG-signed.
- [ ] End-to-end WSJT-X VAX smoke test (deferred to Sub-Phase 9).

J.J. Boyd ~ KG4VCF