### PR TITLE
fix(dsp-menu): full RX DSP parity in top menu, drop overlay flyout

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -307,6 +307,7 @@ warren@wpratt.com
 #include <QMenuBar>
 #include <QMenu>
 #include <QAction>
+#include <QSignalBlocker>
 #include <QActionGroup>
 #include <QStatusBar>
 #include <QLabel>
@@ -1358,52 +1359,121 @@ void MainWindow::buildMenuBar()
     // =========================================================================
     QMenu* dspMenu = menuBar()->addMenu(QStringLiteral("&DSP"));
 
-    // Checkable DSP toggles — stored as members so the overlay panel can sync
-    m_nrAction = dspMenu->addAction(QStringLiteral("&NR"));
-    m_nrAction->setCheckable(true);
-    connect(m_nrAction, &QAction::toggled, this, [this](bool on) {
-        RxChannel* rxCh = m_radioModel->wdspEngine()->rxChannel(0);
-        if (rxCh) { rxCh->setNrEnabled(on); }
-    });
+    // ── NR submenu — full slot bank, mutual exclusion via QActionGroup ─────
+    // Mirrors VfoWidget's 7-button NR bank. Off/NR1/NR2/NR3/NR4/DFNR are
+    // always present; MNR is gated by HAVE_MNR (macOS only) and BNR by
+    // HAVE_BNR (NVIDIA build, currently never defined). Hidden actions
+    // remain in the group so the activeNrChanged sync handler can find
+    // them by index.
+    {
+        QMenu* nrMenu = dspMenu->addMenu(QStringLiteral("&NR"));
+        m_nrGroup = new QActionGroup(this);
+        m_nrGroup->setExclusive(true);
 
-    QAction* nr2Action = dspMenu->addAction(QStringLiteral("NR&2"));
-    nr2Action->setCheckable(true);
-    nr2Action->setToolTip(QStringLiteral("Toggle enhanced multiband noise reduction (NR2/EMNR)"));
-    connect(nr2Action, &QAction::toggled, this, [this](bool on) {
-        SliceModel* slice = m_radioModel->activeSlice();
-        if (slice) {
-            slice->setActiveNr(on ? NereusSDR::NrSlot::NR2 : NereusSDR::NrSlot::Off);
+        using Slot = NereusSDR::NrSlot;
+        struct Entry { const char* label; Slot slot; bool hidden; };
+        const Entry nrSlots[] = {
+            { "&Off",   Slot::Off,  false },
+            { "NR&1",   Slot::NR1,  false },
+            { "NR&2",   Slot::NR2,  false },
+            { "NR&3",   Slot::NR3,  false },
+            { "NR&4",   Slot::NR4,  false },
+            { "&DFNR",  Slot::DFNR, false },
+            { "&MNR",   Slot::MNR,
+#ifdef HAVE_MNR
+                false
+#else
+                true
+#endif
+            },
+            { "&BNR",   Slot::BNR,
+#ifdef HAVE_BNR
+                false
+#else
+                true
+#endif
+            },
+        };
+        for (const auto& nr : nrSlots) {
+            Slot slot = nr.slot;
+            QAction* a = nrMenu->addAction(QString::fromUtf8(nr.label),
+                this, [this, slot]() {
+                    SliceModel* slice = m_radioModel->activeSlice();
+                    if (slice) { slice->setActiveNr(slot); }
+                });
+            a->setCheckable(true);
+            if (nr.hidden) { a->setVisible(false); }
+            m_nrGroup->addAction(a);
         }
+    }
+
+    // ── NB submenu — Off/NB/NB2 mutual exclusion ───────────────────────────
+    // Maps to SliceModel::setNbMode(NbMode). Mirrors VfoWidget's cycling
+    // NB button (Off → NB → NB2 → Off) but as discrete menu items.
+    {
+        QMenu* nbMenu = dspMenu->addMenu(QStringLiteral("N&B"));
+        m_nbGroup = new QActionGroup(this);
+        m_nbGroup->setExclusive(true);
+
+        using Mode = NereusSDR::NbMode;
+        const struct { const char* label; Mode mode; } nbModes[] = {
+            { "&Off",  Mode::Off },
+            { "&NB",   Mode::NB  },
+            { "NB&2",  Mode::NB2 },
+        };
+        for (const auto& nb : nbModes) {
+            Mode mode = nb.mode;
+            QAction* a = nbMenu->addAction(QString::fromUtf8(nb.label),
+                this, [this, mode]() {
+                    SliceModel* slice = m_radioModel->activeSlice();
+                    if (slice) { slice->setNbMode(mode); }
+                });
+            a->setCheckable(true);
+            m_nbGroup->addAction(a);
+        }
+    }
+
+    // ── Single-toggle DSP actions ──────────────────────────────────────────
+    // ANF writes through RxChannel directly (SliceModel::anfEnabled is a
+    // Task 17 follow-up). Cross-surface sync is therefore not yet possible
+    // for ANF; the action emits its own toggled() but isn't checked from
+    // model state. SNB / APF / BIN go through SliceModel and are synced.
+    {
+        QAction* anfAction = dspMenu->addAction(QStringLiteral("&ANF"));
+        anfAction->setCheckable(true);
+        connect(anfAction, &QAction::toggled, this, [this](bool on) {
+            RxChannel* rxCh = m_radioModel->wdspEngine()->rxChannel(0);
+            if (rxCh) { rxCh->setAnfEnabled(on); }
+        });
+    }
+
+    m_snbAction = dspMenu->addAction(QStringLiteral("&SNB"));
+    m_snbAction->setCheckable(true);
+    connect(m_snbAction, &QAction::toggled, this, [this](bool on) {
+        SliceModel* slice = m_radioModel->activeSlice();
+        if (slice) { slice->setSnbEnabled(on); }
     });
 
-    m_nbAction = dspMenu->addAction(QStringLiteral("N&B"));
-    m_nbAction->setCheckable(true);
-    connect(m_nbAction, &QAction::toggled, this, [this](bool on) {
-        RxChannel* rxCh = m_radioModel->wdspEngine()->rxChannel(0);
-        if (rxCh) { rxCh->setNbMode(on ? NereusSDR::NbMode::NB : NereusSDR::NbMode::Off); }
+    m_apfAction = dspMenu->addAction(QStringLiteral("AP&F"));
+    m_apfAction->setCheckable(true);
+    connect(m_apfAction, &QAction::toggled, this, [this](bool on) {
+        SliceModel* slice = m_radioModel->activeSlice();
+        if (slice) { slice->setApfEnabled(on); }
     });
 
-    QAction* nb2Action = dspMenu->addAction(QStringLiteral("NB&2"));
-    nb2Action->setCheckable(true);
-    nb2Action->setEnabled(false);
-    nb2Action->setToolTip(QStringLiteral("NYI — Phase X"));
-
-    m_anfAction = dspMenu->addAction(QStringLiteral("&ANF"));
-    m_anfAction->setCheckable(true);
-    connect(m_anfAction, &QAction::toggled, this, [this](bool on) {
-        RxChannel* rxCh = m_radioModel->wdspEngine()->rxChannel(0);
-        if (rxCh) { rxCh->setAnfEnabled(on); }
+    m_binAction = dspMenu->addAction(QStringLiteral("B&IN"));
+    m_binAction->setCheckable(true);
+    connect(m_binAction, &QAction::toggled, this, [this](bool on) {
+        SliceModel* slice = m_radioModel->activeSlice();
+        if (slice) { slice->setBinauralEnabled(on); }
     });
 
-    QAction* tnfAction = dspMenu->addAction(QStringLiteral("&TNF"));
-    tnfAction->setCheckable(true);
-    tnfAction->setEnabled(false);
-    tnfAction->setToolTip(QStringLiteral("NYI — Phase X"));
-
-    QAction* binAction = dspMenu->addAction(QStringLiteral("&BIN"));
-    binAction->setCheckable(true);
-    binAction->setEnabled(false);
-    binAction->setToolTip(QStringLiteral("NYI — Phase X"));
+    {
+        QAction* tnfAction = dspMenu->addAction(QStringLiteral("&TNF"));
+        tnfAction->setCheckable(true);
+        tnfAction->setEnabled(false);
+        tnfAction->setToolTip(QStringLiteral("NYI — Phase X"));
+    }
 
     dspMenu->addSeparator();
 
@@ -1451,6 +1521,67 @@ void MainWindow::buildMenuBar()
             });
         });
     }
+
+    // ── Sync NR / NB / SNB / APF / BIN checked state from slice 0 ──────────
+    // Mirrors the AGC sync pattern above. Wired via sliceAdded so the
+    // connection survives slice teardown/re-create. ANF intentionally
+    // omitted — its state lives on RxChannel without a notify signal
+    // (SliceModel::anfEnabled is a Task 17 follow-up).
+    connect(m_radioModel, &RadioModel::sliceAdded, this, [this](int index) {
+        if (index != 0) { return; }
+        SliceModel* slice = m_radioModel->activeSlice();
+        if (!slice) { return; }
+
+        // NR submenu sync — actions appended to m_nrGroup in this fixed order.
+        const NereusSDR::NrSlot nrOrder[] = {
+            NereusSDR::NrSlot::Off,  NereusSDR::NrSlot::NR1,
+            NereusSDR::NrSlot::NR2,  NereusSDR::NrSlot::NR3,
+            NereusSDR::NrSlot::NR4,  NereusSDR::NrSlot::DFNR,
+            NereusSDR::NrSlot::MNR,  NereusSDR::NrSlot::BNR,
+        };
+        auto syncNr = [this, nrOrder](NereusSDR::NrSlot slot) {
+            QList<QAction*> acts = m_nrGroup->actions();
+            const int n = static_cast<int>(std::size(nrOrder));
+            for (int i = 0; i < acts.size() && i < n; ++i) {
+                QSignalBlocker b(acts[i]);
+                acts[i]->setChecked(nrOrder[i] == slot);
+            }
+        };
+        syncNr(slice->activeNr());
+        connect(slice, &SliceModel::activeNrChanged, this, syncNr);
+
+        // NB submenu sync — three actions in m_nbGroup: Off, NB, NB2.
+        const NereusSDR::NbMode nbOrder[] = {
+            NereusSDR::NbMode::Off, NereusSDR::NbMode::NB, NereusSDR::NbMode::NB2,
+        };
+        auto syncNb = [this, nbOrder](NereusSDR::NbMode mode) {
+            QList<QAction*> acts = m_nbGroup->actions();
+            for (int i = 0; i < acts.size() && i < 3; ++i) {
+                QSignalBlocker b(acts[i]);
+                acts[i]->setChecked(nbOrder[i] == mode);
+            }
+        };
+        syncNb(slice->nbMode());
+        connect(slice, &SliceModel::nbModeChanged, this, syncNb);
+
+        // Single-toggle initial sync.
+        { QSignalBlocker b(m_snbAction); m_snbAction->setChecked(slice->snbEnabled()); }
+        { QSignalBlocker b(m_apfAction); m_apfAction->setChecked(slice->apfEnabled()); }
+        { QSignalBlocker b(m_binAction); m_binAction->setChecked(slice->binauralEnabled()); }
+
+        connect(slice, &SliceModel::snbEnabledChanged, this, [this](bool v) {
+            QSignalBlocker b(m_snbAction);
+            m_snbAction->setChecked(v);
+        });
+        connect(slice, &SliceModel::apfEnabledChanged, this, [this](bool v) {
+            QSignalBlocker b(m_apfAction);
+            m_apfAction->setChecked(v);
+        });
+        connect(slice, &SliceModel::binauralEnabledChanged, this, [this](bool v) {
+            QSignalBlocker b(m_binAction);
+            m_binAction->setChecked(v);
+        });
+    });
 
     dspMenu->addSeparator();
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -190,10 +190,14 @@ private:
     MeterPoller* m_meterPoller{nullptr};
     void populateDefaultMeter();
 
-    // Menu DSP actions (for overlay sync — Phase 3-UI)
-    QAction* m_nrAction  = nullptr;
-    QAction* m_nbAction  = nullptr;
-    QAction* m_anfAction = nullptr;
+    // Menu DSP actions
+    // NR / NB submenus use exclusive QActionGroups; SNB / APF / BIN are
+    // single toggle actions that mirror SliceModel state.
+    QActionGroup* m_nrGroup   = nullptr;
+    QActionGroup* m_nbGroup   = nullptr;
+    QAction*      m_snbAction = nullptr;
+    QAction*      m_apfAction = nullptr;
+    QAction*      m_binAction = nullptr;
 
     // Mode menu actions (12 modes, mutual exclusion via QActionGroup)
     QAction*      m_modeActions[12]  = {};

--- a/src/gui/SpectrumOverlayPanel.cpp
+++ b/src/gui/SpectrumOverlayPanel.cpp
@@ -212,47 +212,41 @@ SpectrumOverlayPanel::SpectrumOverlayPanel(QWidget* parent)
         m_menuBtns.append(btn);  // index 3
     }
 
-    // Button 6: DSP — flyout
-    {
-        auto* btn = makeMenuBtn("DSP", this);
-        btn->setToolTip("Open DSP noise reduction controls");
-        connect(btn, &QPushButton::clicked, this, &SpectrumOverlayPanel::toggleDspFlyout);
-        m_menuBtns.append(btn);  // index 4
-    }
+    // DSP flyout removed — controls duplicated the VFO flag's DSP grid.
+    // Use the top menu bar's DSP menu (full parity) or the VFO flag.
 
-    // Button 7: Display — flyout
+    // Button 6: Display — flyout
     {
         auto* btn = makeMenuBtn("Display", this);
         btn->setToolTip("Open display settings");
         connect(btn, &QPushButton::clicked, this, &SpectrumOverlayPanel::toggleDisplayFlyout);
-        m_menuBtns.append(btn);  // index 5
+        m_menuBtns.append(btn);  // index 4
     }
 
-    // Button 8: VAX — flyout (NYI Phase 3-VAX)
+    // Button 7: VAX — flyout (NYI Phase 3-VAX)
     {
         auto* btn = makeMenuBtn("VAX", this);
         btn->setToolTip("Open VAX audio routing (NYI Phase 3-VAX)");
         connect(btn, &QPushButton::clicked, this, &SpectrumOverlayPanel::toggleVaxFlyout);
-        m_menuBtns.append(btn);  // index 6
+        m_menuBtns.append(btn);  // index 5
     }
 
-    // Button 9: ATT (NYI)
+    // Button 8: ATT (NYI)
     {
         auto* btn = makeDisabledBtn("ATT", this);
         btn->setToolTip("Attenuator control (NYI)");
-        m_menuBtns.append(btn);  // index 7
+        m_menuBtns.append(btn);  // index 6
     }
 
-    // Button 10: MNF (NYI)
+    // Button 9: MNF (NYI)
     {
         auto* btn = makeDisabledBtn("MNF", this);
         btn->setToolTip("Manual notch filter (NYI)");
-        m_menuBtns.append(btn);  // index 8
+        m_menuBtns.append(btn);  // index 7
     }
 
     buildBandFlyout();
     buildAntFlyout();
-    buildDspFlyout();
     buildDisplayFlyout();
     buildVaxFlyout();
     buildZoomButtons();
@@ -298,7 +292,7 @@ bool SpectrumOverlayPanel::eventFilter(QObject* obj, QEvent* event)
 void SpectrumOverlayPanel::raiseAll()
 {
     raise();
-    for (QWidget* fw : {m_bandFlyout, m_antFlyout, m_dspFlyout,
+    for (QWidget* fw : {m_bandFlyout, m_antFlyout,
                         m_displayFlyout, m_vaxFlyout}) {
         if (fw) { fw->raise(); }
     }
@@ -582,131 +576,6 @@ void SpectrumOverlayPanel::toggleAntFlyout()
     m_activeFlyout = m_antFlyout;
     m_activeButton = antBtn;
     antBtn->setStyleSheet(kMenuBtnActive);
-}
-
-// ── DSP flyout ────────────────────────────────────────────────────────────────
-
-void SpectrumOverlayPanel::buildDspFlyout()
-{
-    m_dspFlyout = new QWidget(parentWidget());
-    m_dspFlyout->setStyleSheet(kPanelStyle);
-    m_dspFlyout->hide();
-
-    auto* vbox = new QVBoxLayout(m_dspFlyout);
-    vbox->setContentsMargins(6, 6, 6, 6);
-    vbox->setSpacing(3);
-
-    // Row 1: compact toggle buttons (NR, NB, SNB, ANF, BIN, MNF)
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(4);
-
-        auto makeToggle = [&](const QString& text, QPushButton*& ptr) {
-            ptr = new QPushButton(text);
-            ptr->setCheckable(true);
-            ptr->setFixedSize(40, 20);
-            ptr->setStyleSheet(kDspBtnStyle);
-            row->addWidget(ptr, 1);
-        };
-
-        makeToggle("NR",  m_nrBtn);
-        makeToggle("NB",  m_nbBtn);
-        makeToggle("SNB", m_snbBtn);
-        makeToggle("ANF", m_anfBtn);
-        makeToggle("BIN", m_binBtn);
-        makeToggle("MNF", m_mnfDspBtn);
-
-        vbox->addLayout(row);
-
-        // Wire signals
-        connect(m_nrBtn,  &QPushButton::toggled, this, &SpectrumOverlayPanel::nrToggled);
-        connect(m_nbBtn,  &QPushButton::toggled, this, &SpectrumOverlayPanel::nbToggled);
-        connect(m_snbBtn, &QPushButton::toggled, this, &SpectrumOverlayPanel::snbToggled);
-        connect(m_anfBtn, &QPushButton::toggled, this, &SpectrumOverlayPanel::anfToggled);
-
-        // BIN and MNF: NYI, disable for now
-        m_binBtn->setEnabled(false);
-        m_binBtn->setToolTip("Binaural processing (NYI)");
-        m_mnfDspBtn->setEnabled(false);
-        m_mnfDspBtn->setToolTip("Manual notch filter (NYI)");
-    }
-
-    // Row 2: NR level slider
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(4);
-        auto* lbl = new QLabel("NR Lvl:");
-        lbl->setStyleSheet(kLabelStyle);
-        lbl->setFixedWidth(46);
-        row->addWidget(lbl);
-
-        m_nrSlider = new QSlider(Qt::Horizontal);
-        m_nrSlider->setRange(0, 100);
-        m_nrSlider->setValue(50);
-        m_nrSlider->setStyleSheet(kSliderStyle);
-        row->addWidget(m_nrSlider, 1);
-
-        m_nrLabel = new QLabel("50");
-        m_nrLabel->setStyleSheet(kLabelStyle);
-        m_nrLabel->setFixedWidth(22);
-        m_nrLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        row->addWidget(m_nrLabel);
-        vbox->addLayout(row);
-
-        connect(m_nrSlider, &QSlider::valueChanged, this, [this](int v) {
-            m_nrLabel->setText(QString::number(v));
-        });
-    }
-
-    // Row 3: NB threshold slider
-    {
-        auto* row = new QHBoxLayout;
-        row->setSpacing(4);
-        auto* lbl = new QLabel("NB Thr:");
-        lbl->setStyleSheet(kLabelStyle);
-        lbl->setFixedWidth(46);
-        row->addWidget(lbl);
-
-        m_nbSlider = new QSlider(Qt::Horizontal);
-        m_nbSlider->setRange(0, 100);
-        m_nbSlider->setValue(50);
-        m_nbSlider->setStyleSheet(kSliderStyle);
-        row->addWidget(m_nbSlider, 1);
-
-        m_nbLabel = new QLabel("50");
-        m_nbLabel->setStyleSheet(kLabelStyle);
-        m_nbLabel->setFixedWidth(22);
-        m_nbLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        row->addWidget(m_nbLabel);
-        vbox->addLayout(row);
-
-        connect(m_nbSlider, &QSlider::valueChanged, this, [this](int v) {
-            m_nbLabel->setText(QString::number(v));
-        });
-    }
-
-    m_dspFlyout->setFixedWidth(200);
-    m_dspFlyout->adjustSize();
-}
-
-void SpectrumOverlayPanel::toggleDspFlyout()
-{
-    // Button index 4 (DSP)
-    QPushButton* dspBtn = m_menuBtns[4];
-
-    if (m_activeFlyout == m_dspFlyout) {
-        hideFlyout();
-        return;
-    }
-    hideFlyout();
-
-    // Top-aligned with panel (from AetherSDR toggleDspPanel)
-    m_dspFlyout->move(x() + width(), y());
-    m_dspFlyout->raise();
-    m_dspFlyout->show();
-    m_activeFlyout = m_dspFlyout;
-    m_activeButton = dspBtn;
-    dspBtn->setStyleSheet(kMenuBtnActive);
 }
 
 // ── Display flyout ────────────────────────────────────────────────────────────
@@ -1024,8 +893,8 @@ void SpectrumOverlayPanel::buildDisplayFlyout()
 
 void SpectrumOverlayPanel::toggleDisplayFlyout()
 {
-    // Button index 5 (Display)
-    QPushButton* dispBtn = m_menuBtns[5];
+    // Button index 4 (Display)
+    QPushButton* dispBtn = m_menuBtns[4];
 
     if (m_activeFlyout == m_displayFlyout) {
         hideFlyout();
@@ -1291,8 +1160,8 @@ void SpectrumOverlayPanel::setBoardCapabilities(const BoardCapabilities& caps)
 
 void SpectrumOverlayPanel::toggleVaxFlyout()
 {
-    // Button index 6 (VAX)
-    QPushButton* vaxBtn = m_menuBtns[6];
+    // Button index 5 (VAX)
+    QPushButton* vaxBtn = m_menuBtns[5];
 
     if (m_activeFlyout == m_vaxFlyout) {
         hideFlyout();

--- a/src/gui/SpectrumOverlayPanel.h
+++ b/src/gui/SpectrumOverlayPanel.h
@@ -81,12 +81,6 @@ signals:
     // Band flyout
     void bandSelected(const QString& bandName, double freqHz, const QString& mode);
 
-    // DSP flyout toggles
-    void nrToggled(bool on);
-    void nbToggled(bool on);
-    void anfToggled(bool on);
-    void snbToggled(bool on);
-
     // Display flyout
     void wfColorGainChanged(int gain);
     void wfBlackLevelChanged(int level);
@@ -132,14 +126,12 @@ private:
     // Flyout builders
     void buildBandFlyout();
     void buildAntFlyout();
-    void buildDspFlyout();
     void buildDisplayFlyout();
     void buildVaxFlyout();
 
     // Flyout toggles
     void toggleBandFlyout();
     void toggleAntFlyout();
-    void toggleDspFlyout();
     void toggleDisplayFlyout();
     void toggleVaxFlyout();
 
@@ -173,19 +165,6 @@ private:
     QSlider*     m_rfGainSlider{nullptr};
     QLabel*      m_rfGainLabel{nullptr};
     QPushButton* m_wnbBtn{nullptr};
-
-    // ── DSP flyout ───────────────────────────────────────────────────────
-    QWidget*     m_dspFlyout{nullptr};
-    QPushButton* m_nrBtn{nullptr};
-    QPushButton* m_nbBtn{nullptr};
-    QPushButton* m_snbBtn{nullptr};
-    QPushButton* m_anfBtn{nullptr};
-    QPushButton* m_binBtn{nullptr};
-    QPushButton* m_mnfDspBtn{nullptr};
-    QSlider*     m_nrSlider{nullptr};
-    QLabel*      m_nrLabel{nullptr};
-    QSlider*     m_nbSlider{nullptr};
-    QLabel*      m_nbLabel{nullptr};
 
     // ── Display flyout ───────────────────────────────────────────────────
     QWidget*     m_displayFlyout{nullptr};


### PR DESCRIPTION
## Summary

- Top menu **DSP** rewrites: NR submenu (Off/NR1/NR2/NR3/NR4/DFNR/MNR + BNR-when-built) and NB submenu (Off/NB/NB2) as exclusive `QActionGroup`s; ANF/SNB/APF/BIN as single toggles. All routed through `SliceModel` (except ANF, still on `RxChannel` until Task 17), with bidirectional sync to the VFO flag mirroring the existing AGC pattern.
- Deletes the left-overlay-strip **DSP** flyout entirely. Its NR/NB/SNB/ANF buttons emitted signals nothing was connected to (every click was a no-op), and it duplicated the VFO flag's DSP grid. The flag, the menu bar, and Setup → DSP are the canonical surfaces.
- Old top-menu had NR running through legacy `RxChannel::setNrEnabled` while NR2 used `setActiveNr` — meaning both could be enabled simultaneously and confuse WDSP. Unified path closes that gap.

## Test plan

- [x] Builds clean on macOS Apple Silicon (`HAVE_MNR=1`, `HAVE_BNR=0`)
- [x] No orphan references to removed symbols (`m_dspFlyout`, `nrToggled`, `m_nrAction`, `buildDspFlyout`, etc.)
- [x] Top menu DSP shows NR ▶ / NB ▶ / ANF / SNB / APF / BIN / TNF (disabled) / AGC ▶ / Equalizer / PureSignal / Diversity
- [x] NR submenu shows Off / NR1 / NR2 / NR3 / NR4 / DFNR / MNR (BNR hidden when \`!HAVE_BNR\`)
- [x] NB submenu shows Off / NB / NB2
- [x] **Flag → menu sync**: VFO flag with DFNR + NB2 active → menu opens with \`✓ DFNR\` and \`✓ NB2\`
- [x] **Menu → flag sync**: clicking NR → NR2 in the menu cleared DFNR on the flag and highlighted NR2
- [x] Mutual exclusion: only one NR slot active at a time across both surfaces
- [x] BIN now functional (was disabled NYI placeholder)
- [x] Left overlay strip shows 8 buttons (+RX +TNF BAND ANT Display VAX ATT MNF) — DSP gone
- [ ] Cross-platform smoke (Linux / Windows) — defer to CI
- [ ] HL2 with FW74 — original report platform

## Notes

ANF cross-surface sync remains a known gap (its state lives on \`RxChannel\` as \`std::atomic<bool>\` with no notify signal). \`SliceModel::anfEnabled\` is on the roadmap as Task 17. Each surface continues to write to \`RxChannel::setAnfEnabled\` directly until then, matching today's behavior.

Fixes #135.