### PR TITLE
tune(display): ship current spectrum/waterfall defaults

### DIFF
--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -346,22 +346,21 @@ void SpectrumWidget::loadSettings()
         return ok ? v : def;
     };
 
-    m_refLevel       = readFloat(QStringLiteral("DisplayGridMax"), -40.0f);
-    m_dynamicRange   = readFloat(QStringLiteral("DisplayGridMax"), -40.0f)
-                     - readFloat(QStringLiteral("DisplayGridMin"), -140.0f);
+    m_refLevel       = readFloat(QStringLiteral("DisplayGridMax"), -36.0f);
+    m_dynamicRange   = readFloat(QStringLiteral("DisplayGridMax"), -36.0f)
+                     - readFloat(QStringLiteral("DisplayGridMin"), -104.0f);
     m_spectrumFrac   = readFloat(QStringLiteral("DisplaySpectrumFrac"), 0.40f);
 
     // Phase 3G-12: persist the spectrum zoom level (visible bandwidth)
     // across app restarts. Center frequency is persisted indirectly via
     // SliceModel (slice frequency), so only bandwidth needs its own key.
-    // Default 200000 Hz = 200 kHz matches the pre-3G-12 hardcoded default
-    // in PanadapterModel / SpectrumWidget construction.
+    // Default 192000 Hz = 192 kHz matches the P1 base sample rate.
     m_bandwidthHz    = static_cast<double>(
-                          readFloat(QStringLiteral("DisplayBandwidth"), 200000.0f));
-    m_wfColorGain    = readInt(QStringLiteral("DisplayWfColorGain"), 50);
-    m_wfBlackLevel   = readInt(QStringLiteral("DisplayWfBlackLevel"), 15);
-    m_wfHighThreshold = readFloat(QStringLiteral("DisplayWfHighLevel"), -80.0f);
-    m_wfLowThreshold = readFloat(QStringLiteral("DisplayWfLowLevel"), -130.0f);
+                          readFloat(QStringLiteral("DisplayBandwidth"), 192000.0f));
+    m_wfColorGain    = readInt(QStringLiteral("DisplayWfColorGain"), 45);
+    m_wfBlackLevel   = readInt(QStringLiteral("DisplayWfBlackLevel"), 98);
+    m_wfHighThreshold = readFloat(QStringLiteral("DisplayWfHighLevel"), -50.0f);
+    m_wfLowThreshold = readFloat(QStringLiteral("DisplayWfLowLevel"), -110.0f);
     m_fillAlpha      = readFloat(QStringLiteral("DisplayFftFillAlpha"), 0.70f);
     m_panFill        = s.value(settingsKey(QStringLiteral("DisplayPanFill"), m_panIndex),
                                QStringLiteral("True")).toString() == QStringLiteral("True");
@@ -375,10 +374,10 @@ void SpectrumWidget::loadSettings()
 
     // Phase 3G-8 commit 3: spectrum renderer state.
     const int avgRaw = readInt(QStringLiteral("DisplayAverageMode"),
-                               static_cast<int>(AverageMode::Weighted));
+                               static_cast<int>(AverageMode::Logarithmic));
     m_averageMode = static_cast<AverageMode>(qBound(0, avgRaw,
                           static_cast<int>(AverageMode::Count) - 1));
-    m_averageAlpha     = readFloat(QStringLiteral("DisplayAverageAlpha"), kSmoothAlpha);
+    m_averageAlpha     = readFloat(QStringLiteral("DisplayAverageAlpha"), 0.05f);
     m_peakHoldDelayMs  = readInt(QStringLiteral("DisplayPeakHoldDelayMs"), 2000);
     m_lineWidth        = readFloat(QStringLiteral("DisplayLineWidth"), 1.5f);
     m_dbmCalOffset     = readFloat(QStringLiteral("DisplayCalOffset"), 0.0f);
@@ -394,11 +393,11 @@ void SpectrumWidget::loadSettings()
 
     // Phase 3G-8 commit 4: waterfall renderer state.
     m_wfAgcEnabled = s.value(settingsKey(QStringLiteral("DisplayWfAgc"), m_panIndex),
-                             QStringLiteral("False")).toString() == QStringLiteral("True");
+                             QStringLiteral("True")).toString() == QStringLiteral("True");
     m_wfReverseScroll = s.value(settingsKey(QStringLiteral("DisplayWfReverseScroll"), m_panIndex),
                                 QStringLiteral("False")).toString() == QStringLiteral("True");
     m_wfOpacity          = readInt(QStringLiteral("DisplayWfOpacity"), 100);
-    m_wfUpdatePeriodMs   = readInt(QStringLiteral("DisplayWfUpdatePeriodMs"), 50);
+    m_wfUpdatePeriodMs   = readInt(QStringLiteral("DisplayWfUpdatePeriodMs"), 30);
     m_wfUseSpectrumMinMax = s.value(settingsKey(QStringLiteral("DisplayWfUseSpectrumMinMax"), m_panIndex),
                                     QStringLiteral("False")).toString() == QStringLiteral("True");
     const int wfAvgRaw = readInt(QStringLiteral("DisplayWfAverageMode"),

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -486,14 +486,14 @@ private:
 
     // ---- Frequency range ----
     double m_centerHz{14225000.0};    // 14.225 MHz default
-    double m_bandwidthHz{200000.0};   // 200 kHz default
+    double m_bandwidthHz{192000.0};   // 192 kHz default (P1 base sample rate)
     double m_ddcCenterHz{14225000.0};   // DDC hardware center frequency
     double m_sampleRateHz{768000.0};    // DDC sample rate
 
     // ---- Display range ----
     // From Thetis display.cs:1743-1754
-    float  m_refLevel{-40.0f};        // top of display (dBm)
-    float  m_dynamicRange{100.0f};    // range in dB (bottom = refLevel - dynamicRange)
+    float  m_refLevel{-36.0f};        // top of display (dBm)
+    float  m_dynamicRange{68.0f};     // range in dB (bottom = refLevel - dynamicRange)
 
     // ---- Waterfall ----
     QImage m_waterfall;               // ring buffer (Format_RGB32)
@@ -502,13 +502,12 @@ private:
     // ---- Waterfall display controls ----
     // From AetherSDR SpectrumWidget defaults + Thetis display.cs:2522-2536
     WfColorScheme m_wfColorScheme{WfColorScheme::Default};
-    int    m_wfColorGain{50};         // 0-100
-    int    m_wfBlackLevel{15};        // 0-125
-    // Waterfall uses its own dBm range (narrower than spectrum for better contrast)
-    // From Thetis display.cs:2522 waterfall_high_threshold = -80.0F
-    // From Thetis display.cs:2536 waterfall_low_threshold = -130.0F
-    float  m_wfHighThreshold{-80.0f};
-    float  m_wfLowThreshold{-130.0f};
+    int    m_wfColorGain{45};         // 0-100
+    int    m_wfBlackLevel{98};        // 0-125
+    // Waterfall uses its own dBm range (narrower than spectrum for better contrast).
+    // Seed values; WfAgc (default on) continuously recomputes these at runtime.
+    float  m_wfHighThreshold{-50.0f};
+    float  m_wfLowThreshold{-110.0f};
 
     // ---- Smoothing constant ----
     // From AetherSDR SpectrumWidget.h:417 — SMOOTH_ALPHA = 0.35f
@@ -529,8 +528,8 @@ private:
 
     // ---- Phase 3G-8 commit 3: spectrum renderer state ----
 
-    AverageMode m_averageMode{AverageMode::Weighted};
-    float       m_averageAlpha{kSmoothAlpha};  // 0..1 exp-smoothing factor
+    AverageMode m_averageMode{AverageMode::Logarithmic};
+    float       m_averageAlpha{0.05f};  // 0..1 exp-smoothing factor
 
     bool        m_peakHoldEnabled{false};
     int         m_peakHoldDelayMs{2000};
@@ -545,11 +544,11 @@ private:
 
     // ---- Phase 3G-8 commit 4: waterfall renderer state ----
 
-    bool  m_wfAgcEnabled{false};
+    bool  m_wfAgcEnabled{true};
     bool  m_clarityActive{false};     // Phase 3G-9c: suppresses legacy AGC when Clarity drives thresholds
     bool  m_wfReverseScroll{false};
     int   m_wfOpacity{100};           // 0..100
-    int   m_wfUpdatePeriodMs{50};     // NereusSDR default per §10 divergence
+    int   m_wfUpdatePeriodMs{30};     // NereusSDR default per §10 divergence
     bool  m_wfUseSpectrumMinMax{false};
     AverageMode m_wfAverageMode{AverageMode::None};
     QVector<float> m_wfSmoothedBins;  // for wf averaging mode


### PR DESCRIPTION
## Summary

Promote the currently-running maintainer config to be what fresh installs see out of the box. Existing users are unaffected — any value already in `AppSettings` still wins over these defaults.

### Spectrum

| Key | Was | Now |
|---|---|---|
| `DisplayGridMax` | -40 | **-36** |
| `DisplayGridMin` | -140 | **-104** (dynamicRange 100 → 68) |
| `DisplayBandwidth` | 200000 | **192000** (P1 base rate) |
| `DisplayAverageAlpha` | 0.35 | **0.05** (heavier smoothing) |
| `DisplayAverageMode` | Weighted | **Logarithmic** |

### Waterfall

| Key | Was | Now |
|---|---|---|
| `DisplayWfAgc` | False | **True** |
| `DisplayWfBlackLevel` | 15 | **98** |
| `DisplayWfColorGain` | 50 | **45** |
| `DisplayWfHighLevel` | -80 | **-50** (seed; AGC overwrites) |
| `DisplayWfLowLevel` | -130 | **-110** (seed; AGC overwrites) |
| `DisplayWfUpdatePeriodMs` | 50 | **30** (~33 fps) |

All changes touch `SpectrumWidget::loadSettings()` default args and the matching member initializers in `SpectrumWidget.h`. `kSmoothAlpha` retained at 0.35 as the AetherSDR provenance reference.

## Test plan

- [ ] Fresh install (delete `~/Library/Preferences/NereusSDR/NereusSDR.settings` or `~/.config/NereusSDR/NereusSDR.settings`) → launch → confirm spectrum/waterfall look like the reference screenshot on first boot.
- [ ] Existing install launched against the new binary → values unchanged (persisted settings override).
- [ ] Setup → Display pages read/write the new defaults correctly; Reset-to-default buttons (if any) land on the new values.
- [ ] WfAgc=True by default: verify thresholds update within ~1 s on a quiet band.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>