### PR TITLE
feat(cli): --profile flag for concurrent multi-radio instances (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- New `--profile <name>` / `-p <name>` CLI flag for running multiple NereusSDR instances against different radios concurrently. Each profile gets its own isolated `NereusSDR.settings` + log directory under `profiles/<name>/`; profile names are validated against `[A-Za-z0-9_-]+` to prevent path traversal. FFTW wisdom stays machine-scoped (shared across profiles). Main window title gains a `[<profile>]` suffix. `SupportDialog` / `SupportBundle` now read the same profile-scoped log directory `main.cpp` writes to. Without `--profile`, behavior is byte-for-byte unchanged. Closes #100.
+
 ### Fixed
 - **Hermes Lite 2 bandpass filter now switches on band/VFO change.** P1RadioConnection was emitting `m_alexHpfBits=0`/`m_alexLpfBits=0` permanently because the filter bits were never recomputed from frequency. P2 had the right code; lifted into shared `src/core/codec/AlexFilterMap` and called from P1's `setReceiverFrequency`/`setTxFrequency`. (Phase 3P-A)
 - **Hermes Lite 2 step attenuator now actually attenuates.** P1's bank 11 C4 was using ramdor's 5-bit mask + 0x20 enable for every board; HL2 needs mi0bot's 6-bit mask + 0x40 enable + MOX TX/RX branch. Fixed via per-board codec subclasses (`P1CodecStandard` for Hermes/Orion, `P1CodecHl2` for HL2). RxApplet S-ATT slider range now widens to 0-63 dB on HL2 from `BoardCapabilities::attenuator.maxDb`. (Phase 3P-A)

--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -65,6 +65,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QRegularExpression>
 #include <QSet>
 #include <QStandardPaths>
 #include <QXmlStreamReader>
@@ -72,6 +73,49 @@
 #include <QDebug>
 
 namespace NereusSDR {
+
+// Profile override set by main() from --profile CLI (Issue #100).
+// Scoped to the AppSettings singleton's file path + main.cpp's log dir.
+// Empty string (default) preserves legacy single-profile behavior.
+static QString s_profileOverride;
+
+void AppSettings::setProfileOverride(const QString& profile)
+{
+    s_profileOverride = profile;
+}
+
+QString AppSettings::profileOverride()
+{
+    return s_profileOverride;
+}
+
+bool AppSettings::isValidProfileName(const QString& profile)
+{
+    if (profile.isEmpty()) {
+        return false;
+    }
+    static const QRegularExpression re(QStringLiteral("^[A-Za-z0-9_-]+$"));
+    return re.match(profile).hasMatch();
+}
+
+QString AppSettings::resolveConfigDir(const QString& profile)
+{
+#ifdef Q_OS_MAC
+    const QString root = QDir::homePath() + QStringLiteral("/Library/Preferences/NereusSDR");
+#else
+    const QString root = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
+                         + QStringLiteral("/NereusSDR");
+#endif
+    if (!isValidProfileName(profile)) {
+        return root;
+    }
+    return root + QStringLiteral("/profiles/") + profile;
+}
+
+QString AppSettings::resolveSettingsPath(const QString& profile)
+{
+    return resolveConfigDir(profile) + QStringLiteral("/NereusSDR.settings");
+}
 
 AppSettings& AppSettings::instance()
 {
@@ -92,12 +136,7 @@ AppSettings::AppSettings(const QString& filePath)
 
 void AppSettings::initFilePath()
 {
-#ifdef Q_OS_MAC
-    m_filePath = QDir::homePath() + "/Library/Preferences/NereusSDR/NereusSDR.settings";
-#else
-    m_filePath = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
-                 + "/NereusSDR/NereusSDR.settings";
-#endif
+    m_filePath = resolveSettingsPath(s_profileOverride);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -144,6 +144,33 @@ public:
     // File path for the settings file.
     QString filePath() const { return m_filePath; }
 
+    // ------------------------------------------------------------------
+    // Profile support (Issue #100) — multiple concurrent NereusSDR
+    // instances against different radios. A profile name scopes the
+    // settings file (and the log dir, in main.cpp) to a per-profile
+    // subdirectory so two instances don't clobber each other's XML.
+    //
+    //   (default / empty profile) → <config>/NereusSDR/NereusSDR.settings
+    //   profile = "hf"            → <config>/NereusSDR/profiles/hf/NereusSDR.settings
+    //
+    // Call setProfileOverride() from main() BEFORE the first
+    // AppSettings::instance() call; the singleton resolves its file
+    // path once in its default constructor.
+    // ------------------------------------------------------------------
+    static void    setProfileOverride(const QString& profile);
+    static QString profileOverride();
+
+    // Path resolvers — pure functions, safe to call before/without the
+    // singleton. main.cpp uses resolveConfigDir() to scope the log dir
+    // and the pre-QApplication UiScalePercent read.
+    static QString resolveSettingsPath(const QString& profile);
+    static QString resolveConfigDir(const QString& profile);
+
+    // Profile names are restricted to [A-Za-z0-9_-] and non-empty.
+    // Anything else (path traversal, whitespace, separators) falls back
+    // to the default/empty profile in the resolvers above.
+    static bool isValidProfileName(const QString& profile);
+
     // -------------------------------------------------------------------------
     // Saved-radio management (Phase 3I Task 15).
     //

--- a/src/core/LogCategories.cpp
+++ b/src/core/LogCategories.cpp
@@ -118,8 +118,11 @@ void LogManager::applyFilterRules()
 
 QString LogManager::logDirPath() const
 {
-    return QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
-           + QStringLiteral("/NereusSDR");
+    // Issue #100 / PR #103: honor the --profile override so SupportDialog
+    // and SupportBundle read from the same directory main.cpp writes logs
+    // to. AppSettings::resolveConfigDir returns the legacy path when no
+    // profile is set and .../NereusSDR/profiles/<name>/ when one is.
+    return AppSettings::resolveConfigDir(AppSettings::profileOverride());
 }
 
 QString LogManager::logFilePath() const

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -488,7 +488,16 @@ MainWindow::~MainWindow() = default;
 
 void MainWindow::buildUI()
 {
-    setWindowTitle(QStringLiteral("NereusSDR %1").arg(NEREUSSDR_VERSION));
+    // Issue #100: suffix the title with the active profile so users
+    // running two instances against different radios can tell the
+    // windows apart.
+    const QString profile = AppSettings::profileOverride();
+    if (profile.isEmpty()) {
+        setWindowTitle(QStringLiteral("NereusSDR %1").arg(NEREUSSDR_VERSION));
+    } else {
+        setWindowTitle(QStringLiteral("NereusSDR %1 [%2]")
+                           .arg(NEREUSSDR_VERSION, profile));
+    }
     setMinimumSize(800, 600);
     resize(1280, 800);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include "core/LogCategories.h"
 
 #include <QApplication>
+#include <QCommandLineOption>
+#include <QCommandLineParser>
 #include <QIcon>
 #include <QStyleFactory>
 #include <QDir>
@@ -14,6 +16,7 @@
 #include <QTextStream>
 #include <QStandardPaths>
 #include <QRegularExpression>
+#include <QStringList>
 
 static QFile* s_logFile = nullptr;
 
@@ -64,15 +67,49 @@ static void messageHandler(QtMsgType type, const QMessageLogContext& ctx, const 
     fprintf(stderr, "%s", line.toLocal8Bit().constData());
 }
 
+// Parse --profile <name> out of argv *before* constructing QApplication so
+// AppSettings can pin the right path on first access. QCommandLineParser
+// wants a QCoreApplication instance, so we do a cheap manual scan here and
+// re-parse properly inside main() once the app is built (for --help / error
+// diagnostics).
+//
+// Issue #100 — multiple NereusSDR instances against different radios.
+static QString extractProfileFromArgv(int argc, char* argv[])
+{
+    for (int i = 1; i < argc; ++i) {
+        const QString a = QString::fromLocal8Bit(argv[i]);
+        if (a == QLatin1String("--profile") || a == QLatin1String("-p")) {
+            if (i + 1 < argc) {
+                return QString::fromLocal8Bit(argv[i + 1]);
+            }
+        } else if (a.startsWith(QLatin1String("--profile="))) {
+            return a.mid(QLatin1String("--profile=").size());
+        }
+    }
+    return {};
+}
+
 int main(int argc, char* argv[])
 {
+    // Resolve profile name first — downstream path lookups (AppSettings,
+    // log dir, pre-QApplication UI scale read) all consult it.
+    const QString earlyProfile = extractProfileFromArgv(argc, argv);
+    if (!earlyProfile.isEmpty()) {
+        if (NereusSDR::AppSettings::isValidProfileName(earlyProfile)) {
+            NereusSDR::AppSettings::setProfileOverride(earlyProfile);
+        } else {
+            fprintf(stderr,
+                    "NereusSDR: ignoring invalid --profile '%s' "
+                    "(allowed: [A-Za-z0-9_-]+)\n",
+                    earlyProfile.toLocal8Bit().constData());
+        }
+    }
+    const QString activeProfile = NereusSDR::AppSettings::profileOverride();
+
     // Apply saved UI scale factor BEFORE QApplication is created.
     {
-#ifdef Q_OS_MAC
-        QString settingsPath = QDir::homePath() + "/Library/Preferences/NereusSDR/NereusSDR.settings";
-#else
-        QString settingsPath = QDir::homePath() + "/.config/NereusSDR/NereusSDR.settings";
-#endif
+        const QString settingsPath =
+            NereusSDR::AppSettings::resolveSettingsPath(activeProfile);
         QFile f(settingsPath);
         if (f.open(QIODevice::ReadOnly | QIODevice::Text)) {
             QByteArray data = f.readAll();
@@ -97,9 +134,29 @@ int main(int argc, char* argv[])
     app.setOrganizationName("NereusSDR");
     app.setWindowIcon(QIcon(":/icons/NereusSDR.png"));
 
-    // Set up file logging in ~/.config/NereusSDR/
-    const QString logDir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation)
-                           + "/NereusSDR";
+    // Re-parse properly so --help / --version / unknown options surface
+    // via Qt's standard machinery. The earlyProfile pass above already
+    // pinned AppSettings; this second pass is purely for user-facing UX.
+    {
+        QCommandLineParser parser;
+        parser.setApplicationDescription(
+            QStringLiteral("NereusSDR — cross-platform OpenHPSDR client."));
+        parser.addHelpOption();
+        parser.addVersionOption();
+        QCommandLineOption profileOpt(
+            QStringList() << QStringLiteral("p") << QStringLiteral("profile"),
+            QStringLiteral(
+                "Run in an isolated profile (separate settings + logs). "
+                "Lets two instances drive two radios without clobbering "
+                "each other. Name must match [A-Za-z0-9_-]+."),
+            QStringLiteral("name"));
+        parser.addOption(profileOpt);
+        parser.process(app);
+    }
+
+    // Set up file logging in ~/.config/NereusSDR/ (or the profile's
+    // isolated config dir when --profile is set).
+    const QString logDir = NereusSDR::AppSettings::resolveConfigDir(activeProfile);
     QDir().mkpath(logDir);
 
     const QString timestamp = QDateTime::currentDateTime().toString("yyyyMMdd-HHmmss");
@@ -145,6 +202,10 @@ int main(int argc, char* argv[])
     NereusSDR::LogManager::instance().loadSettings();
 
     qDebug() << "Starting NereusSDR" << app.applicationVersion();
+    if (!activeProfile.isEmpty()) {
+        qDebug() << "Profile:" << activeProfile
+                 << "config dir:" << logDir;
+    }
 
     // Phase 3G-6 block 5: bring up the MMIO subsystem so persisted
     // endpoints (under AppSettings MmioEndpoints/<guid>/*) start

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -185,6 +185,9 @@ nereus_add_test(tst_transmit_model_tx_owner)
 # ── Phase 3O VAX schema migration ─────────────────────────────────────────
 nereus_add_test(tst_app_settings_vax_migration)
 
+# ── Issue #100: --profile CLI flag for concurrent-instance isolation ─────
+nereus_add_test(tst_app_settings_profile)
+
 # ── Phase 3O Sub-Phase 8: VaxChannelSelector widget ───────────────────────
 nereus_add_test(tst_vax_channel_selector)
 

--- a/tests/tst_app_settings_profile.cpp
+++ b/tests/tst_app_settings_profile.cpp
@@ -1,0 +1,72 @@
+// Issue #100 — multi-instance support via --profile CLI flag.
+//
+// Two instances of NereusSDR connected to different radios need isolated
+// settings + log directories. AppSettings exposes static path resolvers
+// so main.cpp can thread a profile name in from QCommandLineParser
+// without coupling the singleton's constructor to CLI parsing.
+
+#include <QtTest/QtTest>
+#include "core/AppSettings.h"
+
+#include <QDir>
+#include <QStandardPaths>
+
+using namespace NereusSDR;
+
+class TstAppSettingsProfile : public QObject {
+    Q_OBJECT
+private slots:
+    void emptyProfileResolvesToLegacyPath() {
+        const QString path = AppSettings::resolveSettingsPath(QString());
+#ifdef Q_OS_MAC
+        const QString expected = QDir::homePath() +
+            "/Library/Preferences/NereusSDR/NereusSDR.settings";
+#else
+        const QString expected = QStandardPaths::writableLocation(
+            QStandardPaths::GenericConfigLocation) +
+            "/NereusSDR/NereusSDR.settings";
+#endif
+        QCOMPARE(path, expected);
+    }
+
+    void profileScopesUnderProfilesSubdir() {
+        const QString path = AppSettings::resolveSettingsPath("hf");
+        QVERIFY2(path.contains("/profiles/hf/"),
+                 qPrintable("got: " + path));
+        QVERIFY(path.endsWith("/NereusSDR.settings"));
+    }
+
+    void distinctProfilesDoNotCollide() {
+        QCOMPARE(AppSettings::resolveSettingsPath("hf")
+                 == AppSettings::resolveSettingsPath("vhf"), false);
+    }
+
+    void configDirIsSettingsFileParent() {
+        const QString dir  = AppSettings::resolveConfigDir("hf");
+        const QString path = AppSettings::resolveSettingsPath("hf");
+        QVERIFY(path.startsWith(dir + "/"));
+        QCOMPARE(path, dir + "/NereusSDR.settings");
+    }
+
+    void unsafeProfileNameFallsBackToDefault() {
+        // Path-traversal or whitespace names must not escape the
+        // profiles/ sandbox.
+        const QString legacy = AppSettings::resolveSettingsPath(QString());
+        QCOMPARE(AppSettings::resolveSettingsPath("../escape"), legacy);
+        QCOMPARE(AppSettings::resolveSettingsPath("with space"), legacy);
+        QCOMPARE(AppSettings::resolveSettingsPath("a/b"),       legacy);
+    }
+
+    void profileNameIsValidatedToAlnumDashUnderscore() {
+        QVERIFY(AppSettings::isValidProfileName("hf"));
+        QVERIFY(AppSettings::isValidProfileName("anan-8000dle"));
+        QVERIFY(AppSettings::isValidProfileName("vhf_uhf"));
+        QVERIFY(!AppSettings::isValidProfileName(""));
+        QVERIFY(!AppSettings::isValidProfileName("../escape"));
+        QVERIFY(!AppSettings::isValidProfileName("with space"));
+        QVERIFY(!AppSettings::isValidProfileName("a/b"));
+    }
+};
+
+QTEST_APPLESS_MAIN(TstAppSettingsProfile)
+#include "tst_app_settings_profile.moc"


### PR DESCRIPTION
## Summary
- Adds `--profile <name>` / `-p <name>` CLI flag so two NereusSDR instances can drive two radios at once without clobbering each other's settings/logs.
- `AppSettings` gains static path resolvers (`resolveSettingsPath`, `resolveConfigDir`, `isValidProfileName`, `set/get ProfileOverride`); singleton reads the override before pinning its file path.
- Log dir and the pre-`QApplication` `UiScalePercent` read both honour the profile.
- Main window title gets a `[<profile>]` suffix so you can tell two instances apart.
- Profile names restricted to `[A-Za-z0-9_-]+` — invalid names log a stderr warning and fall back to the default config dir (no path-traversal, no whitespace).

Without `--profile`, behaviour is byte-for-byte unchanged (legacy `~/.config/NereusSDR/NereusSDR.settings` on Linux, `~/Library/Preferences/NereusSDR/...` on macOS).

Closes #100.

## Test plan

Automated (new, 8 assertions):
- [x] `tst_app_settings_profile` — empty profile resolves to legacy path, valid profile scopes under `profiles/<name>/`, distinct profiles don't collide, `resolveConfigDir` is the settings-file parent, unsafe names fall back to default, `isValidProfileName` accepts alnum/`_`/`-` and rejects empty/space/slash/traversal.

Full suite:
- [x] `ctest -j8` — 71/75 pass; 4 pre-existing failures on `main` (`tst_container_persistence`, `tst_p1_loopback_connection`, `tst_hardware_page_capability_gating` SEGFAULT, `tst_about_dialog`) verified on baseline via stash + rebuild.

Manual:
- [x] `NereusSDR --help` prints the new `-p, --profile <name>` option.
- [x] `NereusSDR --profile 'badname/../evil'` logs `NereusSDR: ignoring invalid --profile ...` and launches normally against the default config dir.
- [ ] On a machine with two OpenHPSDR radios, launch `NereusSDR --profile hf` + `NereusSDR --profile vhf`, connect each to a different radio, confirm per-profile `lastConnected` MAC and window title suffixes.

## Notes

- QCommandLineParser needs a `QCoreApplication`; since we must set the profile *before* constructing `QApplication` (so the settings singleton pins the right path in its default ctor and the pre-QApplication `UiScalePercent` read sees the right file), `main()` does a cheap manual argv scan first, then re-parses with `QCommandLineParser` after `QApplication` exists to get `--help` / `--version` UX for free.
- FFTW wisdom stays at the shared (non-profile) path — it's machine-specific, not radio-specific; profiles share it safely and skip the 15 min regeneration.
- Related cleanup (not done here): `ConnectionPanel::connectToRadio()` silently forces `autoConnect=true` on every explicit connect, which hides the per-radio auto-connect toggle from users. Worth its own follow-up issue.