### PR TITLE
fix(audio): honor deviceName + fall back through enum list (issue #112)

### DIFF
--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -14,6 +14,109 @@
 
 namespace NereusSDR {
 
+namespace {
+
+// Resolve a PortAudio device index from a PortAudioConfig, with a robust
+// fallback chain. Returns paNoDevice if no suitable device exists on the
+// system. Fixes issue #112: the 0.2.2 IAudioBus refactor hard-coded
+// Pa_GetDefaultOutputDevice(), which returns paNoDevice on Linux hosts
+// that lack an ALSA default (e.g. Ubuntu/PipeWire without pipewire-alsa).
+// It also ignored cfg.deviceName and cfg.hostApiIndex so users couldn't
+// work around it by picking a specific device in Setup → Audio → Devices.
+//
+// Resolution order:
+//   1. If deviceName non-empty: match against all devices of the right
+//      direction (preferring cfg.hostApiIndex if specified). Matching is
+//      case-insensitive and prefers exact match, falling back to
+//      substring match — PortAudio device names vary subtly by host API
+//      and Qt settings may round-trip a slightly different string.
+//   2. Default device for cfg.hostApiIndex (if >= 0 and valid).
+//   3. PortAudio default output / input device.
+//   4. First enumerated device with the correct direction (channels > 0).
+//      This is the critical fallback for the #112 scenario — even when
+//      there is no ALSA default, PortAudio typically still enumerates
+//      "hw:0,0" etc., which at least lets audio reach the user.
+PaDeviceIndex resolveDevice(const PortAudioConfig& cfg,
+                            bool wantOutput)
+{
+    const int deviceCount = Pa_GetDeviceCount();
+    if (deviceCount <= 0) {
+        return paNoDevice;
+    }
+
+    auto directionOk = [wantOutput](const PaDeviceInfo* di) {
+        if (!di) { return false; }
+        return wantOutput ? di->maxOutputChannels > 0
+                          : di->maxInputChannels  > 0;
+    };
+
+    // 1. Named-device match.
+    if (!cfg.deviceName.isEmpty()) {
+        const QString wanted = cfg.deviceName.trimmed();
+        PaDeviceIndex exactMatch     = paNoDevice;
+        PaDeviceIndex substringMatch = paNoDevice;
+        PaDeviceIndex crossApiExact  = paNoDevice;
+        PaDeviceIndex crossApiSub    = paNoDevice;
+
+        for (int i = 0; i < deviceCount; ++i) {
+            const PaDeviceInfo* di = Pa_GetDeviceInfo(i);
+            if (!directionOk(di)) { continue; }
+            const QString name = QString::fromUtf8(di->name);
+            const bool sameApi = (cfg.hostApiIndex < 0)
+                                 || (di->hostApi == cfg.hostApiIndex);
+            const bool exact = (name.compare(wanted, Qt::CaseInsensitive) == 0);
+            const bool sub   = name.contains(wanted, Qt::CaseInsensitive);
+
+            if (sameApi && exact && exactMatch == paNoDevice) {
+                exactMatch = i;
+            } else if (sameApi && sub && substringMatch == paNoDevice) {
+                substringMatch = i;
+            } else if (!sameApi && exact && crossApiExact == paNoDevice) {
+                crossApiExact = i;
+            } else if (!sameApi && sub && crossApiSub == paNoDevice) {
+                crossApiSub = i;
+            }
+        }
+        if (exactMatch     != paNoDevice) { return exactMatch; }
+        if (substringMatch != paNoDevice) { return substringMatch; }
+        if (crossApiExact  != paNoDevice) { return crossApiExact; }
+        if (crossApiSub    != paNoDevice) { return crossApiSub; }
+        // Named device not found: fall through to defaults rather than
+        // erroring out — better silent fallback than no audio at all.
+    }
+
+    // 2. Host-API default.
+    if (cfg.hostApiIndex >= 0) {
+        const PaHostApiInfo* hai = Pa_GetHostApiInfo(cfg.hostApiIndex);
+        if (hai) {
+            const PaDeviceIndex d = wantOutput
+                ? hai->defaultOutputDevice
+                : hai->defaultInputDevice;
+            if (d != paNoDevice && directionOk(Pa_GetDeviceInfo(d))) {
+                return d;
+            }
+        }
+    }
+
+    // 3. Global default.
+    const PaDeviceIndex def = wantOutput
+        ? Pa_GetDefaultOutputDevice()
+        : Pa_GetDefaultInputDevice();
+    if (def != paNoDevice && directionOk(Pa_GetDeviceInfo(def))) {
+        return def;
+    }
+
+    // 4. First enumerated device with matching direction.
+    for (int i = 0; i < deviceCount; ++i) {
+        const PaDeviceInfo* di = Pa_GetDeviceInfo(i);
+        if (directionOk(di)) { return i; }
+    }
+
+    return paNoDevice;
+}
+
+} // namespace
+
 PortAudioBus::PortAudioBus() {
     // 1 second stereo float ring at the nominal default rate. The push
     // path wraps modulo ring size, so a longer stream than 1 s simply
@@ -35,51 +138,36 @@ bool PortAudioBus::open(const AudioFormat& format) {
         close();
     }
 
+    const bool wantOutput = (m_cfg.direction == AudioDirection::Output);
+
     PaStreamParameters params;
     PaError err = paNoError;
     const PaDeviceInfo* di = nullptr;
 
-    if (m_cfg.direction == AudioDirection::Output) {
-        params.device = Pa_GetDefaultOutputDevice();
-        if (params.device == paNoDevice) {
-            m_err = QStringLiteral("No default output device");
-            return false;
-        }
-        di = Pa_GetDeviceInfo(params.device);
-        if (di == nullptr) {
-            m_err = QStringLiteral("Pa_GetDeviceInfo returned null for default device");
-            return false;
-        }
-        params.channelCount              = format.channels;
-        params.sampleFormat              = paFloat32;
-        params.suggestedLatency          = di->defaultLowOutputLatency;
-        params.hostApiSpecificStreamInfo = nullptr;
-
-        err = Pa_OpenStream(
-            &m_stream, nullptr, &params,
-            format.sampleRate, m_cfg.bufferSamples,
-            paClipOff, &PortAudioBus::paCallback, this);
-    } else {
-        params.device = Pa_GetDefaultInputDevice();
-        if (params.device == paNoDevice) {
-            m_err = QStringLiteral("No default input device");
-            return false;
-        }
-        di = Pa_GetDeviceInfo(params.device);
-        if (di == nullptr) {
-            m_err = QStringLiteral("Pa_GetDeviceInfo returned null for default device");
-            return false;
-        }
-        params.channelCount              = format.channels;
-        params.sampleFormat              = paFloat32;
-        params.suggestedLatency          = di->defaultLowInputLatency;
-        params.hostApiSpecificStreamInfo = nullptr;
-
-        err = Pa_OpenStream(
-            &m_stream, &params, nullptr,
-            format.sampleRate, m_cfg.bufferSamples,
-            paClipOff, &PortAudioBus::paCallback, this);
+    params.device = resolveDevice(m_cfg, wantOutput);
+    if (params.device == paNoDevice) {
+        m_err = wantOutput
+            ? QStringLiteral("No output device found")
+            : QStringLiteral("No input device found");
+        return false;
     }
+    di = Pa_GetDeviceInfo(params.device);
+    if (di == nullptr) {
+        m_err = QStringLiteral("Pa_GetDeviceInfo returned null for resolved device");
+        return false;
+    }
+    params.channelCount              = format.channels;
+    params.sampleFormat              = paFloat32;
+    params.suggestedLatency          = wantOutput ? di->defaultLowOutputLatency
+                                                  : di->defaultLowInputLatency;
+    params.hostApiSpecificStreamInfo = nullptr;
+
+    err = Pa_OpenStream(
+        &m_stream,
+        wantOutput ? nullptr : &params,
+        wantOutput ? &params : nullptr,
+        format.sampleRate, m_cfg.bufferSamples,
+        paClipOff, &PortAudioBus::paCallback, this);
 
     if (err != paNoError) {
         m_err = QString::fromUtf8(Pa_GetErrorText(err));

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -37,7 +37,8 @@ namespace {
 //      there is no ALSA default, PortAudio typically still enumerates
 //      "hw:0,0" etc., which at least lets audio reach the user.
 PaDeviceIndex resolveDevice(const PortAudioConfig& cfg,
-                            bool wantOutput)
+                            bool wantOutput,
+                            int requestedChannels)
 {
     const int deviceCount = Pa_GetDeviceCount();
     if (deviceCount <= 0) {
@@ -48,6 +49,18 @@ PaDeviceIndex resolveDevice(const PortAudioConfig& cfg,
         if (!di) { return false; }
         return wantOutput ? di->maxOutputChannels > 0
                           : di->maxInputChannels  > 0;
+    };
+
+    // Step 4 capacity check: prefer devices that actually support the
+    // requested channel count. Without this, the first enumerated output
+    // on a mono-first system (e.g. a USB webcam enumerated ahead of the
+    // onboard stereo card) causes Pa_OpenStream to fail with
+    // paInvalidChannelCount even though a later device would succeed.
+    auto capacityOk = [wantOutput, requestedChannels](const PaDeviceInfo* di) {
+        if (!di) { return false; }
+        const int avail = wantOutput ? di->maxOutputChannels
+                                     : di->maxInputChannels;
+        return avail >= requestedChannels;
     };
 
     // 1. Named-device match.
@@ -106,13 +119,19 @@ PaDeviceIndex resolveDevice(const PortAudioConfig& cfg,
         return def;
     }
 
-    // 4. First enumerated device with matching direction.
+    // 4. First enumerated device with matching direction — prefer one
+    //    that satisfies the requested channel count, fall back to any
+    //    direction-valid device if none does (Pa_OpenStream will then
+    //    surface a clear paInvalidChannelCount error, better than
+    //    silently picking step 3's default which may not even exist).
+    PaDeviceIndex anyDirection = paNoDevice;
     for (int i = 0; i < deviceCount; ++i) {
         const PaDeviceInfo* di = Pa_GetDeviceInfo(i);
-        if (directionOk(di)) { return i; }
+        if (!directionOk(di)) { continue; }
+        if (capacityOk(di))   { return i; }
+        if (anyDirection == paNoDevice) { anyDirection = i; }
     }
-
-    return paNoDevice;
+    return anyDirection;
 }
 
 } // namespace
@@ -144,7 +163,7 @@ bool PortAudioBus::open(const AudioFormat& format) {
     PaError err = paNoError;
     const PaDeviceInfo* di = nullptr;
 
-    params.device = resolveDevice(m_cfg, wantOutput);
+    params.device = resolveDevice(m_cfg, wantOutput, format.channels);
     if (params.device == paNoDevice) {
         m_err = wantOutput
             ? QStringLiteral("No output device found")

--- a/tests/tst_port_audio_bus.cpp
+++ b/tests/tst_port_audio_bus.cpp
@@ -74,6 +74,56 @@ private slots:
         bus.close();
         QVERIFY(!bus.isOpen());
     }
+
+    // Issue #112: open() must honor cfg.deviceName. Pick the first
+    // enumerated output device, feed its name through PortAudioConfig,
+    // and verify the bus opens — previously open() always called
+    // Pa_GetDefaultOutputDevice() and ignored the configured name.
+    void openHonorsConfiguredDeviceName() {
+        const auto apis = PortAudioBus::hostApis();
+        if (apis.isEmpty()) { QSKIP("No PortAudio host APIs on test host"); }
+
+        PortAudioBus::DeviceInfo target{};
+        bool found = false;
+        for (const auto& api : apis) {
+            const auto devs = PortAudioBus::outputDevicesFor(api.index);
+            if (!devs.isEmpty()) { target = devs.first(); found = true; break; }
+        }
+        if (!found) { QSKIP("No output devices on test host"); }
+
+        PortAudioBus bus;
+        PortAudioConfig cfg;
+        cfg.direction    = AudioDirection::Output;
+        cfg.hostApiIndex = target.hostApiIndex;
+        cfg.deviceName   = target.name;
+        bus.setConfig(cfg);
+
+        AudioFormat f;
+        QVERIFY2(bus.open(f), qPrintable(bus.errorString()));
+        QVERIFY(bus.isOpen());
+        bus.close();
+    }
+
+    // Issue #112: when cfg.deviceName doesn't match anything, open() must
+    // fall back through (host-api default → global default → first
+    // enumerated output device) rather than erroring out — on systems
+    // without a configured ALSA default, that final fallback is the only
+    // thing that keeps audio reaching the user.
+    void openFallsBackWhenNameMissing() {
+        PortAudioBus bus;
+        PortAudioConfig cfg;
+        cfg.direction  = AudioDirection::Output;
+        cfg.deviceName = QStringLiteral("::no_such_device_name_12345::");
+        bus.setConfig(cfg);
+
+        AudioFormat f;
+        if (!bus.open(f)) {
+            QSKIP(qPrintable(QStringLiteral("No output devices on test host: ")
+                             + bus.errorString()));
+        }
+        QVERIFY(bus.isOpen());
+        bus.close();
+    }
 };
 
 QTEST_APPLESS_MAIN(TstPortAudioBus)

--- a/tests/tst_port_audio_bus.cpp
+++ b/tests/tst_port_audio_bus.cpp
@@ -124,6 +124,41 @@ private slots:
         QVERIFY(bus.isOpen());
         bus.close();
     }
+
+    // Issue #115 / Codex P2: step-4 fallback must respect the requested
+    // channel count. If the host has at least one stereo-capable output
+    // device, a stereo request must not end up on a mono device — even
+    // if a mono device was enumerated first.
+    void openFallbackRespectsChannelCapacity() {
+        // Find any stereo-capable output; skip if the host has none.
+        const auto apis = PortAudioBus::hostApis();
+        bool hasStereoOutput = false;
+        for (const auto& api : apis) {
+            const auto devs = PortAudioBus::outputDevicesFor(api.index);
+            for (const auto& d : devs) {
+                if (d.maxOutputChannels >= 2) { hasStereoOutput = true; break; }
+            }
+            if (hasStereoOutput) { break; }
+        }
+        if (!hasStereoOutput) {
+            QSKIP("No stereo-capable output device on test host");
+        }
+
+        PortAudioBus bus;
+        PortAudioConfig cfg;
+        cfg.direction  = AudioDirection::Output;
+        cfg.deviceName = QStringLiteral("::force_fallback_::");
+        bus.setConfig(cfg);
+
+        AudioFormat f;
+        f.channels = 2;
+        QVERIFY2(bus.open(f), qPrintable(bus.errorString()));
+        QVERIFY(bus.isOpen());
+        // negotiatedFormat carries what we asked for; the device must
+        // have had capacity for it or Pa_OpenStream would have failed.
+        QCOMPARE(bus.negotiatedFormat().channels, 2);
+        bus.close();
+    }
 };
 
 QTEST_APPLESS_MAIN(TstPortAudioBus)


### PR DESCRIPTION
## Summary

- Fix Linux audio regression in 0.2.2 where speakers bus silently failed to open on Ubuntu/PipeWire hosts without an ALSA default (issue #112).
- `PortAudioBus::open()` now honors `cfg.deviceName` and `cfg.hostApiIndex` — the Setup → Audio → Devices picker was previously a no-op.
- Adds a 4-step fallback chain so the bus still opens against the first enumerated output device when no default is configured.

## Root cause

Phase 3O switched the speakers path from Qt's `QAudioSink` (talks to PipeWire through Qt Multimedia) to `PortAudioBus`. The new code called `Pa_GetDefaultOutputDevice()` unconditionally — which returns `paNoDevice` on systems without a PCM default — and ignored `cfg.deviceName` / `cfg.hostApiIndex`, so users couldn't work around it in the UI either.

## Fallback chain

1. Named-device match (exact, then substring; prefer configured host API, fall across APIs if needed)
2. Host-API default for `cfg.hostApiIndex`
3. Global `Pa_GetDefault{Output,Input}Device()`
4. First enumerated device with matching direction — unblocks the #112 scenario (PortAudio typically still enumerates `hw:0,0` on Ubuntu even without a PCM default)

## Test plan

- [x] `tst_port_audio_bus` (10 passing, 1 skip) — two new cases: `openHonorsConfiguredDeviceName`, `openFallsBackWhenNameMissing`
- [x] Full ctest suite (113/113 pass)
- [ ] Linux smoke (waiting on #112 reporter; regression can't be reproduced on macOS)
- [ ] Windows smoke (WASAPI path — defaults are reliable there but the new match-by-name path should still route device picks correctly)

## Follow-ups (not in this PR)

- If someone has a Linux host where PortAudio enumerates **zero** output devices, step 4 still fails. That case needs a Qt `QAudioSink` fallback bus (or docs pointing at `pipewire-alsa`). Will file a follow-up issue if #112 reporter confirms this PR alone is sufficient.

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)