### PR TITLE
Phase 3O Sub-Phase 7: VirtualCableDetector (Windows BYO helper)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ set(CORE_SOURCES
     src/core/StepAttenuatorController.cpp
     src/core/audio/MasterMixer.cpp
     src/core/audio/PortAudioBus.cpp
+    src/core/audio/VirtualCableDetector.cpp
 )
 
 # CoreAudioHalBus — macOS-only IAudioBus implementation bridging to the

--- a/src/core/audio/VirtualCableDetector.cpp
+++ b/src/core/audio/VirtualCableDetector.cpp
@@ -1,0 +1,74 @@
+// src/core/audio/VirtualCableDetector.cpp (NereusSDR)
+// Implements VirtualCableDetector: regex product matching + PortAudio scan.
+// NereusSDR-original; no Thetis/AetherSDR port.
+#include "VirtualCableDetector.h"
+#include <QRegularExpression>
+#include "PortAudioBus.h"
+
+using namespace NereusSDR;
+
+VirtualCableProduct VirtualCableDetector::matchProduct(const QString& n) {
+    // Rule order is load-bearing:
+    //   - NereusSdrVax first (reserved prefix must not be shadowed by CABLE rules)
+    //   - CABLE-A/B/C/D before CABLE (or the base rule shadows the variants)
+    //   - VbHiFiCable before CABLE (name contains "Hi-Fi Cable", not "CABLE ")
+    // Rules are function-local statics — QRegularExpression constructed once
+    // on first call (thread-safe per C++11).
+    static const struct { QRegularExpression re; VirtualCableProduct p; } rules[] = {
+        { QRegularExpression("^NereusSDR VAX \\d$"),                              VirtualCableProduct::NereusSdrVax },
+        { QRegularExpression("^CABLE-A ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableA },
+        { QRegularExpression("^CABLE-B ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableB },
+        { QRegularExpression("^CABLE-C ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableC },
+        { QRegularExpression("^CABLE-D ",  QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCableD },
+        { QRegularExpression("Hi-?Fi Cable", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbHiFiCable },
+        { QRegularExpression("^CABLE ",    QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::VbCable },
+        { QRegularExpression("Virtual Audio Cable", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::MuzychenkoVac },
+        { QRegularExpression("^Line \\d+", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::MuzychenkoVac },
+        { QRegularExpression("VoiceMeeter", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::Voicemeeter },
+        { QRegularExpression("^Dante ",    QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::Dante },
+        { QRegularExpression("^DAX Audio", QRegularExpression::CaseInsensitiveOption), VirtualCableProduct::FlexRadioDax },
+    };
+    for (const auto& r : rules) {
+        if (r.re.match(n).hasMatch()) { return r.p; }
+    }
+    return VirtualCableProduct::None;
+}
+
+QString VirtualCableDetector::installUrl(VirtualCableProduct p) {
+    switch (p) {
+        case VirtualCableProduct::VbCable:
+        case VirtualCableProduct::VbCableA:
+        case VirtualCableProduct::VbCableB:
+        case VirtualCableProduct::VbCableC:
+        case VirtualCableProduct::VbCableD:
+        case VirtualCableProduct::VbHiFiCable:
+            return "https://vb-audio.com/Cable/";
+        case VirtualCableProduct::MuzychenkoVac:
+            return "https://vac.muzychenko.net/en/";
+        case VirtualCableProduct::Voicemeeter:
+            return "https://voicemeeter.com/";
+        case VirtualCableProduct::Dante:
+            return "https://www.getdante.com/products/software-essentials/dante-virtual-soundcard/";
+        default:
+            return {};
+    }
+}
+
+QVector<DetectedCable> VirtualCableDetector::scan() {
+    QVector<DetectedCable> out;
+    for (const auto& api : PortAudioBus::hostApis()) {
+        for (const auto& dev : PortAudioBus::outputDevicesFor(api.index)) {
+            const auto p = matchProduct(dev.name);
+            if (p != VirtualCableProduct::None) {
+                out.push_back({p, dev.name, false, 0});
+            }
+        }
+        for (const auto& dev : PortAudioBus::inputDevicesFor(api.index)) {
+            const auto p = matchProduct(dev.name);
+            if (p != VirtualCableProduct::None) {
+                out.push_back({p, dev.name, true, 0});
+            }
+        }
+    }
+    return out;
+}

--- a/src/core/audio/VirtualCableDetector.h
+++ b/src/core/audio/VirtualCableDetector.h
@@ -1,0 +1,41 @@
+// src/core/audio/VirtualCableDetector.h (NereusSDR)
+// Detects known Windows virtual-audio-cable products by regex-matching OS
+// device name strings. NereusSDR-original; no Thetis/AetherSDR port.
+#pragma once
+#include <QString>
+#include <QVector>
+
+namespace NereusSDR {
+
+enum class VirtualCableProduct {
+    None = 0,
+    VbCable,
+    VbCableA,  VbCableB,  VbCableC,  VbCableD,
+    VbHiFiCable,
+    MuzychenkoVac,
+    Voicemeeter,
+    Dante,
+    FlexRadioDax,
+    NereusSdrVax,  // reserved for future NereusSDR-owned Windows driver
+};
+
+struct DetectedCable {
+    VirtualCableProduct product;
+    QString deviceName;
+    bool isInput;  // false = render / output
+    int channel;   // 1..N for multi-cable families; 0 if N/A
+};
+
+class VirtualCableDetector {
+public:
+    // Pure-function test-hook. Inspects the OS device name string.
+    static VirtualCableProduct matchProduct(const QString& deviceName);
+
+    // Enumerates OS audio devices via PortAudio and returns matches.
+    static QVector<DetectedCable> scan();
+
+    // Vendor install URL for a given product (for the first-run helper).
+    static QString installUrl(VirtualCableProduct p);
+};
+
+} // namespace NereusSDR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,3 +180,6 @@ endif()
 if(UNIX AND NOT APPLE)
     nereus_add_test(tst_linux_pipe_bus)
 endif()
+
+# ── Phase 3O Sub-Phase 7 Task 7.1: VirtualCableDetector ──────────────────────
+nereus_add_test(tst_virtual_cable_detector)

--- a/tests/tst_virtual_cable_detector.cpp
+++ b/tests/tst_virtual_cable_detector.cpp
@@ -1,0 +1,54 @@
+// tests/tst_virtual_cable_detector.cpp (NereusSDR)
+// Unit tests for VirtualCableDetector::matchProduct() pure-function hook.
+// NereusSDR-original; no Thetis/AetherSDR port.
+#include <QtTest/QtTest>
+#include "core/audio/VirtualCableDetector.h"
+
+using namespace NereusSDR;
+
+class TstVirtualCableDetector : public QObject {
+    Q_OBJECT
+private slots:
+    void detectsVbCableBase() {
+        QVERIFY(VirtualCableDetector::matchProduct(
+            "CABLE Input (VB-Audio Virtual Cable)") == VirtualCableProduct::VbCable);
+    }
+    void detectsVbCableAB() {
+        QVERIFY(VirtualCableDetector::matchProduct("CABLE-A Input") == VirtualCableProduct::VbCableA);
+        QVERIFY(VirtualCableDetector::matchProduct("CABLE-B Input") == VirtualCableProduct::VbCableB);
+    }
+    void detectsVac() {
+        QVERIFY(VirtualCableDetector::matchProduct("Line 1 (Virtual Audio Cable)")
+                == VirtualCableProduct::MuzychenkoVac);
+    }
+    void detectsVoicemeeter() {
+        QVERIFY(VirtualCableDetector::matchProduct("VoiceMeeter Input (VB-Audio VoiceMeeter VAIO)")
+                == VirtualCableProduct::Voicemeeter);
+    }
+    void detectsDante() {
+        QVERIFY(VirtualCableDetector::matchProduct("Dante Tx 01-02")
+                == VirtualCableProduct::Dante);
+    }
+    void detectsFlexDax() {
+        QVERIFY(VirtualCableDetector::matchProduct("DAX Audio RX 1")
+                == VirtualCableProduct::FlexRadioDax);
+    }
+    void detectsReservedNereusVax() {
+        QVERIFY(VirtualCableDetector::matchProduct("NereusSDR VAX 1")
+                == VirtualCableProduct::NereusSdrVax);
+    }
+    void unknownDeviceIsNone() {
+        QVERIFY(VirtualCableDetector::matchProduct("Realtek HD Audio Output")
+                == VirtualCableProduct::None);
+    }
+    // Extra: verify CABLE-A prefix doesn't shadow CABLE-AB (shouldn't match VbCableA)
+    void cableAbDoesNotMatchCableA() {
+        // "CABLE-AB Input" doesn't start with "^CABLE-A " (note trailing space in rule),
+        // so it falls through to "^CABLE " and matches VbCable base, NOT VbCableA.
+        const auto p = VirtualCableDetector::matchProduct("CABLE-AB Input");
+        QVERIFY(p != VirtualCableProduct::VbCableA);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstVirtualCableDetector)
+#include "tst_virtual_cable_detector.moc"


### PR DESCRIPTION
## Summary
- Adds `src/core/audio/VirtualCableDetector.{h,cpp}` — pure-function regex
  matcher + live `PortAudioBus` device scanner for well-known virtual-audio-cable
  products. Used by the Windows "bring-your-own-cable" first-run helper (later
  sub-phase) to detect already-installed products and offer vendor install URLs
  for missing ones.
- 12 rule set (order is load-bearing): reserved `NereusSDR VAX <n>` namespace
  first, then VB-Audio `CABLE-{A..D}`, `Hi-?Fi Cable`, base `CABLE `, Muzychenko
  VAC (`Virtual Audio Cable` + `Line <n>`), VoiceMeeter, Dante, FlexRadio DAX.
- Cross-platform C++ — builds and tests on every OS. No platform guards; no
  OS-specific I/O. Only runtime dependency beyond Qt6 is the existing
  `PortAudioBus`.
- Independent of PR #64 (Sub-Phase 6 / LinuxPipeBus) — branches off the same
  `origin/main` base and can merge in either order.

## Tests
9 QtTest slots (all passing locally):
- 8 required (`detectsVbCableBase`, `detectsVbCableAB`, `detectsVac`,
  `detectsVoicemeeter`, `detectsDante`, `detectsFlexDax`,
  `detectsReservedNereusVax`, `unknownDeviceIsNone`)
- 1 regression guard (`cableAbDoesNotMatchCableA` — ensures the `^CABLE-A `
  trailing-space anchor correctly rejects `CABLE-AB`-style names)

## Test plan
- [ ] Linux CI: `tst_virtual_cable_detector` builds and runs
- [ ] macOS CI: same
- [ ] Windows CI: same
- [ ] `compliance-inventory.py` classifies the new files as
      `nereussdr-original` (no port → no attribution row expected)

## Scope notes
- `scan()` live-enumeration only wires `PortAudioBus::{hostApis,
  outputDevicesFor, inputDevicesFor}`. Manual Windows-host verification with
  real virtual cables is deferred to the first-run UI sub-phase.
- Multi-cable `channel` field in `DetectedCable` is currently always 0;
  per-channel parsing is a later enhancement.

---
J.J. Boyd ~ KG4VCF