### PR TITLE
Reset ReceiverManager on disconnect to avoid same-session receiver leak

### DIFF
--- a/src/core/ReceiverManager.cpp
+++ b/src/core/ReceiverManager.cpp
@@ -119,6 +119,29 @@ void ReceiverManager::destroyReceiver(int receiverIndex)
     emit receiverDestroyed(receiverIndex);
 }
 
+void ReceiverManager::reset()
+{
+    const int priorCount = m_receivers.size();
+    const QList<int> indices = m_receivers.keys();
+
+    m_receivers.clear();
+    m_hwToLogical.clear();
+    m_nextWdspChannel = 0;
+    m_firstForwardLogged = false;
+    m_firstDropLogged = false;
+
+    for (int idx : indices) {
+        emit receiverDestroyed(idx);
+    }
+
+    if (priorCount > 0) {
+        emit activeReceiverCountChanged(0);
+        emit hardwareReceiverCountChanged(0);
+    }
+
+    qCDebug(lcReceiver) << "ReceiverManager reset;" << priorCount << "receivers dropped";
+}
+
 void ReceiverManager::activateReceiver(int receiverIndex)
 {
     if (!m_receivers.contains(receiverIndex)) {

--- a/src/core/ReceiverManager.h
+++ b/src/core/ReceiverManager.h
@@ -108,6 +108,13 @@ public:
     // Destroy a receiver and release its hardware DDC.
     void destroyReceiver(int receiverIndex);
 
+    // Drop all receivers and reset the manager to a just-constructed state.
+    // Called by RadioModel::teardownConnection so the next connectToRadio
+    // starts with a fresh index counter; without this, a same-session
+    // disconnect/reconnect leaks receiver 0 and the new createReceiver()
+    // returns 1, colliding on DDC2 for P2 2-ADC boards (issue #75).
+    void reset();
+
     // Activate/deactivate a receiver.
     // Activating increments the hardware receiver count sent to the radio.
     void activateReceiver(int receiverIndex);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1280,6 +1280,15 @@ void RadioModel::teardownConnection()
     QObject::disconnect(m_connection, nullptr, m_receiverManager, nullptr);
     QObject::disconnect(m_receiverManager, nullptr, this, nullptr);
 
+    // Drop all logical receivers so the next connectToRadio() starts from
+    // index 0 with a fresh wdspChannel counter. Without this, issue #75:
+    // receiver 0 leaks into the next session, createReceiver() returns 1,
+    // and on P2 2-ADC boards both receivers claim DDC2 — the collision in
+    // rebuildHardwareMapping routes DDC2 I/Q to logical 1 whose wdspChannel
+    // is 1, but only WDSP channel 0 is created in connectToRadio, so audio
+    // and spectrum silently drop on the second connect.
+    m_receiverManager->reset();
+
     // Tear down the connection on its own worker thread via the shared
     // helper. See src/core/RadioConnectionTeardown.h for why this must
     // run on the worker — short version: the RadioConnection's QTimers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,9 @@ endfunction()
 # ── Pre-existing tests from main (smoke + 3G-9 meter suite) ────────────────
 nereus_add_test(tst_setup_helpers)
 nereus_add_test(tst_smoke)
+
+# ── Issue #75: receiver leak across disconnect/reconnect ──────────────────
+nereus_add_test(tst_receiver_manager_reconnect)
 nereus_add_test(tst_container_persistence)
 nereus_add_test(tst_meter_item_bar)
 nereus_add_test(tst_reading_name)

--- a/tests/tst_receiver_manager_reconnect.cpp
+++ b/tests/tst_receiver_manager_reconnect.cpp
@@ -1,0 +1,149 @@
+// tst_receiver_manager_reconnect.cpp — issue #75 regression.
+//
+// Reproduces the same-session disconnect/reconnect bug that silently killed
+// audio and spectrum on ANAN-7000DLE/8000DLE (OrionMkII) P2. Without
+// ReceiverManager::reset() the second createReceiver() returns index 1,
+// both receivers claim DDC2, and rebuildHardwareMapping() routes DDC2 I/Q
+// to logical 1 whose wdspChannel is 1 — but only WDSP channel 0 exists, so
+// the data path dead-ends.
+
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+
+#include "core/ReceiverManager.h"
+
+using NereusSDR::ReceiverManager;
+using NereusSDR::ReceiverConfig;
+
+class TstReceiverManagerReconnect : public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    void firstConnectAssignsReceiver0ToDdc2()
+    {
+        ReceiverManager rm;
+        rm.setMaxReceivers(2);
+
+        int rx = rm.createReceiver();
+        QCOMPARE(rx, 0);
+
+        rm.setDdcMapping(rx, 2);
+        rm.activateReceiver(rx);
+
+        const ReceiverConfig cfg = rm.receiverConfig(rx);
+        QCOMPARE(cfg.hardwareRx, 2);
+        QCOMPARE(cfg.wdspChannel, 0);
+        QCOMPARE(rm.activeReceiverCount(), 1);
+    }
+
+    // Without reset(), a second "connect" sequence on the same manager
+    // produces a receiver with index 1 and wdspChannel 1 — the exact
+    // collision that breaks issue #75.
+    void withoutResetSecondConnectLeaksReceiver()
+    {
+        ReceiverManager rm;
+        rm.setMaxReceivers(2);
+
+        int rx1 = rm.createReceiver();
+        rm.setDdcMapping(rx1, 2);
+        rm.activateReceiver(rx1);
+
+        // Simulate reconnect without reset — what the old teardown did.
+        int rx2 = rm.createReceiver();
+        QCOMPARE(rx2, 1);                  // leaked counter hands out 1
+
+        rm.setDdcMapping(rx2, 2);
+        rm.activateReceiver(rx2);
+
+        // Both receivers now claim DDC2. Last writer wins in rebuildHardwareMapping
+        // (QMap iterates ascending by key, so rx2 overwrites rx1's slot).
+        const ReceiverConfig cfg2 = rm.receiverConfig(rx2);
+        QCOMPARE(cfg2.wdspChannel, 1);     // but only WDSP channel 0 exists
+        QCOMPARE(rm.activeReceiverCount(), 2);
+    }
+
+    // With reset(), the next connect sees a clean manager and gets
+    // receiver 0 / wdspChannel 0 back — matches the first-connect state.
+    void resetRestoresFreshConnectState()
+    {
+        ReceiverManager rm;
+        rm.setMaxReceivers(2);
+
+        int rx1 = rm.createReceiver();
+        rm.setDdcMapping(rx1, 2);
+        rm.activateReceiver(rx1);
+
+        QSignalSpy destroyedSpy(&rm, &ReceiverManager::receiverDestroyed);
+        QSignalSpy countSpy(&rm, &ReceiverManager::activeReceiverCountChanged);
+
+        rm.reset();
+
+        QCOMPARE(rm.activeReceiverCount(), 0);
+        QCOMPARE(destroyedSpy.count(), 1);
+        QCOMPARE(destroyedSpy.takeFirst().at(0).toInt(), 0);
+        QVERIFY(countSpy.count() >= 1);
+        QCOMPARE(countSpy.last().at(0).toInt(), 0);
+
+        int rx2 = rm.createReceiver();
+        QCOMPARE(rx2, 0);                  // counter reset
+
+        rm.setDdcMapping(rx2, 2);
+        rm.activateReceiver(rx2);
+
+        const ReceiverConfig cfg = rm.receiverConfig(rx2);
+        QCOMPARE(cfg.hardwareRx, 2);
+        QCOMPARE(cfg.wdspChannel, 0);      // matches WDSP channel 0
+        QCOMPARE(rm.activeReceiverCount(), 1);
+    }
+
+    // I/Q fed through a just-reset manager must land on receiver 0, not
+    // leak to a stale mapping. This is the end-to-end behavior issue #75
+    // reporters actually see.
+    void resetRoutesSubsequentIqToReceiver0()
+    {
+        ReceiverManager rm;
+        rm.setMaxReceivers(2);
+
+        int rx1 = rm.createReceiver();
+        rm.setDdcMapping(rx1, 2);
+        rm.activateReceiver(rx1);
+
+        rm.reset();
+
+        int rx2 = rm.createReceiver();
+        rm.setDdcMapping(rx2, 2);
+        rm.activateReceiver(rx2);
+
+        QSignalSpy forwarded(&rm, &ReceiverManager::iqDataForReceiver);
+
+        QVector<float> samples{1.0f, 0.0f, 0.5f, 0.5f};
+        rm.feedIqData(2, samples);
+
+        QCOMPARE(forwarded.count(), 1);
+        QCOMPARE(forwarded.first().at(0).toInt(), 0);   // logical 0, not 1
+    }
+
+    // P1 path is unaffected by the bug — auto hw assignment avoids
+    // collision even without reset — but reset() must not break it.
+    void resetPreservesAutoAssignForP1()
+    {
+        ReceiverManager rm;
+        rm.setMaxReceivers(2);
+
+        int rx1 = rm.createReceiver();   // no setDdcMapping — P1 path
+        rm.activateReceiver(rx1);
+        QCOMPARE(rm.receiverConfig(rx1).hardwareRx, 0);
+
+        rm.reset();
+
+        int rx2 = rm.createReceiver();
+        rm.activateReceiver(rx2);
+        QCOMPARE(rx2, 0);
+        QCOMPARE(rm.receiverConfig(rx2).hardwareRx, 0);
+    }
+};
+
+QTEST_MAIN(TstReceiverManagerReconnect)
+#include "tst_receiver_manager_reconnect.moc"


### PR DESCRIPTION
## Summary

On a same-session disconnect/reconnect, `ReceiverManager` silently dropped audio and spectrum on Protocol 2 two-ADC boards (ANAN-7000DLE/8000DLE OrionMkII, ANAN-G2, Saturn). `RadioModel::teardownConnection` cleaned up the connection, DSP worker, audio, and WDSP, but never cleared the logical receivers it had asked `ReceiverManager` to create. On the next connect:

- leftover receiver 0 stayed `active=true` with `ddcIndex=2`
- `m_nextWdspChannel` carried over, so `createReceiver()` returned **index 1**
- `setDdcMapping(1, 2)` made both receivers claim DDC2
- `rebuildHardwareMapping()` walks ascending — receiver 1 overwrote receiver 0 in `m_hwToLogical`
- DDC2 I/Q routed to logical receiver 1 whose `wdspChannel=1`, but only WDSP channel 0 exists (hard-created in `connectToRadio`) — samples dead-ended

P1 radios (ANAN-100D, HL2) escape because `setDdcMapping` is P2-only; the `nextAutoHw++` fallback gives each receiver a distinct hardware index and avoids the collision.

## Fix

- Add `ReceiverManager::reset()` that clears the receiver map, hardware mapping, `m_nextWdspChannel`, and the one-shot diagnostic flags; emits `receiverDestroyed` for each dropped index and an `activeReceiverCountChanged(0)` if the manager wasn't already empty.
- Call it from the tail of `RadioModel::teardownConnection`, after signals are disconnected and before the connection-thread teardown helper runs.

Subsequent `connectToRadio()` sees a manager in just-constructed state, `createReceiver()` returns 0 again, and the DDC2 → logical 0 → WDSP channel 0 path matches the first-connect behavior.

## Test plan

New `tests/tst_receiver_manager_reconnect.cpp` covers:
- [x] First-connect baseline: receiver 0 on DDC2, wdspChannel 0
- [x] Without-reset leak repro: second connect returns index 1, wdspChannel 1
- [x] `reset()` restores fresh state + emits `receiverDestroyed` / `activeReceiverCountChanged`
- [x] I/Q fed through DDC2 after reset lands on logical receiver 0
- [x] P1 auto-hw assignment still works after reset
- [x] Full `ctest` run — no new failures introduced (4 pre-existing failures on `main` are unrelated: `tst_container_persistence`, `tst_p1_loopback_connection`, `tst_hardware_page_capability_gating`, `tst_about_dialog`)

## Hardware verification pending

Fix is unit-tested but not yet confirmed on real OrionMkII hardware — reporter (John G0ORX, issue #75) has the exact repro environment. I'll post a build link on the issue once this lands so he can verify end-to-end.

Fixes #75