### PR TITLE
Phase 3O Sub-Phase 10: MasterOutputWidget + TitleBar (menu + master output consolidation)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,7 @@ set(GUI_SOURCES
     src/gui/widgets/VfoModeContainers.cpp
     src/gui/widgets/VfoModeContainers.h
     src/gui/widgets/VaxChannelSelector.cpp
+    src/gui/widgets/MasterOutputWidget.cpp
     src/gui/widgets/VfoStyles.h
     src/gui/widgets/VfoWidget.cpp
     src/gui/containers/ContainerWidget.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ set(MODEL_SOURCES
 
 set(GUI_SOURCES
     src/gui/MainWindow.cpp
+    src/gui/TitleBar.cpp
     src/gui/ConnectionPanel.cpp
     src/gui/AddCustomRadioDialog.cpp
     src/gui/SupportDialog.cpp

--- a/docs/attribution/aethersdr-contributor-index.md
+++ b/docs/attribution/aethersdr-contributor-index.md
@@ -288,7 +288,7 @@ per-file NereusSDR-side diff).
 | `src/gui/SMeterWidget.{h,cpp}` | (split into `MeterWidget` + S-meter `ItemGroup` preset) | |
 | `src/gui/MeterApplet.{h,cpp}` | `src/gui/meters/MeterWidget.{h,cpp}` + `MeterPoller.{h,cpp}` + `MeterItem.{h,cpp}` + all the item subclasses + `ItemGroup.{h,cpp}` | NereusSDR's meter system is a **major divergence** — it's Thetis-MeterManager-ported (per NereusSDR CLAUDE.md, 3G-2/3G-3/3G-4/3G-5/3G-6), not AetherSDR-derived. Any `// From AetherSDR` comments on `src/gui/meters/*` items should be re-checked against Thetis `MeterManager.cs` — flag for 25b. |
 | `src/gui/DspParamPopup.{h,cpp}` / `AetherDspDialog.{h,cpp}` | (none — NereusSDR uses inline applet controls) | |
-| `src/gui/TitleBar.{h,cpp}` | (none yet — 3G-14 plans 💡 menu corner widget) | AetherSDR's TitleBar has the AI-assisted bug-report lightbulb that 3G-14 plans to port. |
+| `src/gui/TitleBar.{h,cpp}` | `src/gui/TitleBar.{h,cpp}` | **Scoped-down port** (Phase 3O Sub-Phase 10 Task 10c, 2026-04-20). NereusSDR's TitleBar is a thin 32 px host strip hosting the menu bar + MasterOutputWidget only; AetherSDR's heartbeat / multiFLEX / PC-audio / headphone / minimal-mode / feature-request widgets are intentionally omitted (deferred to separate NereusSDR phases — 3G-14 plans the 💡 feature-request widget; headphone devices land in Sub-Phase 12 Setup → Audio → Devices). `setMenuBar()` is a line-for-line port of AetherSDR `TitleBar.cpp:282-295`. |
 | `src/gui/ComboStyle.h` / `HGauge.h` / `SliceColors.h` | `src/gui/StyleConstants.h` and co. | Shared style constants. |
 | `src/generated/WhatsNewData.cpp` | (none — auto-generated) | Change-log entries. |
 

--- a/docs/attribution/aethersdr-reconciliation.md
+++ b/docs/attribution/aethersdr-reconciliation.md
@@ -181,6 +181,19 @@ upstream source file.
 |---|---|---|---|
 | `src/gui/SetupPage.cpp` | `src/gui/RadioSetupDialog.{h,cpp}` | Line 8 "Shared style strings — mirror AetherSDR RadioSetupDialog constants". | "Shared setup-page style constants mirror AetherSDR `src/gui/RadioSetupDialog.{h,cpp}`." |
 
+### Phase 3O Sub-Phase 10 Task 10c — TitleBar host strip
+
+Added 2026-04-20 (Sub-Phase 10 Task 10c). Scoped-down port of AetherSDR's
+monolithic TitleBar — keeps the 32 px host-strip + `setMenuBar()` re-
+parent pattern + app-name label, drops everything else. Files carry a
+NereusSDR port-citation header (HOW-TO-PORT.md rule 6 — AetherSDR has no
+per-file GPL header to copy) naming AetherSDR `src/gui/TitleBar.{h,cpp}`.
+
+| NereusSDR file | AetherSDR counterpart | Evidence | Specific mod-history wording |
+|---|---|---|---|
+| `src/gui/TitleBar.h` | `src/gui/TitleBar.h` + `TitleBar.cpp:27-34, 94-104, 282-295` | Port-citation header names both AetherSDR files. Structural pattern (fixed 32 px host strip, `[menu][stretch][app-name][stretch][right-cluster]` hbox, `setMenuBar()` re-parent at position 0) comes directly from AetherSDR. Scope intentionally reduced: only the master-output right cluster is included; AetherSDR's heartbeat / multiFLEX / PC-audio / headphone / minimal-mode / feature-request widgets are deferred to separate NereusSDR phases. | "Scoped-down port of AetherSDR `src/gui/TitleBar.{h,cpp}` — master-output strip only; heartbeat / multiFLEX / PC-audio / headphone / minimal-mode / feature-request widgets intentionally omitted (deferred to separate phases — 3G-14 plans the 💡 feature-request widget; headphone devices land in Sub-Phase 12). Hosts `MasterOutputWidget` (Task 10b) on the right; `setMenuBar()` copied from AetherSDR `TitleBar.cpp:282-295`." |
+| `src/gui/TitleBar.cpp` | Same | Same — constructor background (#0a0a14) + bottom border (#203040) + `setFixedHeight(32)` from AetherSDR `TitleBar.cpp:30-31`; app-name label from `TitleBar.cpp:101-104` with "AetherSDR" → "NereusSDR". `setMenuBar()` is a line-for-line port of `TitleBar.cpp:282-295`. | Same as `.h`. |
+
 ---
 
 ## Bucket B — False AetherSDR citations (126 files)

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -35,6 +35,16 @@
 //                 degrades to silence on that channel; surviving slots
 //                 stay live. Windows path stays null pending Sub-Phase 9
 //                 BYO wiring.
+//   2026-04-20 — Sub-Phase 10 Task 10a master-mute API by J.J. Boyd
+//                 (KG4VCF), AI-assisted via Anthropic Claude Code. Adds
+//                 setMasterMuted implementation (acq_rel exchange +
+//                 masterMutedChanged emission on distinct state), and a
+//                 single-atomic-load mute gate around the speakers push in
+//                 rxBlockReady. Gate covers the speakers bus ONLY — VAX
+//                 tap path and master-mix accumulation remain unconditional
+//                 so 3rd-party consumers of VAX aren't silenced by the
+//                 local monitor mute. No alloc, no lock, no logging —
+//                 RT-safety preserved.
 // =================================================================
 
 #include "AudioEngine.h"
@@ -512,11 +522,20 @@ void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
 
     // Same snapshot idiom as the VAX tap: one load into a local so the
     // isOpen() guard and the push() observe the same IAudioBus.
-    IAudioBus* speakersBus = m_speakersBus.get();
-    if (speakersBus != nullptr && speakersBus->isOpen()) {
-        speakersBus->push(
-            reinterpret_cast<const char*>(mix.data()),
-            static_cast<qint64>(stereoFloats) * sizeof(float));
+    //
+    // Master-mute gate (Sub-Phase 10 Task 10a): single atomic acquire
+    // load per block. Gates the speakers push ONLY — the master-mix
+    // accumulate() above and the VAX tap earlier in this method run
+    // unconditionally, so 3rd-party apps consuming a VAX channel keep
+    // receiving audio while the local monitor is muted. No alloc, no
+    // lock, no logging — RT-safety preserved.
+    if (!m_masterMuted.load(std::memory_order_acquire)) {
+        IAudioBus* speakersBus = m_speakersBus.get();
+        if (speakersBus != nullptr && speakersBus->isOpen()) {
+            speakersBus->push(
+                reinterpret_cast<const char*>(mix.data()),
+                static_cast<qint64>(stereoFloats) * sizeof(float));
+        }
     }
 }
 
@@ -529,6 +548,18 @@ void AudioEngine::setVolume(float volume)
     const float prev = m_masterVolume.exchange(volume, std::memory_order_acq_rel);
     if (prev != volume) {
         emit volumeChanged(volume);
+    }
+}
+
+void AudioEngine::setMasterMuted(bool muted)
+{
+    // Same acq_rel / acquire pairing as setVolume above — the
+    // DSP-thread read in rxBlockReady uses acquire; a plain release
+    // would not synchronize the read-side observation order on weak
+    // memory models.
+    const bool prev = m_masterMuted.exchange(muted, std::memory_order_acq_rel);
+    if (prev != muted) {
+        emit masterMutedChanged(muted);
     }
 }
 

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -36,6 +36,16 @@
 //                 (m_vaxTxBus) so 3rd-party apps see the virtual devices the
 //                 moment audio is running. Windows BYO wiring deferred to
 //                 Sub-Phase 9.
+//   2026-04-20 — Sub-Phase 10 Task 10a master-mute API by J.J. Boyd
+//                 (KG4VCF), AI-assisted via Anthropic Claude Code. Adds
+//                 setMasterMuted / masterMuted / masterMutedChanged
+//                 mirroring the existing setVolume pattern. Mute gates the
+//                 speakers push in rxBlockReady ONLY — VAX taps continue to
+//                 run regardless (per-channel VAX mute lives in the VAX
+//                 applet; the local monitor mute must not silence 3rd-party
+//                 apps consuming VAX). Persistence + UI (MasterOutputWidget)
+//                 land in Task 10b. Design spec:
+//                 docs/architecture/2026-04-19-vax-design.md §5.4 and §6.3.
 // =================================================================
 
 #include "AudioDeviceConfig.h"
@@ -139,8 +149,17 @@ public:
     void setVolume(float volume);
     float volume() const { return m_masterVolume.load(std::memory_order_acquire); }
 
+    // Master mute. Read on the DSP thread, written on the main thread.
+    // Gates the speakers push in rxBlockReady ONLY — VAX taps run
+    // regardless (per-channel VAX mute is owned by the VAX applet, not
+    // AudioEngine). Sub-Phase 10 Task 10a; persistence + menu-bar
+    // MasterOutputWidget wiring land in Task 10b.
+    void setMasterMuted(bool muted);
+    bool masterMuted() const { return m_masterMuted.load(std::memory_order_acquire); }
+
 signals:
     void volumeChanged(float volume);
+    void masterMutedChanged(bool muted);
 
 private:
     // Translate AudioDeviceConfig → AudioFormat + PortAudioConfig and
@@ -186,6 +205,11 @@ private:
     // the DSP thread. Atomic for the cross-thread handshake per
     // CLAUDE.md C++ style guide.
     std::atomic<float> m_masterVolume{0.5f};
+
+    // Written by setMasterMuted() on the UI thread, read by
+    // rxBlockReady() on the DSP thread. Same acq_rel / acquire pairing
+    // as m_masterVolume above.
+    std::atomic<bool> m_masterMuted{false};
 
     // Was Pa_Initialize() actually successful? Guards the matching
     // Pa_Terminate() in the destructor so unit tests that construct

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -313,7 +313,6 @@ warren@wpratt.com
 #include <QTimer>
 #include <QThread>
 #include <QPushButton>
-#include <QToolBar>
 #include <QClipboard>
 #include <QDesktopServices>
 #include <QUrl>
@@ -364,6 +363,12 @@ MainWindow::MainWindow(QWidget* parent)
             engine->setSpeakersConfig(cfg);
         }
     });
+
+    // Phase 3O Sub-Phase 10 Task 10d — the 💡 feature-request button
+    // now lives inside TitleBar (consolidated from the old featureBar
+    // QToolBar). Wire its click signal to the existing slot.
+    connect(m_titleBar, &TitleBar::featureRequestClicked,
+            this, &MainWindow::showFeatureRequestDialog);
 
     buildStatusBar();
     applyDarkTheme();
@@ -1592,83 +1597,6 @@ void MainWindow::buildMenuBar()
         AboutDialog dlg(this);
         dlg.exec();
     });
-
-    // =========================================================================
-    // 💡 ISSUE REPORTER — toolbar button (Phase 3G-14)
-    // Ported from AetherSDR TitleBar::showFeatureRequestDialog()
-    // Uses a QToolBar so the button is visible on macOS (native menu bar)
-    // and on Linux/Windows (in-window menu bar) alike.
-    // =========================================================================
-    auto* featureBar = new QToolBar(this);
-    featureBar->setMovable(false);
-    featureBar->setFloatable(false);
-    featureBar->setIconSize(QSize(28, 28));
-    featureBar->setFixedHeight(32);
-    featureBar->setStyleSheet(QStringLiteral(
-        "QToolBar { background: #0f0f1a; border-bottom: 1px solid #203040; spacing: 0; padding: 0 4px; }"));
-
-    auto* spacer = new QWidget;
-    spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-    featureBar->addWidget(spacer);
-
-    // Paint a lightbulb icon so it renders cleanly at any DPI
-    auto makeBulbIcon = [](QColor bulbColor, QColor baseColor) -> QIcon {
-        constexpr int sz = 64;  // paint large, Qt scales down
-        QPixmap pm(sz, sz);
-        pm.fill(Qt::transparent);
-        QPainter p(&pm);
-        p.setRenderHint(QPainter::Antialiasing);
-
-        // Bulb (circle)
-        p.setPen(Qt::NoPen);
-        p.setBrush(bulbColor);
-        p.drawEllipse(QRectF(14, 4, 36, 36));
-
-        // Neck (trapezoid connecting bulb to base)
-        QPolygonF neck;
-        neck << QPointF(22, 36) << QPointF(42, 36)
-             << QPointF(40, 44) << QPointF(24, 44);
-        p.drawPolygon(neck);
-
-        // Base (screw threads — 3 thin lines)
-        p.setPen(QPen(baseColor, 2.5));
-        p.drawLine(QPointF(24, 46), QPointF(40, 46));
-        p.drawLine(QPointF(25, 50), QPointF(39, 50));
-        p.drawLine(QPointF(27, 54), QPointF(37, 54));
-
-        // Tip
-        p.setPen(Qt::NoPen);
-        p.setBrush(baseColor);
-        p.drawEllipse(QRectF(29, 56, 6, 4));
-
-        // Filament lines inside bulb
-        p.setPen(QPen(baseColor, 1.5));
-        p.drawLine(QPointF(28, 34), QPointF(28, 22));
-        p.drawLine(QPointF(28, 22), QPointF(32, 16));
-        p.drawLine(QPointF(32, 16), QPointF(36, 22));
-        p.drawLine(QPointF(36, 22), QPointF(36, 34));
-
-        p.end();
-        return QIcon(pm);
-    };
-
-    QIcon bulbIcon = makeBulbIcon(QColor(0xFF, 0xD0, 0x60), QColor(0x80, 0x60, 0x20));
-
-    m_featureBtn = new QPushButton;
-    m_featureBtn->setIcon(bulbIcon);
-    m_featureBtn->setIconSize(QSize(22, 22));
-    m_featureBtn->setFixedSize(28, 28);
-    m_featureBtn->setToolTip(QStringLiteral("Submit a feature request or bug report"));
-    m_featureBtn->setAccessibleName(QStringLiteral("Feature request"));
-    m_featureBtn->setStyleSheet(QStringLiteral(
-        "QPushButton { background: #3a2a00; border: 1px solid #806020; "
-        "border-radius: 4px; padding: 0; }"
-        "QPushButton:hover { background: #504000; border-color: #a08030; }"));
-    connect(m_featureBtn, &QPushButton::clicked,
-            this, &MainWindow::showFeatureRequestDialog);
-    featureBar->addWidget(m_featureBtn);
-
-    addToolBar(Qt::TopToolBarArea, featureBar);
 }
 
 void MainWindow::buildStatusBar()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -283,6 +283,10 @@ warren@wpratt.com
 #include "applets/TunerApplet.h"
 #include "SpectrumOverlayPanel.h"
 #include "SetupDialog.h"
+#include "TitleBar.h"
+#include "widgets/MasterOutputWidget.h"
+#include "core/AudioDeviceConfig.h"
+#include "core/AudioEngine.h"
 
 #include <cmath>
 
@@ -334,6 +338,33 @@ MainWindow::MainWindow(QWidget* parent)
 {
     buildUI();
     buildMenuBar();
+
+    // Phase 3O Sub-Phase 10 Task 10c — host the menu bar + master-output
+    // controls in a custom TitleBar strip. Must run AFTER buildMenuBar()
+    // so the menu is fully populated with actions before we re-parent it.
+    //
+    // setMenuWidget() hands ownership to QMainWindow and installs the
+    // strip at the top of the window. On macOS this also disables Qt's
+    // promotion of the menu bar to the native global bar — menus render
+    // in-window alongside the master-output controls (explicit design
+    // choice, user-approved option D for Sub-Phase 10).
+    m_titleBar = new TitleBar(m_radioModel->audioEngine(), this);
+    m_titleBar->setMenuBar(menuBar());
+    setMenuWidget(m_titleBar);
+
+    // Wire the MasterOutputWidget device picker → AudioEngine so picking
+    // an output device rebuilds the speakers bus. Task 10b exposes only
+    // the deviceName; AudioEngine::makeBus fills in sensible defaults
+    // (sample rate 48 kHz stereo, default buffer) per AudioEngine.h:165.
+    connect(m_titleBar->masterOutput(), &MasterOutputWidget::outputDeviceChanged,
+            this, [this](const QString& name) {
+        AudioDeviceConfig cfg;
+        cfg.deviceName = name;
+        if (auto* engine = m_radioModel->audioEngine()) {
+            engine->setSpeakersConfig(cfg);
+        }
+    });
+
     buildStatusBar();
     applyDarkTheme();
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -93,6 +93,7 @@ class ClarityController;
 class ContainerManager;
 class MeterWidget;
 class MeterPoller;
+class TitleBar;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -221,6 +222,10 @@ private:
 
     // Applet panel — scrollable content widget inside Container #0
     class AppletPanelWidget* m_appletPanel{nullptr};
+
+    // Phase 3O Sub-Phase 10 Task 10c: host strip for the menu bar +
+    // MasterOutputWidget. Owned by QMainWindow via setMenuWidget().
+    TitleBar* m_titleBar{nullptr};
 };
 
 } // namespace NereusSDR

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -75,7 +75,6 @@
 #include <QActionGroup>
 #include <QTimer>
 
-class QPushButton;
 class QProgressDialog;
 class QThread;
 class QSplitter;
@@ -216,9 +215,6 @@ private:
 
     // Spectrum overlay panel
     class SpectrumOverlayPanel* m_overlayPanel{nullptr};
-
-    // Phase 3G-14: Issue reporter corner widget
-    QPushButton* m_featureBtn{nullptr};
 
     // Applet panel — scrollable content widget inside Container #0
     class AppletPanelWidget* m_appletPanel{nullptr};

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -33,6 +33,15 @@
 //                 preserved verbatim.
 //                 Design spec: docs/architecture/2026-04-19-vax-design.md
 //                 §6.3 + §7.3.
+//   2026-04-20 — Task 10d: added the 💡 feature-request button as the
+//                 rightmost element (past MasterOutputWidget, 6 px
+//                 spacing). Button construction (lightbulb painter,
+//                 28×28 sizing, #3a2a00/#806020 dark-amber style) moved
+//                 verbatim from the now-deleted featureBar QToolBar in
+//                 MainWindow.cpp. Emits featureRequestClicked(); MainWindow
+//                 wires that to showFeatureRequestDialog. Matches
+//                 AetherSDR's pattern of the feature button being the
+//                 rightmost strip element.
 // =================================================================
 
 #include "TitleBar.h"
@@ -40,8 +49,15 @@
 #include "widgets/MasterOutputWidget.h"
 
 #include <QHBoxLayout>
+#include <QIcon>
 #include <QLabel>
 #include <QMenuBar>
+#include <QPainter>
+#include <QPen>
+#include <QPixmap>
+#include <QPolygonF>
+#include <QPushButton>
+#include <QSize>
 #include <QSizePolicy>
 
 namespace NereusSDR {
@@ -105,6 +121,72 @@ TitleBar::TitleBar(AudioEngine* audio, QWidget* parent)
     // ── MasterOutputWidget — Task 10b composite ────────────────────────────
     m_master = new MasterOutputWidget(audio, this);
     m_hbox->addWidget(m_master);
+
+    // ── 💡 Feature-request button — Task 10d ───────────────────────────────
+    // Construction moved verbatim from the now-deleted featureBar QToolBar
+    // in MainWindow.cpp (Phase 3G-14). The button lives at the far right
+    // of the TitleBar strip, past the MasterOutputWidget — this matches
+    // AetherSDR's pattern where the feature button is the rightmost strip
+    // element.
+    m_hbox->addSpacing(6);
+
+    // Paint a lightbulb icon so it renders cleanly at any DPI.
+    auto makeBulbIcon = [](QColor bulbColor, QColor baseColor) -> QIcon {
+        constexpr int sz = 64;  // paint large, Qt scales down
+        QPixmap pm(sz, sz);
+        pm.fill(Qt::transparent);
+        QPainter p(&pm);
+        p.setRenderHint(QPainter::Antialiasing);
+
+        // Bulb (circle)
+        p.setPen(Qt::NoPen);
+        p.setBrush(bulbColor);
+        p.drawEllipse(QRectF(14, 4, 36, 36));
+
+        // Neck (trapezoid connecting bulb to base)
+        QPolygonF neck;
+        neck << QPointF(22, 36) << QPointF(42, 36)
+             << QPointF(40, 44) << QPointF(24, 44);
+        p.drawPolygon(neck);
+
+        // Base (screw threads — 3 thin lines)
+        p.setPen(QPen(baseColor, 2.5));
+        p.drawLine(QPointF(24, 46), QPointF(40, 46));
+        p.drawLine(QPointF(25, 50), QPointF(39, 50));
+        p.drawLine(QPointF(27, 54), QPointF(37, 54));
+
+        // Tip
+        p.setPen(Qt::NoPen);
+        p.setBrush(baseColor);
+        p.drawEllipse(QRectF(29, 56, 6, 4));
+
+        // Filament lines inside bulb
+        p.setPen(QPen(baseColor, 1.5));
+        p.drawLine(QPointF(28, 34), QPointF(28, 22));
+        p.drawLine(QPointF(28, 22), QPointF(32, 16));
+        p.drawLine(QPointF(32, 16), QPointF(36, 22));
+        p.drawLine(QPointF(36, 22), QPointF(36, 34));
+
+        p.end();
+        return QIcon(pm);
+    };
+
+    QIcon bulbIcon = makeBulbIcon(QColor(0xFF, 0xD0, 0x60), QColor(0x80, 0x60, 0x20));
+
+    m_featureBtn = new QPushButton(this);
+    m_featureBtn->setObjectName(QStringLiteral("featureButton"));
+    m_featureBtn->setIcon(bulbIcon);
+    m_featureBtn->setIconSize(QSize(22, 22));
+    m_featureBtn->setFixedSize(28, 28);
+    m_featureBtn->setToolTip(QStringLiteral("Submit a feature request or bug report"));
+    m_featureBtn->setAccessibleName(QStringLiteral("Feature request"));
+    m_featureBtn->setStyleSheet(QStringLiteral(
+        "QPushButton { background: #3a2a00; border: 1px solid #806020; "
+        "border-radius: 4px; padding: 0; }"
+        "QPushButton:hover { background: #504000; border-color: #a08030; }"));
+    connect(m_featureBtn, &QPushButton::clicked,
+            this, &TitleBar::featureRequestClicked);
+    m_hbox->addWidget(m_featureBtn);
 }
 
 void TitleBar::setMenuBar(QMenuBar* mb)

--- a/src/gui/TitleBar.cpp
+++ b/src/gui/TitleBar.cpp
@@ -1,0 +1,123 @@
+// =================================================================
+// src/gui/TitleBar.cpp  (NereusSDR)
+// =================================================================
+//
+// Ported from AetherSDR source:
+//   src/gui/TitleBar.cpp (especially lines 27-34, 94-104, 282-295)
+//
+// AetherSDR is licensed under the GNU General Public License v3; see
+// https://github.com/ten9876/AetherSDR for the contributor list and
+// project-level LICENSE. NereusSDR is also GPLv3. AetherSDR source
+// files carry no per-file GPL header; attribution is at project level
+// per docs/attribution/HOW-TO-PORT.md rule 6.
+//
+// Upstream reference: AetherSDR v0.8.16 (2026-04).
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-20 — Ported/adapted in C++20/Qt6 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via Anthropic
+//                 Claude Code. Phase 3O Sub-Phase 10 Task 10c.
+//                 Scoped-down port: master-output strip only. AetherSDR's
+//                 heartbeat / multiFLEX / PC-audio / headphone /
+//                 minimal-mode / feature-request widgets intentionally
+//                 omitted (deferred to separate phases).
+//                 Constructor preserves AetherSDR's 32 px fixed height,
+//                 dark background (#0a0a14) with bottom-border (#203040),
+//                 and the [menu][stretch][app-name][stretch][master]
+//                 layout pattern. `setMenuBar()` is a line-for-line port
+//                 of AetherSDR TitleBar.cpp:282-295 (restyle QMenuBar,
+//                 `m_hbox->insertWidget(0, mb)`). App-name label: text
+//                 "AetherSDR" swapped to "NereusSDR", accent colour
+//                 (#00b4d8), font (14 px bold), and QLabel::AlignCenter
+//                 preserved verbatim.
+//                 Design spec: docs/architecture/2026-04-19-vax-design.md
+//                 §6.3 + §7.3.
+// =================================================================
+
+#include "TitleBar.h"
+
+#include "widgets/MasterOutputWidget.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMenuBar>
+#include <QSizePolicy>
+
+namespace NereusSDR {
+
+namespace {
+
+// Strip background + bottom border. From AetherSDR TitleBar.cpp:31.
+constexpr auto kStripStyle =
+    "TitleBar { background: #0a0a14; border-bottom: 1px solid #203040; }";
+
+// App-name label. From AetherSDR TitleBar.cpp:102.
+constexpr auto kAppNameStyle =
+    "QLabel { color: #00b4d8; font-size: 14px; font-weight: bold; }";
+
+// Menu-bar restyle. From AetherSDR TitleBar.cpp:285-290.
+constexpr auto kMenuBarStyle =
+    "QMenuBar { background: transparent; color: #8aa8c0; font-size: 12px; }"
+    "QMenuBar::item { padding: 4px 8px; }"
+    "QMenuBar::item:selected { background: #203040; color: #ffffff; }"
+    "QMenu { background: #0f0f1a; color: #c8d8e8; border: 1px solid #304050; }"
+    "QMenu::item:selected { background: #0070c0; }";
+
+// Content-margins + spacing from AetherSDR TitleBar.cpp:34-35.
+constexpr int kMarginLeft   = 4;
+constexpr int kMarginTop    = 2;
+constexpr int kMarginRight  = 8;
+constexpr int kMarginBottom = 2;
+constexpr int kSpacing      = 6;
+
+// Fixed strip height. From AetherSDR TitleBar.cpp:30.
+constexpr int kStripHeight = 32;
+
+} // namespace
+
+TitleBar::TitleBar(AudioEngine* audio, QWidget* parent)
+    : QWidget(parent)
+{
+    setFixedHeight(kStripHeight);
+    setStyleSheet(QLatin1String(kStripStyle));
+
+    m_hbox = new QHBoxLayout(this);
+    m_hbox->setContentsMargins(kMarginLeft, kMarginTop, kMarginRight, kMarginBottom);
+    m_hbox->setSpacing(kSpacing);
+
+    // Position 0 is reserved for the menu bar (inserted via setMenuBar()).
+    // Until setMenuBar() runs, the layout is [stretch][app-name][stretch][master].
+
+    // ── Left stretch ───────────────────────────────────────────────────────
+    m_hbox->addStretch(1);
+
+    // ── App-name label ─────────────────────────────────────────────────────
+    // From AetherSDR TitleBar.cpp:101-104 — text swapped to "NereusSDR".
+    auto* appName = new QLabel(QStringLiteral("NereusSDR"), this);
+    appName->setStyleSheet(QLatin1String(kAppNameStyle));
+    appName->setAlignment(Qt::AlignCenter);
+    m_hbox->addWidget(appName);
+
+    // ── Right stretch ──────────────────────────────────────────────────────
+    m_hbox->addStretch(1);
+
+    // ── MasterOutputWidget — Task 10b composite ────────────────────────────
+    m_master = new MasterOutputWidget(audio, this);
+    m_hbox->addWidget(m_master);
+}
+
+void TitleBar::setMenuBar(QMenuBar* mb)
+{
+    // Ported line-for-line from AetherSDR TitleBar.cpp:282-295.
+    if (!mb) {
+        return;
+    }
+    mb->setStyleSheet(QLatin1String(kMenuBarStyle));
+    mb->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
+    m_menuBar = mb;
+    // Insert at position 0 (before the first stretch).
+    m_hbox->insertWidget(0, mb);
+}
+
+} // namespace NereusSDR

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -1,0 +1,91 @@
+#pragma once
+
+// =================================================================
+// src/gui/TitleBar.h  (NereusSDR)
+// =================================================================
+//
+// Ported from AetherSDR source:
+//   src/gui/TitleBar.h
+//   src/gui/TitleBar.cpp
+//
+// AetherSDR is licensed under the GNU General Public License v3; see
+// https://github.com/ten9876/AetherSDR for the contributor list and
+// project-level LICENSE. NereusSDR is also GPLv3. AetherSDR source
+// files carry no per-file GPL header; attribution is at project level
+// per docs/attribution/HOW-TO-PORT.md rule 6.
+//
+// Upstream reference: AetherSDR v0.8.16 (2026-04).
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-20 — Ported/adapted in C++20/Qt6 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via Anthropic
+//                 Claude Code. Phase 3O Sub-Phase 10 Task 10c.
+//                 Scoped-down port: master-output strip only. AetherSDR's
+//                 heartbeat / multiFLEX / PC-audio / headphone / minimal-
+//                 mode / feature-request widgets are intentionally omitted
+//                 (deferred to separate NereusSDR phases — 3G-14 plans the
+//                 💡 feature-request widget; headphone devices land in
+//                 Sub-Phase 12 Setup → Audio → Devices; connection-state
+//                 UI is already served elsewhere).
+//                 Hosts `MasterOutputWidget` (Task 10b) on the right edge;
+//                 `setMenuBar()` pattern copied from AetherSDR
+//                 `src/gui/TitleBar.cpp:282-295` (re-style QMenuBar,
+//                 `m_hbox->insertWidget(0, mb)`). Strip geometry and
+//                 background (#0a0a14, 32 px, `border-bottom: 1px solid
+//                 #203040`) follow AetherSDR `TitleBar.cpp:30-31`. App-
+//                 name label colour and font follow AetherSDR
+//                 `TitleBar.cpp:101-103` with the literal "AetherSDR"
+//                 replaced by "NereusSDR".
+//                 Design spec: docs/architecture/2026-04-19-vax-design.md
+//                 §6.3 + §7.3.
+// =================================================================
+
+#include <QWidget>
+
+class QHBoxLayout;
+class QMenuBar;
+
+namespace NereusSDR {
+
+class AudioEngine;
+class MasterOutputWidget;
+
+// TitleBar — thin 32 px host strip at the top of the main window.
+//
+// Layout (left → right):
+//   [menuBar, inserted at position 0 via setMenuBar()]
+//   [stretch]
+//   [NereusSDR app-name label]
+//   [stretch]
+//   [MasterOutputWidget — speaker button + master slider + readout]
+//
+// macOS caveat: embedding the QMenuBar inside a custom widget prevents Qt
+// from promoting it to the native global menu bar at the top of the
+// screen. The menus render in-window instead. This is the explicit design
+// choice per user-approved Sub-Phase 10 decision (option D); the
+// MasterOutputWidget master-volume controls MUST be visible at all times
+// alongside the menus, and the native global bar cannot host them.
+class TitleBar : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit TitleBar(AudioEngine* audio, QWidget* parent = nullptr);
+
+    // Re-style `mb` and insert it at position 0 of the hbox layout.
+    // Pattern from AetherSDR TitleBar.cpp:282. Caller must ensure `mb`
+    // is fully populated with actions BEFORE invoking this — otherwise
+    // the menu bar's size policy negotiation happens on an empty widget.
+    void setMenuBar(QMenuBar* mb);
+
+    // Non-owning accessor so MainWindow can wire the device-picker
+    // signal into AudioEngine::setSpeakersConfig.
+    MasterOutputWidget* masterOutput() const { return m_master; }
+
+private:
+    QHBoxLayout*        m_hbox{nullptr};
+    QMenuBar*           m_menuBar{nullptr};
+    MasterOutputWidget* m_master{nullptr};
+};
+
+} // namespace NereusSDR

--- a/src/gui/TitleBar.h
+++ b/src/gui/TitleBar.h
@@ -39,12 +39,20 @@
 //                 replaced by "NereusSDR".
 //                 Design spec: docs/architecture/2026-04-19-vax-design.md
 //                 §6.3 + §7.3.
+//   2026-04-20 — Task 10d: consolidated the 💡 feature-request button
+//                 (previously hosted by a separate `featureBar` QToolBar
+//                 in MainWindow) into TitleBar's far-right slot, past the
+//                 MasterOutputWidget. Emits `featureRequestClicked()`;
+//                 MainWindow wires that to its existing
+//                 showFeatureRequestDialog slot. Matches AetherSDR's
+//                 pattern of the feature button as the rightmost element.
 // =================================================================
 
 #include <QWidget>
 
 class QHBoxLayout;
 class QMenuBar;
+class QPushButton;
 
 namespace NereusSDR {
 
@@ -59,6 +67,8 @@ class MasterOutputWidget;
 //   [NereusSDR app-name label]
 //   [stretch]
 //   [MasterOutputWidget — speaker button + master slider + readout]
+//   [6 px spacing]
+//   [💡 feature-request button]
 //
 // macOS caveat: embedding the QMenuBar inside a custom widget prevents Qt
 // from promoting it to the native global menu bar at the top of the
@@ -82,10 +92,16 @@ public:
     // signal into AudioEngine::setSpeakersConfig.
     MasterOutputWidget* masterOutput() const { return m_master; }
 
+signals:
+    // Emitted when the 💡 feature-request button is clicked. MainWindow
+    // connects this to its showFeatureRequestDialog slot.
+    void featureRequestClicked();
+
 private:
     QHBoxLayout*        m_hbox{nullptr};
     QMenuBar*           m_menuBar{nullptr};
     MasterOutputWidget* m_master{nullptr};
+    QPushButton*        m_featureBtn{nullptr};
 };
 
 } // namespace NereusSDR

--- a/src/gui/widgets/MasterOutputWidget.cpp
+++ b/src/gui/widgets/MasterOutputWidget.cpp
@@ -128,10 +128,19 @@ MasterOutputWidget::MasterOutputWidget(AudioEngine* audio, QWidget* parent)
 
     // ── Seed the engine with the saved values BEFORE wiring widget→model ──
     // so the engine matches the UI state at startup (same contract as
-    // the in-session echo path — engine and widget agree).
+    // the in-session echo path — engine and widget agree). The saved
+    // speakers device is applied too so a restart honors the device the
+    // user last picked from the right-click menu; without this the
+    // engine defaults to the platform default output until the user
+    // reselects.
     if (m_audio) {
         m_audio->setVolume(savedVolume);
         m_audio->setMasterMuted(savedMuted);
+        if (!savedDevice.isEmpty()) {
+            AudioDeviceConfig cfg;
+            cfg.deviceName = savedDevice;
+            m_audio->setSpeakersConfig(cfg);
+        }
     }
 
     // ── Widget → Model: slider drives engine volume + persists ─────────────

--- a/src/gui/widgets/MasterOutputWidget.cpp
+++ b/src/gui/widgets/MasterOutputWidget.cpp
@@ -1,0 +1,264 @@
+// =================================================================
+// src/gui/widgets/MasterOutputWidget.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original widget. See MasterOutputWidget.h for the full
+// attribution block. Styling references AetherSDR
+// `src/gui/TitleBar.cpp:172-215`; the structure here is original to
+// NereusSDR because this widget isolates JUST the master-output
+// triad from AetherSDR's monolithic TitleBar.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-20 — Written by J.J. Boyd (KG4VCF), with AI-assisted
+//                transformation via Anthropic Claude Code.
+//                Phase 3O Sub-Phase 10 Task 10b.
+// =================================================================
+
+#include "MasterOutputWidget.h"
+
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "core/audio/PortAudioBus.h"
+
+#include <QAction>
+#include <QActionGroup>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMenu>
+#include <QPoint>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QSlider>
+
+namespace NereusSDR {
+
+// Speaker button style — matches AetherSDR TitleBar.cpp:175-177:
+//   transparent background, no border, 14 px glyph font, flattens
+//   the checked state by dimming opacity (mute visual cue).
+static const char* kSpeakerBtnStyle =
+    "QPushButton { background: transparent; border: none; font-size: 14px; padding: 0; }"
+    "QPushButton:checked { opacity: 0.4; }";
+
+// Horizontal volume slider — copies AetherSDR TitleBar.cpp:195-198
+// palette verbatim: #1a2a3a groove, #00b4d8 handle + sub-page fill.
+static const char* kSliderStyle =
+    "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"
+    "QSlider::handle:horizontal { background: #00b4d8; width: 10px; margin: -3px 0; border-radius: 5px; }"
+    "QSlider::sub-page:horizontal { background: #00b4d8; border-radius: 2px; }";
+
+// Inset value readout — STYLEGUIDE.md line 137 "Inset Value Display".
+static const char* kDbLabelStyle =
+    "QLabel {"
+    "  font-size: 10px;"
+    "  background: #0a0a18;"
+    "  border: 1px solid #1e2e3e;"
+    "  border-radius: 3px;"
+    "  padding: 1px 2px;"
+    "  color: #8aa8c0;"
+    "}";
+
+// UTF-8 encodings of the two speaker glyphs — kept as raw escape
+// bytes to match the AetherSDR source style (no <QChar> fuss).
+static const char* kSpeakerOn  = "\xF0\x9F\x94\x8A";  // 🔊 U+1F50A
+static const char* kSpeakerOff = "\xF0\x9F\x94\x87";  // 🔇 U+1F507
+
+MasterOutputWidget::MasterOutputWidget(AudioEngine* audio, QWidget* parent)
+    : QWidget(parent)
+    , m_audio(audio)
+{
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(4);
+
+    // ── Saved state ────────────────────────────────────────────────────────
+    // Read BEFORE we wire widget→model signals so seeding the slider
+    // and button does not re-emit volumeChanged/mutedChanged back
+    // into the engine. The m_updatingFromModel guard covers this
+    // belt-and-braces style, but keeping the order correct keeps the
+    // signal-flow graph readable.
+    auto& s = AppSettings::instance();
+    const float savedVolume = s.value(QStringLiteral("audio/Master/Volume"),
+                                      QStringLiteral("1.0")).toString().toFloat();
+    const bool savedMuted = s.value(QStringLiteral("audio/Master/Muted"),
+                                    QStringLiteral("False")).toString()
+                            == QStringLiteral("True");
+    const QString savedDevice = s.value(QStringLiteral("audio/Speakers/DeviceName"),
+                                        QString()).toString();
+    m_currentDeviceName = savedDevice;
+
+    // ── Speaker button ─────────────────────────────────────────────────────
+    m_speakerBtn = new QPushButton(
+        QString::fromUtf8(savedMuted ? kSpeakerOff : kSpeakerOn), this);
+    m_speakerBtn->setObjectName(QStringLiteral("speakerBtn"));
+    m_speakerBtn->setFixedSize(20, 20);
+    m_speakerBtn->setCheckable(true);
+    m_speakerBtn->setChecked(savedMuted);
+    m_speakerBtn->setStyleSheet(QLatin1String(kSpeakerBtnStyle));
+    m_speakerBtn->setToolTip(QStringLiteral(
+        "Click to mute/unmute master output — right-click for output devices"));
+    m_speakerBtn->setAccessibleName(QStringLiteral("Master mute"));
+    m_speakerBtn->setAccessibleDescription(QStringLiteral(
+        "Mute or unmute master output; right-click for device picker"));
+    m_speakerBtn->setContextMenuPolicy(Qt::CustomContextMenu);
+    layout->addWidget(m_speakerBtn);
+
+    // ── Slider (100 px wide, 16 px tall per design spec §7.3) ──────────────
+    m_slider = new QSlider(Qt::Horizontal, this);
+    m_slider->setObjectName(QStringLiteral("masterSlider"));
+    m_slider->setRange(0, 100);
+    m_slider->setFixedWidth(100);
+    m_slider->setFixedHeight(16);
+    m_slider->setStyleSheet(QLatin1String(kSliderStyle));
+    m_slider->setAccessibleName(QStringLiteral("Master volume"));
+    m_slider->setAccessibleDescription(
+        QStringLiteral("Master output volume level, 0 to 100 percent"));
+    // Seed slider from saved linear volume.
+    const int pct = static_cast<int>(savedVolume * 100.0f + 0.5f);
+    m_slider->setValue(pct);
+    layout->addWidget(m_slider);
+
+    // ── Inset percent readout ──────────────────────────────────────────────
+    m_dbLabel = new QLabel(QString::number(pct), this);
+    m_dbLabel->setObjectName(QStringLiteral("dbLabel"));
+    m_dbLabel->setFixedWidth(22);
+    m_dbLabel->setAlignment(Qt::AlignCenter);
+    m_dbLabel->setStyleSheet(QLatin1String(kDbLabelStyle));
+    layout->addWidget(m_dbLabel);
+
+    // ── Seed the engine with the saved values BEFORE wiring widget→model ──
+    // so the engine matches the UI state at startup (same contract as
+    // the in-session echo path — engine and widget agree).
+    if (m_audio) {
+        m_audio->setVolume(savedVolume);
+        m_audio->setMasterMuted(savedMuted);
+    }
+
+    // ── Widget → Model: slider drives engine volume + persists ─────────────
+    connect(m_slider, &QSlider::valueChanged, this, [this](int value) {
+        if (m_updatingFromModel) {
+            return;
+        }
+        const float v = static_cast<float>(value) / 100.0f;
+        m_dbLabel->setText(QString::number(value));
+        if (m_audio) {
+            m_audio->setVolume(v);
+        }
+        auto& ss = AppSettings::instance();
+        ss.setValue(QStringLiteral("audio/Master/Volume"),
+                    QString::number(v, 'f', 3));
+        ss.save();
+        emit volumeChanged(v);
+    });
+
+    // ── Widget → Model: speaker button drives engine mute + persists ───────
+    connect(m_speakerBtn, &QPushButton::toggled, this, [this](bool muted) {
+        m_speakerBtn->setText(QString::fromUtf8(muted ? kSpeakerOff : kSpeakerOn));
+        if (m_updatingFromModel) {
+            return;
+        }
+        if (m_audio) {
+            m_audio->setMasterMuted(muted);
+        }
+        auto& ss = AppSettings::instance();
+        ss.setValue(QStringLiteral("audio/Master/Muted"),
+                    muted ? QStringLiteral("True") : QStringLiteral("False"));
+        ss.save();
+        emit mutedChanged(muted);
+    });
+
+    // ── Right-click → device picker ────────────────────────────────────────
+    connect(m_speakerBtn, &QWidget::customContextMenuRequested,
+            this, &MasterOutputWidget::onSpeakerContextMenu);
+
+    // ── Model → Widget echo paths ──────────────────────────────────────────
+    if (m_audio) {
+        connect(m_audio, &AudioEngine::volumeChanged,
+                this, &MasterOutputWidget::onAudioEngineVolumeChanged);
+        connect(m_audio, &AudioEngine::masterMutedChanged,
+                this, &MasterOutputWidget::onAudioEngineMasterMutedChanged);
+    }
+
+    setLayout(layout);
+}
+
+void MasterOutputWidget::setCurrentOutputDevice(const QString& name)
+{
+    // Sync-from-elsewhere path only — do NOT emit outputDeviceChanged.
+    // The caller (Setup → Audio → Devices or the picker's own action
+    // handler) is responsible for emitting that signal exactly once
+    // per user action.
+    m_currentDeviceName = name;
+}
+
+void MasterOutputWidget::onSpeakerContextMenu(const QPoint& pos)
+{
+    QMenu menu(this);
+    menu.setTitle(QStringLiteral("Output device"));
+
+    auto* group = new QActionGroup(&menu);
+    group->setExclusive(true);
+
+    // Enumerate host APIs + their output devices. Each API becomes a
+    // section header followed by its devices. The design spec allows
+    // either a flat list or per-API submenus; flat-with-section-headers
+    // reads best at this widget's size.
+    const auto apis = PortAudioBus::hostApis();
+    bool anyDevice = false;
+    for (const auto& api : apis) {
+        const auto devices = PortAudioBus::outputDevicesFor(api.index);
+        if (devices.isEmpty()) {
+            continue;
+        }
+        QAction* header = menu.addSection(api.name);
+        Q_UNUSED(header);
+        for (const auto& dev : devices) {
+            QAction* act = menu.addAction(dev.name);
+            act->setCheckable(true);
+            act->setChecked(dev.name == m_currentDeviceName);
+            group->addAction(act);
+            const QString devName = dev.name;
+            connect(act, &QAction::triggered, this, [this, devName]() {
+                m_currentDeviceName = devName;
+                emit outputDeviceChanged(devName);
+                auto& ss = AppSettings::instance();
+                ss.setValue(QStringLiteral("audio/Speakers/DeviceName"), devName);
+                ss.save();
+            });
+            anyDevice = true;
+        }
+    }
+
+    if (!anyDevice) {
+        QAction* none = menu.addAction(QStringLiteral("No output devices"));
+        none->setEnabled(false);
+    }
+
+    menu.exec(m_speakerBtn->mapToGlobal(pos));
+}
+
+void MasterOutputWidget::onAudioEngineVolumeChanged(float v)
+{
+    m_updatingFromModel = true;
+    const int pct = static_cast<int>(v * 100.0f + 0.5f);
+    m_slider->setValue(pct);
+    m_dbLabel->setText(QString::number(pct));
+    m_updatingFromModel = false;
+}
+
+void MasterOutputWidget::onAudioEngineMasterMutedChanged(bool m)
+{
+    m_updatingFromModel = true;
+    // QSignalBlocker prevents the button's toggled() from re-entering
+    // the widget→model lambda while we mirror the engine state into
+    // the UI. The text update still has to happen manually because
+    // the toggled() handler (which normally sets the glyph) is blocked.
+    {
+        QSignalBlocker blocker(m_speakerBtn);
+        m_speakerBtn->setChecked(m);
+        m_speakerBtn->setText(QString::fromUtf8(m ? kSpeakerOff : kSpeakerOn));
+    }
+    m_updatingFromModel = false;
+}
+
+} // namespace NereusSDR

--- a/src/gui/widgets/MasterOutputWidget.cpp
+++ b/src/gui/widgets/MasterOutputWidget.cpp
@@ -153,10 +153,10 @@ MasterOutputWidget::MasterOutputWidget(AudioEngine* audio, QWidget* parent)
 
     // ── Widget → Model: speaker button drives engine mute + persists ───────
     connect(m_speakerBtn, &QPushButton::toggled, this, [this](bool muted) {
-        m_speakerBtn->setText(QString::fromUtf8(muted ? kSpeakerOff : kSpeakerOn));
         if (m_updatingFromModel) {
             return;
         }
+        m_speakerBtn->setText(QString::fromUtf8(muted ? kSpeakerOff : kSpeakerOn));
         if (m_audio) {
             m_audio->setMasterMuted(muted);
         }
@@ -219,6 +219,9 @@ void MasterOutputWidget::onSpeakerContextMenu(const QPoint& pos)
             group->addAction(act);
             const QString devName = dev.name;
             connect(act, &QAction::triggered, this, [this, devName]() {
+                if (devName == m_currentDeviceName) {
+                    return;
+                }
                 m_currentDeviceName = devName;
                 emit outputDeviceChanged(devName);
                 auto& ss = AppSettings::instance();

--- a/src/gui/widgets/MasterOutputWidget.h
+++ b/src/gui/widgets/MasterOutputWidget.h
@@ -1,0 +1,107 @@
+#pragma once
+
+// =================================================================
+// src/gui/widgets/MasterOutputWidget.h  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original widget. Visual styling draws on AetherSDR
+// `src/gui/TitleBar.cpp:172-215` (the master-volume section of
+// AetherSDR's title bar): speaker emoji button with mute glyph flip,
+// horizontal volume slider with the shared #00b4d8 handle/sub-page
+// palette, and an inset percent readout to the right of the slider.
+// The structure here is NereusSDR-original because this widget
+// isolates JUST the master-output triad; AetherSDR's TitleBar
+// combines master + headphones + PC-audio + minimal-mode in one
+// monolithic bar. TitleBar-strip host wiring lands in Task 10c.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-04-20 — Written by J.J. Boyd (KG4VCF), with AI-assisted
+//                transformation via Anthropic Claude Code. Phase 3O
+//                Sub-Phase 10 Task 10b. Widget layout + mute-glyph
+//                flip + inset readout styling take cues from
+//                AetherSDR TitleBar.cpp:172-215. Two-way bind to
+//                AudioEngine setVolume / setMasterMuted with the
+//                m_updatingFromModel + QSignalBlocker echo guard
+//                pattern documented in CLAUDE.md "GUI↔Model Sync".
+//                Persists audio/Master/Volume and audio/Master/Muted
+//                per design spec
+//                docs/architecture/2026-04-19-vax-design.md §5.4.
+// =================================================================
+
+#include <QString>
+#include <QWidget>
+
+class QLabel;
+class QPoint;
+class QPushButton;
+class QSlider;
+
+namespace NereusSDR {
+
+class AudioEngine;
+
+// MasterOutputWidget — menu-bar master-output composite.
+//
+// Layout (matches design spec §7.3, ~222 px wide × 22 px tall):
+//
+//   [speaker 20] [slider 100] [label 22]
+//
+// - Speaker button: left-click toggles mute (🔊 ↔ 🔇). Right-click
+//   opens an output-device picker populated from
+//   PortAudioBus::hostApis() + PortAudioBus::outputDevicesFor. The
+//   picker emits outputDeviceChanged(name); the host (Task 10c
+//   TitleBar inside MainWindow) is responsible for calling
+//   AudioEngine::setSpeakersConfig to actually rebuild the speakers
+//   bus. See design spec §6.3.
+// - Slider: 0–100 range mapped linearly to AudioEngine volume [0,1].
+// - Label: inset percent readout (0–100, shown as the raw integer
+//   slider value — Option A per task brief, matches AetherSDR).
+//
+// volumeChanged / mutedChanged / outputDeviceChanged signals fire
+// ONLY on user action. The m_updatingFromModel guard plus a
+// QSignalBlocker on the speaker button prevents the engine→widget
+// echo from re-emitting into the engine.
+class MasterOutputWidget : public QWidget {
+    Q_OBJECT
+public:
+    explicit MasterOutputWidget(AudioEngine* audio, QWidget* parent = nullptr);
+
+    // Called by Setup → Audio → Devices when the user picks a
+    // speakers device elsewhere in the app, so the context-menu
+    // check state stays in sync with the engine's current device.
+    // Does NOT emit outputDeviceChanged — this is a sync-from-
+    // elsewhere path, not a user action.
+    void setCurrentOutputDevice(const QString& name);
+
+signals:
+    // User moved the slider. Value is the 0.0–1.0 linear volume.
+    void volumeChanged(float v);
+    // User clicked the speaker button.
+    void mutedChanged(bool muted);
+    // User picked an output device from the right-click context menu.
+    void outputDeviceChanged(QString deviceName);
+
+private slots:
+    // Populate and pop the right-click device picker at `pos`
+    // (widget-local coordinates, as delivered by
+    // QWidget::customContextMenuRequested).
+    void onSpeakerContextMenu(const QPoint& pos);
+
+    // AudioEngine → widget echo handlers. Both use the
+    // m_updatingFromModel / QSignalBlocker guard so a setValue /
+    // setChecked driven by these slots does not reenter the
+    // widget→engine path.
+    void onAudioEngineVolumeChanged(float v);
+    void onAudioEngineMasterMutedChanged(bool m);
+
+private:
+    AudioEngine* m_audio{nullptr};
+    QPushButton* m_speakerBtn{nullptr};
+    QSlider*     m_slider{nullptr};
+    QLabel*      m_dbLabel{nullptr};
+    bool         m_updatingFromModel{false};
+    QString      m_currentDeviceName;
+};
+
+} // namespace NereusSDR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -199,3 +199,11 @@ nereus_add_test(tst_audio_engine_vax_tee)
 # rxBlockReady mute check gates ONLY the speakers push (VAX taps must keep
 # running so 3rd-party consumer apps don't hear the local monitor mute).
 nereus_add_test(tst_audio_engine_master_mute)
+
+# ── Phase 3O Sub-Phase 10 Task 10b: MasterOutputWidget ──────────────────────
+# Menu-bar composite: speaker-mute button, master-volume slider (0–100),
+# inset percent readout, right-click output-device picker. Verifies the
+# widget→AudioEngine user path, the AudioEngine→widget echo path with
+# re-entry prevention, AppSettings round-trip (audio/Master/Volume,
+# audio/Master/Muted), and construction-time restore of saved values.
+nereus_add_test(tst_master_output_widget)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -207,3 +207,10 @@ nereus_add_test(tst_audio_engine_master_mute)
 # re-entry prevention, AppSettings round-trip (audio/Master/Volume,
 # audio/Master/Muted), and construction-time restore of saved values.
 nereus_add_test(tst_master_output_widget)
+
+# ── Phase 3O Sub-Phase 10 Task 10c: TitleBar host strip ─────────────────────
+# 32 px strip that hosts the QMenuBar + MasterOutputWidget. Smoke only:
+# construction, setMenuBar() re-parenting, masterOutput() accessor, and
+# the fixed 32 px height. Live UI verification is the canonical check for
+# the menu-re-parent + in-window render on macOS.
+nereus_add_test(tst_title_bar)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,3 +193,9 @@ nereus_add_test(tst_virtual_cable_detector)
 # seam on AudioEngine. No real CoreAudioHalBus / LinuxPipeBus / PortAudio
 # backend required — runs on every platform.
 nereus_add_test(tst_audio_engine_vax_tee)
+
+# ── Phase 3O Sub-Phase 10 Task 10a: AudioEngine master-mute API ──────────────
+# Covers setMasterMuted / masterMuted / masterMutedChanged. Verifies the
+# rxBlockReady mute check gates ONLY the speakers push (VAX taps must keep
+# running so 3rd-party consumer apps don't hear the local monitor mute).
+nereus_add_test(tst_audio_engine_master_mute)

--- a/tests/tst_audio_engine_master_mute.cpp
+++ b/tests/tst_audio_engine_master_mute.cpp
@@ -1,0 +1,184 @@
+// =================================================================
+// tests/tst_audio_engine_master_mute.cpp  (NereusSDR)
+// =================================================================
+//
+// Exercises AudioEngine's master-mute API — Phase 3O Sub-Phase 10
+// Task 10a.
+//
+// Coverage: see private-slot test methods below — each verifies one
+// contract scenario for the setMasterMuted / masterMuted /
+// masterMutedChanged trio added in Sub-Phase 10.
+//
+// Uses FakeAudioBus injected via the NEREUS_BUILD_TESTS-only
+// AudioEngine::setVaxBusForTest / setSpeakersBusForTest seam so the
+// test doesn't need a real CoreAudioHalBus / LinuxPipeBus / PortAudio
+// backend. Cross-platform. Modeled on tst_audio_engine_vax_tee.cpp.
+//
+// Design spec: docs/architecture/2026-04-19-vax-design.md §5.4
+// (audio/Master/Muted key) + §6.3 (MasterOutputWidget mute button
+// wiring row).
+// =================================================================
+
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+
+#include "core/AudioEngine.h"
+#include "core/IAudioBus.h"
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+#include "fakes/FakeAudioBus.h"
+
+#include <array>
+#include <memory>
+
+using namespace NereusSDR;
+
+namespace {
+
+// Standard test block: 2 frames of stereo float (4 floats / 16 bytes).
+constexpr int kTestFrames = 2;
+constexpr int kTestStereoFloats = kTestFrames * 2;
+
+const std::array<float, kTestStereoFloats> kTestSamples = {
+    0.10f, 0.20f,   // frame 0  L,R
+    -0.30f, -0.40f, // frame 1  L,R
+};
+
+} // namespace
+
+class TstAudioEngineMasterMute : public QObject {
+    Q_OBJECT
+
+private:
+    // Mirrors the Harness used by tst_audio_engine_vax_tee.cpp. Builds
+    // a RadioModel + AudioEngine pair and injects a fake speakers bus
+    // so the speaker push() in rxBlockReady is observable.
+    struct Harness {
+        std::unique_ptr<RadioModel> radio;
+        AudioEngine* engine;        // non-owning view
+        FakeAudioBus* speakers;     // non-owning view (engine owns it)
+
+        // Add a slice with the given vaxChannel value; returns its index.
+        int addSlice(int vaxChannel) {
+            const int idx = radio->addSlice();
+            SliceModel* slice = radio->sliceAt(idx);
+            slice->setVaxChannel(vaxChannel);
+            return idx;
+        }
+    };
+
+    Harness makeHarness() {
+        Harness h;
+        h.radio = std::make_unique<RadioModel>();
+        h.engine = h.radio->audioEngine();
+
+        auto speakers = std::make_unique<FakeAudioBus>(QStringLiteral("FakeSpeakers"));
+        AudioFormat fmt;
+        fmt.sampleRate = 48000;
+        fmt.channels = 2;
+        fmt.sample = AudioFormat::Sample::Float32;
+        speakers->open(fmt);
+        h.speakers = speakers.get();
+        h.engine->setSpeakersBusForTest(std::move(speakers));
+
+        return h;
+    }
+
+    FakeAudioBus* injectFakeVax(AudioEngine* engine, int channel) {
+        auto bus = std::make_unique<FakeAudioBus>(
+            QStringLiteral("FakeVax%1").arg(channel));
+        AudioFormat fmt;
+        fmt.sampleRate = 48000;
+        fmt.channels = 2;
+        fmt.sample = AudioFormat::Sample::Float32;
+        bus->open(fmt);
+        FakeAudioBus* view = bus.get();
+        engine->setVaxBusForTest(channel, std::move(bus));
+        return view;
+    }
+
+private slots:
+
+    // ── 1. Fresh AudioEngine: masterMuted() defaults to false ──────────────
+
+    void defaultsToUnmuted() {
+        AudioEngine engine;
+        QCOMPARE(engine.masterMuted(), false);
+    }
+
+    // ── 2. setMasterMuted(true) gates the speakers push ────────────────────
+
+    void setMutedGatesSpeakersPush() {
+        Harness h = makeHarness();
+        const int s = h.addSlice(/*vaxChannel=*/0);
+
+        h.engine->setMasterMuted(true);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+
+        QCOMPARE(h.speakers->pushCount(), 0);
+    }
+
+    // ── 3. Mute must NOT gate the VAX tap — 3rd-party apps consuming VAX
+    //      (WSJT-X, DAWs, etc.) expect audio regardless of the local
+    //      monitor mute state. Per-channel VAX mute is the applet's
+    //      concern, not AudioEngine's. ──────────────────────────────────────
+
+    void setMutedDoesNotGateVaxTap() {
+        Harness h = makeHarness();
+        FakeAudioBus* vax1 = injectFakeVax(h.engine, 1);
+
+        const int s = h.addSlice(/*vaxChannel=*/1);
+
+        h.engine->setMasterMuted(true);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+
+        QCOMPARE(vax1->pushCount(), 1);
+        // Sanity: speakers is still gated.
+        QCOMPARE(h.speakers->pushCount(), 0);
+    }
+
+    // ── 4. Clearing mute restores the speakers push path ───────────────────
+
+    void clearMuteRestoresPush() {
+        Harness h = makeHarness();
+        const int s = h.addSlice(/*vaxChannel=*/0);
+
+        h.engine->setMasterMuted(true);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+        QCOMPARE(h.speakers->pushCount(), 0);
+
+        h.engine->setMasterMuted(false);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+        QCOMPARE(h.speakers->pushCount(), 1);
+    }
+
+    // ── 5. masterMutedChanged emits once per distinct state change ─────────
+
+    void emitsSignalOnChange() {
+        AudioEngine engine;
+        QSignalSpy spy(&engine, &AudioEngine::masterMutedChanged);
+
+        engine.setMasterMuted(true);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), true);
+
+        // Redundant set — same value, no emission.
+        engine.setMasterMuted(true);
+        QCOMPARE(spy.count(), 0);
+    }
+
+    // ── 6. setMasterMuted(false) when already false is a no-op signal ──────
+
+    void noSignalOnNoChange() {
+        AudioEngine engine;
+        QCOMPARE(engine.masterMuted(), false);
+
+        QSignalSpy spy(&engine, &AudioEngine::masterMutedChanged);
+        engine.setMasterMuted(false);
+        QCOMPARE(spy.count(), 0);
+    }
+};
+
+QTEST_MAIN(TstAudioEngineMasterMute)
+#include "tst_audio_engine_master_mute.moc"

--- a/tests/tst_master_output_widget.cpp
+++ b/tests/tst_master_output_widget.cpp
@@ -220,6 +220,30 @@ private slots:
         QVERIFY(std::abs(engine.volume() - 0.60f) < 1e-3f);
         QCOMPARE(engine.masterMuted(), true);
     }
+
+    // ── 10. Saved device name applies at construction (smoke) ─────────────
+    //
+    // Regression for the gap where audio/Speakers/DeviceName was read but
+    // never pushed into AudioEngine on startup, leaving the engine on the
+    // platform default until the user reopened the picker. AudioEngine
+    // exposes no "current device" getter, so this covers the construction
+    // path running cleanly with a non-empty saved device and seeding the
+    // same value into the picker anchor.
+
+    void restoresSavedDeviceOnConstruction() {
+        AppSettings::instance().setValue(
+            QStringLiteral("audio/Speakers/DeviceName"),
+            QStringLiteral("SomeDevice"));
+
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+
+        // Picker anchor round-trip: setCurrentOutputDevice re-setting the
+        // value the constructor already stored must not re-emit.
+        QSignalSpy spy(&w, &MasterOutputWidget::outputDeviceChanged);
+        w.setCurrentOutputDevice(QStringLiteral("SomeDevice"));
+        QCOMPARE(spy.count(), 0);
+    }
 };
 
 QTEST_MAIN(TstMasterOutputWidget)

--- a/tests/tst_master_output_widget.cpp
+++ b/tests/tst_master_output_widget.cpp
@@ -1,0 +1,226 @@
+// =================================================================
+// tests/tst_master_output_widget.cpp  (NereusSDR)
+// =================================================================
+//
+// Exercises MasterOutputWidget — the menu-bar composite widget
+// combining a speaker-mute button, a 0–100 master-volume slider,
+// an inset value readout, and a right-click output-device picker.
+// Phase 3O Sub-Phase 10 Task 10b.
+//
+// Test seams used:
+//   - AudioEngine default constructor is valid without a real device
+//     (m_paInitialized may be false on headless CI; rxBlockReady is a
+//     no-op without a RadioModel, so bare AudioEngine is safe).
+//   - MasterOutputWidget exposes findChild<QSlider*>("masterSlider")
+//     and findChild<QPushButton*>("speakerBtn") via objectName so the
+//     tests can drive them directly (no fragile eventFilter plumbing).
+//
+// Design spec: docs/architecture/2026-04-19-vax-design.md
+//   §5.4 (AppSettings keys: audio/Master/Volume, audio/Master/Muted,
+//   audio/Speakers/DeviceName)
+//   §6.3 (wiring table for menu-bar MasterOutputWidget)
+//   §7.3 (UI layout: speaker icon + 100px slider + inset readout)
+// =================================================================
+
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include <QPushButton>
+#include <QSlider>
+#include <QLabel>
+
+#include "core/AppSettings.h"
+#include "core/AudioEngine.h"
+#include "gui/widgets/MasterOutputWidget.h"
+
+using namespace NereusSDR;
+
+class TstMasterOutputWidget : public QObject {
+    Q_OBJECT
+
+private:
+    // Reset the AppSettings keys the widget reads/writes so each test
+    // starts from a known-clean slate. The test sandbox (via
+    // TestSandboxInit.cpp) guarantees we're not touching the real
+    // ~/.config file.
+    void clearMasterKeys() {
+        auto& s = AppSettings::instance();
+        s.remove(QStringLiteral("audio/Master/Volume"));
+        s.remove(QStringLiteral("audio/Master/Muted"));
+        s.remove(QStringLiteral("audio/Speakers/DeviceName"));
+    }
+
+private slots:
+
+    void init() {
+        clearMasterKeys();
+    }
+
+    // ── 1. Constructs without crashing ─────────────────────────────────────
+
+    void constructsWithoutCrash() {
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+        // Slider and speaker button must be reachable for downstream tests.
+        QVERIFY(w.findChild<QSlider*>("masterSlider") != nullptr);
+        QVERIFY(w.findChild<QPushButton*>("speakerBtn") != nullptr);
+        QVERIFY(w.findChild<QLabel*>("dbLabel") != nullptr);
+    }
+
+    // ── 2. Slider move writes through to engine volume ─────────────────────
+
+    void sliderWritesEngineVolume() {
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+        auto* slider = w.findChild<QSlider*>("masterSlider");
+        QVERIFY(slider);
+
+        slider->setValue(75);
+
+        QVERIFY(std::abs(engine.volume() - 0.75f) < 1e-3f);
+    }
+
+    // ── 3. Slider move persists audio/Master/Volume ────────────────────────
+
+    void sliderPersistsVolume() {
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+        auto* slider = w.findChild<QSlider*>("masterSlider");
+        QVERIFY(slider);
+
+        slider->setValue(75);
+
+        const QString stored = AppSettings::instance()
+            .value(QStringLiteral("audio/Master/Volume")).toString();
+        QVERIFY2(!stored.isEmpty(), "audio/Master/Volume not written");
+        const float val = stored.toFloat();
+        QVERIFY(std::abs(val - 0.75f) < 1e-3f);
+    }
+
+    // ── 4. Mute button toggle drives engine masterMuted ────────────────────
+
+    void muteButtonTogglesEngine() {
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+        auto* btn = w.findChild<QPushButton*>("speakerBtn");
+        QVERIFY(btn);
+
+        btn->click();  // press: muted
+        QCOMPARE(engine.masterMuted(), true);
+
+        btn->click();  // press again: unmuted
+        QCOMPARE(engine.masterMuted(), false);
+    }
+
+    // ── 5. Mute persists audio/Master/Muted as "True"/"False" ──────────────
+
+    void mutePersists() {
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+        auto* btn = w.findChild<QPushButton*>("speakerBtn");
+        QVERIFY(btn);
+
+        btn->click();
+        QCOMPARE(AppSettings::instance()
+                     .value(QStringLiteral("audio/Master/Muted")).toString(),
+                 QStringLiteral("True"));
+
+        btn->click();
+        QCOMPARE(AppSettings::instance()
+                     .value(QStringLiteral("audio/Master/Muted")).toString(),
+                 QStringLiteral("False"));
+    }
+
+    // ── 6. Engine volume echo updates slider without re-firing engine ──────
+
+    void engineVolumeEchoesToSlider() {
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+        auto* slider = w.findChild<QSlider*>("masterSlider");
+        QVERIFY(slider);
+
+        // Seed with a distinct starting value so we can detect the echo.
+        slider->setValue(10);
+
+        QSignalSpy engineSpy(&engine, &AudioEngine::volumeChanged);
+
+        engine.setVolume(0.30f);
+
+        // Slider reflects new engine value (30 percent).
+        QCOMPARE(slider->value(), 30);
+
+        // The echo path must NOT cause the widget to call setVolume again.
+        // setVolume(0.30f) itself emitted volumeChanged once; no extras.
+        QCOMPARE(engineSpy.count(), 1);
+    }
+
+    // ── 7. Engine mute echo updates button without re-emission ─────────────
+
+    void engineMuteEchoesToButton() {
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+        auto* btn = w.findChild<QPushButton*>("speakerBtn");
+        QVERIFY(btn);
+
+        QSignalSpy engineSpy(&engine, &AudioEngine::masterMutedChanged);
+
+        engine.setMasterMuted(true);
+
+        QCOMPARE(btn->isChecked(), true);
+        // 🔇 U+1F507 when muted
+        QCOMPARE(btn->text(), QString::fromUtf8("\xF0\x9F\x94\x87"));
+
+        // The engine emitted exactly once (its own setMasterMuted). The
+        // button update via the echo slot must not cause a second emission.
+        QCOMPARE(engineSpy.count(), 1);
+    }
+
+    // ── 8. setCurrentOutputDevice stores device name for the picker ────────
+    //
+    // The context-menu QActionGroup is awkward to exercise headlessly
+    // (popup + action activation fights QTest without show()). Per the
+    // task brief we take the lighter smoke: setCurrentOutputDevice()
+    // stores the name the picker will use as its check-state anchor.
+
+    void setCurrentOutputDeviceTracksName() {
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+
+        w.setCurrentOutputDevice(QStringLiteral("TestDevice"));
+        // No public getter — verify via outputDeviceChangedSignal round-trip
+        // is Task 10c's job. Smoke: the call does not crash, does not emit
+        // a spurious outputDeviceChanged (setCurrentOutputDevice is a
+        // sync-from-elsewhere path, not a user action).
+        QSignalSpy spy(&w, &MasterOutputWidget::outputDeviceChanged);
+        w.setCurrentOutputDevice(QStringLiteral("AnotherDevice"));
+        QCOMPARE(spy.count(), 0);
+    }
+
+    // ── 9. Applied saved volume/mute at construction time ──────────────────
+    //
+    // AppSettings persistence round-trip: a widget built after a prior
+    // session's values were saved should come up with the slider/button
+    // reflecting those values AND the engine seeded to match.
+
+    void restoresSavedValuesOnConstruction() {
+        auto& s = AppSettings::instance();
+        s.setValue(QStringLiteral("audio/Master/Volume"),
+                   QStringLiteral("0.600"));
+        s.setValue(QStringLiteral("audio/Master/Muted"),
+                   QStringLiteral("True"));
+
+        AudioEngine engine;
+        MasterOutputWidget w(&engine);
+
+        auto* slider = w.findChild<QSlider*>("masterSlider");
+        auto* btn    = w.findChild<QPushButton*>("speakerBtn");
+        QVERIFY(slider && btn);
+
+        QCOMPARE(slider->value(), 60);
+        QCOMPARE(btn->isChecked(), true);
+        QVERIFY(std::abs(engine.volume() - 0.60f) < 1e-3f);
+        QCOMPARE(engine.masterMuted(), true);
+    }
+};
+
+QTEST_MAIN(TstMasterOutputWidget)
+#include "tst_master_output_widget.moc"

--- a/tests/tst_title_bar.cpp
+++ b/tests/tst_title_bar.cpp
@@ -13,6 +13,8 @@
 //   3. masterOutputAccessible — masterOutput() returns the embedded
 //      MasterOutputWidget.
 //   4. fixedHeight32 — strip height is pinned to 32 px.
+//   5. featureButtonEmitsSignal — clicking the 💡 feature button emits
+//      featureRequestClicked() exactly once (Task 10d).
 //
 // Live UI smoke (hosted-inside-QMainWindow + menu bar re-parenting
 // visuals) is the canonical verify; these tests only guard the
@@ -24,6 +26,8 @@
 #include <QtTest/QtTest>
 #include <QMenu>
 #include <QMenuBar>
+#include <QPushButton>
+#include <QSignalSpy>
 
 #include "core/AudioEngine.h"
 #include "gui/TitleBar.h"
@@ -93,6 +97,24 @@ private slots:
         // windowing system (QTEST_MAIN uses a QApplication so this is safe).
         bar.adjustSize();
         QCOMPARE(bar.height(), 32);
+    }
+
+    // ── 5. Feature button emits featureRequestClicked ──────────────────────
+
+    void featureButtonEmitsSignal() {
+        AudioEngine engine;
+        TitleBar bar(&engine);
+
+        // The 💡 button is a QPushButton with objectName "featureButton",
+        // set in TitleBar's constructor (Task 10d).
+        auto* btn = bar.findChild<QPushButton*>(QStringLiteral("featureButton"));
+        QVERIFY(btn != nullptr);
+
+        QSignalSpy spy(&bar, &TitleBar::featureRequestClicked);
+        QVERIFY(spy.isValid());
+
+        btn->click();
+        QCOMPARE(spy.count(), 1);
     }
 };
 

--- a/tests/tst_title_bar.cpp
+++ b/tests/tst_title_bar.cpp
@@ -1,0 +1,100 @@
+// =================================================================
+// tests/tst_title_bar.cpp  (NereusSDR)
+// =================================================================
+//
+// Smoke tests for TitleBar — the 32 px host strip that holds the
+// QMenuBar and MasterOutputWidget. Phase 3O Sub-Phase 10 Task 10c.
+//
+// Coverage:
+//   1. constructsWithoutCrash — TitleBar builds against a real
+//      AudioEngine without crashing.
+//   2. setMenuBarInserts — setMenuBar() actually re-parents the
+//      supplied QMenuBar into the strip at position 0.
+//   3. masterOutputAccessible — masterOutput() returns the embedded
+//      MasterOutputWidget.
+//   4. fixedHeight32 — strip height is pinned to 32 px.
+//
+// Live UI smoke (hosted-inside-QMainWindow + menu bar re-parenting
+// visuals) is the canonical verify; these tests only guard the
+// construction contract, not appearance.
+//
+// Design spec: docs/architecture/2026-04-19-vax-design.md §6.3 + §7.3.
+// =================================================================
+
+#include <QtTest/QtTest>
+#include <QMenu>
+#include <QMenuBar>
+
+#include "core/AudioEngine.h"
+#include "gui/TitleBar.h"
+#include "gui/widgets/MasterOutputWidget.h"
+
+using namespace NereusSDR;
+
+class TstTitleBar : public QObject {
+    Q_OBJECT
+
+private slots:
+
+    // ── 1. Constructs without crashing ─────────────────────────────────────
+
+    void constructsWithoutCrash() {
+        AudioEngine engine;
+        TitleBar bar(&engine);
+        QVERIFY(bar.masterOutput() != nullptr);
+    }
+
+    // ── 2. setMenuBar re-parents the menu bar into the strip ──────────────
+
+    void setMenuBarInserts() {
+        AudioEngine engine;
+        TitleBar bar(&engine);
+
+        auto* mb = new QMenuBar;
+        QMenu* dummy = mb->addMenu(QStringLiteral("Dummy"));
+        dummy->addAction(QStringLiteral("Nothing"));
+
+        bar.setMenuBar(mb);
+
+        // After setMenuBar() the menu bar must be reachable as a child
+        // of the title bar AND parented to it.
+        QMenuBar* found = bar.findChild<QMenuBar*>();
+        QVERIFY(found != nullptr);
+        QCOMPARE(found, mb);
+        QCOMPARE(mb->parentWidget(), &bar);
+    }
+
+    // ── 3. masterOutput accessor ───────────────────────────────────────────
+
+    void masterOutputAccessible() {
+        AudioEngine engine;
+        TitleBar bar(&engine);
+
+        MasterOutputWidget* m = bar.masterOutput();
+        QVERIFY(m != nullptr);
+        // Round-trip check: the widget sits inside the title bar tree.
+        QVERIFY(bar.findChild<MasterOutputWidget*>() == m);
+    }
+
+    // ── 4. Fixed strip height of 32 px ─────────────────────────────────────
+
+    void fixedHeight32() {
+        AudioEngine engine;
+        TitleBar bar(&engine);
+
+        // setFixedHeight() pins minimumHeight == maximumHeight == 32. The
+        // widget's visible height only resolves after show() / polish, but
+        // the height contract is already locked in by setFixedHeight() at
+        // construction time and is the canonical check.
+        QCOMPARE(bar.minimumHeight(), 32);
+        QCOMPARE(bar.maximumHeight(), 32);
+
+        // adjustSize() is enough to resolve the size hint without needing a
+        // windowing system (QTEST_MAIN uses a QApplication so this is safe).
+        bar.adjustSize();
+        QCOMPARE(bar.height(), 32);
+    }
+};
+
+QTEST_MAIN(TstTitleBar)
+#include "tst_title_bar.moc"


### PR DESCRIPTION
## Summary

Phase 3O Sub-Phase 10 introduces NereusSDR's top-of-window strip: a
`TitleBar` widget that hosts the menu bar + a new `MasterOutputWidget`
composite (speaker-mute button, master volume slider, percent readout,
right-click output-device picker). Also adds the `AudioEngine`
master-mute API so the speaker button actually gates the audio, and
consolidates the previously-standalone 💡 feature-request toolbar
into the new strip.

## What landed

- **AudioEngine master mute** (`src/core/AudioEngine.{h,cpp}`) —
  `setMasterMuted(bool)` / `masterMuted()` / `masterMutedChanged`
  signal, mirroring the existing `setVolume` pattern. Mute gates ONLY
  the speakers-bus push in `rxBlockReady`; master-mix accumulate and
  VAX taps are unconditional (3rd-party apps consuming VAX keep
  receiving audio while the local monitor is muted). Atomic
  acq_rel / acquire pairing preserves RT-safety.
- **MasterOutputWidget** (`src/gui/widgets/`) — composite: 20 px
  speaker button (🔊 / 🔇 glyphs), 100 px volume slider, inset percent
  label (per STYLEGUIDE "Inset Value Display"), right-click
  device-picker context menu populated from
  `PortAudioBus::outputDevicesFor`. Echo-prevention via
  `m_updatingFromModel` + `QSignalBlocker`. Persists
  `audio/Master/Volume` (3-decimal float), `audio/Master/Muted`
  ("True"/"False"), `audio/Speakers/DeviceName` per spec §5.4.
- **TitleBar** (`src/gui/TitleBar.{h,cpp}`) — scoped-down port of
  AetherSDR's `src/gui/TitleBar.{h,cpp}`. Host strip (32 px, dark
  background, bottom border) that embeds the `QMenuBar` on the left
  via `setMenuBar(QMenuBar*)` + `insertWidget(0, mb)`, then
  "NereusSDR" accent label + stretch + `MasterOutputWidget` +
  💡 feature-request button on the right.
- **MainWindow refactor** — `setMenuWidget(m_titleBar)` installs the
  strip and disables Qt6's macOS global-menu-bar promotion;
  `m_titleBar->setMenuBar(menuBar())` re-parents the populated menu
  into the strip; `MasterOutputWidget::outputDeviceChanged` routes to
  `AudioEngine::setSpeakersConfig` so the device picker rebuilds the
  speakers bus. Deletes the now-redundant `featureBar` QToolBar that
  previously existed solely as a macOS-compatible host for the 💡
  icon.

### Intentionally omitted from this phase

AetherSDR's `TitleBar` carries additional widgets we don't yet have
the backend for or that belong in separate phases:

- Heartbeat indicator (NereusSDR connection-state UI lives elsewhere)
- multiFLEX button (not applicable to OpenHPSDR single-client)
- PC Audio toggle (AetherSDR DAX-specific)
- Other-client-TX label (multiFLEX artifact)
- Headphone slider (deferred to Sub-Phase 12 Setup → Audio → Devices)
- Minimal-mode button (separate phase)

The NereusSDR `TitleBar` starts lean and grows as those phases land.

## Cross-platform behavior

- **macOS:** Native global menu bar is suppressed; menus render
  in-window inside the TitleBar strip. This is the deliberate
  trade-off for cross-platform consistency (matches AetherSDR).
- **Linux / Windows:** Menus render in TitleBar as they already did
  in-window.

## Tests

Three new test binaries (FakeAudioBus + `setVaxBusForTest` /
`setSpeakersBusForTest` seams — no platform audio required):

- `tst_audio_engine_master_mute` — 6 cases: default-unmuted,
  mute-gates-speakers, mute-does-not-gate-VAX (the critical UX
  invariant), clear-restores-push, signal-emit-on-change,
  no-signal-on-no-change.
- `tst_master_output_widget` — 9 cases: construct, slider→engine,
  slider→persist, mute→engine, mute→persist, engine→slider echo
  (no re-emit), engine→mute echo (no re-emit), device-name sync,
  construction-time restore.
- `tst_title_bar` — 5 cases: construct, `setMenuBar` re-parent,
  `masterOutput()` accessor, fixed 32 px height,
  `featureRequestClicked` signal emission.

Pre-existing baseline failures on `main` (`tst_container_persistence`,
`tst_p1_loopback_connection`, `tst_hardware_page_capability_gating`,
`tst_about_dialog`) are unchanged by this branch.

## Attribution

`TitleBar.{h,cpp}` is a direct AetherSDR port (scoped down); carries
the full port-citation block per `docs/attribution/HOW-TO-PORT.md`
rule 6. `MasterOutputWidget.{h,cpp}` is NereusSDR-original with
AetherSDR-inspired styling (cites `TitleBar.cpp:172-215` in the
modification-history block). Rows added to both
`docs/attribution/aethersdr-reconciliation.md` (hook-authoritative)
and `docs/attribution/aethersdr-contributor-index.md`.
`scripts/verify-thetis-headers.py --all-kinds` and
`scripts/check-new-ports.py` both pass.

## Commits (all GPG-signed by KG4VCF)

- `8b65a73` feat(audio): master mute API on AudioEngine
- `4cc926b` feat(widgets): MasterOutputWidget — speaker + master volume + device picker
- `89f70e6` style(widgets): address code-quality review on MasterOutputWidget
- `9153b4d` feat(gui): TitleBar strip — hosts menu bar + MasterOutputWidget
- `c914438` refactor(gui): move feature-request button into TitleBar

## Test plan

- [ ] Top-of-window TitleBar strip visible on launch (32 px, dark)
- [ ] macOS: no global top-of-screen menu bar; menus are in-window
- [ ] Linux/Windows: menus in TitleBar, no regression from prior layout
- [ ] Speaker button: left-click mutes (🔊 → 🔇, audio silent); click again unmutes
- [ ] Volume slider: percent label tracks; audio level responds
- [ ] Right-click speaker: device-picker submenu lists output devices, current device checked
- [ ] Selecting a different device: audio continues (bus rebuilt)
- [ ] 💡 icon at far right of TitleBar past percent readout: click opens feature-request dialog
- [ ] Volume + mute persist across restart (`audio/Master/*` keys)
- [ ] Master mute does NOT silence VAX channels (verified in `tst_audio_engine_master_mute::setMutedDoesNotGateVaxTap`)

J.J. Boyd ~ KG4VCF