### PR TITLE
fix(theme): install app-wide dark QPalette + baseline QSS bootstrap

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -17,5 +17,7 @@
     </qresource>
     <qresource prefix="/icons">
         <file alias="NereusSDR.png">resources/icons/NereusSDR.png</file>
+        <file alias="spin-up.svg">resources/icons/spin-up.svg</file>
+        <file alias="spin-down.svg">resources/icons/spin-down.svg</file>
     </qresource>
 </RCC>

--- a/resources/icons/spin-down.svg
+++ b/resources/icons/spin-down.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8">
+  <path d="M 1,2 L 4,6 L 7,2 Z" fill="#c8d8e8"/>
+</svg>

--- a/resources/icons/spin-up.svg
+++ b/resources/icons/spin-up.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8">
+  <path d="M 1,6 L 4,2 L 7,6 Z" fill="#c8d8e8"/>
+</svg>

--- a/src/gui/SpectrumOverlayMenu.cpp
+++ b/src/gui/SpectrumOverlayMenu.cpp
@@ -21,8 +21,15 @@ void SpectrumOverlayMenu::buildUI()
     layout->setSpacing(4);
 
     // Dark theme matching NereusSDR STYLEGUIDE
+    // QSS Type selectors match QMetaObject::className(), and Qt rewrites
+    // namespace `::` as `--`. The bare `SpectrumOverlayMenu` selector
+    // never matched `NereusSDR::SpectrumOverlayMenu`, so the popup
+    // background fell through to the system Fusion palette (white on
+    // Linux/Ubuntu Yaru). With the namespaced form below the panel
+    // gets its dark surface back. Same trap applies to any future
+    // top-level QWidget popup in this namespace.
     setStyleSheet(QStringLiteral(
-        "SpectrumOverlayMenu {"
+        "NereusSDR--SpectrumOverlayMenu {"
         "  background: #1a2a3a;"
         "  border: 1px solid #2e4e6e;"
         "  border-radius: 4px;"

--- a/src/gui/setup/AppearanceSetupPages.cpp
+++ b/src/gui/setup/AppearanceSetupPages.cpp
@@ -35,7 +35,9 @@ void applyDarkStyle(QWidget* w)
         "QSlider::sub-page:horizontal { background: #00b4d8; border-radius: 2px; }"
         "QSpinBox { background: #1a2a3a; color: #c8d8e8;"
         "  border: 1px solid #203040; border-radius: 3px; padding: 1px 4px; }"
-        "QSpinBox::up-button, QSpinBox::down-button { background: #203040; border: none; }"
+        // Up/down buttons: rely on Fusion + app-level dark palette
+        // (see main.cpp / AppTheme.h). Styling the subcontrols here
+        // would erase the native arrow images.
         "QCheckBox { color: #c8d8e8; }"
         "QCheckBox::indicator { width: 14px; height: 14px; background: #1a2a3a;"
         "  border: 1px solid #203040; border-radius: 2px; }"

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -112,9 +112,12 @@ void applyDarkStyle(QWidget* w)
         "QSlider::sub-page:horizontal { background: #00b4d8; border-radius: 2px; }"
         "QSpinBox, QDoubleSpinBox { background: #1a2a3a; color: #c8d8e8;"
         "  border: 1px solid #203040; border-radius: 3px; padding: 1px 4px; }"
-        "QSpinBox::up-button, QSpinBox::down-button,"
-        "QDoubleSpinBox::up-button, QDoubleSpinBox::down-button"
-        "  { background: #203040; border: none; }"
+        // Up/down buttons left to Fusion native rendering: the moment
+        // we style the subcontrol, Qt drops the native arrow image
+        // and we'd need to provide our own. With the app-level dark
+        // palette installed in main.cpp, Fusion paints the native
+        // arrows in the right color against the surrounding QSpinBox
+        // background.
         "QCheckBox { color: #c8d8e8; }"
         "QCheckBox::indicator { width: 14px; height: 14px; background: #1a2a3a;"
         "  border: 1px solid #203040; border-radius: 2px; }"

--- a/src/gui/setup/GeneralOptionsPage.cpp
+++ b/src/gui/setup/GeneralOptionsPage.cpp
@@ -88,8 +88,9 @@ void applyDarkStyle(QWidget* w)
         "  selection-background-color: #00b4d8; }"
         "QSpinBox { background: #1a2a3a; color: #c8d8e8;"
         "  border: 1px solid #203040; border-radius: 3px; padding: 1px 4px; }"
-        "QSpinBox::up-button, QSpinBox::down-button"
-        "  { background: #203040; border: none; }"
+        // Up/down buttons: rely on Fusion + app-level dark palette
+        // (see main.cpp / AppTheme.h). Styling the subcontrols here
+        // would erase the native arrow images.
         "QCheckBox { color: #c8d8e8; }"
         "QCheckBox::indicator { width: 14px; height: 14px; background: #1a2a3a;"
         "  border: 1px solid #203040; border-radius: 2px; }"

--- a/src/gui/setup/TransmitSetupPages.cpp
+++ b/src/gui/setup/TransmitSetupPages.cpp
@@ -96,9 +96,9 @@ void applyDarkStyle(QWidget* w)
         "QSlider::sub-page:horizontal { background: #00b4d8; border-radius: 2px; }"
         "QSpinBox, QDoubleSpinBox { background: #1a2a3a; color: #c8d8e8;"
         "  border: 1px solid #203040; border-radius: 3px; padding: 1px 4px; }"
-        "QSpinBox::up-button, QSpinBox::down-button,"
-        "QDoubleSpinBox::up-button, QDoubleSpinBox::down-button"
-        "  { background: #203040; border: none; }"
+        // Up/down buttons: rely on Fusion + app-level dark palette
+        // (see main.cpp / AppTheme.h). Styling the subcontrols here
+        // would erase the native arrow images.
         "QCheckBox { color: #c8d8e8; }"
         "QCheckBox::indicator { width: 14px; height: 14px; background: #1a2a3a;"
         "  border: 1px solid #203040; border-radius: 2px; }"

--- a/src/gui/styles/AppTheme.h
+++ b/src/gui/styles/AppTheme.h
@@ -1,0 +1,145 @@
+// src/gui/styles/AppTheme.h (NereusSDR)
+//
+// Application-wide dark-theme bootstrap. Installs a QPalette + minimal
+// baseline QSS on the QApplication so every widget — even ones that
+// don't carry their own stylesheet — picks up the NereusSDR dark theme
+// instead of falling through to the host platform's Fusion defaults.
+//
+// Why this exists:
+//   On Linux/Ubuntu (Yaru theme), bare Fusion produces light backgrounds
+//   and an orange highlight color. Per-page stylesheets covered most of
+//   the UI but missed popups, group-box titles, tooltips, and any
+//   widget added without an explicit `setStyleSheet`. This file is the
+//   single source of truth that fills those gaps.
+//
+// Usage (main.cpp, after `app.setStyle(QStyleFactory::create("Fusion"))`):
+//
+//     NereusSDR::applyDarkPalette(app);
+//     NereusSDR::applyAppBaselineQss(app);
+//
+// Per-page stylesheets remain authoritative — the baseline only paints
+// what they don't.
+
+#pragma once
+
+#include <QApplication>
+#include <QColor>
+#include <QPalette>
+#include <QString>
+#include <QStringLiteral>
+
+#include "../StyleConstants.h"
+
+namespace NereusSDR {
+
+// Build a dark QPalette from STYLEGUIDE.md constants and install it on
+// the QApplication. Run AFTER QApplication::setStyle("Fusion") and
+// BEFORE any widgets are constructed so children inherit the right
+// defaults from creation.
+inline void applyDarkPalette(QApplication& app)
+{
+    QPalette p = app.palette();
+
+    auto c = [](const char* hex) { return QColor(QString::fromLatin1(hex)); };
+
+    const QColor appBg        = c(Style::kAppBg);          // #0f0f1a
+    const QColor panelBg      = c(Style::kPanelBg);        // #0a0a18
+    const QColor buttonBg     = c(Style::kButtonBg);       // #1a2a3a
+    const QColor textPrimary  = c(Style::kTextPrimary);    // #c8d8e8
+    const QColor textInactive = c(Style::kTextInactive);   // #405060
+    const QColor accent       = c(Style::kAccent);         // #00b4d8
+    const QColor border       = c(Style::kBorder);         // #205070
+    const QColor disabledBg   = c(Style::kDisabledBg);     // #1a1a2a
+    const QColor disabledText = c(Style::kDisabledText);   // #556070
+
+    // Active and Inactive groups share colors so unfocused windows
+    // still match the dark theme.
+    for (auto group : { QPalette::Active, QPalette::Inactive }) {
+        p.setColor(group, QPalette::Window,          appBg);
+        p.setColor(group, QPalette::WindowText,      textPrimary);
+        p.setColor(group, QPalette::Base,            buttonBg);
+        p.setColor(group, QPalette::AlternateBase,   panelBg);
+        p.setColor(group, QPalette::Text,            textPrimary);
+        p.setColor(group, QPalette::Button,          buttonBg);
+        p.setColor(group, QPalette::ButtonText,      textPrimary);
+        p.setColor(group, QPalette::ToolTipBase,     buttonBg);
+        p.setColor(group, QPalette::ToolTipText,     textPrimary);
+        p.setColor(group, QPalette::Highlight,       accent);
+        p.setColor(group, QPalette::HighlightedText, appBg);
+        p.setColor(group, QPalette::Link,            accent);
+        p.setColor(group, QPalette::LinkVisited,     accent);
+        p.setColor(group, QPalette::PlaceholderText, textInactive);
+        p.setColor(group, QPalette::BrightText,      QColor(Qt::white));
+        // Frame shading roles — used by Fusion to draw bevels/grooves.
+        p.setColor(group, QPalette::Light,           border);
+        p.setColor(group, QPalette::Midlight,        border);
+        p.setColor(group, QPalette::Dark,            panelBg);
+        p.setColor(group, QPalette::Mid,             panelBg);
+        p.setColor(group, QPalette::Shadow,          appBg);
+    }
+
+    // Disabled group — dim everything so disabled controls read as dim
+    // against the dark surface instead of vanishing or flipping bright.
+    p.setColor(QPalette::Disabled, QPalette::WindowText,      disabledText);
+    p.setColor(QPalette::Disabled, QPalette::Text,            disabledText);
+    p.setColor(QPalette::Disabled, QPalette::ButtonText,      disabledText);
+    p.setColor(QPalette::Disabled, QPalette::Button,          disabledBg);
+    p.setColor(QPalette::Disabled, QPalette::Base,            disabledBg);
+    p.setColor(QPalette::Disabled, QPalette::HighlightedText, disabledText);
+    p.setColor(QPalette::Disabled, QPalette::PlaceholderText, disabledText);
+
+    app.setPalette(p);
+}
+
+// Minimal app-wide QSS baseline for things QPalette can't fully cover:
+//   - QGroupBox::title  — subcontrol; doesn't reliably inherit color from
+//                         the parent QGroupBox rule on Fusion
+//   - QToolTip          — Qt ignores the palette ToolTip roles unless
+//                         a stylesheet is also present
+//   - QMenu             — so any future menu added without the explicit
+//                         kPopupMenu helper still renders dark, not
+//                         dark-on-dark or white-on-light (issue #98 family)
+//
+// Per-page setStyleSheet calls override these whenever they want; this
+// only fills the gap when nothing more specific applies.
+inline void applyAppBaselineQss(QApplication& app)
+{
+    app.setStyleSheet(QStringLiteral(
+        "QToolTip {"
+        "  color: %1; background: %2; border: 1px solid %3;"
+        "  padding: 3px; border-radius: 3px;"
+        "}"
+        "QGroupBox::title { color: %4; }"
+        "QMenu { background: %2; color: %1; border: 1px solid %3; }"
+        "QMenu::item { padding: 4px 20px; }"
+        "QMenu::item:selected { background: #2a5a8a; color: #ffffff; }"
+        "QMenu::item:disabled { color: %5; }"
+        // Spinbox arrows: Fusion paints these with palette.foreground()
+        // darkened, which is unreadable against our dark surfaces. Point
+        // QSS at the bundled SVG triangles (kTextPrimary fill) so every
+        // spinbox in the app gets the same legible arrow regardless of
+        // whether the parent page has its own QSpinBox styling. The
+        // buttons are widened so the arrow image isn't clipped to
+        // Fusion's narrow default subcontrol width.
+        "QSpinBox::up-button, QDoubleSpinBox::up-button {"
+        "  subcontrol-origin: border; subcontrol-position: top right;"
+        "  width: 20px; border: none;"
+        "}"
+        "QSpinBox::down-button, QDoubleSpinBox::down-button {"
+        "  subcontrol-origin: border; subcontrol-position: bottom right;"
+        "  width: 20px; border: none;"
+        "}"
+        "QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {"
+        "  image: url(:/icons/spin-up.svg); width: 14px; height: 14px;"
+        "}"
+        "QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {"
+        "  image: url(:/icons/spin-down.svg); width: 14px; height: 14px;"
+        "}"
+    ).arg(QString::fromLatin1(Style::kTextPrimary),
+          QString::fromLatin1(Style::kButtonBg),
+          QString::fromLatin1(Style::kBorder),
+          QString::fromLatin1(Style::kTitleText),
+          QString::fromLatin1(Style::kTextInactive)));
+}
+
+} // namespace NereusSDR

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "gui/MainWindow.h"
+#include "gui/styles/AppTheme.h"
 #include "core/AppSettings.h"
 #include "core/AudioDeviceConfig.h"
 #include "core/RadioConnection.h"
@@ -185,8 +186,15 @@ int main(int argc, char* argv[])
         s_logFile = nullptr;
     }
 
-    // Fusion style as a clean cross-platform base
+    // Fusion style as a clean cross-platform base, then layer the
+    // NereusSDR dark palette + minimal baseline QSS on top so every
+    // widget (including ones without their own stylesheet) renders
+    // with the dark theme. Without this, Linux/Ubuntu Yaru leaks
+    // light-grey backgrounds and orange Highlight through into popups,
+    // group-box titles, tooltips, and any unstyled control.
     app.setStyle(QStyleFactory::create("Fusion"));
+    NereusSDR::applyDarkPalette(app);
+    NereusSDR::applyAppBaselineQss(app);
 
     // Register custom metatypes for cross-thread signal/slot connections.
     qRegisterMetaType<NereusSDR::RadioConnectionError>();


### PR DESCRIPTION
## Summary

Linux/Ubuntu Yaru leaked light-grey backgrounds and the system orange Highlight color through to popups, group-box titles, tooltips, and any unstyled control because `main.cpp` set Fusion as the style but never installed a custom `QPalette` or app-level QSS. Per-page stylesheets covered most of the UI but missed every gap. Fix the bootstrap once at `QApplication` scope instead of patching each page (and the next page after that, etc.).

- **New `gui/styles/AppTheme.h`** — `applyDarkPalette()` builds a `QPalette` (Window/Base/Button/Text/Highlight/ToolTip + dimmed Disabled group) from `STYLEGUIDE.md` constants; `applyAppBaselineQss()` installs a small baseline QSS for `QToolTip`, `QGroupBox::title` color, a generic `QMenu` fallback, and the `QSpinBox`/`QDoubleSpinBox` subcontrol arrows. Wired in immediately after `setStyle("Fusion")`.
- **`SpectrumOverlayMenu` QSS** — bare `SpectrumOverlayMenu` Type selector never matched the namespaced class; corrected to `NereusSDR--SpectrumOverlayMenu` (Qt rewrites `::` → `--` for QSS Type selectors). The popup background resolves to the dark surface again instead of the host Window color.
- **4 setup pages** (Display / Appearance / GeneralOptions / Transmit) — removed `QSpinBox::up-button/down-button` rules that erased Fusion's native arrow images. App baseline now provides widened (20 px) subcontrol buttons + bundled SVG triangle arrows (`resources/icons/spin-{up,down}.svg`, 14 px in `kTextPrimary` fill).

### Before / after

| Symptom on Ubuntu Yaru | After |
|---|---|
| Right-click spectrum overlay menu rendered with a **white** background; cyan section labels nearly invisible against it. | Renders against `#1a2a3a` with the intended cyan border. |
| Spectrum Defaults group titles (`FFT`, `Rendering`, `Trace Colors`, `Calibration & Peak Hold`) nearly invisible; QSpinBox up/down arrows missing; "Reset to Smooth Defaults" had a Yaru-orange focus ring. | Titles in `kTitleText` (`#8aa8c0`). Spinbox arrows render as legible light triangles. Focus ring tracks the cyan accent (`#00b4d8`). |

## Test plan

- [x] Clean `cmake --build build -j$(nproc)`
- [x] `ctest -R "popup_style|spectrum_overlay_panel|settings_hygiene"` — 3/3 pass
- [x] Live-verified on Ubuntu (ANAN-G2 connected): right-click spectrum overlay menu, Setup → Display → Spectrum Defaults, every QSpinBox up/down arrow across the setup pages
- [ ] Cross-platform smoke check on macOS + Windows — palette change is additive over the existing per-page QSS, so no expected regression, but worth a sanity launch on each before merge

## Notes / follow-ups

- The two existing `setPalette(QPalette::Window, ...)` callsites in `SpectrumWidget.cpp:301-303` and `MeterWidget.cpp:124-126` are now redundant (they were trying to fix the same bug at widget scope) but left untouched — out of scope per the "fix style only in files you're modifying" rule. Safe to remove in a follow-up.
- Fusion's spinbox up/down subcontrols are now app-styled, so any future page that wants different spinbox sizing has to override at the page level. A note in `STYLEGUIDE.md` would be useful — happy to fold in here if you want, otherwise follow-up.

73 — JJ Boyd / KG4VCF

Co-Authored with Claude Code