### PR TITLE
fix(theme): Mac spinbox arrows + drop kSpinBoxStyle override + suppress NYI badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           sudo apt-get install -y \
             cmake ninja-build pkg-config g++ \
             qt6-base-dev qt6-base-private-dev qt6-multimedia-dev \
-            qt6-shadertools-dev \
+            qt6-shadertools-dev qt6-svg-dev \
             libgl1-mesa-dev libfftw3-dev \
             libasound2-dev libjack-jackd2-dev \
             libpipewire-0.3-dev

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install -y \
             cmake ninja-build pkg-config g++ \
             qt6-base-dev qt6-base-private-dev qt6-multimedia-dev \
-            qt6-shadertools-dev \
+            qt6-shadertools-dev qt6-svg-dev \
             libgl1-mesa-dev libfftw3-dev \
             libasound2-dev libjack-jackd2-dev \
             libpipewire-0.3-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,14 +132,14 @@ jobs:
         if: matrix.use_aqt == false
         run: |
           sudo apt-get install -y qt6-base-dev qt6-multimedia-dev \
-            qt6-base-private-dev qt6-shadertools-dev
+            qt6-base-private-dev qt6-shadertools-dev qt6-svg-dev
 
       - name: Install Qt 6.7 via aqtinstall (x86_64)
         if: matrix.use_aqt == true
         run: |
           pip3 install aqtinstall
           aqt install-qt linux desktop 6.7.3 linux_gcc_64 \
-            -m qtmultimedia qtshadertools \
+            -m qtmultimedia qtshadertools qtsvg \
             --outputdir ${{ github.workspace }}/Qt
           echo "Qt6_DIR=${{ github.workspace }}/Qt/6.7.3/gcc_64/lib/cmake/Qt6" >> $GITHUB_ENV
           echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/6.7.3/gcc_64" >> $GITHUB_ENV
@@ -474,7 +474,7 @@ jobs:
           host: 'windows'
           target: 'desktop'
           arch: 'win64_msvc2019_64'
-          modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools'
+          modules: 'qtmultimedia qtserialport qtwebsockets qtshadertools qtsvg'
           cache: true
 
       - name: Install Ninja and NSIS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(Qt6 REQUIRED COMPONENTS
     Widgets
     Network
     Multimedia
+    Svg
 )
 
 # Optional Qt components
@@ -649,6 +650,7 @@ target_link_libraries(NereusSDRObjs PUBLIC
     Qt6::Widgets
     Qt6::Network
     Qt6::Multimedia
+    Qt6::Svg
 )
 
 if(WIN32)

--- a/src/gui/StyleConstants.h
+++ b/src/gui/StyleConstants.h
@@ -230,8 +230,7 @@ constexpr auto kLineEditStyle =
 
 constexpr auto kSpinBoxStyle =
     "QSpinBox { background: #1a2a3a; border: 1px solid #304050;"
-    " border-radius: 3px; color: #c8d8e8; font-size: 12px; padding: 2px 4px; }"
-    "QSpinBox::up-button, QSpinBox::down-button { background: #203040; border: none; }";
+    " border-radius: 3px; color: #c8d8e8; font-size: 12px; padding: 2px 4px; }";
 
 constexpr auto kSliderStyle =
     "QSlider::groove:horizontal { background: #1a2a3a; height: 4px; border-radius: 2px; }"

--- a/src/gui/applets/NyiOverlay.cpp
+++ b/src/gui/applets/NyiOverlay.cpp
@@ -28,9 +28,8 @@ NyiOverlay* NyiOverlay::markNyi(QWidget* target, const QString& phaseHint)
 {
     if (!target) { return nullptr; }
     target->setEnabled(false);
-    auto* badge = new NyiOverlay(phaseHint, target->parentWidget());
-    badge->attachTo(target);
-    return badge;
+    target->setToolTip(QStringLiteral("Not Yet Implemented — Available in %1").arg(phaseHint));
+    return nullptr;
 }
 
 } // namespace NereusSDR


### PR DESCRIPTION
## Summary

Three small theme/build fixes that came out of investigating why [PR #127](https://github.com/boydsoftprez/NereusSDR/pull/127)'s new spinbox arrows didn't show up on the macOS DMG.

### Commit 1 — `fix(build): link Qt6::Svg so macdeployqt bundles libqsvg.dylib`

Root cause of the visible Mac symptom. PR #127 wired up bundled SVG triangles for `QSpinBox`/`QDoubleSpinBox` arrows via QSS in `src/gui/styles/AppTheme.h`. Linux/Windows looked fine; the Mac DMG showed empty spinbox up/down buttons.

`macdeployqt` walks the binary's linked Qt modules to decide which plugins to copy into `Contents/PlugIns/`. Nothing in NereusSDR linked `Qt6::Svg`, so `libqsvg.dylib` was silently skipped. With no SVG decoder available at runtime, `QImageReader` returned a null image and the `image: url(:/icons/spin-up.svg)` QSS rule no-op'd.

```diff
 find_package(Qt6 REQUIRED COMPONENTS
     Core
     Widgets
     Network
     Multimedia
+    Svg
 )
@@
 target_link_libraries(NereusSDRObjs PUBLIC
     Qt6::Core
     Qt6::Widgets
     Qt6::Network
     Qt6::Multimedia
+    Qt6::Svg
 )
```

Why this only hit the Mac DMG:

| Platform | Why it worked / didn't |
|---|---|
| **Linux** | System Qt at `/usr/lib/qt6/plugins/imageformats/` exposes qsvg unconditionally — nothing to deploy. |
| **Windows** | `windeployqt`'s default ships all standard imageformats unless told not to, so `qsvg.dll` got bundled even without the link. |
| **macOS** | `macdeployqt` is strict; only copies plugins matching linked Qt modules. No `Qt6::Svg` linked → no qsvg plugin → silent rule failure. |

Adds ~300 KB to the Mac DMG (`QtSvg.framework` + `libqsvg.dylib`). Defensively closes the same potential gap on Windows in case `windeployqt`'s default ever tightens.

### Commit 2 — `fix(theme): drop kSpinBoxStyle subcontrol override`

`kSpinBoxStyle` in `src/gui/StyleConstants.h` kept its legacy `QSpinBox::up-button/down-button { background; border: none }` rule with no arrow image. Used by `CatNetworkSetupPages.cpp` and `DiagnosticsSetupPages.cpp`, so spinboxes on those two setup pages had invisible arrows on every platform — per-page QSS wins over the app baseline. Drop the up-button/down-button rule and let the app baseline (with the SVG arrows) win. The QSpinBox body rule (background/border/text/padding) stays.

### Commit 3 — `fix(theme): suppress orange NYI badge`

`NyiOverlay::markNyi` was sprouting an orange corner "NYI" sticker on every disabled placeholder control — across RxApplet, TunerApplet, DiversityApplet, EqApplet, PureSignalApplet, DigitalApplet, PhoneCwApplet, FmApplet, DvkApplet, CatApplet, CwxApplet, TxApplet, and VfoWidget. Lots of visual noise competing with the actual UI for attention.

Strip the badge widget out of `markNyi` but keep the two real side effects:

- `target->setEnabled(false)` — disabled controls still read as disabled
- `target->setToolTip("Not Yet Implemented — Available in <phase>")` — the same info surfaces on hover

All ~163 existing `markNyi` callsites stay intact and keep working. The `NyiOverlay` class is left in place so any callsite that wants to build a free-standing NYI label still can.

## Test plan

- [x] `cmake --build build -j` clean on macOS Apple Silicon
- [x] Pre-commit hooks pass (Thetis attribution, inline cite, tag preservation)
- [x] `otool -L build/NereusSDR.app/Contents/MacOS/NereusSDR | grep -i svg` — confirms `QtSvg.framework` linked
- [x] `macdeployqt build/NereusSDR.app` — `Contents/PlugIns/imageformats/libqsvg.dylib` (91 KB) present
- [x] Live-verified on macOS: ad-hoc-signed worktree build, opened **Radio → Radio Setup → Display → Spectrum Defaults**, QSpinBox up/down arrows render as cyan-grey triangles
- [x] Live-verified: Setup → CAT/Network and Setup → Diagnostics pages also render arrows after Commit 2
- [x] Live-verified: orange NYI corner badges no longer appear; controls stay greyed out with tooltip on hover
- [ ] Sanity smoke check on Linux (no expected change — system qsvg unchanged, NYI badge change is universal)
- [ ] Sanity smoke check on Windows (no expected change — `windeployqt` default unchanged)

## Notes

The macdeployqt warnings about `QtPdf.framework` / `QtVirtualKeyboard.framework` during `gh actions` builds are noise — those modules aren't actually used. The release.yml `macdeployqt` invocation already handles them.

J.J. Boyd ~ KG4VCF