### PR TITLE
fix(vax): honest HAL detection UX on macOS/Linux

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -768,6 +768,15 @@ float AudioEngine::vaxRxLevel(int channel) const
     return bus->rxLevel();
 }
 
+bool AudioEngine::isVaxBusOpen(int channel) const
+{
+    if (channel < 1 || channel > 4) {
+        return false;
+    }
+    const IAudioBus* bus = m_vaxBus[channel - 1].get();
+    return bus != nullptr && bus->isOpen();
+}
+
 float AudioEngine::vaxTxLevel() const
 {
     const IAudioBus* bus = m_vaxTxBus.get();

--- a/src/core/AudioEngine.h
+++ b/src/core/AudioEngine.h
@@ -219,6 +219,15 @@ public:
     float vaxRxLevel(int channel) const;
     float vaxTxLevel() const;
 
+    // True when the VAX slot's IAudioBus has been minted AND its open() call
+    // succeeded. False when the slot is empty (pre-start, user-disabled via
+    // setVaxEnabled(false)) OR when makeVaxBus() / makeBus() failed to open
+    // the underlying device (CoreAudio HAL not loaded, shm mmap failed,
+    // PortAudio cable unplugged mid-session, etc.).  Drives the Setup →
+    // Audio → VAX card banner so users see an amber "unavailable" state
+    // rather than a false-positive green "bound" when the route is broken.
+    bool isVaxBusOpen(int channel) const;
+
 signals:
     void volumeChanged(float volume);
     void masterMutedChanged(bool muted);

--- a/src/gui/VaxFirstRunDialog.cpp
+++ b/src/gui/VaxFirstRunDialog.cpp
@@ -682,16 +682,64 @@ void VaxFirstRunDialog::buildBodyWindowsNoCables(QVBoxLayout* bodyLayout)
 
 void VaxFirstRunDialog::buildBodyMacNative(QVBoxLayout* bodyLayout)
 {
-    // Intro — byte-verbatim from mockup.
+    // Per-slot HAL-detection map. Earlier revisions hardcoded "Ready" for
+    // all 4 rows regardless of m_detected, so the dialog happily claimed
+    // the plugin was live even on installs where it had been removed or
+    // blocked (e.g. System Settings → Privacy had coreaudiod quarantined
+    // after a bad install). Drive slot status from m_detected so the UX
+    // doesn't lie on broken installs.
+    std::array<bool, 4> slotDetected{false, false, false, false};
+    for (const auto& cable : m_detected) {
+        if (cable.product != VirtualCableProduct::NereusSdrVax) {
+            continue;
+        }
+        // Device name matches "NereusSDR VAX <digit>" (enforced by the
+        // VirtualCableDetector::matchProduct regex). Pull the digit off
+        // the tail to place the row in the right slot; anything that
+        // doesn't trail with 1-4 gets ignored here.
+        const QChar c = cable.deviceName.isEmpty()
+                             ? QChar(0)
+                             : cable.deviceName.back();
+        const int slot = c.isDigit() ? (c.digitValue()) : 0;
+        if (slot >= 1 && slot <= 4) {
+            slotDetected[slot - 1] = true;
+        }
+    }
+
+    int detectedCount = 0;
+    for (bool on : slotDetected) {
+        if (on) { ++detectedCount; }
+    }
+
+    // Intro — adapts to actual detection count. "All 4 ready" when the
+    // plugin is fully live; "<N> of 4 ready" when partial; a clear
+    // "not detected" warning when coreaudiod hasn't loaded the driver.
     auto* intro = new QLabel(this);
     intro->setTextFormat(Qt::RichText);
     intro->setWordWrap(true);
     intro->setStyleSheet(introLabelStyle());
-    intro->setText(QStringLiteral(
-        "NereusSDR ships native VAX audio devices on macOS."
-        " <b style='color:%1'>All 4 VAX channels are ready to use</b>"
-        " &mdash; no extra installation needed.")
-        .arg(Style::kAccent));
+    if (detectedCount == 4) {
+        intro->setText(QStringLiteral(
+            "NereusSDR ships native VAX audio devices on macOS."
+            " <b style='color:%1'>All 4 VAX channels are ready to use</b>"
+            " &mdash; no extra installation needed.")
+            .arg(Style::kAccent));
+    } else if (detectedCount > 0) {
+        intro->setText(QStringLiteral(
+            "NereusSDR ships native VAX audio devices on macOS."
+            " <b style='color:%1'>%2 of 4 VAX channels detected.</b>"
+            " Reinstall NereusSDR if this persists.")
+            .arg(Style::kAmberText)
+            .arg(detectedCount));
+    } else {
+        intro->setText(QStringLiteral(
+            "NereusSDR ships a native CoreAudio HAL plugin for VAX."
+            " <b style='color:%1'>The HAL plugin was not detected.</b>"
+            " Reinstall NereusSDR or unblock"
+            " <code>NereusSDRVAX.driver</code> in System Settings"
+            " &rarr; Privacy &amp; Security to enable native VAX.")
+            .arg(Style::kAmberText));
+    }
     bodyLayout->addWidget(intro);
 
     auto* listFrame = new QFrame(this);
@@ -703,6 +751,8 @@ void VaxFirstRunDialog::buildBodyMacNative(QVBoxLayout* bodyLayout)
 
     // Row 1 has the "NereusSDR TX" tail per mockup; rows 2-4 are the
     // plain "NereusSDR VAX N" line. Device-name copy byte-verbatim.
+    // Each row's status pill flips between "Ready" (detected) and
+    // "— not detected —" (absent from m_detected).
     for (int slot = 1; slot <= 4; ++slot) {
         QString deviceLine;
         if (slot == 1) {
@@ -711,11 +761,20 @@ void VaxFirstRunDialog::buildBodyMacNative(QVBoxLayout* bodyLayout)
         } else {
             deviceLine = QStringLiteral("NereusSDR VAX %1").arg(slot);
         }
-        listLayout->addWidget(makeDetRow(
-            slot, deviceLine,
-            QStringLiteral("CoreAudio HAL \u2022 native"),
-            QStringLiteral("Ready"), pillNewStyle(),
-            QString(), listFrame));
+        if (slotDetected[slot - 1]) {
+            listLayout->addWidget(makeDetRow(
+                slot, deviceLine,
+                QStringLiteral("CoreAudio HAL \u2022 native"),
+                QStringLiteral("Ready"), pillNewStyle(),
+                QString(), listFrame));
+        } else {
+            listLayout->addWidget(makeDetRow(
+                slot, deviceLine,
+                QStringLiteral("CoreAudio HAL \u2022 not loaded"),
+                QString(), QString(),
+                QStringLiteral("not detected"),
+                listFrame));
+        }
     }
     bodyLayout->addWidget(listFrame);
 

--- a/src/gui/setup/AudioVaxPage.cpp
+++ b/src/gui/setup/AudioVaxPage.cpp
@@ -68,7 +68,59 @@ static const char* kAutoDetectStyle =
     "}"
     "QPushButton:hover { background: #1d3045; }";
 
+// Binding-status banner — persistent one-line indicator at the top of each
+// VaxChannelCard. Colour encodes state: green = native HAL active, blue =
+// BYO cable bound, amber = nothing bound (Windows case).
+[[maybe_unused]] static const char* kStatusNativeStyle =
+    "QLabel {"
+    "  background: #0f2a1a;"
+    "  border: 1px solid #2a6a3a;"
+    "  border-radius: 3px;"
+    "  color: #00ff88;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 8px;"
+    "}";
+
+static const char* kStatusBYOStyle =
+    "QLabel {"
+    "  background: #0f2030;"
+    "  border: 1px solid #2a5a8a;"
+    "  border-radius: 3px;"
+    "  color: #00b4d8;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 8px;"
+    "}";
+
+[[maybe_unused]] static const char* kStatusUnboundStyle =
+    "QLabel {"
+    "  background: #2a1a00;"
+    "  border: 1px solid #b87300;"
+    "  border-radius: 3px;"
+    "  color: #e8a030;"
+    "  font-size: 11px;"
+    "  font-weight: bold;"
+    "  padding: 3px 8px;"
+    "}";
+
+// Label builder for the disabled "native (bound automatically)" info
+// row shown at the top of the Auto-detect menu on Mac/Linux when the
+// platform-native HAL/pipe bridge is live. Exposed via a static
+// VaxChannelCard::nativeHalLabelForCableForTest seam for unit coverage.
+QString nativeHalLabelForCableImpl(const DetectedCable& cable)
+{
+    return QStringLiteral(
+               "\u25ba  %1 \u00b7 NereusSDR \u00b7 native (bound automatically)")
+        .arg(cable.deviceName);
+}
+
 } // namespace
+
+QString VaxChannelCard::nativeHalLabelForCable(const DetectedCable& cable)
+{
+    return nativeHalLabelForCableImpl(cable);
+}
 
 // ---------------------------------------------------------------------------
 // VaxChannelCard
@@ -83,6 +135,14 @@ VaxChannelCard::VaxChannelCard(int channel, QWidget* parent)
     auto* outerLayout = new QVBoxLayout(this);
     outerLayout->setContentsMargins(8, 16, 8, 8);
     outerLayout->setSpacing(6);
+
+    // Persistent binding-status banner — always-visible one-liner telling
+    // the user what this channel is currently routed through. Populated
+    // in updateBindingStatus(), which is driven off currentDeviceName().
+    m_statusLabel = new QLabel(this);
+    m_statusLabel->setWordWrap(false);
+    m_statusLabel->setTextFormat(Qt::PlainText);
+    outerLayout->addWidget(m_statusLabel);
 
     // Inner DeviceCard (7-row form + enable checkbox in title).
     m_deviceCard = new DeviceCard(m_prefix, DeviceCard::Role::Output,
@@ -115,6 +175,10 @@ VaxChannelCard::VaxChannelCard(int channel, QWidget* parent)
             this, &VaxChannelCard::onInnerEnabledChanged);
     connect(m_autoDetectBtn, &QPushButton::clicked,
             this, &VaxChannelCard::onAutoDetectClicked);
+
+    // Populate the status banner with the card's initial state so it reads
+    // correctly even if loadFromSettings() isn't invoked (tests, previews).
+    updateBadge();
 }
 
 void VaxChannelCard::loadFromSettings()
@@ -215,8 +279,67 @@ void VaxChannelCard::onInnerEnabledChanged(bool on)
 void VaxChannelCard::updateBadge()
 {
     // Auto-detect button: show when no device is bound (name empty).
-    const bool hasDevice = !currentDeviceName().isEmpty();
+    const QString deviceName = currentDeviceName();
+    const bool hasDevice = !deviceName.isEmpty();
     m_autoDetectBtn->setVisible(!hasDevice);
+
+    // Persistent binding-status banner — answers "what is this channel
+    // routed through?" at a glance. Three states: native HAL (green),
+    // BYO cable (blue), unbound (amber, Windows-only case).
+    if (m_statusLabel) {
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+        if (hasDevice) {
+            m_statusLabel->setStyleSheet(QLatin1String(kStatusBYOStyle));
+            m_statusLabel->setText(
+                QStringLiteral("\u2713  Bound: %1").arg(deviceName));
+            m_statusLabel->setToolTip(QStringLiteral(
+                "VAX channel is routed through the selected 3rd-party "
+                "virtual cable (BYO override). Clear the Device picker "
+                "to fall back to the native HAL/pipe bridge."));
+        } else {
+#  if defined(Q_OS_MAC)
+            const QString nativeName =
+                QStringLiteral("NereusSDR VAX %1").arg(m_channel);
+            m_statusLabel->setText(
+                QStringLiteral("\u2713  Bound: Native HAL \u00b7 %1")
+                    .arg(nativeName));
+            m_statusLabel->setToolTip(QStringLiteral(
+                "VAX channel is routed through the bundled CoreAudio "
+                "HAL plugin. Consumer apps (WSJT-X, FLDIGI, etc.) can "
+                "select \"%1\" as their audio input device.")
+                .arg(nativeName));
+#  else
+            const QString nativeName =
+                QStringLiteral("NereusSDR VAX %1").arg(m_channel);
+            m_statusLabel->setText(
+                QStringLiteral("\u2713  Bound: Native (PipeWire) \u00b7 %1")
+                    .arg(nativeName));
+            m_statusLabel->setToolTip(QStringLiteral(
+                "VAX channel is routed through a native PipeWire pipe "
+                "source. Consumer apps can select \"%1\" as their audio "
+                "input device.")
+                .arg(nativeName));
+#  endif
+            m_statusLabel->setStyleSheet(QLatin1String(kStatusNativeStyle));
+        }
+#else  // Q_OS_WIN
+        if (hasDevice) {
+            m_statusLabel->setStyleSheet(QLatin1String(kStatusBYOStyle));
+            m_statusLabel->setText(
+                QStringLiteral("\u2713  Bound: %1").arg(deviceName));
+            m_statusLabel->setToolTip(QStringLiteral(
+                "VAX channel is routed through the selected virtual cable."));
+        } else {
+            m_statusLabel->setStyleSheet(QLatin1String(kStatusUnboundStyle));
+            m_statusLabel->setText(QStringLiteral(
+                "\u26a0  Not bound \u2014 pick a virtual cable"));
+            m_statusLabel->setToolTip(QStringLiteral(
+                "Windows has no built-in virtual audio cable. Install "
+                "VB-CABLE, Voicemeeter, or VAC and pick it in the Device "
+                "dropdown to enable this VAX channel."));
+        }
+#endif
+    }
 
 #if defined(Q_OS_WIN)
     // Windows has no native HAL fallback — empty deviceName on setVaxConfig
@@ -233,11 +356,10 @@ void VaxChannelCard::updateBadge()
     // The native device name contains "NereusSDR" (reserved for the NereusSDR
     // HAL plugin). If the device is native, badge is always suppressed.
     if (hasDevice) {
-        const QString devName = currentDeviceName();
-        const bool isNative = devName.contains(QStringLiteral("NereusSDR"),
-                                                Qt::CaseInsensitive);
+        const bool isNative = deviceName.contains(QStringLiteral("NereusSDR"),
+                                                   Qt::CaseInsensitive);
         const bool badgeOn = !isNative
-            && (VirtualCableDetector::consumerCount(devName) == 0);
+            && (VirtualCableDetector::consumerCount(deviceName) == 0);
         m_badgeLabel->setVisible(badgeOn);
     } else {
         m_badgeLabel->setVisible(false);
@@ -275,6 +397,29 @@ void VaxChannelCard::onAutoDetectClicked()
         "QMenu::item:selected { background: #203040; }"
         "QMenu::item:disabled { color: #506070; }");
 
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+    // Surface the platform-native HAL/pipe VAX devices as disabled info
+    // rows. Binding is automatic (AudioEngine::makeVaxBus sets up the shm
+    // bridge at start()) so these rows are not selectable — they exist so
+    // users can confirm the native plugin is alive. Absent when the plugin
+    // is not installed; the honest empty menu that follows is informative.
+    int nativeHalCount = 0;
+    for (const DetectedCable& cable : cables) {
+        if (cable.product != VirtualCableProduct::NereusSdrVax) {
+            continue;
+        }
+        // HAL plugin publishes VAX N as input-only on macOS; Linux pipe
+        // module analog is also input-only. Accept either side to future-
+        // proof against a dual-sided native bridge.
+        QAction* act = menu.addAction(nativeHalLabelForCable(cable));
+        act->setEnabled(false);
+        ++nativeHalCount;
+    }
+    if (nativeHalCount > 0) {
+        menu.addSeparator();
+    }
+#endif
+
     if (cables.isEmpty()) {
         // No cables case.
         QAction* noCablesAct = menu.addAction(
@@ -296,6 +441,15 @@ void VaxChannelCard::onAutoDetectClicked()
         // those are the cables that a consumer app reads from).
         bool hasAny = false;
         for (const DetectedCable& cable : cables) {
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+            // Native HAL/pipe entries were already surfaced above as info
+            // rows. Don't re-offer them as BYO targets: the HAL plugin
+            // publishes input-only devices on Mac, so setVaxConfig →
+            // makeBus(capture=false) can't open them via PortAudio.
+            if (cable.product == VirtualCableProduct::NereusSdrVax) {
+                continue;
+            }
+#endif
             if (cable.isInput) {
                 continue; // skip capture side
             }
@@ -377,10 +531,25 @@ void VaxChannelCard::onAutoDetectClicked()
         }
 
         if (!hasAny) {
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+            if (nativeHalCount > 0) {
+                // Native HAL/pipe is already surfaced above. No 3rd-party
+                // BYO cables are installed — hint that this is optional.
+                QAction* hintAct = menu.addAction(
+                    QStringLiteral(
+                        "No 3rd-party cables available (BYO override optional)"));
+                hintAct->setEnabled(false);
+            } else {
+                QAction* noCablesAct = menu.addAction(
+                    QStringLiteral("No output-side virtual cables detected"));
+                noCablesAct->setEnabled(false);
+            }
+#else
             // Only input-side cables found; surface a message.
             QAction* noCablesAct = menu.addAction(
                 QStringLiteral("No output-side virtual cables detected"));
             noCablesAct->setEnabled(false);
+#endif
         }
     }
 

--- a/src/gui/setup/AudioVaxPage.cpp
+++ b/src/gui/setup/AudioVaxPage.cpp
@@ -93,7 +93,7 @@ static const char* kStatusBYOStyle =
     "  padding: 3px 8px;"
     "}";
 
-[[maybe_unused]] static const char* kStatusUnboundStyle =
+static const char* kStatusUnboundStyle =
     "QLabel {"
     "  background: #2a1a00;"
     "  border: 1px solid #b87300;"
@@ -273,7 +273,21 @@ void VaxChannelCard::onInnerConfigChanged(AudioDeviceConfig cfg)
 
 void VaxChannelCard::onInnerEnabledChanged(bool on)
 {
+    // Refresh the banner so the amber "Disabled" / green "Bound" read
+    // flips in lockstep with the checkbox. Without this the user could
+    // uncheck Enabled and still see a stale green "Bound: Native HAL"
+    // even though AudioEngine::setVaxEnabled(false) has closed the bus.
+    updateBadge();
     emit enabledChanged(m_channel, on);
+}
+
+void VaxChannelCard::setBusOpen(bool open)
+{
+    if (m_busOpen == open) {
+        return;
+    }
+    m_busOpen = open;
+    updateBadge();
 }
 
 void VaxChannelCard::updateBadge()
@@ -284,61 +298,141 @@ void VaxChannelCard::updateBadge()
     m_autoDetectBtn->setVisible(!hasDevice);
 
     // Persistent binding-status banner — answers "what is this channel
-    // routed through?" at a glance. Three states: native HAL (green),
-    // BYO cable (blue), unbound (amber, Windows-only case).
+    // routed through?" at a glance. State machine:
+    //   - enabled=false                  → amber "Disabled"
+    //   - busOpen=false + empty (Mac/Lx) → amber "Native HAL unavailable"
+    //   - busOpen=false + BYO            → amber "Bus failed to open"
+    //   - busOpen=true  + empty (Mac/Lx) → green "Bound: Native HAL · …"
+    //   - busOpen=true  + BYO            → blue  "Bound: <name>"
+    //   - Windows empty                  → amber "Not bound — pick a cable"
+    // enabled+busOpen are tracked separately because setVaxEnabled(false)
+    // closes the bus (busOpen=false) but leaves m_engine's accounting
+    // intact, while a makeVaxBus() failure leaves the slot null without
+    // the user ever unchecking anything.
     if (m_statusLabel) {
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
-        if (hasDevice) {
-            m_statusLabel->setStyleSheet(QLatin1String(kStatusBYOStyle));
-            m_statusLabel->setText(
-                QStringLiteral("\u2713  Bound: %1").arg(deviceName));
-            m_statusLabel->setToolTip(QStringLiteral(
-                "VAX channel is routed through the selected 3rd-party "
-                "virtual cable (BYO override). Clear the Device picker "
-                "to fall back to the native HAL/pipe bridge."));
-        } else {
-#  if defined(Q_OS_MAC)
-            const QString nativeName =
-                QStringLiteral("NereusSDR VAX %1").arg(m_channel);
-            m_statusLabel->setText(
-                QStringLiteral("\u2713  Bound: Native HAL \u00b7 %1")
-                    .arg(nativeName));
-            m_statusLabel->setToolTip(QStringLiteral(
-                "VAX channel is routed through the bundled CoreAudio "
-                "HAL plugin. Consumer apps (WSJT-X, FLDIGI, etc.) can "
-                "select \"%1\" as their audio input device.")
-                .arg(nativeName));
-#  else
-            const QString nativeName =
-                QStringLiteral("NereusSDR VAX %1").arg(m_channel);
-            m_statusLabel->setText(
-                QStringLiteral("\u2713  Bound: Native (PipeWire) \u00b7 %1")
-                    .arg(nativeName));
-            m_statusLabel->setToolTip(QStringLiteral(
-                "VAX channel is routed through a native PipeWire pipe "
-                "source. Consumer apps can select \"%1\" as their audio "
-                "input device.")
-                .arg(nativeName));
-#  endif
-            m_statusLabel->setStyleSheet(QLatin1String(kStatusNativeStyle));
-        }
-#else  // Q_OS_WIN
-        if (hasDevice) {
-            m_statusLabel->setStyleSheet(QLatin1String(kStatusBYOStyle));
-            m_statusLabel->setText(
-                QStringLiteral("\u2713  Bound: %1").arg(deviceName));
-            m_statusLabel->setToolTip(QStringLiteral(
-                "VAX channel is routed through the selected virtual cable."));
-        } else {
+        const bool enabled = isChannelEnabled();
+        if (!enabled) {
             m_statusLabel->setStyleSheet(QLatin1String(kStatusUnboundStyle));
             m_statusLabel->setText(QStringLiteral(
-                "\u26a0  Not bound \u2014 pick a virtual cable"));
+                "\u26a0  Disabled \u2014 enable to route audio"));
             m_statusLabel->setToolTip(QStringLiteral(
-                "Windows has no built-in virtual audio cable. Install "
-                "VB-CABLE, Voicemeeter, or VAC and pick it in the Device "
-                "dropdown to enable this VAX channel."));
-        }
+                "The VAX channel's Enabled checkbox is off. Check it to "
+                "open the audio bus and route receiver audio through this "
+                "slot."));
+        } else {
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+            const QString nativeName =
+                QStringLiteral("NereusSDR VAX %1").arg(m_channel);
+            if (hasDevice) {
+                // BYO override path.
+                if (!m_busOpen) {
+                    m_statusLabel->setStyleSheet(
+                        QLatin1String(kStatusUnboundStyle));
+                    m_statusLabel->setText(
+                        QStringLiteral("\u26a0  Bus failed to open: %1")
+                            .arg(deviceName));
+                    m_statusLabel->setToolTip(QStringLiteral(
+                        "NereusSDR tried to open the selected 3rd-party "
+                        "virtual cable but the PortAudio stream failed. "
+                        "The device may be busy, unplugged, or the "
+                        "Driver API / sample-rate combo may be "
+                        "unsupported. Clear the Device picker to fall "
+                        "back to the native HAL/pipe bridge."));
+                } else {
+                    m_statusLabel->setStyleSheet(
+                        QLatin1String(kStatusBYOStyle));
+                    m_statusLabel->setText(
+                        QStringLiteral("\u2713  Bound: %1").arg(deviceName));
+                    m_statusLabel->setToolTip(QStringLiteral(
+                        "VAX channel is routed through the selected "
+                        "3rd-party virtual cable (BYO override). Clear "
+                        "the Device picker to fall back to the native "
+                        "HAL/pipe bridge."));
+                }
+            } else {
+                // Native HAL / pipe bridge path.
+                if (!m_busOpen) {
+                    m_statusLabel->setStyleSheet(
+                        QLatin1String(kStatusUnboundStyle));
+#  if defined(Q_OS_MAC)
+                    m_statusLabel->setText(QStringLiteral(
+                        "\u26a0  Native HAL unavailable \u2014 reinstall "
+                        "NereusSDR"));
+                    m_statusLabel->setToolTip(QStringLiteral(
+                        "NereusSDR could not open the bundled CoreAudio "
+                        "HAL plugin's shared-memory bridge. Reinstall "
+                        "NereusSDR, or unblock NereusSDRVAX.driver in "
+                        "System Settings \u2192 Privacy & Security."));
+#  else
+                    m_statusLabel->setText(QStringLiteral(
+                        "\u26a0  Native PipeWire bridge unavailable"));
+                    m_statusLabel->setToolTip(QStringLiteral(
+                        "NereusSDR could not create a PipeWire "
+                        "pipe-source for this VAX slot. Check that "
+                        "PipeWire is running and that pactl is "
+                        "available on PATH."));
+#  endif
+                } else {
+                    m_statusLabel->setStyleSheet(
+                        QLatin1String(kStatusNativeStyle));
+#  if defined(Q_OS_MAC)
+                    m_statusLabel->setText(
+                        QStringLiteral(
+                            "\u2713  Bound: Native HAL \u00b7 %1")
+                            .arg(nativeName));
+                    m_statusLabel->setToolTip(QStringLiteral(
+                        "VAX channel is routed through the bundled "
+                        "CoreAudio HAL plugin. Consumer apps (WSJT-X, "
+                        "FLDIGI, etc.) can select \"%1\" as their "
+                        "audio input device.")
+                            .arg(nativeName));
+#  else
+                    m_statusLabel->setText(
+                        QStringLiteral(
+                            "\u2713  Bound: Native (PipeWire) \u00b7 %1")
+                            .arg(nativeName));
+                    m_statusLabel->setToolTip(QStringLiteral(
+                        "VAX channel is routed through a native "
+                        "PipeWire pipe source. Consumer apps can select "
+                        "\"%1\" as their audio input device.")
+                            .arg(nativeName));
+#  endif
+                }
+            }
+#else  // Q_OS_WIN
+            if (hasDevice) {
+                if (!m_busOpen) {
+                    m_statusLabel->setStyleSheet(
+                        QLatin1String(kStatusUnboundStyle));
+                    m_statusLabel->setText(
+                        QStringLiteral("\u26a0  Bus failed to open: %1")
+                            .arg(deviceName));
+                    m_statusLabel->setToolTip(QStringLiteral(
+                        "NereusSDR tried to open the selected virtual "
+                        "cable but the PortAudio stream failed. The "
+                        "device may be busy, unplugged, or the Driver "
+                        "API / sample-rate combo may be unsupported."));
+                } else {
+                    m_statusLabel->setStyleSheet(
+                        QLatin1String(kStatusBYOStyle));
+                    m_statusLabel->setText(
+                        QStringLiteral("\u2713  Bound: %1").arg(deviceName));
+                    m_statusLabel->setToolTip(QStringLiteral(
+                        "VAX channel is routed through the selected "
+                        "virtual cable."));
+                }
+            } else {
+                m_statusLabel->setStyleSheet(
+                    QLatin1String(kStatusUnboundStyle));
+                m_statusLabel->setText(QStringLiteral(
+                    "\u26a0  Not bound \u2014 pick a virtual cable"));
+                m_statusLabel->setToolTip(QStringLiteral(
+                    "Windows has no built-in virtual audio cable. "
+                    "Install VB-CABLE, Voicemeeter, or VAC and pick it "
+                    "in the Device dropdown to enable this VAX channel."));
+            }
 #endif
+        }
     }
 
 #if defined(Q_OS_WIN)
@@ -608,13 +702,31 @@ void AudioVaxPage::buildPage()
 
         // Wire configChanged to AudioEngine.
         if (m_engine) {
+            // Seed the card with the engine's current bus-open state so the
+            // banner reflects reality from the first paint (green bound /
+            // amber "Native HAL unavailable" / amber "Bus failed to open").
+            card->setBusOpen(m_engine->isVaxBusOpen(ch));
+
             connect(card, &VaxChannelCard::configChanged, this,
                     [this](int channel, AudioDeviceConfig cfg) {
                 m_engine->setVaxConfig(channel, cfg);
+                // setVaxConfig may have torn down + rebuilt the slot's bus
+                // (BYO path) or fallen back to the native bridge (empty
+                // deviceName). Reflect the post-op open state immediately
+                // so the banner doesn't lag.
+                if (auto* c = channelCard(channel)) {
+                    c->setBusOpen(m_engine->isVaxBusOpen(channel));
+                }
             });
             connect(card, &VaxChannelCard::enabledChanged, this,
                     [this](int channel, bool on) {
                 m_engine->setVaxEnabled(channel, on);
+                // setVaxEnabled(false) closes the bus; setVaxEnabled(true)
+                // re-mints the native or BYO bus. Push the resulting state
+                // back onto the card so the green/amber banner matches.
+                if (auto* c = channelCard(channel)) {
+                    c->setBusOpen(m_engine->isVaxBusOpen(channel));
+                }
             });
         }
     }
@@ -640,12 +752,17 @@ void AudioVaxPage::wirePillFeedback()
         return;
     }
 
-    // Connect AudioEngine::vaxConfigChanged back to each card's pill.
+    // Connect AudioEngine::vaxConfigChanged back to each card's pill and
+    // banner. vaxConfigChanged is also emitted on the resetAudioSettings
+    // path (factory-reset wipe + native-bus re-mint), so the banner has
+    // to re-read isVaxBusOpen here too.
     connect(m_engine, &AudioEngine::vaxConfigChanged, this,
             [this](int channel, AudioDeviceConfig cfg) {
         const int idx = channel - 1;
         if (idx >= 0 && idx < m_channelCards.size()) {
             m_channelCards[idx]->updateNegotiatedPill(cfg);
+            m_channelCards[idx]->setBusOpen(
+                m_engine->isVaxBusOpen(channel));
         }
     });
 }

--- a/src/gui/setup/AudioVaxPage.h
+++ b/src/gui/setup/AudioVaxPage.h
@@ -72,6 +72,12 @@ public:
     // to close the engine bus, and updates badge visibility.
     void clearBinding();
 
+    // Pure label builder for the disabled "native (bound automatically)"
+    // info row shown at the top of the Auto-detect menu on Mac/Linux when
+    // a platform-native HAL/pipe VAX bridge is live. Public so unit tests
+    // can assert the label format without opening a modal QMenu.
+    static QString nativeHalLabelForCable(const DetectedCable& cable);
+
 #ifdef NEREUS_BUILD_TESTS
     // Test seam — override the cable vector used by onAutoDetectClicked()
     // so unit tests can exercise menu population without PortAudio.
@@ -125,6 +131,7 @@ private:
     DeviceCard*  m_deviceCard{nullptr};
     QPushButton* m_autoDetectBtn{nullptr};
     QLabel*      m_badgeLabel{nullptr};
+    QLabel*      m_statusLabel{nullptr};
 
 #ifdef NEREUS_BUILD_TESTS
     bool                    m_useTestCables{false};

--- a/src/gui/setup/AudioVaxPage.h
+++ b/src/gui/setup/AudioVaxPage.h
@@ -115,6 +115,14 @@ public:
 
     int channelIndex() const { return m_channel; }
 
+    // Reflect the actual AudioEngine bus-open state into the card banner.
+    // AudioVaxPage calls this once per card after buildPage() and again on
+    // every AudioEngine::vaxConfigChanged / enabledChanged round-trip so
+    // the banner doesn't lie when makeVaxBus() fails (HAL plugin missing)
+    // or the user toggles the channel off (setVaxEnabled(false) closes
+    // the bus).
+    void setBusOpen(bool open);
+
 signals:
     void configChanged(int channel, NereusSDR::AudioDeviceConfig cfg);
     void enabledChanged(int channel, bool on);
@@ -132,6 +140,13 @@ private:
     QPushButton* m_autoDetectBtn{nullptr};
     QLabel*      m_badgeLabel{nullptr};
     QLabel*      m_statusLabel{nullptr};
+
+    // Mirror of AudioEngine::isVaxBusOpen(m_channel). Defaults to true so
+    // standalone card instances (tests, previews without a RadioModel)
+    // render the "bound" happy path rather than a misleading amber
+    // "unavailable" banner. AudioVaxPage overrides via setBusOpen() once
+    // the engine pointer is in hand.
+    bool         m_busOpen{true};
 
 #ifdef NEREUS_BUILD_TESTS
     bool                    m_useTestCables{false};

--- a/tests/tst_audio_vax_page_auto_detect.cpp
+++ b/tests/tst_audio_vax_page_auto_detect.cpp
@@ -363,6 +363,88 @@ private slots:
         QCOMPARE(s.value(base + QStringLiteral("ManualLatencyMs"), QString()).toString().toInt(), 0);
     }
 
+    // ── 12c. nativeHalLabelForCable (option-2 Mac/Linux info row) ───────────
+    // Pure label builder used by onAutoDetectClicked() on Mac/Linux to
+    // render the disabled "native (bound automatically)" row for each
+    // detected NereusSdrVax device. Assertions keep the label contract
+    // stable so the UI doesn't silently regress when the string changes.
+    void nativeHalLabel_containsDeviceNameAndVendor()
+    {
+        const DetectedCable cable{
+            VirtualCableProduct::NereusSdrVax,
+            QStringLiteral("NereusSDR VAX 1"),
+            /*isInput=*/true, 0};
+
+        const QString label = VaxChannelCard::nativeHalLabelForCable(cable);
+
+        QVERIFY2(label.contains(QStringLiteral("NereusSDR VAX 1")),
+                 qPrintable(QStringLiteral(
+                     "Expected label to contain the device name; got: %1")
+                     .arg(label)));
+        QVERIFY2(label.contains(QStringLiteral("NereusSDR")),
+                 "Expected vendor name in native HAL label");
+        QVERIFY2(label.contains(QStringLiteral("bound automatically"),
+                                Qt::CaseInsensitive),
+                 "Expected native rows to declare they are bound automatically");
+    }
+
+    // ── 12d. Binding-status banner reflects current state ──────────────────
+    // The persistent status banner must always answer "what is this channel
+    // bound to?" without requiring the user to open any menu. Cases:
+    //   - empty deviceName on Mac/Linux → "Bound: Native HAL · NereusSDR VAX N"
+    //   - non-empty deviceName → "Bound: <name>"
+    void statusLabel_reflectsNativeHalWhenUnbound()
+    {
+        clearAudioKeys();
+
+        VaxChannelCard card(2, nullptr);
+        // Status banner is populated from updateBadge() which is invoked at
+        // the end of the ctor. On macOS/Linux an empty deviceName means the
+        // channel is bound to the native HAL/pipe bridge.
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+        QLabel* statusLabel = nullptr;
+        for (QLabel* l : card.findChildren<QLabel*>()) {
+            const QString t = l->text();
+            if (t.contains(QStringLiteral("Bound:"), Qt::CaseInsensitive)) {
+                statusLabel = l;
+                break;
+            }
+        }
+        QVERIFY2(statusLabel, "Expected a binding-status label on VaxChannelCard");
+        QVERIFY2(statusLabel->text().contains(
+                     QStringLiteral("NereusSDR VAX 2")),
+                 qPrintable(QStringLiteral(
+                     "Expected status to name the channel's native HAL device;"
+                     " got: %1").arg(statusLabel->text())));
+#else
+        QSKIP("Native-HAL status only applies on macOS/Linux.");
+#endif
+    }
+
+    void statusLabel_reflectsByoBinding()
+    {
+        clearAudioKeys();
+
+        VaxChannelCard card(3, nullptr);
+        const QString cableName =
+            QStringLiteral("CABLE-A Output (VB-Audio Virtual Cable)");
+        card.bindDeviceNameForTest(cableName);
+
+        QLabel* statusLabel = nullptr;
+        for (QLabel* l : card.findChildren<QLabel*>()) {
+            if (l->text().contains(QStringLiteral("Bound:"),
+                                   Qt::CaseInsensitive)) {
+                statusLabel = l;
+                break;
+            }
+        }
+        QVERIFY2(statusLabel, "Expected a binding-status label on VaxChannelCard");
+        QVERIFY2(statusLabel->text().contains(cableName),
+                 qPrintable(QStringLiteral(
+                     "Expected status to name the BYO cable; got: %1")
+                     .arg(statusLabel->text())));
+    }
+
     // ── 13. autoDetectFreeCable_refreshesDeviceCardUI (C2) ───────────────────
     // After binding via the test seam, currentDeviceName() on the live card
     // must reflect the new binding (not the stale empty value).

--- a/tests/tst_audio_vax_page_auto_detect.cpp
+++ b/tests/tst_audio_vax_page_auto_detect.cpp
@@ -80,6 +80,30 @@ private:
         return {VirtualCableProduct::VbCableA, name, true, 0};
     }
 
+    // Pull the banner QLabel out of a VaxChannelCard. The banner is
+    // the QLabel whose current text matches any of the state-machine
+    // outcomes from updateBadge(). Returns nullptr if none match so
+    // the caller can fail fast.
+    static QLabel* findStatusBanner(VaxChannelCard& card)
+    {
+        for (QLabel* l : card.findChildren<QLabel*>()) {
+            const QString t = l->text();
+            if (t.contains(QStringLiteral("Bound:"),
+                           Qt::CaseInsensitive)
+                || t.contains(QStringLiteral("Disabled"),
+                              Qt::CaseInsensitive)
+                || t.contains(QStringLiteral("Not bound"),
+                              Qt::CaseInsensitive)
+                || t.contains(QStringLiteral("failed to open"),
+                              Qt::CaseInsensitive)
+                || t.contains(QStringLiteral("unavailable"),
+                              Qt::CaseInsensitive)) {
+                return l;
+            }
+        }
+        return nullptr;
+    }
+
 private slots:
 
     void init()    { clearAudioKeys(); }
@@ -396,20 +420,17 @@ private slots:
     void statusLabel_reflectsNativeHalWhenUnbound()
     {
         clearAudioKeys();
+        // VAX card defaults to Enabled=True via test seam so the banner
+        // doesn't short-circuit to the "Disabled" state. `m_busOpen`
+        // defaults to true (assumed healthy when no engine is wired).
+        AppSettings::instance().setValue(
+            QStringLiteral("audio/Vax2/Enabled"), QStringLiteral("True"));
 
         VaxChannelCard card(2, nullptr);
-        // Status banner is populated from updateBadge() which is invoked at
-        // the end of the ctor. On macOS/Linux an empty deviceName means the
-        // channel is bound to the native HAL/pipe bridge.
+        card.loadFromSettings();
+
 #if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
-        QLabel* statusLabel = nullptr;
-        for (QLabel* l : card.findChildren<QLabel*>()) {
-            const QString t = l->text();
-            if (t.contains(QStringLiteral("Bound:"), Qt::CaseInsensitive)) {
-                statusLabel = l;
-                break;
-            }
-        }
+        QLabel* statusLabel = findStatusBanner(card);
         QVERIFY2(statusLabel, "Expected a binding-status label on VaxChannelCard");
         QVERIFY2(statusLabel->text().contains(
                      QStringLiteral("NereusSDR VAX 2")),
@@ -424,25 +445,131 @@ private slots:
     void statusLabel_reflectsByoBinding()
     {
         clearAudioKeys();
+        AppSettings::instance().setValue(
+            QStringLiteral("audio/Vax3/Enabled"), QStringLiteral("True"));
 
         VaxChannelCard card(3, nullptr);
+        card.loadFromSettings();
         const QString cableName =
             QStringLiteral("CABLE-A Output (VB-Audio Virtual Cable)");
         card.bindDeviceNameForTest(cableName);
 
-        QLabel* statusLabel = nullptr;
-        for (QLabel* l : card.findChildren<QLabel*>()) {
-            if (l->text().contains(QStringLiteral("Bound:"),
-                                   Qt::CaseInsensitive)) {
-                statusLabel = l;
-                break;
-            }
-        }
+        QLabel* statusLabel = findStatusBanner(card);
         QVERIFY2(statusLabel, "Expected a binding-status label on VaxChannelCard");
         QVERIFY2(statusLabel->text().contains(cableName),
                  qPrintable(QStringLiteral(
                      "Expected status to name the BYO cable; got: %1")
                      .arg(statusLabel->text())));
+    }
+
+    // ── Banner flips to amber "Disabled" when the Enabled checkbox is off.
+    // Regression gate for Codex P2: "Show unbound state before claiming
+    // native HAL is bound" — users can uncheck the card's Enabled box
+    // (which closes the bus via AudioEngine::setVaxEnabled(false)) and
+    // previously still saw the green "Bound: Native HAL …" banner.
+    void statusLabel_flipsToDisabledWhenChannelOff()
+    {
+        clearAudioKeys();
+        AppSettings::instance().setValue(
+            QStringLiteral("audio/Vax1/Enabled"), QStringLiteral("False"));
+
+        VaxChannelCard card(1, nullptr);
+        card.loadFromSettings();
+
+        QLabel* statusLabel = findStatusBanner(card);
+        QVERIFY2(statusLabel, "Expected a banner label");
+        const QString txt = statusLabel->text();
+        QVERIFY2(txt.contains(QStringLiteral("Disabled"), Qt::CaseInsensitive),
+                 qPrintable(QStringLiteral(
+                     "Expected banner to read 'Disabled' when Enabled=False;"
+                     " got: %1").arg(txt)));
+        // Must NOT claim any binding while the checkbox is off.
+        QVERIFY2(!txt.contains(QStringLiteral("Bound:"), Qt::CaseInsensitive),
+                 "Disabled banner must not also claim 'Bound:'");
+    }
+
+    // ── Banner flips to amber "unavailable" / "failed to open" when the
+    // engine reports the VAX bus is NOT open, regardless of whether the
+    // card thinks it has a binding. Second half of the Codex P2 gate.
+    void statusLabel_flipsToUnavailableWhenBusNotOpen()
+    {
+        clearAudioKeys();
+        AppSettings::instance().setValue(
+            QStringLiteral("audio/Vax4/Enabled"), QStringLiteral("True"));
+
+        VaxChannelCard card(4, nullptr);
+        card.loadFromSettings();
+        card.setBusOpen(false);
+
+        QLabel* statusLabel = findStatusBanner(card);
+        QVERIFY2(statusLabel, "Expected a banner label");
+        const QString txt = statusLabel->text();
+#if defined(Q_OS_MAC)
+        QVERIFY2(txt.contains(QStringLiteral("unavailable"), Qt::CaseInsensitive)
+                     || txt.contains(QStringLiteral("failed to open"),
+                                     Qt::CaseInsensitive),
+                 qPrintable(QStringLiteral(
+                     "Expected banner to warn when bus is not open;"
+                     " got: %1").arg(txt)));
+#elif defined(Q_OS_LINUX)
+        QVERIFY2(txt.contains(QStringLiteral("unavailable"), Qt::CaseInsensitive)
+                     || txt.contains(QStringLiteral("failed to open"),
+                                     Qt::CaseInsensitive),
+                 qPrintable(QStringLiteral(
+                     "Expected banner to warn when bus is not open;"
+                     " got: %1").arg(txt)));
+#else
+        // Windows with no device name and busOpen=false: the existing
+        // "Not bound — pick a virtual cable" copy covers this since
+        // Windows has no native-HAL fallback.
+        QVERIFY2(txt.contains(QStringLiteral("Not bound"), Qt::CaseInsensitive)
+                     || txt.contains(QStringLiteral("failed to open"),
+                                     Qt::CaseInsensitive),
+                 qPrintable(QStringLiteral(
+                     "Expected Windows banner to warn when no cable picked;"
+                     " got: %1").arg(txt)));
+#endif
+        QVERIFY2(!txt.contains(QStringLiteral("\u2713  Bound:"),
+                               Qt::CaseInsensitive),
+                 "Unavailable banner must not also claim a successful bind");
+    }
+
+    // ── setBusOpen toggles the banner between green/amber without
+    // requiring a full re-load cycle.
+    void statusLabel_tracksBusOpenTransitions()
+    {
+        clearAudioKeys();
+        AppSettings::instance().setValue(
+            QStringLiteral("audio/Vax2/Enabled"), QStringLiteral("True"));
+
+        VaxChannelCard card(2, nullptr);
+        card.loadFromSettings();
+
+        // Start healthy (default m_busOpen=true).
+        QLabel* banner = findStatusBanner(card);
+        QVERIFY(banner);
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+        QVERIFY(banner->text().contains(QStringLiteral("\u2713  Bound:"),
+                                        Qt::CaseInsensitive));
+
+        // Flip to unhealthy.
+        card.setBusOpen(false);
+        banner = findStatusBanner(card);
+        QVERIFY(banner);
+        QVERIFY(banner->text().contains(QStringLiteral("unavailable"),
+                                        Qt::CaseInsensitive)
+                || banner->text().contains(QStringLiteral("failed to open"),
+                                           Qt::CaseInsensitive));
+
+        // Flip back to healthy.
+        card.setBusOpen(true);
+        banner = findStatusBanner(card);
+        QVERIFY(banner);
+        QVERIFY(banner->text().contains(QStringLiteral("\u2713  Bound:"),
+                                        Qt::CaseInsensitive));
+#else
+        QSKIP("Native-HAL transitions only apply on macOS/Linux.");
+#endif
     }
 
     // ── 13. autoDetectFreeCable_refreshesDeviceCardUI (C2) ───────────────────

--- a/tests/tst_vax_first_run_dialog.cpp
+++ b/tests/tst_vax_first_run_dialog.cpp
@@ -324,6 +324,60 @@ private slots:
                  "Device name with HTML special chars was not escaped"
                  " before rich-text injection");
     }
+
+    // ── 10. MacNative body reflects m_detected (regression for "always
+    //       Ready" bug).  When the HAL plugin is NOT detected the dialog
+    //       must say so instead of claiming all 4 channels are ready.
+    void macNativeBody_showsNotDetectedWhenHalMissing()
+    {
+        VaxFirstRunDialog dlg(FirstRunScenario::MacNative, {});
+
+        bool sawWarning = false;
+        bool sawAllReadyLie = false;
+        for (const auto* label : dlg.findChildren<QLabel*>()) {
+            const QString t = label->text();
+            if (t.contains(QStringLiteral("not detected"),
+                           Qt::CaseInsensitive)) {
+                sawWarning = true;
+            }
+            if (t.contains(QStringLiteral("All 4 VAX channels are ready"),
+                           Qt::CaseInsensitive)) {
+                sawAllReadyLie = true;
+            }
+        }
+        QVERIFY2(sawWarning,
+                 "Expected MacNative body to surface a 'not detected' warning"
+                 " when m_detected is empty");
+        QVERIFY2(!sawAllReadyLie,
+                 "MacNative body must not claim all 4 channels are ready"
+                 " when the HAL plugin was not detected");
+    }
+
+    // ── 11. MacNative body claims "ready" only when HAL is live ────────
+    void macNativeBody_showsAllReadyWhenHalFullyDetected()
+    {
+        QVector<DetectedCable> payload;
+        for (int slot = 1; slot <= 4; ++slot) {
+            payload.push_back({VirtualCableProduct::NereusSdrVax,
+                               QStringLiteral("NereusSDR VAX %1").arg(slot),
+                               /*isInput=*/true, 0});
+        }
+
+        VaxFirstRunDialog dlg(FirstRunScenario::MacNative, payload);
+
+        bool sawAllReady = false;
+        for (const auto* label : dlg.findChildren<QLabel*>()) {
+            if (label->text().contains(
+                    QStringLiteral("All 4 VAX channels are ready"),
+                    Qt::CaseInsensitive)) {
+                sawAllReady = true;
+                break;
+            }
+        }
+        QVERIFY2(sawAllReady,
+                 "Expected MacNative body to claim 'All 4 VAX channels are"
+                 " ready to use' when all 4 HAL devices were detected");
+    }
 };
 
 // The applySuggested signal carries QVector<QPair<int, QString>>; the


### PR DESCRIPTION
## Summary

- Setup → Audio → VAX "Auto-detect…" menu no longer lies about the
  native HAL plugin on macOS/Linux — native devices now appear as
  disabled "bound automatically" info rows above any BYO 3rd-party
  cable entries.
- `VaxFirstRunDialog`'s macOS "Ready" screen adapts to real detection
  instead of hardcoded copy, so an uninstalled or quarantined HAL
  plugin produces an amber warning + reinstall hint.
- Each VAX card gets a persistent green/blue/amber one-line status
  banner naming what the channel is currently routed through. No more
  guessing whether native HAL is live.

## Non-goals

- Source audio path is unchanged. The `AudioEngine::rxBlockReady` tap
  + `CoreAudioHalBus::push` shm-ring contract and the eager
  `makeVaxBus()` open in `AudioEngine::start()` were not touched.
- Windows is behaviourally unchanged. The Auto-detect filter edits and
  the new status banner are platform-guarded; the Windows 3rd-party
  BYO flow and the `DeviceCard::setEnableAllowed` gate still work
  exactly as before.

## Platform impact

| Platform | Behaviour change |
|---|---|
| **macOS** | Auto-detect menu now lists HAL VAX 1–4 as info rows; first-run dialog truthful; status banner |
| **Linux** | Status banner shows "Native (PipeWire)" when unbound; auto-detect info rows will light up once `VirtualCableDetector` learns PipeWire (future work) |
| **Windows** | Status banner only (amber "Not bound" or blue "Bound: …"). Everything else identical |

## Test plan

- [x] `./build/tests/tst_audio_vax_page_auto_detect` — 21 pass, 1 skip (macOS modal flake)
- [x] `./build/tests/tst_vax_first_run_dialog` — 19 pass
- [x] Manual: Setup → Audio → VAX → Auto-detect on a VAX card shows the 4 `▸ NereusSDR VAX N · native (bound automatically)` info rows on macOS
- [x] Manual: binding RX1 to VAX 2 via VFO flag → WSJT-X hears audio from `NereusSDR VAX 2`

## Related / follow-ups (not in this PR)

- **HAL plugin codesign step** belongs in `.github/workflows/release.yml`'s macOS DMG job. The Apr 19 alpha shipped a linker-signed bundle and coreaudiod refused to route IO through it — explicit `codesign --force --deep --sign -` after the CMake MODULE link produces a proper ad-hoc bundle and fixes audio delivery. Will swap `-` for a Developer ID once the cert lands.
- `Slice<N>/VaxChannel` persists to AppSettings but isn't applied to the `SliceModel::m_vaxChannel` atomic at cold launch — takes a UI click to activate. Separate issue.
- Pre-AGC VAX tap for digital modes (WSJT-X decode quality). Separate issue.

J.J. Boyd ~ KG4VCF