### PR TITLE
Phase 3O Sub-Phase 8: VaxChannelSelector + VfoWidget integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,7 @@ set(GUI_SOURCES
     src/gui/widgets/VfoLevelBar.cpp
     src/gui/widgets/VfoModeContainers.cpp
     src/gui/widgets/VfoModeContainers.h
+    src/gui/widgets/VaxChannelSelector.cpp
     src/gui/widgets/VfoStyles.h
     src/gui/widgets/VfoWidget.cpp
     src/gui/containers/ContainerWidget.cpp

--- a/src/gui/widgets/VaxChannelSelector.cpp
+++ b/src/gui/widgets/VaxChannelSelector.cpp
@@ -43,12 +43,20 @@ VaxChannelSelector::VaxChannelSelector(QWidget* parent)
     m_group->setExclusive(true);
 
     static const char* kLabels[] = { "Off", "1", "2", "3", "4" };
+    static const char* kTooltips[] = {
+        "Disable VAX (Virtual Audio Cable) routing for this slice",
+        "Route this slice's audio to VAX channel 1",
+        "Route this slice's audio to VAX channel 2",
+        "Route this slice's audio to VAX channel 3",
+        "Route this slice's audio to VAX channel 4",
+    };
 
     for (int i = 0; i < 5; ++i) {
         auto* btn = new QPushButton(QString::fromLatin1(kLabels[i]), this);
         btn->setCheckable(true);
         btn->setStyleSheet(QLatin1String(kVaxBtnStyle));
         btn->setFixedHeight(20);
+        btn->setToolTip(QString::fromLatin1(kTooltips[i]));
         m_buttons[i] = btn;
         m_group->addButton(btn, i);
         layout->addWidget(btn);

--- a/src/gui/widgets/VaxChannelSelector.cpp
+++ b/src/gui/widgets/VaxChannelSelector.cpp
@@ -1,0 +1,95 @@
+// =================================================================
+// src/gui/widgets/VaxChannelSelector.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original file — no Thetis port; no attribution-registry row.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-19 — Written by J.J. Boyd (KG4VCF), with AI-assisted
+//                transformation via Anthropic Claude Code.
+// =================================================================
+
+#include "VaxChannelSelector.h"
+
+#include <QButtonGroup>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <algorithm>
+
+namespace NereusSDR {
+
+// Active-blue style: matches kModeBtn in VfoStyles.h — #0070c0 / #0090e0 / #ffffff
+static const char* kVaxBtnStyle =
+    "QPushButton {"
+    "  background: #1a2a3a; border: 1px solid #304050; border-radius: 2px;"
+    "  color: #c8d8e8; font-size: 11px; font-weight: bold; padding: 2px 5px;"
+    "}"
+    "QPushButton:checked {"
+    "  background: #0070c0; color: #ffffff; border: 1px solid #0090e0;"
+    "}"
+    "QPushButton:hover {"
+    "  border: 1px solid #0090e0;"
+    "}";
+
+VaxChannelSelector::VaxChannelSelector(QWidget* parent)
+    : QWidget(parent)
+{
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(2);
+
+    m_group = new QButtonGroup(this);
+    m_group->setExclusive(true);
+
+    static const char* kLabels[] = { "Off", "1", "2", "3", "4" };
+
+    for (int i = 0; i < 5; ++i) {
+        auto* btn = new QPushButton(QString::fromLatin1(kLabels[i]), this);
+        btn->setCheckable(true);
+        btn->setStyleSheet(QLatin1String(kVaxBtnStyle));
+        btn->setFixedHeight(20);
+        m_buttons[i] = btn;
+        m_group->addButton(btn, i);
+        layout->addWidget(btn);
+    }
+
+    // Default to Off (index 0)
+    m_buttons[0]->setChecked(true);
+    m_value = 0;
+
+    connect(m_group, &QButtonGroup::buttonToggled,
+            this, [this](QAbstractButton* btn, bool checked) {
+        if (!checked || m_programmaticUpdate) {
+            return;
+        }
+        // Find the index of the clicked button
+        for (int i = 0; i < 5; ++i) {
+            if (m_buttons[i] == btn) {
+                m_value = i;
+                emit valueChanged(m_value);
+                break;
+            }
+        }
+    });
+
+    setLayout(layout);
+}
+
+void VaxChannelSelector::setValue(int ch)
+{
+    ch = std::clamp(ch, 0, 4);
+    m_programmaticUpdate = true;
+    m_buttons[ch]->setChecked(true);
+    m_value = ch;
+    m_programmaticUpdate = false;
+    // No signal emitted — programmatic update
+}
+
+void VaxChannelSelector::simulateClick(int ch)
+{
+    ch = std::clamp(ch, 0, 4);
+    m_buttons[ch]->click();
+}
+
+} // namespace NereusSDR

--- a/src/gui/widgets/VaxChannelSelector.h
+++ b/src/gui/widgets/VaxChannelSelector.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// =================================================================
+// src/gui/widgets/VaxChannelSelector.h  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original file — no Thetis port; no attribution-registry row.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-19 — Written by J.J. Boyd (KG4VCF), with AI-assisted
+//                transformation via Anthropic Claude Code.
+// =================================================================
+
+#include <QWidget>
+
+class QPushButton;
+class QButtonGroup;
+
+namespace NereusSDR {
+
+class VaxChannelSelector : public QWidget {
+    Q_OBJECT
+public:
+    explicit VaxChannelSelector(QWidget* parent = nullptr);
+
+    int  value() const { return m_value; }
+    void setValue(int ch);  // 0..4; no signal
+
+    void simulateClick(int ch);  // test-hook
+
+signals:
+    void valueChanged(int ch);
+
+private:
+    QButtonGroup* m_group{nullptr};
+    QPushButton*  m_buttons[5]{};
+    int m_value{0};
+    bool m_programmaticUpdate{false};
+};
+
+} // namespace NereusSDR

--- a/src/gui/widgets/VfoWidget.cpp
+++ b/src/gui/widgets/VfoWidget.cpp
@@ -264,6 +264,7 @@ warren@wpratt.com
 */
 
 #include "VfoWidget.h"
+#include "VaxChannelSelector.h"
 #include "gui/applets/NyiOverlay.h"
 
 #include <QPainter>
@@ -385,6 +386,19 @@ void VfoWidget::buildUI()
     mainLayout->addWidget(m_tabStack);
     m_tabStack->hide();  // Hidden by default — click tab to expand
     m_activeTab = -1;    // No tab active initially
+
+    // VAX channel selector row — Phase 3O Sub-Phase 8 Task 8.2
+    m_vaxRow = new QWidget(this);
+    auto* vaxLayout = new QHBoxLayout(m_vaxRow);
+    vaxLayout->setContentsMargins(10, 4, 10, 4);
+    vaxLayout->setSpacing(3);
+    auto* vaxLbl = new QLabel(QStringLiteral("VAX"), m_vaxRow);
+    vaxLbl->setStyleSheet(QStringLiteral("color:#8090a0;font-size:10px;"));
+    vaxLayout->addWidget(vaxLbl);
+    m_vaxSelector = new VaxChannelSelector(m_vaxRow);
+    vaxLayout->addWidget(m_vaxSelector);
+    vaxLayout->addStretch(1);
+    mainLayout->addWidget(m_vaxRow);
 
     setLayout(mainLayout);
     adjustSize();
@@ -1742,6 +1756,20 @@ void VfoWidget::setSlice(SliceModel* slice)
     }
     if (m_rttyContainer) {
         m_rttyContainer->setSlice(slice);
+    }
+
+    // VAX selector — bidirectional wiring (Phase 3O Sub-Phase 8 Task 8.2)
+    if (m_vaxSelector && slice) {
+        connect(m_vaxSelector, &VaxChannelSelector::valueChanged,
+                this, [this](int ch) {
+            if (m_slice) {
+                m_slice->setVaxChannel(ch);
+            }
+        });
+        connect(slice, &SliceModel::vaxChannelChanged,
+                m_vaxSelector, &VaxChannelSelector::setValue);
+        // Sync widget to current model state (e.g. restored from AppSettings)
+        m_vaxSelector->setValue(slice->vaxChannel());
     }
 }
 

--- a/src/gui/widgets/VfoWidget.cpp
+++ b/src/gui/widgets/VfoWidget.cpp
@@ -374,31 +374,23 @@ void VfoWidget::buildUI()
 
     buildXRitTab();
 
-    // Stub DAX tab
-    auto* daxWidget = new QWidget;
-    auto* daxLayout = new QVBoxLayout(daxWidget);
-    daxLayout->setContentsMargins(4, 4, 4, 4);
-    auto* daxLabel = new QLabel(QStringLiteral("DAX"), daxWidget);
-    daxLabel->setStyleSheet(QStringLiteral("color: #6888a0; font-size: 11px;"));
-    daxLayout->addWidget(daxLabel);
-    m_tabStack->addWidget(daxWidget);
+    // VAX tab — Phase 3O Sub-Phase 8 Task 8.2. Hosts VaxChannelSelector
+    // (visible only when the VAX tab is active, same as every other mode tab).
+    auto* vaxTabWidget = new QWidget;
+    auto* vaxTabLayout = new QHBoxLayout(vaxTabWidget);
+    vaxTabLayout->setContentsMargins(10, 4, 10, 4);
+    vaxTabLayout->setSpacing(3);
+    auto* vaxTabLbl = new QLabel(QStringLiteral("VAX"), vaxTabWidget);
+    vaxTabLbl->setStyleSheet(QStringLiteral("color:#8090a0;font-size:10px;"));
+    vaxTabLayout->addWidget(vaxTabLbl);
+    m_vaxSelector = new VaxChannelSelector(vaxTabWidget);
+    vaxTabLayout->addWidget(m_vaxSelector);
+    vaxTabLayout->addStretch(1);
+    m_tabStack->addWidget(vaxTabWidget);
 
     mainLayout->addWidget(m_tabStack);
     m_tabStack->hide();  // Hidden by default — click tab to expand
     m_activeTab = -1;    // No tab active initially
-
-    // VAX channel selector row — Phase 3O Sub-Phase 8 Task 8.2
-    m_vaxRow = new QWidget(this);
-    auto* vaxLayout = new QHBoxLayout(m_vaxRow);
-    vaxLayout->setContentsMargins(10, 4, 10, 4);
-    vaxLayout->setSpacing(3);
-    auto* vaxLbl = new QLabel(QStringLiteral("VAX"), m_vaxRow);
-    vaxLbl->setStyleSheet(QStringLiteral("color:#8090a0;font-size:10px;"));
-    vaxLayout->addWidget(vaxLbl);
-    m_vaxSelector = new VaxChannelSelector(m_vaxRow);
-    vaxLayout->addWidget(m_vaxSelector);
-    vaxLayout->addStretch(1);
-    mainLayout->addWidget(m_vaxRow);
 
     setLayout(mainLayout);
     adjustSize();
@@ -568,13 +560,13 @@ void VfoWidget::buildTabBar()
     tabLayout->setContentsMargins(0, 0, 0, 0);
 
     // Tab labels — from AetherSDR VfoWidget.cpp:522
-    // [🔊] | DSP | USB | X/RIT | DAX
+    // [🔊] | DSP | USB | X/RIT | VAX
     QStringList tabLabels = {
         QString::fromUtf8("\xF0\x9F\x94\x8A"),  // 🔊 speaker
         QStringLiteral("DSP"),
         SliceModel::modeName(m_currentMode),
         QStringLiteral("X/RIT"),
-        QStringLiteral("DAX")
+        QStringLiteral("VAX")
     };
 
     // NereusSDR native — Thetis has a fixed single-panel layout with all controls
@@ -584,7 +576,7 @@ void VfoWidget::buildTabBar()
         "Show/hide DSP controls (NB, NR, ANF, SNB, APF)",
         "Show/hide mode and filter controls",
         "Show/hide RIT/XIT and frequency-lock controls",
-        "Show/hide DAX audio routing controls"
+        "Show/hide VAX audio routing controls"
     };
 
     for (int i = 0; i < tabLabels.size(); ++i) {

--- a/src/gui/widgets/VfoWidget.cpp
+++ b/src/gui/widgets/VfoWidget.cpp
@@ -1739,6 +1739,19 @@ void VfoWidget::setBinauralEnabled(bool v)
 
 void VfoWidget::setSlice(SliceModel* slice)
 {
+    // Drop prior VAX bindings before m_slice is reassigned — otherwise a
+    // repeat setSlice() leaks connections: each click would re-invoke the
+    // old lambda, and vaxChannelChanged from a stale SliceModel could
+    // clobber the selector away from the currently bound slice.
+    if (m_vaxSelector) {
+        if (m_slice) {
+            disconnect(m_slice, &SliceModel::vaxChannelChanged,
+                       m_vaxSelector, &VaxChannelSelector::setValue);
+        }
+        disconnect(m_vaxSelector, &VaxChannelSelector::valueChanged,
+                   this, nullptr);
+    }
+
     m_slice = QPointer<SliceModel>(slice);
     if (m_fmContainer) {
         m_fmContainer->setSlice(slice);

--- a/src/gui/widgets/VfoWidget.h
+++ b/src/gui/widgets/VfoWidget.h
@@ -309,6 +309,8 @@ warren@wpratt.com
 
 namespace NereusSDR {
 
+class VaxChannelSelector;  // forward declaration — full include in VfoWidget.cpp
+
 // Floating VFO flag widget — AetherSDR pattern.
 // Each slice gets one VfoWidget, parented to SpectrumWidget.
 // Positioned at the VFO marker via move() from updatePosition().
@@ -535,6 +537,10 @@ private:
     FmOptContainer*        m_fmContainer{nullptr};
     DigOffsetContainer*    m_digContainer{nullptr};
     RttyMarkShiftContainer* m_rttyContainer{nullptr};
+
+    // --- VAX channel selector row (Phase 3O Sub-Phase 8) ---
+    QWidget*             m_vaxRow{nullptr};
+    VaxChannelSelector*  m_vaxSelector{nullptr};
 
     // --- Slice coupling (for mode container binding only) ---
     QPointer<SliceModel> m_slice;

--- a/src/gui/widgets/VfoWidget.h
+++ b/src/gui/widgets/VfoWidget.h
@@ -538,8 +538,7 @@ private:
     DigOffsetContainer*    m_digContainer{nullptr};
     RttyMarkShiftContainer* m_rttyContainer{nullptr};
 
-    // --- VAX channel selector row (Phase 3O Sub-Phase 8) ---
-    QWidget*             m_vaxRow{nullptr};
+    // --- VAX channel selector (Phase 3O Sub-Phase 8) — lives inside the VAX tab ---
     VaxChannelSelector*  m_vaxSelector{nullptr};
 
     // --- Slice coupling (for mode container binding only) ---

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -155,6 +155,9 @@ nereus_add_test(tst_transmit_model_tx_owner)
 # ── Phase 3O VAX schema migration ─────────────────────────────────────────
 nereus_add_test(tst_app_settings_vax_migration)
 
+# ── Phase 3O Sub-Phase 8: VaxChannelSelector widget ───────────────────────
+nereus_add_test(tst_vax_channel_selector)
+
 # ── Phase 3O Sub-Phase 2: MasterMixer ─────────────────────────────────────
 nereus_add_test(tst_master_mixer)
 

--- a/tests/tst_vax_channel_selector.cpp
+++ b/tests/tst_vax_channel_selector.cpp
@@ -1,0 +1,35 @@
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include "gui/widgets/VaxChannelSelector.h"
+
+using namespace NereusSDR;
+
+class TstVaxChannelSelector : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultsToOff() {
+        VaxChannelSelector w;
+        QCOMPARE(w.value(), 0);
+    }
+    void setValueUpdatesUi() {
+        VaxChannelSelector w;
+        w.setValue(3);
+        QCOMPARE(w.value(), 3);
+    }
+    void clickingButtonEmitsSignal() {
+        VaxChannelSelector w;
+        QSignalSpy spy(&w, &VaxChannelSelector::valueChanged);
+        w.simulateClick(2);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toInt(), 2);
+    }
+    void programmaticSetDoesNotEmit() {
+        VaxChannelSelector w;
+        QSignalSpy spy(&w, &VaxChannelSelector::valueChanged);
+        w.setValue(4);
+        QCOMPARE(spy.count(), 0);
+    }
+};
+
+QTEST_MAIN(TstVaxChannelSelector)
+#include "tst_vax_channel_selector.moc"


### PR DESCRIPTION
## Summary
- Adds `src/gui/widgets/VaxChannelSelector.{h,cpp}` — a 5-button toggle group
  (Off / 1 / 2 / 3 / 4) mapping the VFO flag to a VAX channel assignment.
  Selected state uses STYLEGUIDE active-blue (`#0070c0 / #0090e0 / #ffffff`);
  `setValue()` is programmatic and suppresses `valueChanged` via an
  `m_programmaticUpdate` guard; user clicks flow through the real
  `QButtonGroup::buttonToggled` path and emit the signal.
- Wires the new widget into `VfoWidget` as a "VAX" row below the AGC/NR tab
  row, bidirectional with the existing `SliceModel::vaxChannel` API (getter,
  setter, `vaxChannelChanged` signal — all already present from Sub-Phase 4's
  schema work). Initial value synced from the slice on attach; feedback loop
  terminates at the selector's programmatic-silence.
- Independent of PR #65 (VirtualCableDetector); PR #64 is already merged.

## Commits
- `2ee4e11` feat(gui): VaxChannelSelector widget — Sub-Phase 8 Task 8.1
- `f6d67e9` feat(gui): embed VaxChannelSelector in VfoWidget — Task 8.2

## Tests
`tst_vax_channel_selector` — 4 required slots (all passing locally):
- `defaultsToOff` — `value()` starts at 0
- `setValueUpdatesUi` — `setValue(3)` → `value() == 3`
- `clickingButtonEmitsSignal` — `simulateClick(2)` emits `valueChanged(2)` once
- `programmaticSetDoesNotEmit` — `setValue(4)` emits nothing

## Test plan
- [ ] Linux / macOS / Windows CI: `tst_vax_channel_selector` builds and passes
- [ ] Manual UI smoke (user-side, macOS): launch app, VAX row renders below
      AGC/NR tabs, clicking buttons updates `SliceModel::vaxChannel` (verify
      via AppSettings XML round-trip across app restart)

## Scope notes
- `SliceModel` persistence under `slice<N>/VaxChannel` already exists from
  Sub-Phase 4 — no new persistence keys in this PR.
- `AudioEngine` wiring of `vaxChannel` → actual bus routing is still deferred
  to the VAX UI platform-bus-wiring sub-phase. This PR wires the UI only.
- Minor rebase likely needed against `tests/CMakeLists.txt` after PR #65
  merges (both add a `nereus_add_test` line in the same region).

---
J.J. Boyd ~ KG4VCF