### PR TITLE
docs(vax): surface VAX in README + add alpha-guide step 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@
 > Full v0.2.3 walkthrough of what to try, what "success" looks like on
 > your OpenHPSDR radio, and — just as important — which UI controls are
 > intentionally stubbed so you don't file bugs against them. Includes
-> 18 numbered steps from launch → live SSB QSO → quit, plus
+> 19 numbered steps from launch → live SSB QSO → quit, plus
 > v0.2.3-specific tests for the dBm scale strip (step 12), the DSP grid
 > + 7-filter NR family (step 13), Alex antenna routing per-band
-> (step 14), and the new Linux PipeWire audio bridge (step 15).
+> (step 14), VAX audio routing (step 15), and the new Linux PipeWire
+> audio bridge (step 16).
 > Earlier-release walkthroughs remain at
 > [docs/debugging/alpha-tester-hl2-smoke-test.md](docs/debugging/alpha-tester-hl2-smoke-test.md)
 > for historical reference.
@@ -77,6 +78,7 @@ sha256sum -c SHA256SUMS.txt
 - **Auto AGC-T** — `NoiseFloorTracker` feeds the Auto-threshold timer with MOX guard and `agcCalOffset`; AUTO button toggles auto-mode; right-click the AGC-T slider opens Setup directly on the AGC/ALC page.
 - **Step attenuator + ADC overload** — `StepAttenuatorController` with Classic + Adaptive auto-attenuation modes, hysteresis, per-MAC persistence. P1/P2 `adcOverflow` signal from frame parsers, OVL status badge in RxApplet, per-model preamp items from Thetis `SetComboPreampForHPSDR`.
 - **Container / meter system** — GPU-rendered meter engine (QRhi 3-pipeline), 31 `MeterItem` types, 38+ ItemGroup presets (S-Meter, Power/SWR, ALC, ANANMM 7-needle, CrossNeedle, Magic Eye, History, SignalText, TX bar meters), full Thetis-parity Container Settings Dialog (3-column layout, per-item property editors), MMIO external-data subsystem (UDP / TCP-listen / TCP-client / Serial transports; JSON / XML / RAW formats).
+- **VAX audio routing** — NereusSDR-native multi-channel audio bus. `IAudioBus` abstraction with 5 platform backends (CoreAudio HAL plugin on macOS, PulseAudio pipes / pactl on Linux, PortAudio on Windows). First-run VAX dialog auto-detects Windows virtual-cable families (VB-Audio / VAC / Voicemeeter / Dante / FlexRadio DAX); `MasterOutputWidget` in the menu bar; Setup → Audio sub-tabs (Devices / VAX / TCI / Advanced); per-slice VAX channel assignment on the VFO Flag, persisted under `Slice<N>/`.
 - **App polish** — Help → About NereusSDR (version / Qt / WDSP / GPG fingerprint / heritage credits), 💡 AI-assisted issue reporter in the menu bar corner (structured prompts, submits to the `bug_report.yml` / `feature_request.yml` GitHub templates), radio-model override persistence, P1 full 17-bank C&C round-robin.
 - **Packaging** — `release.yml` prepare → build×3 → sign-and-publish pipeline. GPG-signed alpha artifacts: Linux AppImage (x86_64 + aarch64), macOS Apple Silicon DMG, Windows portable ZIP + NSIS installer.
 
@@ -111,6 +113,7 @@ sha256sum -c SHA256SUMS.txt
 - GPU-rendered meter engine (QRhi 3-pipeline), 31 `MeterItem` types, 38+ ItemGroup presets, ANANMM 7-needle with exact Thetis calibration, CrossNeedle dual fwd/rev, Magic Eye, History, Edge mode
 - Full Thetis-parity Container Settings Dialog — 3-column layout, per-item property editors (~155 fields), snapshot+revert, container-level Lock/Notes/Highlight/Minimises/Auto-height, Duplicate, Copy/Paste item settings
 - MMIO (Multi-Meter I/O) external-data subsystem — UDP / TCP-listen / TCP-client / Serial transports, JSON / XML / RAW formats, endpoint manager, variable picker, 10 fps polled bindings
+- VAX multi-channel audio bus — 5 platform backends, Windows virtual-cable auto-detect (VB-Audio / VAC / Voicemeeter / Dante / DAX), MasterOutputWidget, per-slice VAX channel routing
 - Interactive button grids — band (14), mode, filter, antenna, tuning step, macro — with hover/click feedback
 - Full UI skeleton — 12 applets, 9-menu bar, 47-page SetupDialog, SpectrumOverlayPanel with 5 flyout sub-panels, status bar
 - Help → About dialog + 💡 AI-assisted issue reporter wired to the GitHub issue tracker
@@ -176,6 +179,7 @@ sha256sum -c SHA256SUMS.txt
 | **3G-13: Step Attenuator & ADC Overload** | `StepAttenuatorController` (Classic + Adaptive), P1/P2 `adcOverflow` emission, OVL status badge, Setup→General→Options page, RxApplet ATT/S-ATT row, per-model preamp items | **Complete** |
 | **3G-14: About + AI Issue Reporter** | Help → About dialog, 💡 menu-bar issue reporter with structured prompts submitting to `bug_report.yml` / `feature_request.yml` | **Complete** |
 | **3N: Packaging** | Consolidated `release.yml`, `/release` skill, GPG-signed alpha builds: Linux AppImage ×2 archs, macOS Apple Silicon DMG, Windows portable ZIP + NSIS installer | **Complete** |
+| **3O: VAX Audio Routing** | NereusSDR-native multi-channel audio bus — 5 platform backends + first-run virtual-cable auto-detect (VB-Audio / VAC / Voicemeeter / Dante / DAX) + `MasterOutputWidget` + Setup → Audio sub-tabs + per-slice VAX channel persistence | **Complete** |
 | **3P: All-Board Radio-Control Parity** | 8 stacked sub-phases (A-H) delivering: HL2 BPF + S-ATT bug fixes, per-board P1/P2 codec subclasses, Alex-1/2 Filters live-LED sub-sub-tabs, OC Outputs matrix page, Calibration page (incl. freq-correction factor), Antenna Control per-band grid, HL2 I/O (closes Phase 3L), Accessories (Alex/Apollo/Penny), Diagnostics → Radio Status dashboard + 4 sibling sub-tabs, attribution enforcement pipeline. After merge: NereusSDR's **hardware / radio-plumbing / status-readout surfaces are userland-complete vs Thetis** — DSP-parameter / Transmit / CAT / Appearance / Keyboard Setup pages are still page shells with disabled controls pending later phases (see the [alpha-tester guide](docs/debugging/alpha-tester-hl2-smoke-test.md) for the honest wired-vs-stub breakdown). | **Complete** |
 | 3M-1: Basic SSB TX | TxChannel, mic input, MOX state machine, I/Q output | **Next** |
 | 3M-2: CW TX | Sidetone, firmware keyer, QSK/break-in | Planned |

--- a/docs/debugging/v0.2.3-alpha-tester-smoketest.md
+++ b/docs/debugging/v0.2.3-alpha-tester-smoketest.md
@@ -527,7 +527,30 @@ If your radio has an Alex board (most ANAN family), antenna routing is now reach
 
 **✅ Success bar for step 14:** band changes switch antennas live across all 5 UI surfaces consistently; selections persist across restart; SKU-specific UI gates correctly (BYPS button only on bypass-capable boards; antenna row hidden on HL2/Atlas).
 
-### 15. Linux PipeWire audio bridge (new in v0.2.3, Phase 3O — Linux only)
+### 15. VAX audio routing (Phase 3O)
+
+VAX is NereusSDR's multi-channel audio bus. It lets a digital-mode program (WSJT-X, fldigi, JTDX, N1MM+) read RX audio from a specific slice without a physical loopback cable or a second USB sound card. Each VAX channel is a virtual audio destination the OS exposes; you assign a slice to one of them on the VFO Flag, point your digital app's input at that destination, and audio flows.
+
+**How VAX is delivered per OS:**
+- **Windows** — first-run VAX dialog auto-detects the major virtual-cable families (VB-Audio Virtual Cable, VAC, Voicemeeter, Dante Via, FlexRadio DAX) and pre-fills channel bindings against whichever you already have installed. If none are present, the dialog tells you which to grab.
+- **macOS** — delivered as a CoreAudio HAL plugin (`NereusSDRVAX.driver`), not in the DMG today (Developer ID needed). See "macOS notes — code signing and the VAX HAL plugin" above for the 5-minute self-sign procedure if you want VAX routing on a Mac.
+- **Linux** — PulseAudio pipe modules (`module-pipe-source × 4` + `module-pipe-sink × 1`) under a `nereussdr-vax-*` namespace, or the PipeWire-native equivalent on Phase 3P-built systems (see step 16). VAX channels appear as recordable inputs in `pavucontrol` (or `helvum` / `qpwgraph` on PipeWire).
+
+**Test:**
+1. Open **Setup → Audio → VAX**. You should see four channel strips, each with a meter, gain slider, mute, device picker, and an Auto-detect button. On Windows / Linux, click **Auto-detect** if any channel shows "(unbound)".
+2. On the **VFO Flag**, locate the VAX channel selector. Assign the current slice to **VAX 1**.
+3. Open WSJT-X (or any digital-mode app you have around). Set its **audio input** to the VAX 1 destination. The WSJT-X waterfall should show the same audio you're hearing on speakers.
+4. **MasterOutputWidget** lives in the top-right corner of the menu bar — global volume + mute, scroll-wheel for fine volume, right-click for the device picker. Confirm scroll-wheel adjusts level smoothly and the picker lists your real output devices.
+5. Quit and relaunch. Per-slice VAX channel assignment, MasterOutputWidget device choice, and per-channel gain/mute should all persist.
+
+**Known limits:**
+- **macOS without the self-signed HAL plugin** = no VAX. The app runs fine over any normal CoreAudio device; you just lose per-slice VAX routing.
+- **Windows** needs at least one virtual cable family installed before VAX has output destinations to bind to. If Auto-detect comes up empty, install VB-Audio Virtual Cable (free) and re-scan.
+- The first-run VAX dialog can be re-opened anytime via **Help → Diagnose audio backend…** (Linux first, Windows/macOS in a follow-up).
+
+**✅ Success bar for step 15:** Setup → Audio → VAX shows four channel strips; you can assign a slice to a VAX channel via the VFO Flag and consume that audio in another app on the same machine; assignment + gain + device-picker choice persist across restart.
+
+### 16. Linux PipeWire audio bridge (new in v0.2.3, Phase 3O — Linux only)
 
 **Linux users only — skip on macOS / Windows.**
 
@@ -543,15 +566,15 @@ If you're on a recent Linux system (Ubuntu 24.04+, Fedora 39+, Arch — anything
 - The PipeWire path is alpha. Several shakedown bugs were caught on Ubuntu 25.10 and fixed in v0.2.3. If you see audio cut out, log a bug with the AudioBackendStrip → Open-logs output.
 - The pactl / PulseAudio fallback path still works for systems without PipeWire.
 
-**✅ Success bar for step 15:** AudioBackendStrip shows the right backend; speakers + (if used) VAX virtual sources work end-to-end; latency telemetry updates live; no SIGKILL / SEGFAULT mid-session.
+**✅ Success bar for step 16:** AudioBackendStrip shows the right backend; speakers + (if used) VAX virtual sources work end-to-end; latency telemetry updates live; no SIGKILL / SEGFAULT mid-session.
 
-### 16. Quit cleanly
+### 17. Quit cleanly
 
 Close the app (red close button, or File → Quit, or ⌘Q on macOS, Alt+F4 on Windows).
 
-**✅ Success bar for step 16:** the app closes without a crash dialog and without leaving a new crash report in your system's diagnostic reports folder (see "Reporting bugs" below for where to find it on each OS).
+**✅ Success bar for step 17:** the app closes without a crash dialog and without leaving a new crash report in your system's diagnostic reports folder (see "Reporting bugs" below for where to find it on each OS).
 
-### 17. Relaunch + persistence
+### 18. Relaunch + persistence
 
 Open the app again. If you had your radio connected when you quit, it should **silently auto-reconnect** within a few seconds without you needing to open ConnectionPanel.
 
@@ -562,9 +585,9 @@ Then check that your persisted settings came back:
 - Antenna Control per-band antenna mappings
 - Window splitter + dock layout + container contents
 
-**✅ Success bar for step 17:** auto-reconnect works (or silently gives up without popping an error), and all persisted settings restore correctly.
+**✅ Success bar for step 18:** auto-reconnect works (or silently gives up without popping an error), and all persisted settings restore correctly.
 
-### 18. Multi-instance via `--profile` (optional, Phase 3O)
+### 19. Multi-instance via `--profile` (optional, Phase 3O)
 
 If you have two radios on your network and want to run them concurrently:
 ```bash


### PR DESCRIPTION
## Summary

VAX (Phase 3O) was effectively invisible in the front-door docs — no row in the
README roadmap, no bullet in "What's working today" or "Key Features", and no
numbered step in the v0.2.3 alpha smoketest. Alpha testers had to infer how to
exercise it from the macOS HAL-plugin section.

This PR closes that gap with documentation only — no code changes.

### README
- New **3O: VAX Audio Routing** row in the Phase 3 roadmap table.
- New VAX bullet in "What's working end-to-end today" covering the `IAudioBus`
  abstraction, 5 platform backends (CoreAudio HAL plugin / PulseAudio / pactl /
  PortAudio), the first-run dialog, `MasterOutputWidget`, Setup → Audio
  sub-tabs, and per-slice persistence.
- New VAX line in "Key Features".
- Alpha-guide preamble updated: "18 numbered steps" → "19", VAX added as
  step 15, PipeWire bumped to step 16.

### Alpha guide (`docs/debugging/v0.2.3-alpha-tester-smoketest.md`)
- New **step 15 — VAX audio routing (Phase 3O)** with:
  - Per-OS delivery breakdown (Windows virtual-cable auto-detect for VB-Audio
    / VAC / Voicemeeter / Dante / DAX; macOS HAL plugin with cross-link to
    the existing self-sign section; Linux pipe modules / PipeWire).
  - 5-step test flow using WSJT-X as the audio consumer.
  - Per-platform known limits.
  - Success bar.
- Renumbered subsequent steps: PipeWire 15→16, Quit 16→17, Relaunch +
  persistence 17→18, Multi-instance 18→19. Internal "✅ Success bar for step N:"
  references updated to match.

## Test plan

- [ ] Render the README on github.com — confirm "What's working today" /
      "Key Features" / Roadmap show VAX where intended.
- [ ] Render the alpha guide — confirm step 15 reads cleanly, anchor links
      from the preamble work, no orphaned step-N references remain.
- [ ] Verify nothing else in the repo references "step 15" / "step 16" /
      "step 17" / "step 18" against the alpha guide and stayed correct
      (already grep-checked locally).

J.J. Boyd ~ KG4VCF