### PR TITLE
fix: wire VFO STEP arrows in RxApplet + add 500 Hz step (closes #69)

### DIFF
--- a/src/gui/applets/RxApplet.cpp
+++ b/src/gui/applets/RxApplet.cpp
@@ -315,7 +315,8 @@ void RxApplet::buildUi()
     leftCol->setSpacing(2);
 
     // Control 17: Step size row — STEP: [<] [value] [>]
-    // NYI: SliceModel::setStepHz exists, but step cycling not yet wired
+    // Cycles SliceModel::stepHz through kStageOneStepLadder
+    // {1, 10, 100, 500, 1k, 10k}.
     {
         auto* row = new QHBoxLayout;
         row->setSpacing(0);
@@ -340,8 +341,30 @@ void RxApplet::buildUi()
 
         leftCol->addLayout(row);
 
-        NyiOverlay::markNyi(m_stepDown, QStringLiteral("Phase 3I"));
-        NyiOverlay::markNyi(m_stepUp,   QStringLiteral("Phase 3I"));
+        // Step arrows cycle through kStageOneStepLadder
+        // {1, 10, 100, 500, 1k, 10k}. Down = previous, Up = next.
+        // Wraps at both ends. Issue #69.
+        connect(m_stepDown, &QPushButton::clicked, this, [this]() {
+            if (!m_slice) { return; }
+            const int current = m_slice->stepHz();
+            int idx = 0;
+            for (int i = 0; i < kStageOneStepLadderSize; ++i) {
+                if (kStageOneStepLadder[i] == current) { idx = i; break; }
+            }
+            const int prev = (idx - 1 + kStageOneStepLadderSize)
+                             % kStageOneStepLadderSize;
+            m_slice->setStepHz(kStageOneStepLadder[prev]);
+        });
+        connect(m_stepUp, &QPushButton::clicked, this, [this]() {
+            if (!m_slice) { return; }
+            const int current = m_slice->stepHz();
+            int idx = 0;
+            for (int i = 0; i < kStageOneStepLadderSize; ++i) {
+                if (kStageOneStepLadder[i] == current) { idx = i; break; }
+            }
+            const int next = (idx + 1) % kStageOneStepLadderSize;
+            m_slice->setStepHz(kStageOneStepLadder[next]);
+        });
     }
 
     // Control 7: Filter preset buttons — 10 buttons in 2×5 grid
@@ -940,6 +963,9 @@ void RxApplet::syncFromModel()
             .arg(hz));
     }
 
+    // Step size label (Issue #69)
+    m_stepLabel->setText(QStringLiteral("%1 Hz").arg(m_slice->stepHz()));
+
     m_updatingFromModel = false;
 }
 
@@ -1014,6 +1040,11 @@ void RxApplet::connectSlice(SliceModel* s)
         m_ritLabel->setText(QStringLiteral("%1%2 Hz")
             .arg(hz >= 0 ? QStringLiteral("+") : QString{})
             .arg(hz));
+    });
+
+    // Step size model → label sync (Issue #69)
+    connect(s, &SliceModel::stepHzChanged, this, [this](int hz) {
+        m_stepLabel->setText(QStringLiteral("%1 Hz").arg(hz));
     });
 
     // ATT/S-ATT — wire to StepAttenuatorController if available

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -128,9 +128,9 @@
 namespace NereusSDR {
 
 // Stage 1 stub ladder — Stage 2 replaces with Thetis tune_step_list
-// (console.cs tune_step_list has 11 entries; Stage 1 uses this 5-entry
+// (console.cs tune_step_list has 11 entries; Stage 1 uses this 6-entry
 // subset only for the X/RIT STEP cycle button).
-inline constexpr int kStageOneStepLadder[] = {1, 10, 100, 1000, 10000};
+inline constexpr int kStageOneStepLadder[] = {1, 10, 100, 500, 1000, 10000};
 inline constexpr int kStageOneStepLadderSize =
     static_cast<int>(sizeof(kStageOneStepLadder) / sizeof(kStageOneStepLadder[0]));
 


### PR DESCRIPTION
## Summary
- Wires the previously-NYI < / > arrows on the RxApplet STEP row to
  `SliceModel::setStepHz`, cycling through `kStageOneStepLadder`.
- Syncs `m_stepLabel` from `SliceModel::stepHzChanged` + seeds it on bind,
  so the label tracks every source of step changes (arrows, VfoWidget
  cycle button, persistence restore).
- Adds 500 Hz to `kStageOneStepLadder`. New ladder:
  `{1, 10, 100, 500, 1k, 10k}`.

Fixes #69 (Step is stuck on 100 Hz).

## Test plan
- [ ] Click left arrow on STEP — value cycles 100 → 10 → 1 → 10k → ...
- [ ] Click right arrow — value cycles 100 → 500 → 1k → 10k → 1 → ...
- [ ] Tune via VFO knob/wheel at each step value, confirm freq jump matches
- [ ] Toggle STEP cycle button on VfoWidget — RxApplet label tracks
- [ ] Restart app — last step persists per-slice via existing AppSettings
- [ ] Verify on Windows 11 / HL2 P1 (the reporter's environment)

J.J. Boyd ~ KG4VCF