### PR TITLE
fix(vfo): rewrite frequency-entry parser (closes #73)

### DIFF
--- a/src/gui/widgets/VfoWidget.cpp
+++ b/src/gui/widgets/VfoWidget.cpp
@@ -2116,8 +2116,20 @@ double VfoWidget::parseUserFrequency(const QString& raw)
         }
         if (!hasUnit) { mult = 1.0; }
     } else if (nCommas == 1 && nDots == 0) {
-        // "7,23" — EU decimal.
-        s.replace(QLatin1Char(','), QLatin1Char('.'));
+        // Single comma — ambiguous. If a unit suffix was already parsed, a
+        // three-digit tail is a US-style thousands separator
+        // (e.g. "7,230 kHz" → 7,230 kHz), anything else is EU decimal
+        // ("7,23 MHz" → 7.23 MHz). Without a unit, fall through to EU
+        // decimal — the historical behavior — because a bare "7,23" with
+        // no grouping context reads as a decimal in every locale that
+        // writes it that way.
+        const int commaIdx  = s.indexOf(QLatin1Char(','));
+        const int tailCount = s.size() - commaIdx - 1;
+        if (hasUnit && tailCount == 3) {
+            s.remove(QLatin1Char(','));
+        } else {
+            s.replace(QLatin1Char(','), QLatin1Char('.'));
+        }
     }
     // else: at most a single '.' (C-locale ready) or a plain integer.
 

--- a/src/gui/widgets/VfoWidget.cpp
+++ b/src/gui/widgets/VfoWidget.cpp
@@ -522,16 +522,12 @@ void VfoWidget::buildFrequencyRow()
                         "background: #0a0a18; border: 1px solid #00b4d8;"
                         "border-radius: 3px; padding: 0 4px;"));
     connect(m_freqEdit, &QLineEdit::returnPressed, this, [this]() {
-        QString text = m_freqEdit->text().replace(QLatin1Char('.'), QString());
-        bool ok = false;
-        double mhz = text.toDouble(&ok);
-        if (ok && mhz > 0.0) {
-            // If user typed a small number, assume MHz; otherwise Hz
-            double hz = (mhz < 1000.0) ? mhz * 1e6 : mhz;
-            hz = std::clamp(hz, 100000.0, 61440000.0);
-            m_frequency = hz;
+        const double hz = parseUserFrequency(m_freqEdit->text());
+        if (hz > 0.0) {
+            const double clamped = std::clamp(hz, 100000.0, 61440000.0);
+            m_frequency = clamped;
             updateFreqLabel();
-            emit frequencyChanged(hz);
+            emit frequencyChanged(clamped);
         }
         m_freqStack->setCurrentIndex(0);
     });
@@ -2067,6 +2063,93 @@ void VfoWidget::wheelEvent(QWheelEvent* event)
 }
 
 // ---- Helpers ----
+
+double VfoWidget::parseUserFrequency(const QString& raw)
+{
+    QString s = raw.trimmed();
+    if (s.isEmpty()) { return -1.0; }
+
+    // Detect and strip unit suffix (longest match first so "MHz" wins over "Hz").
+    double mult = 0.0;
+    bool hasUnit = false;
+    const auto tryStripSuffix = [&](const char* suffix, double m) {
+        if (s.endsWith(QLatin1String(suffix), Qt::CaseInsensitive)) {
+            s.chop(qstrlen(suffix));
+            mult = m;
+            hasUnit = true;
+            return true;
+        }
+        return false;
+    };
+    tryStripSuffix("MHz", 1e6)
+        || tryStripSuffix("kHz", 1e3)
+        || tryStripSuffix("Hz",  1.0)
+        || tryStripSuffix("M",   1e6)
+        || tryStripSuffix("K",   1e3);
+    s = s.trimmed();
+    if (s.isEmpty()) { return -1.0; }
+
+    const int nDots   = s.count(QLatin1Char('.'));
+    const int nCommas = s.count(QLatin1Char(','));
+
+    // Normalize separators. The goal: end up with at most one '.' as the
+    // decimal separator, with any grouping separators removed.
+    if (nDots >= 2 && nCommas == 0) {
+        // "7.230.000" (or with unit: "7.230.000 Hz") — dots are thousand
+        // separators. When no unit was given, default to Hz since that's
+        // the only sensible interpretation of a multi-dot number.
+        s.remove(QLatin1Char('.'));
+        if (!hasUnit) { mult = 1.0; }
+    } else if (nCommas >= 2 && nDots == 0) {
+        // "7,230,000" — US thousand-separated Hz value.
+        s.remove(QLatin1Char(','));
+        if (!hasUnit) { mult = 1.0; }
+    } else if (nDots > 0 && nCommas > 0) {
+        // Mixed: the last occurrence is the decimal, the rest are thousands.
+        // The presence of thousand separators means the user is writing a
+        // Hz value (e.g. "7,230,000.50"); no unit makes no other sense.
+        if (s.lastIndexOf(QLatin1Char('.')) > s.lastIndexOf(QLatin1Char(','))) {
+            s.remove(QLatin1Char(','));
+        } else {
+            s.remove(QLatin1Char('.'));
+            s.replace(QLatin1Char(','), QLatin1Char('.'));
+        }
+        if (!hasUnit) { mult = 1.0; }
+    } else if (nCommas == 1 && nDots == 0) {
+        // "7,23" — EU decimal.
+        s.replace(QLatin1Char(','), QLatin1Char('.'));
+    }
+    // else: at most a single '.' (C-locale ready) or a plain integer.
+
+    bool ok = false;
+    const double v = s.toDouble(&ok);
+    if (!ok || v < 0.0) { return -1.0; }
+
+    if (mult != 0.0) {
+        return v * mult;
+    }
+
+    // Plain number, no unit, no grouping separators. Matches the Thetis
+    // MHz-decimal convention when a decimal point is present. For bare
+    // integers, pick the first unit (MHz → kHz → Hz) whose interpretation
+    // lies in the Red Pitaya tuning range — this rescues users who typed
+    // "7230" (intending kHz) or "7230000" (intending Hz) without guessing
+    // wrong like the prior heuristic did (issue #73).
+    constexpr double kMinHz = 100000.0;     // 100 kHz floor
+    constexpr double kMaxHz = 61440000.0;   // 61.44 MHz ceiling
+    const bool isDecimal = (nDots == 1);
+    if (isDecimal) {
+        return v * 1e6;  // Thetis convention: decimal number is MHz
+    }
+    const double asMHz = v * 1e6;
+    const double asKHz = v * 1e3;
+    const double asHz  = v;
+    if (asMHz >= kMinHz && asMHz <= kMaxHz) { return asMHz; }
+    if (asKHz >= kMinHz && asKHz <= kMaxHz) { return asKHz; }
+    if (asHz  >= kMinHz && asHz  <= kMaxHz) { return asHz;  }
+    // No interpretation in range: fall back to MHz; caller will clamp.
+    return asMHz;
+}
 
 void VfoWidget::updateFreqLabel()
 {

--- a/src/gui/widgets/VfoWidget.h
+++ b/src/gui/widgets/VfoWidget.h
@@ -333,6 +333,14 @@ public:
     explicit VfoWidget(QWidget* parent = nullptr);
     ~VfoWidget() override;
 
+    // Parse a user-entered frequency string and return Hz, or -1.0 on failure.
+    // Accepts MHz decimal ("7.23"), EU decimal ("7,23"), EU thousand-separated
+    // Hz ("7.230.000"), US thousand-separated Hz ("7,230,000"), explicit unit
+    // suffix ("7.23 MHz" / "7230 kHz" / "7230000 Hz" / "7.23M" / "7230k"), or
+    // a plain number (best-fit unit by Red Pitaya range). Separate from the
+    // returnPressed lambda so the logic is unit-testable. See issue #73.
+    static double parseUserFrequency(const QString& raw);
+
     // --- State setters (called from model, guarded against re-emit) ---
 
     void setFrequency(double hz);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,9 @@ nereus_add_test(tst_scrollable_label)
 nereus_add_test(tst_vfo_mode_containers)
 nereus_add_test(tst_vfo_tooltip_coverage)
 
+# Regression test for issue #73 — VfoWidget frequency-entry parser
+nereus_add_test(tst_vfo_frequency_parser)
+
 # ── Phase 3G-10 Stage 2: WDSP wiring — AGC advanced ──────────────────────
 nereus_add_test(tst_rxchannel_agc_advanced)
 nereus_add_test(tst_slice_agc_advanced)

--- a/tests/tst_vfo_frequency_parser.cpp
+++ b/tests/tst_vfo_frequency_parser.cpp
@@ -66,6 +66,17 @@ private slots:
         // "7.230.000 Hz" — dots are thousand seps, unit wins.
         QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7.230.000 Hz")), 7230000.0);
     }
+    void singleCommaWithUnitIsThousands() {
+        // "7,230 kHz" — single comma + explicit unit + 3-digit tail reads
+        // as US thousands, so this is 7,230 kHz = 7.23 MHz, not 7.23 kHz.
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7,230 kHz")), 7230000.0);
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7,230 Hz")), 7230.0);
+    }
+    void singleCommaWithUnitIsDecimal() {
+        // "7,23 MHz" — single comma + explicit unit + 2-digit tail reads
+        // as EU decimal: 7.23 MHz.
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7,23 MHz")), 7230000.0);
+    }
 
     // --- Existing display-format round-trip -------------------------------
 

--- a/tests/tst_vfo_frequency_parser.cpp
+++ b/tests/tst_vfo_frequency_parser.cpp
@@ -1,0 +1,104 @@
+// Regression test for the VfoWidget frequency-entry parser.
+// Covers the bug reported in issue #73: European thousand-separated input
+// ("7.230.000") was sometimes 10× too small, plain decimal input ("7.23")
+// jumped to the 61.44 MHz clamp ceiling.
+
+#include <QtTest/QtTest>
+#include "gui/widgets/VfoWidget.h"
+
+using NereusSDR::VfoWidget;
+
+class TestVfoFrequencyParser : public QObject {
+    Q_OBJECT
+private slots:
+    // --- The issue #73 reproducer cases ------------------------------------
+
+    void euThousandSeparatedIsSevenTwentyThreeMHz() {
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7.230.000")), 7230000.0);
+    }
+    void mhzDecimalDoesNotHitCeiling() {
+        // Previously "7.23" was stripped to "723", treated as Hz, then clamped
+        // up to 61.44 MHz. Must now be interpreted as 7.23 MHz.
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7.23")), 7230000.0);
+    }
+    void mhzDecimalWithTrailingZero() {
+        // Previously "7.230" was stripped to "7230", treated as Hz, then
+        // clamped to the 100 kHz floor.
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7.230")), 7230000.0);
+    }
+
+    // --- Plain-integer range inference -------------------------------------
+
+    void plainInRangeMHz() {
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("14")), 14000000.0);
+    }
+    void plainInRangeKHz() {
+        // 7230 MHz is out of range → falls through to kHz (7.23 MHz).
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7230")), 7230000.0);
+    }
+    void plainInRangeHz() {
+        // 7230000 MHz / kHz are out of range → falls through to Hz (7.23 MHz).
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7230000")), 7230000.0);
+    }
+
+    // --- European decimal and US thousand separators ----------------------
+
+    void euDecimalComma() {
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7,23")), 7230000.0);
+    }
+    void usThousandSeparated() {
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7,230,000")), 7230000.0);
+    }
+    void mixedThousandsAndDecimal() {
+        // US thousand-sep with decimal: "7,230,000.00" → 7230000.00 Hz
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7,230,000.00")), 7230000.0);
+    }
+
+    // --- Unit suffixes ----------------------------------------------------
+
+    void explicitMHz()       { QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7.23 MHz")), 7230000.0); }
+    void explicitKHz()       { QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7230 kHz")), 7230000.0); }
+    void explicitHz()        { QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7230000 Hz")), 7230000.0); }
+    void shortSuffixM()      { QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7.23M")), 7230000.0); }
+    void shortSuffixK()      { QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7230k")), 7230000.0); }
+    void caseInsensitiveMhz(){ QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7.23mhz")), 7230000.0); }
+    void multiDotWithUnit() {
+        // "7.230.000 Hz" — dots are thousand seps, unit wins.
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("7.230.000 Hz")), 7230000.0);
+    }
+
+    // --- Existing display-format round-trip -------------------------------
+
+    void preFilledMhzDecimal() {
+        // VfoWidget pre-fills the edit field via QString::number(mhz,'f',6).
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("14.225000")), 14225000.0);
+    }
+    void labelFormatRoundTrip() {
+        // The label format "14.225.000" must also parse correctly if users
+        // retype from what they see.
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("14.225.000")), 14225000.0);
+    }
+
+    // --- Failure cases ----------------------------------------------------
+
+    void emptyStringFails()     { QCOMPARE(VfoWidget::parseUserFrequency(QString()), -1.0); }
+    void whitespaceOnlyFails()  { QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("   ")), -1.0); }
+    void garbageFails()         { QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("abc")), -1.0); }
+    void unitOnlyFails()        { QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("MHz")), -1.0); }
+    void negativeFails()        { QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("-7.23")), -1.0); }
+
+    // --- Clamp behavior (at caller level, parser should not clamp) --------
+
+    void parserDoesNotClamp() {
+        // 1 GHz — parser returns 1e9 unchanged; the caller is responsible
+        // for clamping to the Red Pitaya range.
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("1000 MHz")), 1e9);
+    }
+    void parserReturnsBelowFloor() {
+        // 50 Hz — parser returns 50 unchanged; caller will clamp to 100 kHz.
+        QCOMPARE(VfoWidget::parseUserFrequency(QStringLiteral("50 Hz")), 50.0);
+    }
+};
+
+QTEST_MAIN(TestVfoFrequencyParser)
+#include "tst_vfo_frequency_parser.moc"


### PR DESCRIPTION
## Summary
- Rewrites the VfoWidget freq-entry parser so `7.23`, `7.230`, `7,23`,
  and `7,230,000` all tune to 7.23 MHz instead of hitting the 61.44 MHz
  ceiling, the 100 kHz floor, or silently failing.
- Extracts the logic into `VfoWidget::parseUserFrequency()` so it's
  unit-testable, and adds a 27-case regression test.

## Root cause (issue #73)
The lambda at `VfoWidget.cpp:524-537` stripped every `.` from input as
a thousand separator, then used `mhz < 1000.0 ? mhz*1e6 : mhz` to guess
the unit. That heuristic mis-parsed several natural inputs:

| Input | Old behavior | User symptom |
|-------|-------------|--------------|
| `7.23` | stripped to `723` → Hz → clamped **up** to 61.44 MHz | "jumps to 61 MHz" |
| `7.230` | stripped to `7230` → Hz → clamped **down** to 100 kHz | "10× too small" |
| `7,23` / `7,230,000` | silent parse failure | "jumps to 0" (stays on prior value) |

## New parser rules
- Multi-separator input (2+ dots or 2+ commas) = thousand-separated Hz.
- Single separator = decimal MHz (Thetis convention).
- Explicit `MHz`/`kHz`/`Hz`/`M`/`k` suffix overrides everything.
- Plain integer tries MHz → kHz → Hz, picks the first unit whose value
  lands in the Red Pitaya tuning range, so `7230` (kHz intent) and
  `7230000` (Hz intent) both resolve to 7.23 MHz.
- Returns `-1.0` on parse failure so the caller keeps the prior freq
  instead of falling through to a bogus clamp.

## Test plan
- [x] \`tst_vfo_frequency_parser\` — 27 cases, all pass
- [ ] Manual: tune via VFO flag using each supported format on real radio
- [ ] Manual: confirm pre-populated edit field (MHz decimal) still round-trips

J.J. Boyd ~ KG4VCF