### PR TITLE
Phase 3O Sub-Phase 8.5: AudioEngine platform VAX bus wiring

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -408,9 +408,9 @@ void AudioEngine::setVaxEnabled(int channel, bool on)
         return;
     }
     // Already populated (eagerly opened by start() on Mac/Linux, or via a
-    // prior setVaxConfig BYO call): no-op. Re-open semantics fall through
-    // to the platform-native bus (Mac/Linux) or the PortAudio default
-    // fallback (Windows) when the slot is empty.
+    // prior setVaxConfig BYO call): no-op. Empty slot: mint the
+    // platform-native bus (Mac/Linux) or the PortAudio default (Windows
+    // BYO) below.
     if (m_vaxBus[idx]) {
         return;
     }

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -27,6 +27,14 @@
 //                 synchronous flush on the DSP thread; no QTimer, no
 //                 QAudioSink. (docs/architecture/2026-04-19-phase3o-vax-plan.md
 //                 §Sub-Phase 4 Task 4.1.)
+//   2026-04-19 — Sub-Phase 8.5 platform-bus wiring by J.J. Boyd (KG4VCF),
+//                 AI-assisted via Anthropic Claude Code. start() eagerly
+//                 constructs CoreAudioHalBus (macOS) / LinuxPipeBus (Linux)
+//                 instances for VAX RX 1..4 and a separate VAX TX virtual
+//                 bus (m_vaxTxBus). Failed open() per slot logs and
+//                 degrades to silence on that channel; surviving slots
+//                 stay live. Windows path stays null pending Sub-Phase 9
+//                 BYO wiring.
 // =================================================================
 
 #include "AudioEngine.h"
@@ -35,6 +43,13 @@
 #include "audio/PortAudioBus.h"
 #include "../models/RadioModel.h"
 #include "../models/SliceModel.h"
+
+#ifdef Q_OS_MAC
+#include "audio/CoreAudioHalBus.h"
+#endif
+#ifdef Q_OS_LINUX
+#include "audio/LinuxPipeBus.h"
+#endif
 
 #include <portaudio.h>
 
@@ -110,6 +125,44 @@ void AudioEngine::start()
     }
 
     ensureSpeakersOpen();
+
+    // Sub-Phase 8.5: eagerly construct platform-native VAX RX buses + the
+    // VAX TX virtual bus on macOS / Linux so coreaudiod / pactl publish the
+    // virtual devices the moment audio is running. Each slot opens
+    // independently — a single failure (e.g. HAL plugin not installed,
+    // pactl missing) logs a warning, leaves the slot null, and the
+    // rxBlockReady tee silently skips that channel.
+    //
+    // On Windows m_vaxBus / m_vaxTxBus stay null here.
+    // TODO(sub-phase-9-byo): wire user-picked virtual cables via
+    // setVaxConfig() once the Setup → Audio → VAX BYO UI lands.
+    for (int channel = 1; channel <= 4; ++channel) {
+        const int idx = channel - 1;
+        if (m_vaxBus[idx]) {
+            // Caller wired an explicit device via setVaxConfig() before
+            // start() ran — honour that and don't clobber it with the
+            // platform-native bus.
+            continue;
+        }
+        m_vaxBus[idx] = makeVaxBus(channel);
+        if (m_vaxBus[idx]) {
+            qCInfo(lcAudio) << "VAX" << channel << "bus opened (eager)"
+                            << "[" << m_vaxBus[idx]->backendName() << "]";
+        }
+    }
+
+    if (!m_vaxTxBus) {
+        m_vaxTxBus = makeVaxTxBus();
+        if (m_vaxTxBus) {
+            qCInfo(lcAudio) << "VAX TX bus opened (eager)"
+                            << "[" << m_vaxTxBus->backendName() << "]";
+        }
+        // TODO(phase3M): pull TX audio from m_vaxTxBus when
+        // TransmitModel::txOwnerSlot() != MicDirect. The bus is opened
+        // here so 3rd-party apps see the virtual TX device immediately;
+        // no consumer is wired in this phase.
+    }
+
     m_running = true;
 
     qCInfo(lcAudio) << "AudioEngine started ("
@@ -132,8 +185,21 @@ void AudioEngine::stop()
     // the ordering contract is that the caller (RadioModel teardown)
     // stops the DSP worker thread before calling stop(). That contract
     // is preserved from the pre-refactor code.
+    //
+    // LinuxPipeBus::close() invokes QProcess to drive `pactl unload-module`,
+    // which requires a running event loop on the calling thread; AudioEngine
+    // is parented to the main (GUI) thread by RadioModel so stop() always
+    // runs there. The same contract covers the destructor path (~unique_ptr
+    // → ~LinuxPipeBus → close()). The CoreAudioHalBus / PortAudioBus dtors
+    // have no main-thread requirement.
     m_speakersBus.reset();
     m_txInputBus.reset();
+    // Reset VAX TX before iterating m_vaxBus so the close ordering is
+    // TX-first then RX-1..4 — symmetric with the start() construction
+    // order (RX-1..4 then TX) inverted on teardown, and lets a future
+    // TX-poll consumer release any reference to the TX bus before the
+    // RX taps come down.
+    m_vaxTxBus.reset();
     for (auto& bus : m_vaxBus) {
         bus.reset();
     }
@@ -145,8 +211,9 @@ void AudioEngine::stop()
 std::unique_ptr<IAudioBus> AudioEngine::makeBus(const AudioDeviceConfig& cfg,
                                                 bool capture)
 {
-    // TODO(phase3o-5/6): swap direct PortAudioBus construction for
-    // AudioBusFactory::create() once CoreAudioHalBus / LinuxPipeBus land.
+    // PortAudio path — used for speakers / mic / Windows-BYO VAX devices.
+    // Platform-native VAX RX/TX virtual buses use makeVaxBus() /
+    // makeVaxTxBus() (Sub-Phase 8.5).
     auto bus = std::make_unique<PortAudioBus>();
     PortAudioConfig pcfg;
     pcfg.direction     = capture ? AudioDirection::Input
@@ -163,6 +230,95 @@ std::unique_ptr<IAudioBus> AudioEngine::makeBus(const AudioDeviceConfig& cfg,
         return nullptr;
     }
     return bus;
+}
+
+std::unique_ptr<IAudioBus> AudioEngine::makeVaxBus(int channel)
+{
+    // Sub-Phase 8.5: platform-native VAX RX virtual bus. Format is fixed at
+    // 48 kHz stereo float32 — this is the contract both CoreAudioHalBus and
+    // LinuxPipeBus enforce in open(), and it matches the spec §8.1 wire
+    // format the HAL plugin / pactl source expose to consumer apps.
+    if (channel < 1 || channel > 4) {
+        return nullptr;
+    }
+
+    AudioFormat fmt;
+    fmt.sampleRate = 48000;
+    fmt.channels   = 2;
+    fmt.sample     = AudioFormat::Sample::Float32;
+
+#if defined(Q_OS_MAC)
+    CoreAudioHalBus::Role role = CoreAudioHalBus::Role::Vax1;
+    switch (channel) {
+        case 1: role = CoreAudioHalBus::Role::Vax1; break;
+        case 2: role = CoreAudioHalBus::Role::Vax2; break;
+        case 3: role = CoreAudioHalBus::Role::Vax3; break;
+        case 4: role = CoreAudioHalBus::Role::Vax4; break;
+    }
+    auto bus = std::make_unique<CoreAudioHalBus>(role);
+    if (!bus->open(fmt)) {
+        qCWarning(lcAudio) << "CoreAudioHalBus open failed for VAX" << channel
+                           << ":" << bus->errorString();
+        return nullptr;
+    }
+    return bus;
+#elif defined(Q_OS_LINUX)
+    LinuxPipeBus::Role role = LinuxPipeBus::Role::Vax1;
+    switch (channel) {
+        case 1: role = LinuxPipeBus::Role::Vax1; break;
+        case 2: role = LinuxPipeBus::Role::Vax2; break;
+        case 3: role = LinuxPipeBus::Role::Vax3; break;
+        case 4: role = LinuxPipeBus::Role::Vax4; break;
+    }
+    auto bus = std::make_unique<LinuxPipeBus>(role);
+    if (!bus->open(fmt)) {
+        qCWarning(lcAudio) << "LinuxPipeBus open failed for VAX" << channel
+                           << ":" << bus->errorString();
+        return nullptr;
+    }
+    return bus;
+#else
+    // Windows: TODO(sub-phase-9-byo): wire user-picked virtual cables via
+    // setVaxConfig(). Returning nullptr here leaves the slot empty so the
+    // rxBlockReady tee silently skips this channel until BYO config arrives.
+    (void)channel;
+    return nullptr;
+#endif
+}
+
+std::unique_ptr<IAudioBus> AudioEngine::makeVaxTxBus()
+{
+    // Sub-Phase 8.5: platform-native VAX TX virtual bus. Opened so coreaudiod
+    // / pactl publish the virtual TX device for 3rd-party apps that write
+    // outgoing audio (WSJT-X, fldigi, VARA). Consumption (pull() into
+    // TxChannel) is a Phase 3M concern — see m_vaxTxBus comment in
+    // AudioEngine.h and the TODO in start().
+    AudioFormat fmt;
+    fmt.sampleRate = 48000;
+    fmt.channels   = 2;
+    fmt.sample     = AudioFormat::Sample::Float32;
+
+#if defined(Q_OS_MAC)
+    auto bus = std::make_unique<CoreAudioHalBus>(CoreAudioHalBus::Role::TxInput);
+    if (!bus->open(fmt)) {
+        qCWarning(lcAudio) << "CoreAudioHalBus open failed for VAX TX:"
+                           << bus->errorString();
+        return nullptr;
+    }
+    return bus;
+#elif defined(Q_OS_LINUX)
+    auto bus = std::make_unique<LinuxPipeBus>(LinuxPipeBus::Role::TxInput);
+    if (!bus->open(fmt)) {
+        qCWarning(lcAudio) << "LinuxPipeBus open failed for VAX TX:"
+                           << bus->errorString();
+        return nullptr;
+    }
+    return bus;
+#else
+    // Windows: TODO(sub-phase-9-byo): wire user-picked virtual cables via
+    // setVaxConfig() (a future TX-side equivalent setter).
+    return nullptr;
+#endif
 }
 
 void AudioEngine::ensureSpeakersOpen()
@@ -220,6 +376,12 @@ void AudioEngine::setTxInputConfig(const AudioDeviceConfig& cfg)
 
 void AudioEngine::setVaxConfig(int channel, const AudioDeviceConfig& cfg)
 {
+    // BYO override path. Replaces whatever bus is currently in the slot
+    // (platform-native eager bus from start(), or a previous BYO PortAudio
+    // bus) with a user-picked PortAudio device. On Mac/Linux this is
+    // intentional — power users may prefer to route VAX through a third-
+    // party virtual cable instead of the bundled HAL plugin / pactl
+    // module. On Windows this is the only VAX path (Sub-Phase 9 BYO).
     if (channel < 1 || channel > 4) {
         return;
     }
@@ -230,7 +392,7 @@ void AudioEngine::setVaxConfig(int channel, const AudioDeviceConfig& cfg)
     }
     m_vaxBus[idx] = makeBus(cfg, /*capture=*/false);
     if (m_vaxBus[idx]) {
-        qCInfo(lcAudio) << "VAX" << channel << "bus opened"
+        qCInfo(lcAudio) << "VAX" << channel << "bus reconfigured (BYO)"
                         << "[" << m_vaxBus[idx]->backendName() << "]";
     }
 }
@@ -245,14 +407,49 @@ void AudioEngine::setVaxEnabled(int channel, bool on)
         m_vaxBus[idx].reset();
         return;
     }
-    // Enable with defaults if no explicit setVaxConfig has been wired yet.
-    // Real config lands via the VaxApplet / Setup→Audio→VAX UI in
-    // Sub-Phase 7 / 8.
-    if (!m_vaxBus[idx]) {
-        AudioDeviceConfig defaults;
-        m_vaxBus[idx] = makeBus(defaults, /*capture=*/false);
+    // Already populated (eagerly opened by start() on Mac/Linux, or via a
+    // prior setVaxConfig BYO call): no-op. Re-open semantics fall through
+    // to the platform-native bus (Mac/Linux) or the PortAudio default
+    // fallback (Windows) when the slot is empty.
+    if (m_vaxBus[idx]) {
+        return;
     }
+
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+    // Re-mint the platform-native bus that start() would have used. Lets
+    // a user toggle a VAX channel off and back on without restarting
+    // AudioEngine.
+    m_vaxBus[idx] = makeVaxBus(channel);
+    if (m_vaxBus[idx]) {
+        qCInfo(lcAudio) << "VAX" << channel << "bus re-enabled"
+                        << "[" << m_vaxBus[idx]->backendName() << "]";
+    }
+#else
+    // Windows lazy PortAudio fallback: enable with defaults if no explicit
+    // setVaxConfig has been wired yet. Real config lands via the
+    // VirtualCableDetector / Setup→Audio→VAX BYO UI in Sub-Phase 9.
+    if (!m_paInitialized) {
+        return;
+    }
+    AudioDeviceConfig defaults;
+    m_vaxBus[idx] = makeBus(defaults, /*capture=*/false);
+#endif
 }
+
+#ifdef NEREUS_BUILD_TESTS
+void AudioEngine::setVaxBusForTest(int channel, std::unique_ptr<IAudioBus> bus)
+{
+    if (channel < 1 || channel > 4) {
+        return;
+    }
+    m_vaxBus[channel - 1] = std::move(bus);
+}
+
+void AudioEngine::setSpeakersBusForTest(std::unique_ptr<IAudioBus> bus)
+{
+    m_speakersBus = std::move(bus);
+}
+#endif
 
 void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
 {

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -29,6 +29,13 @@
 //                 synchronous flush on the DSP thread; no QTimer, no
 //                 QAudioSink. (docs/architecture/2026-04-19-phase3o-vax-plan.md
 //                 §Sub-Phase 4 Task 4.1.)
+//   2026-04-19 — Sub-Phase 8.5 platform-bus wiring by J.J. Boyd (KG4VCF),
+//                 AI-assisted via Anthropic Claude Code. start() now eagerly
+//                 constructs platform-native VAX RX buses (CoreAudioHalBus on
+//                 macOS, LinuxPipeBus on Linux) plus a VAX TX virtual bus
+//                 (m_vaxTxBus) so 3rd-party apps see the virtual devices the
+//                 moment audio is running. Windows BYO wiring deferred to
+//                 Sub-Phase 9.
 // =================================================================
 
 #include "AudioDeviceConfig.h"
@@ -95,8 +102,32 @@ public:
     // Audio → Devices) and is not provided by this class.
     void setSpeakersConfig(const AudioDeviceConfig& cfg);
     void setTxInputConfig(const AudioDeviceConfig& cfg);
+
+    // Per-VAX device configuration. On Mac/Linux the VAX slots are populated
+    // eagerly by start() with the platform-native virtual bus
+    // (CoreAudioHalBus / LinuxPipeBus); calling setVaxConfig there replaces
+    // the slot with a user-picked PortAudio device (BYO). On Windows the
+    // slots stay null until setVaxConfig() runs (Sub-Phase 9 BYO wiring).
     void setVaxConfig(int channel, const AudioDeviceConfig& cfg);  // 1..4
+
+    // Toggle a VAX slot on/off. On Mac/Linux, calling setVaxEnabled(ch, true)
+    // for a channel that's already eagerly opened by start() is a no-op (the
+    // platform-native bus is already live); setVaxEnabled(ch, false) closes
+    // the bus regardless of how it was constructed. On Windows it remains
+    // the lazy PortAudio path (creates a default-config PortAudioBus).
     void setVaxEnabled(int channel, bool on);
+
+#ifdef NEREUS_BUILD_TESTS
+    // Test seam — inject a fake IAudioBus into a VAX slot so unit tests
+    // can exercise the rxBlockReady tee without standing up a real
+    // CoreAudioHalBus/LinuxPipeBus shm/FIFO. channel is 1..4. Takes
+    // ownership of `bus`.
+    void setVaxBusForTest(int channel, std::unique_ptr<IAudioBus> bus);
+
+    // Test seam — inject a fake IAudioBus into the speakers slot so unit
+    // tests can verify speakers tee without opening a PortAudio device.
+    void setSpeakersBusForTest(std::unique_ptr<IAudioBus> bus);
+#endif
 
     // Called by RxDspWorker when a slice produces an RX audio block.
     // samples is interleaved stereo float32, length = frames * 2.
@@ -113,11 +144,22 @@ signals:
 
 private:
     // Translate AudioDeviceConfig → AudioFormat + PortAudioConfig and
-    // open the given bus slot. Direct PortAudioBus construction today;
-    // TODO(phase3o-5/6): swap for AudioBusFactory::create() once
-    // CoreAudioHalBus and LinuxPipeBus land.
+    // open the given bus slot. Used for the speakers / TX-mic / Windows-BYO
+    // VAX paths; the platform-native VAX RX/TX virtual buses are minted via
+    // makeVaxBus() / makeVaxTxBus() instead.
     std::unique_ptr<IAudioBus> makeBus(const AudioDeviceConfig& cfg,
                                        bool capture);
+
+    // Sub-Phase 8.5: construct + open the platform-native VAX RX bus for
+    // `channel` (1..4). macOS → CoreAudioHalBus(Role::VaxN). Linux →
+    // LinuxPipeBus(Role::VaxN). Windows → returns nullptr; Windows BYO
+    // wiring lands in Sub-Phase 9 via setVaxConfig().
+    std::unique_ptr<IAudioBus> makeVaxBus(int channel);
+
+    // Sub-Phase 8.5: construct + open the platform-native VAX TX virtual
+    // bus. Opened so coreaudiod / pactl register the virtual TX device for
+    // 3rd-party apps. Pulled from in Phase 3M when txOwnerSlot() != MicDirect.
+    std::unique_ptr<IAudioBus> makeVaxTxBus();
 
     // Open m_speakersBus with a sensible platform default if nothing
     // has been wired by the time start() runs. Keeps the live RX path
@@ -128,6 +170,10 @@ private:
 
     std::unique_ptr<IAudioBus> m_speakersBus;
     std::unique_ptr<IAudioBus> m_txInputBus;
+    // Sub-Phase 8.5: platform-native VAX TX virtual bus. Distinct from
+    // m_txInputBus, which is the OS mic-capture device owned by MicDirect.
+    // Opened in start(), reset in stop(); consumption is a Phase 3M concern.
+    std::unique_ptr<IAudioBus> m_vaxTxBus;
     std::array<std::unique_ptr<IAudioBus>, 4> m_vaxBus;
     MasterMixer m_masterMix;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,3 +186,10 @@ endif()
 
 # ── Phase 3O Sub-Phase 7 Task 7.1: VirtualCableDetector ──────────────────────
 nereus_add_test(tst_virtual_cable_detector)
+
+# ── Phase 3O Sub-Phase 8.5: AudioEngine VAX tee logic ────────────────────────
+# Exercises the rxBlockReady → m_vaxBus[] tee using FakeAudioBus injected
+# via the NEREUS_BUILD_TESTS-only setVaxBusForTest / setSpeakersBusForTest
+# seam on AudioEngine. No real CoreAudioHalBus / LinuxPipeBus / PortAudio
+# backend required — runs on every platform.
+nereus_add_test(tst_audio_engine_vax_tee)

--- a/tests/fakes/FakeAudioBus.h
+++ b/tests/fakes/FakeAudioBus.h
@@ -1,0 +1,76 @@
+// =================================================================
+// tests/fakes/FakeAudioBus.h  (NereusSDR)
+// =================================================================
+//
+// Minimal IAudioBus stub for unit tests. Captures every push() into a
+// growable byte buffer so callers can assert what was routed where.
+// Counts pushes, and lets the test toggle isOpen() to exercise the
+// "bus exists but isn't open" branch in AudioEngine::rxBlockReady.
+//
+// NereusSDR-original test fake — no ported logic, no Thetis attribution
+// needed.
+// =================================================================
+
+#pragma once
+
+#include "core/IAudioBus.h"
+
+#include <QByteArray>
+#include <QString>
+
+#include <atomic>
+#include <vector>
+
+namespace NereusSDR {
+
+class FakeAudioBus : public IAudioBus {
+public:
+    explicit FakeAudioBus(QString name = QStringLiteral("Fake"))
+        : m_name(std::move(name)) {}
+
+    bool open(const AudioFormat& format) override {
+        m_negotiatedFormat = format;
+        m_open = true;
+        return true;
+    }
+
+    void close() override { m_open = false; }
+    bool isOpen() const override { return m_open; }
+
+    qint64 push(const char* data, qint64 bytes) override {
+        if (!m_open || data == nullptr || bytes <= 0) {
+            return 0;
+        }
+        m_pushes.fetch_add(1, std::memory_order_acq_rel);
+        m_lastPushBytes.store(static_cast<int>(bytes), std::memory_order_release);
+        m_buffer.append(data, static_cast<int>(bytes));
+        return bytes;
+    }
+
+    qint64 pull(char*, qint64) override { return 0; }
+
+    float rxLevel() const override { return 0.0f; }
+    float txLevel() const override { return 0.0f; }
+
+    QString backendName() const override { return m_name; }
+    AudioFormat negotiatedFormat() const override { return m_negotiatedFormat; }
+
+    // Test inspectors
+    int pushCount() const { return m_pushes.load(std::memory_order_acquire); }
+    int lastPushBytes() const { return m_lastPushBytes.load(std::memory_order_acquire); }
+    const QByteArray& buffer() const { return m_buffer; }
+
+    // Force-toggle isOpen() to false so AudioEngine::rxBlockReady's
+    // isOpen() guard skips the push.
+    void setForceOpen(bool open) { m_open = open; }
+
+private:
+    QString          m_name;
+    AudioFormat      m_negotiatedFormat;
+    bool             m_open{false};
+    QByteArray       m_buffer;
+    std::atomic<int> m_pushes{0};
+    std::atomic<int> m_lastPushBytes{0};
+};
+
+} // namespace NereusSDR

--- a/tests/fakes/FakeAudioBus.h
+++ b/tests/fakes/FakeAudioBus.h
@@ -18,17 +18,20 @@
 #include <QByteArray>
 #include <QString>
 
-#include <atomic>
 #include <vector>
 
 namespace NereusSDR {
 
+// Single-threaded test fake — not safe for concurrent push from multiple threads.
 class FakeAudioBus : public IAudioBus {
 public:
     explicit FakeAudioBus(QString name = QStringLiteral("Fake"))
         : m_name(std::move(name)) {}
 
     bool open(const AudioFormat& format) override {
+        if (!m_openResult) {
+            return false;
+        }
         m_negotiatedFormat = format;
         m_open = true;
         return true;
@@ -41,8 +44,8 @@ public:
         if (!m_open || data == nullptr || bytes <= 0) {
             return 0;
         }
-        m_pushes.fetch_add(1, std::memory_order_acq_rel);
-        m_lastPushBytes.store(static_cast<int>(bytes), std::memory_order_release);
+        ++m_pushes;
+        m_lastPushBytes = bytes;
         m_buffer.append(data, static_cast<int>(bytes));
         return bytes;
     }
@@ -56,21 +59,26 @@ public:
     AudioFormat negotiatedFormat() const override { return m_negotiatedFormat; }
 
     // Test inspectors
-    int pushCount() const { return m_pushes.load(std::memory_order_acquire); }
-    int lastPushBytes() const { return m_lastPushBytes.load(std::memory_order_acquire); }
+    int pushCount() const { return m_pushes; }
+    qint64 lastPushBytes() const { return m_lastPushBytes; }
     const QByteArray& buffer() const { return m_buffer; }
 
     // Force-toggle isOpen() to false so AudioEngine::rxBlockReady's
     // isOpen() guard skips the push.
     void setForceOpen(bool open) { m_open = open; }
 
+    // Drive the failure-path branch in AudioEngine::start() by making the
+    // next open() call return false (and leave the bus closed).
+    void setOpenResult(bool ok) { m_openResult = ok; }
+
 private:
-    QString          m_name;
-    AudioFormat      m_negotiatedFormat;
-    bool             m_open{false};
-    QByteArray       m_buffer;
-    std::atomic<int> m_pushes{0};
-    std::atomic<int> m_lastPushBytes{0};
+    QString     m_name;
+    AudioFormat m_negotiatedFormat;
+    bool        m_open{false};
+    bool        m_openResult{true};
+    QByteArray  m_buffer;
+    int         m_pushes{0};
+    qint64      m_lastPushBytes{0};
 };
 
 } // namespace NereusSDR

--- a/tests/tst_audio_engine_vax_tee.cpp
+++ b/tests/tst_audio_engine_vax_tee.cpp
@@ -1,0 +1,236 @@
+// =================================================================
+// tests/tst_audio_engine_vax_tee.cpp  (NereusSDR)
+// =================================================================
+//
+// Exercises AudioEngine's RX → VAX bus tee logic — Phase 3O Sub-Phase 8.5.
+//
+// Coverage:
+//   1. fanIn — multiple slices routed to the same VAX channel get all
+//      their pushes (one push per rxBlockReady call per slice).
+//   2. vaxOffSkipsBus — a slice with vaxChannel == 0 does NOT push to
+//      any bus.
+//   3. vaxDoesNotGateSpeakers — a slice's audio still goes to the
+//      speakers bus regardless of vaxChannel value.
+//   4. nullVaxSlotIsSafeNoOp — when the bus pointer is null (failed
+//      open), the tee is silent and rxBlockReady returns cleanly.
+//   5. closedVaxBusSkipsPush — bus exists but isOpen() == false: tee
+//      respects the isOpen() guard.
+//
+// Uses FakeAudioBus injected via the NEREUS_BUILD_TESTS-only
+// AudioEngine::setVaxBusForTest / setSpeakersBusForTest seam, so the
+// test doesn't need a real CoreAudioHalBus / LinuxPipeBus / PortAudio
+// backend. Cross-platform.
+// =================================================================
+
+#include <QtTest/QtTest>
+
+#include "core/AudioEngine.h"
+#include "core/IAudioBus.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include "fakes/FakeAudioBus.h"
+
+#include <array>
+#include <memory>
+
+using namespace NereusSDR;
+
+namespace {
+
+// Standard test block: 2 frames of stereo float (4 floats / 16 bytes).
+// Matches what rxBlockReady will forward to push() byte-for-byte.
+constexpr int kTestFrames = 2;
+constexpr int kTestStereoFloats = kTestFrames * 2;
+constexpr qint64 kExpectedPushBytes = static_cast<qint64>(kTestStereoFloats) * sizeof(float);
+
+const std::array<float, kTestStereoFloats> kTestSamples = {
+    0.10f, 0.20f,   // frame 0  L,R
+    -0.30f, -0.40f, // frame 1  L,R
+};
+
+} // namespace
+
+class TstAudioEngineVaxTee : public QObject {
+    Q_OBJECT
+
+private:
+    // Build a RadioModel + AudioEngine pair, register slice 0 with the
+    // master mixer (mirrors AudioEngine::start() pre-registration), and
+    // hand the engine a fake speakers bus so the speaker push() in
+    // rxBlockReady is observable. RadioModel owns AudioEngine so we just
+    // hold a unique_ptr to RadioModel and reach into it.
+    struct Harness {
+        std::unique_ptr<RadioModel> radio;
+        AudioEngine* engine;        // non-owning view
+        FakeAudioBus* speakers;     // non-owning view (engine owns it)
+
+        // Add a slice with the given vaxChannel value; returns its index.
+        int addSlice(int vaxChannel) {
+            const int idx = radio->addSlice();
+            SliceModel* slice = radio->sliceAt(idx);
+            slice->setVaxChannel(vaxChannel);
+            return idx;
+        }
+    };
+
+    Harness makeHarness() {
+        Harness h;
+        h.radio = std::make_unique<RadioModel>();
+        h.engine = h.radio->audioEngine();
+
+        // Inject the fake speakers bus before any rxBlockReady call. We
+        // do NOT call engine->start() — that would try to construct
+        // platform-native VAX buses, and on Mac CI without the HAL
+        // plugin installed CoreAudioHalBus::open could noisily fail.
+        // The test only cares about the tee logic, which runs
+        // independent of the m_running flag (rxBlockReady gates on
+        // m_radio + samples + frames, not m_running).
+        auto speakers = std::make_unique<FakeAudioBus>(QStringLiteral("FakeSpeakers"));
+        AudioFormat fmt;
+        fmt.sampleRate = 48000;
+        fmt.channels = 2;
+        fmt.sample = AudioFormat::Sample::Float32;
+        speakers->open(fmt);
+        h.speakers = speakers.get();
+        h.engine->setSpeakersBusForTest(std::move(speakers));
+
+        return h;
+    }
+
+    // Inject a fresh fake bus at the given VAX channel; returns a
+    // non-owning view for inspection.
+    FakeAudioBus* injectFakeVax(AudioEngine* engine, int channel) {
+        auto bus = std::make_unique<FakeAudioBus>(
+            QStringLiteral("FakeVax%1").arg(channel));
+        AudioFormat fmt;
+        fmt.sampleRate = 48000;
+        fmt.channels = 2;
+        fmt.sample = AudioFormat::Sample::Float32;
+        bus->open(fmt);
+        FakeAudioBus* view = bus.get();
+        engine->setVaxBusForTest(channel, std::move(bus));
+        return view;
+    }
+
+private slots:
+
+    // ── 1. Fan-in: two slices on the same VAX channel both push ─────────────
+
+    void fanIn() {
+        Harness h = makeHarness();
+        FakeAudioBus* vax2 = injectFakeVax(h.engine, 2);
+
+        const int s1 = h.addSlice(/*vaxChannel=*/2);
+        const int s2 = h.addSlice(/*vaxChannel=*/2);
+
+        h.engine->rxBlockReady(s1, kTestSamples.data(), kTestFrames);
+        h.engine->rxBlockReady(s2, kTestSamples.data(), kTestFrames);
+
+        QCOMPARE(vax2->pushCount(), 2);
+        QCOMPARE(static_cast<qint64>(vax2->buffer().size()),
+                 kExpectedPushBytes * 2);
+    }
+
+    // ── 2. vaxChannel == 0 → no VAX push ────────────────────────────────────
+
+    void vaxOffSkipsBus() {
+        Harness h = makeHarness();
+        // Inject fakes on every channel so we can prove none of them
+        // received a push.
+        FakeAudioBus* vax1 = injectFakeVax(h.engine, 1);
+        FakeAudioBus* vax2 = injectFakeVax(h.engine, 2);
+        FakeAudioBus* vax3 = injectFakeVax(h.engine, 3);
+        FakeAudioBus* vax4 = injectFakeVax(h.engine, 4);
+
+        const int s = h.addSlice(/*vaxChannel=*/0);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+
+        QCOMPARE(vax1->pushCount(), 0);
+        QCOMPARE(vax2->pushCount(), 0);
+        QCOMPARE(vax3->pushCount(), 0);
+        QCOMPARE(vax4->pushCount(), 0);
+    }
+
+    // ── 3. Speakers tee runs regardless of vaxChannel ──────────────────────
+
+    void vaxDoesNotGateSpeakers() {
+        Harness h = makeHarness();
+        FakeAudioBus* vax3 = injectFakeVax(h.engine, 3);
+
+        const int s = h.addSlice(/*vaxChannel=*/3);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+
+        // VAX3 saw the push.
+        QCOMPARE(vax3->pushCount(), 1);
+        QCOMPARE(static_cast<qint64>(vax3->lastPushBytes()), kExpectedPushBytes);
+
+        // Speakers also saw the push (the master-mix flush at the end of
+        // rxBlockReady). The size matches because frames is identical and
+        // the mixer is stereo.
+        QCOMPARE(h.speakers->pushCount(), 1);
+        QCOMPARE(static_cast<qint64>(h.speakers->lastPushBytes()),
+                 kExpectedPushBytes);
+    }
+
+    // Repeat (3) but with vaxChannel == 0: speakers still get the audio.
+    void vaxOffStillFeedsSpeakers() {
+        Harness h = makeHarness();
+        const int s = h.addSlice(/*vaxChannel=*/0);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+
+        QCOMPARE(h.speakers->pushCount(), 1);
+        QCOMPARE(static_cast<qint64>(h.speakers->lastPushBytes()),
+                 kExpectedPushBytes);
+    }
+
+    // ── 4. Null VAX slot is a safe no-op ───────────────────────────────────
+
+    void nullVaxSlotIsSafeNoOp() {
+        Harness h = makeHarness();
+        // Deliberately do NOT inject a VAX bus on channel 4.
+        const int s = h.addSlice(/*vaxChannel=*/4);
+
+        // Should not crash, should not throw, should still flush the
+        // mix to speakers.
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+
+        QCOMPARE(h.speakers->pushCount(), 1);
+    }
+
+    // ── 5. Closed bus is gated by isOpen() guard ───────────────────────────
+
+    void closedVaxBusSkipsPush() {
+        Harness h = makeHarness();
+        FakeAudioBus* vax1 = injectFakeVax(h.engine, 1);
+        vax1->setForceOpen(false);  // bus exists, but isOpen() → false
+
+        const int s = h.addSlice(/*vaxChannel=*/1);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+
+        QCOMPARE(vax1->pushCount(), 0);
+        // Speakers tee still runs — VAX failure must not break the
+        // primary RX audio path.
+        QCOMPARE(h.speakers->pushCount(), 1);
+    }
+
+    // ── 6. Out-of-range vaxChannel values are ignored (defensive) ──────────
+
+    void outOfRangeVaxChannelIgnored() {
+        Harness h = makeHarness();
+        FakeAudioBus* vax1 = injectFakeVax(h.engine, 1);
+        FakeAudioBus* vax4 = injectFakeVax(h.engine, 4);
+
+        // vaxChannel = 5 is invalid (> 4); rxBlockReady's guard rejects.
+        const int s = h.addSlice(/*vaxChannel=*/5);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+
+        QCOMPARE(vax1->pushCount(), 0);
+        QCOMPARE(vax4->pushCount(), 0);
+        // Speakers still gets the audio (vaxChannel is a tap, not a gate).
+        QCOMPARE(h.speakers->pushCount(), 1);
+    }
+};
+
+QTEST_MAIN(TstAudioEngineVaxTee)
+#include "tst_audio_engine_vax_tee.moc"

--- a/tests/tst_audio_engine_vax_tee.cpp
+++ b/tests/tst_audio_engine_vax_tee.cpp
@@ -4,17 +4,8 @@
 //
 // Exercises AudioEngine's RX → VAX bus tee logic — Phase 3O Sub-Phase 8.5.
 //
-// Coverage:
-//   1. fanIn — multiple slices routed to the same VAX channel get all
-//      their pushes (one push per rxBlockReady call per slice).
-//   2. vaxOffSkipsBus — a slice with vaxChannel == 0 does NOT push to
-//      any bus.
-//   3. vaxDoesNotGateSpeakers — a slice's audio still goes to the
-//      speakers bus regardless of vaxChannel value.
-//   4. nullVaxSlotIsSafeNoOp — when the bus pointer is null (failed
-//      open), the tee is silent and rxBlockReady returns cleanly.
-//   5. closedVaxBusSkipsPush — bus exists but isOpen() == false: tee
-//      respects the isOpen() guard.
+// Coverage: see private-slot test methods below — each verifies one
+// routing-contract scenario.
 //
 // Uses FakeAudioBus injected via the NEREUS_BUILD_TESTS-only
 // AudioEngine::setVaxBusForTest / setSpeakersBusForTest seam, so the


### PR DESCRIPTION
## Summary
- Closes the `TODO(phase3o-5/6)` in `AudioEngine::makeBus` left by Sub-Phase 4.
  `start()` now eagerly mints platform-native VAX RX 1..4 + a VAX TX virtual
  bus per platform: `CoreAudioHalBus(Role::Vax1..4 + Role::TxInput)` on macOS,
  `LinuxPipeBus(Role::Vax1..4 + Role::TxInput)` on Linux. Windows BYO stays
  null with a `TODO(sub-phase-9-byo)` marker.
- New `m_vaxTxBus` member alongside the existing `m_txInputBus` (mic). The
  bus is opened so coreaudiod / pactl can publish "NereusSDR TX" to consumer
  apps; the actual `pull()` consumer is deferred to Phase 3M with a
  `TODO(phase3M)` marker.
- Per-slot `open()` failure logs `qCWarning(lcAudio)` with `errorString()` and
  leaves the slot null. The `rxBlockReady` tee already skips null slots, so a
  partial backend failure (HAL plugin missing, pactl not installed) leaves
  speakers + surviving VAX channels live without crashing.
- New `NEREUS_BUILD_TESTS`-gated test seam (`setVaxBusForTest` /
  `setSpeakersBusForTest`) plus a `FakeAudioBus` and a 7-case
  `tst_audio_engine_vax_tee` exercising the routing contract independent of
  any real CoreAudio / pactl backend.

## Commits
- `3ccff7e` feat(audio): wire CoreAudioHalBus + LinuxPipeBus into AudioEngine (Sub-Phase 8.5)
- `c918ba4` fix(audio): address code-quality findings on Sub-Phase 8.5 wiring

## Tests
`tst_audio_engine_vax_tee` — 7 cases (all passing locally):
- `fanIn` — multi-slice routing into the same VAX channel pushes both
- `vaxOffSkipsBus` — `vaxChannel == 0` skips the VAX tap
- `vaxDoesNotGateSpeakers` — speakers keep playing while VAX is on
- `vaxOffStillFeedsSpeakers` — speakers keep playing when VAX is off
- `nullVaxSlotIsSafeNoOp` — null bus pointer = safe skip
- `closedVaxBusSkipsPush` — `isOpen() == false` = safe skip
- `outOfRangeVaxChannelIgnored` — defensive bound check on slice ID

## Test plan
- [ ] Linux CI: tests pass + LinuxPipeBus path compiles cleanly under `Q_OS_LINUX`
- [ ] macOS CI: tests pass + CoreAudioHalBus call path links
- [ ] Windows CI: build clean (Windows path is `nullptr` + TODO marker; no behavior change)
- [x] Manual smoke (macOS): NereusSDR + locally-built `NereusSDRVAX.driver` —
      full e2e verified. Slice → VAX 1 routes audio through the HAL plugin to
      a CoreAudio consumer; direct `AVAudioEngine` probe captured 48 kHz stereo
      float32 at peak −0 dBFS / RMS −2.6 dBFS.

## Scope notes
- `rxBlockReady` body intentionally untouched — the tee logic from Sub-Phase 4
  was already correct per design spec §3.4.
- TX consumer wiring (`pull()` from `m_vaxTxBus` when
  `TransmitModel::txOwnerSlot() != MicDirect`) is Phase 3M, marked inline.
- Per-VAX RX gain UI is Sub-Phase 9 (lands with VaxApplet).
- Reference: `docs/architecture/2026-04-19-vax-design.md` §§3–4.

## Known follow-ups (separate PRs)
- #70 — Wire or remove the disabled "VAX Ch" / "IQ Ch" stub combos in
  `SpectrumOverlayPanel.cpp:1012-1034` (NYI placeholders from before
  Sub-Phase 8).
- `hal-plugin/CMakeLists.txt` doesn't isolate `libASPL`'s transitive `install`
  rules — `cmake --install build-hal` tries to write `/usr/local/lib`. Local
  dev install needs `sudo cp -R build-hal/NereusSDRVAX.driver
  /Library/Audio/Plug-Ins/HAL/` + ad-hoc codesign re-sign.

---
J.J. Boyd ~ KG4VCF