### PR TITLE
Phase 3O: finish DAX→VAX UI rebrand

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1501,7 +1501,7 @@ void MainWindow::buildMenuBar()
         tciAction->setToolTip(QStringLiteral("NYI — Phase 3J"));
     }
     {
-        QAction* daxAction = toolsMenu->addAction(QStringLiteral("&DAX Audio..."));
+        QAction* daxAction = toolsMenu->addAction(QStringLiteral("&VAX Audio..."));
         daxAction->setEnabled(false);
         daxAction->setToolTip(QStringLiteral("NYI — Phase X"));
     }

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -159,7 +159,7 @@ void SetupDialog::buildTree()
     add(audio, "ASIO Config",      new AsioConfigPage(m_model));
     add(audio, "VAC 1",            new Vac1Page(m_model));
     add(audio, "VAC 2",            new Vac2Page(m_model));
-    add(audio, "NereusDAX",        new NereusDaxPage(m_model));
+    add(audio, "NereusVAX",        new NereusVaxPage(m_model));
     add(audio, "Recording",        new RecordingPage(m_model));
 
     // ── DSP ───────────────────────────────────────────────────────────────────

--- a/src/gui/SpectrumOverlayPanel.cpp
+++ b/src/gui/SpectrumOverlayPanel.cpp
@@ -215,11 +215,11 @@ SpectrumOverlayPanel::SpectrumOverlayPanel(QWidget* parent)
         m_menuBtns.append(btn);  // index 5
     }
 
-    // Button 8: DAX — flyout (NYI Phase 3-DAX)
+    // Button 8: VAX — flyout (NYI Phase 3-VAX)
     {
-        auto* btn = makeMenuBtn("DAX", this);
-        btn->setToolTip("Open DAX audio routing (NYI Phase 3-DAX)");
-        connect(btn, &QPushButton::clicked, this, &SpectrumOverlayPanel::toggleDaxFlyout);
+        auto* btn = makeMenuBtn("VAX", this);
+        btn->setToolTip("Open VAX audio routing (NYI Phase 3-VAX)");
+        connect(btn, &QPushButton::clicked, this, &SpectrumOverlayPanel::toggleVaxFlyout);
         m_menuBtns.append(btn);  // index 6
     }
 
@@ -241,7 +241,7 @@ SpectrumOverlayPanel::SpectrumOverlayPanel(QWidget* parent)
     buildAntFlyout();
     buildDspFlyout();
     buildDisplayFlyout();
-    buildDaxFlyout();
+    buildVaxFlyout();
     buildZoomButtons();
 
     // Install event filter for auto-close on outside click and parent resize tracking
@@ -286,7 +286,7 @@ void SpectrumOverlayPanel::raiseAll()
 {
     raise();
     for (QWidget* fw : {m_bandFlyout, m_antFlyout, m_dspFlyout,
-                        m_displayFlyout, m_daxFlyout}) {
+                        m_displayFlyout, m_vaxFlyout}) {
         if (fw) { fw->raise(); }
     }
 }
@@ -993,30 +993,30 @@ void SpectrumOverlayPanel::toggleDisplayFlyout()
     dispBtn->setStyleSheet(kMenuBtnActive);
 }
 
-// ── DAX flyout ────────────────────────────────────────────────────────────────
+// ── VAX flyout ────────────────────────────────────────────────────────────────
 
-void SpectrumOverlayPanel::buildDaxFlyout()
+void SpectrumOverlayPanel::buildVaxFlyout()
 {
-    m_daxFlyout = new QWidget(parentWidget());
-    m_daxFlyout->setStyleSheet(kPanelStyle);
-    m_daxFlyout->hide();
+    m_vaxFlyout = new QWidget(parentWidget());
+    m_vaxFlyout->setStyleSheet(kPanelStyle);
+    m_vaxFlyout->hide();
 
-    auto* vb = new QVBoxLayout(m_daxFlyout);
+    auto* vb = new QVBoxLayout(m_vaxFlyout);
     vb->setContentsMargins(6, 6, 6, 6);
     vb->setSpacing(4);
 
-    // DAX Ch combo (from AetherSDR buildDaxPanel)
+    // VAX Ch combo (from AetherSDR buildDaxPanel)
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
-        auto* lbl = new QLabel("DAX Ch");
+        auto* lbl = new QLabel("VAX Ch");
         lbl->setStyleSheet(kLabelStyle);
         row->addWidget(lbl);
-        m_daxCmb = new QComboBox;
-        m_daxCmb->addItems({"Off", "1", "2", "3", "4"});
-        m_daxCmb->setEnabled(false);
-        m_daxCmb->setToolTip("DAX channel (NYI Phase 3-DAX)");
-        row->addWidget(m_daxCmb, 1);
+        m_vaxCmb = new QComboBox;
+        m_vaxCmb->addItems({"Off", "1", "2", "3", "4"});
+        m_vaxCmb->setEnabled(false);
+        m_vaxCmb->setToolTip("VAX channel (NYI Phase 3-VAX)");
+        row->addWidget(m_vaxCmb, 1);
         vb->addLayout(row);
     }
 
@@ -1027,38 +1027,38 @@ void SpectrumOverlayPanel::buildDaxFlyout()
         auto* lbl = new QLabel("IQ Ch");
         lbl->setStyleSheet(kLabelStyle);
         row->addWidget(lbl);
-        m_daxIqCmb = new QComboBox;
-        m_daxIqCmb->addItems({"None", "1", "2", "3", "4"});
-        m_daxIqCmb->setEnabled(false);
-        m_daxIqCmb->setToolTip("DAX IQ channel (NYI Phase 3-DAX)");
-        row->addWidget(m_daxIqCmb, 1);
+        m_vaxIqCmb = new QComboBox;
+        m_vaxIqCmb->addItems({"None", "1", "2", "3", "4"});
+        m_vaxIqCmb->setEnabled(false);
+        m_vaxIqCmb->setToolTip("VAX IQ channel (NYI Phase 3-VAX)");
+        row->addWidget(m_vaxIqCmb, 1);
         vb->addLayout(row);
     }
 
-    m_daxFlyout->setFixedWidth(140);
-    m_daxFlyout->adjustSize();
+    m_vaxFlyout->setFixedWidth(140);
+    m_vaxFlyout->adjustSize();
 }
 
-void SpectrumOverlayPanel::toggleDaxFlyout()
+void SpectrumOverlayPanel::toggleVaxFlyout()
 {
-    // Button index 6 (DAX)
-    QPushButton* daxBtn = m_menuBtns[6];
+    // Button index 6 (VAX)
+    QPushButton* vaxBtn = m_menuBtns[6];
 
-    if (m_activeFlyout == m_daxFlyout) {
+    if (m_activeFlyout == m_vaxFlyout) {
         hideFlyout();
         return;
     }
     hideFlyout();
 
-    // Center vertically on DAX button (from AetherSDR toggleDaxPanel)
-    int btnCenterY = daxBtn->y() + daxBtn->height() / 2;
-    int panelY = y() + btnCenterY - m_daxFlyout->sizeHint().height() / 2;
-    m_daxFlyout->move(x() + width(), std::max(0, panelY));
-    m_daxFlyout->raise();
-    m_daxFlyout->show();
-    m_activeFlyout = m_daxFlyout;
-    m_activeButton = daxBtn;
-    daxBtn->setStyleSheet(kMenuBtnActive);
+    // Center vertically on VAX button (from AetherSDR toggleDaxPanel)
+    int btnCenterY = vaxBtn->y() + vaxBtn->height() / 2;
+    int panelY = y() + btnCenterY - m_vaxFlyout->sizeHint().height() / 2;
+    m_vaxFlyout->move(x() + width(), std::max(0, panelY));
+    m_vaxFlyout->raise();
+    m_vaxFlyout->show();
+    m_activeFlyout = m_vaxFlyout;
+    m_activeButton = vaxBtn;
+    vaxBtn->setStyleSheet(kMenuBtnActive);
 }
 
 void SpectrumOverlayPanel::wheelEvent(QWheelEvent* event) { event->accept(); }

--- a/src/gui/SpectrumOverlayPanel.h
+++ b/src/gui/SpectrumOverlayPanel.h
@@ -109,14 +109,14 @@ private:
     void buildAntFlyout();
     void buildDspFlyout();
     void buildDisplayFlyout();
-    void buildDaxFlyout();
+    void buildVaxFlyout();
 
     // Flyout toggles
     void toggleBandFlyout();
     void toggleAntFlyout();
     void toggleDspFlyout();
     void toggleDisplayFlyout();
-    void toggleDaxFlyout();
+    void toggleVaxFlyout();
 
     // Auto-close helper
     void hideFlyout();
@@ -176,10 +176,10 @@ private:
     QLabel*      m_clarityBadge{nullptr};
     QPushButton* m_clarityRetuneBtn{nullptr};
 
-    // ── DAX flyout ───────────────────────────────────────────────────────
-    QWidget*   m_daxFlyout{nullptr};
-    QComboBox* m_daxCmb{nullptr};
-    QComboBox* m_daxIqCmb{nullptr};
+    // ── VAX flyout ───────────────────────────────────────────────────────
+    QWidget*   m_vaxFlyout{nullptr};
+    QComboBox* m_vaxCmb{nullptr};
+    QComboBox* m_vaxIqCmb{nullptr};
 
     // ── Waterfall zoom buttons (bottom-left of spectrum widget) ──────────
     QWidget*     m_zoomStrip{nullptr};   // container for the 4 zoom buttons

--- a/src/gui/applets/CatApplet.cpp
+++ b/src/gui/applets/CatApplet.cpp
@@ -154,26 +154,26 @@ void CatApplet::buildUI()
 
     vbox->addWidget(divider());
 
-    // --- Control 4: DAX enable + 4 channel status labels ---
+    // --- Control 4: VAX enable + 4 channel status labels ---
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
 
-        m_daxBtn = greenToggle(QStringLiteral("DAX"));
-        m_daxBtn->setCheckable(true);
-        row->addWidget(m_daxBtn);
+        m_vaxBtn = greenToggle(QStringLiteral("VAX"));
+        m_vaxBtn->setCheckable(true);
+        row->addWidget(m_vaxBtn);
 
         for (int i = 0; i < 4; ++i) {
-            m_daxStatus[i] = makeLed(QStringLiteral("Ch%1").arg(i + 1), this);
-            row->addWidget(m_daxStatus[i]);
+            m_vaxStatus[i] = makeLed(QStringLiteral("Ch%1").arg(i + 1), this);
+            row->addWidget(m_vaxStatus[i]);
         }
         row->addStretch();
 
         vbox->addLayout(row);
-        NyiOverlay::markNyi(m_daxBtn, QStringLiteral("3-DAX"));
+        NyiOverlay::markNyi(m_vaxBtn, QStringLiteral("3-VAX"));
     }
 
-    // --- Control 5: DAX IQ enable + rate combo ---
+    // --- Control 5: VAX IQ enable + rate combo ---
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
@@ -193,8 +193,8 @@ void CatApplet::buildUI()
 
         vbox->addLayout(row);
 
-        NyiOverlay::markNyi(m_iqBtn,       QStringLiteral("3-DAX"));
-        NyiOverlay::markNyi(m_iqRateCombo, QStringLiteral("3-DAX"));
+        NyiOverlay::markNyi(m_iqBtn,       QStringLiteral("3-VAX"));
+        NyiOverlay::markNyi(m_iqRateCombo, QStringLiteral("3-VAX"));
     }
 
     vbox->addStretch();
@@ -203,7 +203,7 @@ void CatApplet::buildUI()
 
 void CatApplet::syncFromModel()
 {
-    // NYI — Phase 3K / 3J / 3-DAX
+    // NYI — Phase 3K / 3J / 3-VAX
 }
 
 } // namespace NereusSDR

--- a/src/gui/applets/CatApplet.h
+++ b/src/gui/applets/CatApplet.h
@@ -33,14 +33,14 @@ class QComboBox;
 namespace NereusSDR {
 
 // CAT / rigctld / TCI control interfaces.
-// NYI — Phase 3K (CAT/rigctld) + 3J (TCI) + 3-DAX (DAX/IQ).
+// NYI — Phase 3K (CAT/rigctld) + 3J (TCI) + 3-VAX (VAX/IQ).
 //
 // Controls:
 //   1. CAT TCP enable + LEDs — QPushButton green "TCP" + 4x QLabel (A/B/C/D)
 //   2. CAT PTY enable + paths — QPushButton green "PTY" + 4x QLabel paths
 //   3. TCI enable + port + LED — QPushButton green "TCI" + QLineEdit port + QLabel LED
-//   4. DAX enable + meters — QPushButton green "DAX" + 4x QLabel channel status
-//   5. DAX IQ enable + rate — QPushButton green "IQ" + QComboBox rate
+//   4. VAX enable + meters — QPushButton green "VAX" + 4x QLabel channel status
+//   5. VAX IQ enable + rate — QPushButton green "IQ" + QComboBox rate
 class CatApplet : public AppletWidget {
     Q_OBJECT
 public:
@@ -66,11 +66,11 @@ private:
     QLineEdit*   m_tciPort       = nullptr;
     QLabel*      m_tciLed        = nullptr;
 
-    // Control 4 — DAX: enable button + 4 channel status labels
-    QPushButton* m_daxBtn        = nullptr;
-    QLabel*      m_daxStatus[4]  = {};
+    // Control 4 — VAX: enable button + 4 channel status labels
+    QPushButton* m_vaxBtn        = nullptr;
+    QLabel*      m_vaxStatus[4]  = {};
 
-    // Control 5 — DAX IQ: enable button + rate combo
+    // Control 5 — VAX IQ: enable button + rate combo
     QPushButton* m_iqBtn         = nullptr;
     QComboBox*   m_iqRateCombo   = nullptr;
 };

--- a/src/gui/applets/DigitalApplet.cpp
+++ b/src/gui/applets/DigitalApplet.cpp
@@ -318,9 +318,9 @@ void DigitalApplet::buildUI()
     root->addWidget(body);
 
     // -----------------------------------------------------------------------
-    // Mark all controls NYI — Phase 3-DAX
+    // Mark all controls NYI — Phase 3-VAX
     // -----------------------------------------------------------------------
-    const QString kPhase = QStringLiteral("Phase 3-DAX");
+    const QString kPhase = QStringLiteral("Phase 3-VAX");
     NyiOverlay::markNyi(m_vac1Btn,          kPhase);
     NyiOverlay::markNyi(m_vac1DevCombo,     kPhase);
     NyiOverlay::markNyi(m_vac2Btn,          kPhase);
@@ -335,7 +335,7 @@ void DigitalApplet::buildUI()
 
 void DigitalApplet::syncFromModel()
 {
-    // NYI — no model wiring until Phase 3-DAX
+    // NYI — no model wiring until Phase 3-VAX
 }
 
 } // namespace NereusSDR

--- a/src/gui/applets/DigitalApplet.h
+++ b/src/gui/applets/DigitalApplet.h
@@ -122,7 +122,7 @@ class QLabel;
 
 namespace NereusSDR {
 
-// VAC/DAX digital audio routing applet — NYI shell (Phase 3-DAX).
+// VAC/VAX digital audio routing applet — NYI shell (Phase 3-VAX).
 //
 // Controls:
 //   1. VAC 1 enable       — QPushButton("VAC 1", green, checkable)

--- a/src/gui/applets/PhoneCwApplet.cpp
+++ b/src/gui/applets/PhoneCwApplet.cpp
@@ -90,7 +90,7 @@ static constexpr const char* kButtonBase =
     "border-radius: 3px; color: #c8d8e8; font-size: 10px; font-weight: bold; }"
     "QPushButton:hover { background: #204060; }";
 
-// Blue active style: used for DAX, Iambic, tab buttons
+// Blue active style: used for VAX, Iambic, tab buttons
 static constexpr const char* kBlueActive =
     "QPushButton:checked { background-color: #0070c0; color: #ffffff; "
     "border: 1px solid #0090e0; }";
@@ -122,7 +122,7 @@ static constexpr int kGap      = 4;
 static const QString kNyiPhone  = QStringLiteral("Phase 3I-1");
 static const QString kNyiCw     = QStringLiteral("Phase 3I-2");
 static const QString kNyiProc   = QStringLiteral("Phase 3I-3");
-static const QString kNyiDax    = QStringLiteral("Phase 3-DAX");
+static const QString kNyiVax    = QStringLiteral("Phase 3-VAX");
 static const QString kNyiFm     = QStringLiteral("Phase 3I-1");
 
 // CTCSS tones (standard 38-tone list from Thetis setup.cs)
@@ -308,7 +308,7 @@ void PhoneCwApplet::buildPhonePage(QWidget* page)
         vbox->addLayout(row);
     }
 
-    // ── Control 7: PROC + Control 8: PROC slider + Control 9: DAX ───────────
+    // ── Control 7: PROC + Control 8: PROC slider + Control 9: VAX ───────────
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(4);
@@ -356,14 +356,14 @@ void PhoneCwApplet::buildPhonePage(QWidget* page)
 
         row->addWidget(procGroup, 1);
 
-        // Control 9: DAX button (blue, checkable, fixedWidth 48, fixedHeight 22)
-        m_daxBtn = new QPushButton(QStringLiteral("DAX"), page);
-        m_daxBtn->setCheckable(true);
-        m_daxBtn->setFixedWidth(48);
-        m_daxBtn->setFixedHeight(22);
-        m_daxBtn->setStyleSheet(QString(kButtonBase) + kBlueActive);
-        m_daxBtn->setAccessibleName(QStringLiteral("DAX digital audio"));
-        row->addWidget(m_daxBtn);
+        // Control 9: VAX button (blue, checkable, fixedWidth 48, fixedHeight 22)
+        m_vaxBtn = new QPushButton(QStringLiteral("VAX"), page);
+        m_vaxBtn->setCheckable(true);
+        m_vaxBtn->setFixedWidth(48);
+        m_vaxBtn->setFixedHeight(22);
+        m_vaxBtn->setStyleSheet(QString(kButtonBase) + kBlueActive);
+        m_vaxBtn->setAccessibleName(QStringLiteral("VAX digital audio"));
+        row->addWidget(m_vaxBtn);
 
         vbox->addLayout(row);
     }
@@ -553,7 +553,7 @@ void PhoneCwApplet::buildPhonePage(QWidget* page)
     NyiOverlay::markNyi(m_accBtn,           kNyiPhone);   // #6
     NyiOverlay::markNyi(m_procBtn,          kNyiProc);    // #7 — Phase 3I-3
     NyiOverlay::markNyi(m_procSlider,       kNyiProc);    // #7 slider
-    NyiOverlay::markNyi(m_daxBtn,           kNyiDax);     // #8 — Phase 3-DAX
+    NyiOverlay::markNyi(m_vaxBtn,           kNyiVax);     // #8 — Phase 3-VAX
     NyiOverlay::markNyi(m_monBtn,           kNyiPhone);   // #9
     NyiOverlay::markNyi(m_monSlider,        kNyiPhone);   // #9 slider
     NyiOverlay::markNyi(m_voxBtn,           kNyiProc);    // #10 — Phase 3I-3

--- a/src/gui/applets/PhoneCwApplet.h
+++ b/src/gui/applets/PhoneCwApplet.h
@@ -78,7 +78,7 @@ class HGauge;
 
 // PhoneCwApplet — QStackedWidget with Phone (0) and CW (1) pages.
 // FM is a separate FmApplet per the reconciled design spec.
-// Phone page: 13 controls — Phase 3I-1 / 3I-3 / 3-DAX
+// Phone page: 13 controls — Phase 3I-1 / 3I-3 / 3-VAX
 // CW page:     9 controls — Phase 3I-2
 class PhoneCwApplet : public AppletWidget {
     Q_OBJECT
@@ -122,8 +122,8 @@ private:
     QPushButton* m_procBtn{nullptr};
     QSlider*     m_procSlider{nullptr};
     QLabel*      m_procLabel{nullptr};
-    // #8  DAX button (blue toggle, 48px)
-    QPushButton* m_daxBtn{nullptr};
+    // #8  VAX button (blue toggle, 48px)
+    QPushButton* m_vaxBtn{nullptr};
     // #9  MON button (green 48px) + slider (0-100) + inset "50"
     QPushButton* m_monBtn{nullptr};
     QSlider*     m_monSlider{nullptr};

--- a/src/gui/setup/AudioSetupPages.cpp
+++ b/src/gui/setup/AudioSetupPages.cpp
@@ -116,20 +116,20 @@ Vac2Page::Vac2Page(RadioModel* model, QWidget* parent)
 }
 
 // ---------------------------------------------------------------------------
-// NereusDaxPage
+// NereusVaxPage
 // ---------------------------------------------------------------------------
 
-NereusDaxPage::NereusDaxPage(RadioModel* model, QWidget* parent)
-    : SetupPage(QStringLiteral("NereusDAX"), model, parent)
+NereusVaxPage::NereusVaxPage(RadioModel* model, QWidget* parent)
+    : SetupPage(QStringLiteral("NereusVAX"), model, parent)
 {
-    addSection(QStringLiteral("DAX Channels"));
+    addSection(QStringLiteral("VAX Channels"));
 
     // 4 audio channels — each shows channel label, status, and device combo
     const QStringList channelNames = {
-        QStringLiteral("DAX Audio 1"),
-        QStringLiteral("DAX Audio 2"),
-        QStringLiteral("DAX Audio 3"),
-        QStringLiteral("DAX Audio 4"),
+        QStringLiteral("VAX Audio 1"),
+        QStringLiteral("VAX Audio 2"),
+        QStringLiteral("VAX Audio 3"),
+        QStringLiteral("VAX Audio 4"),
     };
 
     for (const QString& ch : channelNames) {

--- a/src/gui/setup/AudioSetupPages.h
+++ b/src/gui/setup/AudioSetupPages.h
@@ -41,12 +41,12 @@ public:
 };
 
 // ---------------------------------------------------------------------------
-// Audio > NereusDAX
+// Audio > NereusVAX
 // ---------------------------------------------------------------------------
-class NereusDaxPage : public SetupPage {
+class NereusVaxPage : public SetupPage {
     Q_OBJECT
 public:
-    explicit NereusDaxPage(RadioModel* model, QWidget* parent = nullptr);
+    explicit NereusVaxPage(RadioModel* model, QWidget* parent = nullptr);
 };
 
 // ---------------------------------------------------------------------------

--- a/src/gui/widgets/VfoWidget.cpp
+++ b/src/gui/widgets/VfoWidget.cpp
@@ -373,14 +373,14 @@ void VfoWidget::buildUI()
 
     buildXRitTab();
 
-    // Stub DAX tab
-    auto* daxWidget = new QWidget;
-    auto* daxLayout = new QVBoxLayout(daxWidget);
-    daxLayout->setContentsMargins(4, 4, 4, 4);
-    auto* daxLabel = new QLabel(QStringLiteral("DAX"), daxWidget);
-    daxLabel->setStyleSheet(QStringLiteral("color: #6888a0; font-size: 11px;"));
-    daxLayout->addWidget(daxLabel);
-    m_tabStack->addWidget(daxWidget);
+    // Stub VAX tab
+    auto* vaxWidget = new QWidget;
+    auto* vaxLayout = new QVBoxLayout(vaxWidget);
+    vaxLayout->setContentsMargins(4, 4, 4, 4);
+    auto* vaxLabel = new QLabel(QStringLiteral("VAX"), vaxWidget);
+    vaxLabel->setStyleSheet(QStringLiteral("color: #6888a0; font-size: 11px;"));
+    vaxLayout->addWidget(vaxLabel);
+    m_tabStack->addWidget(vaxWidget);
 
     mainLayout->addWidget(m_tabStack);
     m_tabStack->hide();  // Hidden by default — click tab to expand
@@ -554,13 +554,13 @@ void VfoWidget::buildTabBar()
     tabLayout->setContentsMargins(0, 0, 0, 0);
 
     // Tab labels — from AetherSDR VfoWidget.cpp:522
-    // [🔊] | DSP | USB | X/RIT | DAX
+    // [🔊] | DSP | USB | X/RIT | VAX
     QStringList tabLabels = {
         QString::fromUtf8("\xF0\x9F\x94\x8A"),  // 🔊 speaker
         QStringLiteral("DSP"),
         SliceModel::modeName(m_currentMode),
         QStringLiteral("X/RIT"),
-        QStringLiteral("DAX")
+        QStringLiteral("VAX")
     };
 
     // NereusSDR native — Thetis has a fixed single-panel layout with all controls
@@ -570,7 +570,7 @@ void VfoWidget::buildTabBar()
         "Show/hide DSP controls (NB, NR, ANF, SNB, APF)",
         "Show/hide mode and filter controls",
         "Show/hide RIT/XIT and frequency-lock controls",
-        "Show/hide DAX audio routing controls"
+        "Show/hide VAX audio routing controls"
     };
 
     for (int i = 0; i < tabLabels.size(); ++i) {


### PR DESCRIPTION
## Summary
Finishes the Phase 3O VAX rename on the UI side — completes what PRs #62–#65
did for the backend (`CoreAudioHalBus`, `LinuxPipeBus`, `VirtualCableDetector`,
`SliceModel::vaxChannel`, `VaxChannelSelector`). Every NereusSDR-owned
`DAX`/`Dax`/`dax` identifier and every user-visible `"DAX"` string is renamed
to the `VAX` equivalent.

Preserved (intentionally NOT touched):
- Port-citation headers in `src/core/audio/` that document the historical
  AetherSDR path names (`/aethersdr-dax-*` → `/nereussdr-vax-*`).
- Upstream-reference comments citing AetherSDR functions (e.g.
  `// VAX Ch combo (from AetherSDR buildDaxPanel)`).
- `"^DAX Audio"` regex in `VirtualCableDetector` — that's FlexRadio third-party
  hardware detection, not a NereusSDR identifier.
- `tests/tst_virtual_cable_detector.cpp` — tests the same FlexRadio detection.

## Commit
- `f9583ae` refactor(gui): finish DAX→VAX UI rebrand (Phase 3O)

## Scope (13 files)
- Applets: `CatApplet.{h,cpp}`, `DigitalApplet.{h,cpp}`, `PhoneCwApplet.{h,cpp}`
- `MainWindow.cpp` (File menu item)
- `SpectrumOverlayPanel.{h,cpp}` (whole "VAX" flyout panel, button #7, tooltips)
- `setup/AudioSetupPages.{h,cpp}` — `NereusDaxPage` class renamed to
  `NereusVaxPage` in place (no dedicated file → no `git mv`)
- `SetupDialog.cpp` — registration key `"NereusDAX"` → `"NereusVAX"` (display
  label only — not persisted; SetupDialog stores only stack-index, not the key)
- `VfoWidget.cpp` — 3 residual DAX hits (brief assumed PR #66 had already
  handled these, but PR #66 hadn't merged when this branch was cut; addressed
  here. No conflict with #66 — both branches made the same `DAX`→`VAX` tab
  rename, git will resolve cleanly)

## Independence from other PRs
- Branched off `origin/main` @ `807d26d` (post-PR #65 merge).
- Does NOT depend on PR #66 (VaxChannelSelector). When both merge, a trivial
  `VfoWidget.cpp` rebase may be needed on whichever lands second — both PRs
  make identical tab-label edits.

## Persistence
No AppSettings keys renamed. `"NereusDAX"` → `"NereusVAX"` is a SetupDialog
display label, stored nowhere on disk — no user-settings migration needed.

## Test plan
- [ ] Linux / macOS / Windows CI: builds clean (no orphaned DAX references)
- [ ] \`compliance-inventory.py\` full-tree scanner classifies all files
      correctly (passed locally pre-commit)
- [ ] Manual UI smoke (macOS): sidebar VAX button, Spectrum overlay VAX
      button + flyout (VAX Ch / VAX IQ combos), PhoneCW green VAX toggle,
      CAT applet green VAX toggle + 4 channel status labels, Setup →
      Audio → NereusVAX page, File menu "&VAX Audio..." item

---
J.J. Boyd ~ KG4VCF