### PR TITLE
fix(vfo): remove raw deletes in ~VfoWidget — closes #113

### DIFF
--- a/src/gui/widgets/VfoWidget.cpp
+++ b/src/gui/widgets/VfoWidget.cpp
@@ -340,18 +340,15 @@ VfoWidget::VfoWidget(QWidget* parent)
     buildUI();
 }
 
-VfoWidget::~VfoWidget()
-{
-    // Floating buttons are parented to parentWidget() (SpectrumWidget),
-    // not to this widget, so Qt's parent chain won't auto-delete them.
-    // AetherSDR VfoWidget.cpp:223-233 pattern: explicit delete on destruction.
-    // All four pointers are initialized to nullptr in the header, so deletes
-    // are safe even if buildFloatingButtons() was never called.
-    delete m_closeBtn;
-    delete m_lockBtn;
-    delete m_recBtn;
-    delete m_playBtn;
-}
+// Floating buttons (m_closeBtn/m_lockBtn/m_recBtn/m_playBtn) are parented to
+// parentWidget() (SpectrumWidget), i.e. they are SIBLINGS of VfoWidget in
+// SpectrumWidget's children list. Qt's parent chain already owns them — do
+// NOT explicitly delete here. Explicit deletes caused issue #113: Qt's
+// QObjectPrivate::deleteChildren() walks SpectrumWidget's children in an
+// order that freed a floating button before ~VfoWidget ran, leaving the
+// button pointer dangling and SIGSEGV'ing the delete. Same fix as fd03d51;
+// regressed by ff94942.
+VfoWidget::~VfoWidget() = default;
 
 void VfoWidget::buildUI()
 {


### PR DESCRIPTION
## Summary

- Fixes [#113](https://github.com/boydsoftprez/NereusSDR/issues/113) — SIGSEGV in `NereusSDR::VfoWidget::~VfoWidget()` on exit, reported against 0.2.1 and 0.2.2 on Linux / HL2.
- Reverts the destructor to `= default`. The 4 floating buttons (`m_closeBtn` / `m_lockBtn` / `m_recBtn` / `m_playBtn`) are parented to `parentWidget()` (SpectrumWidget), i.e. siblings of `VfoWidget` in SpectrumWidget's children list — Qt already owns them.
- Adds an explanatory comment citing the fix history so this doesn't re-regress.

## Root cause

Explicit `delete m_closeBtn;` etc. in the destructor races Qt's `QObjectPrivate::deleteChildren()`. When SpectrumWidget tears down, Qt walks its children list and whichever floating button gets freed before `~VfoWidget()` runs leaves the pointer dangling — the subsequent `delete` in `~VfoWidget` hits freed memory → SIGSEGV, frame 0 in `~VfoWidget()` exactly matching the backtrace in the issue.

## History

This is a regression. The same bug was fixed in [fd03d51](https://github.com/boydsoftprez/NereusSDR/commit/fd03d51) on 2026-04-14 with the same diagnosis ("whichever floating button got freed first left VfoWidget double-deleting a dangling pointer on shutdown. Let Qt's parent ownership handle it"). Then [ff94942](https://github.com/boydsoftprez/NereusSDR/commit/ff94942) on 2026-04-15 reintroduced the explicit deletes during the phase3g10 floating-button wiring, rationalizing them as required for cleanup — but Qt's parent chain already handles it since the buttons are SpectrumWidget's children.

## Test plan

- [x] Local build (macOS RelWithDebInfo) clean — 304/304 objects
- [ ] Linux AppImage smoke: launch → connect HL2 → disconnect → exit cleanly, no core dump (reproduces original issue)
- [ ] Verify no visible change to the floating buttons (close / lock / record / play) during normal operation
- [ ] Reporter (@bluzee) confirms fix on their setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)