### PR TITLE
ci: pin mi0bot-Thetis to c26a8a4 to fix tag-preservation drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,19 +102,30 @@ jobs:
       # ------------------------------------------------------------------
       - name: Clone Thetis + mi0bot-Thetis upstream for tag check
         if: runner.os == 'Linux'
-        # Thetis (ramdor) is pinned to the archive commit 501e3f5 (tag
-        # v2.10.3.13, "Archive project and end active development") so
-        # the tag-preservation hook compares against the exact upstream
-        # state our [v2.10.3.13] inline cite stamps were verified
-        # against. Without this pin, HEAD drift (post-archive forks
-        # pushing to the mirror branch) shifts line numbers out from
-        # under our cites and the hook flags phantom missing tags that
-        # live at the NEW line of an unrelated edit.
+        # Both upstreams are pinned to the exact commit our inline cites
+        # were verified against. Without these pins, HEAD drift shifts
+        # line numbers out from under our cites and the hook flags
+        # phantom missing tags that live at the NEW line of an unrelated
+        # edit.
+        #
+        # ramdor/Thetis pinned to 501e3f5 (tag v2.10.3.13, "Archive
+        # project and end active development") to match every
+        # `[v2.10.3.13]` inline cite stamp.
         # See PR #120 CI failure 2026-04-23 for the original incident.
+        #
+        # mi0bot/OpenHPSDR-Thetis pinned to c26a8a4 ("Updated for
+        # release", 2026-04-01) to match every `[@c26a8a4]` inline cite
+        # stamp in the HL2 IO board epic.
+        # See main CI failure 2026-04-25 (post PR #137) for the
+        # incident that motivated this pin: mi0bot HEAD inserted a new
+        # ANAN_G1 case at setup.cs:20238 carrying a `//N1GP` tag,
+        # making the verifier flag four phantom missing tags on the
+        # untouched HermesLite cite block we ported from c26a8a4.
         run: |
           git clone https://github.com/ramdor/Thetis.git ../Thetis
           git -C ../Thetis checkout 501e3f513f73f07742d7e1b85a0e9528bd14977d
-          git clone --depth=1 https://github.com/mi0bot/OpenHPSDR-Thetis.git ../mi0bot-Thetis
+          git clone https://github.com/mi0bot/OpenHPSDR-Thetis.git ../mi0bot-Thetis
+          git -C ../mi0bot-Thetis checkout c26a8a4c7592605039be5f4b5973b33e04e91e54
 
       - name: Corpus drift — upstream author tags match committed corpus
         # Fails if upstream Thetis (ramdor or mi0bot fork) contains


### PR DESCRIPTION
## Summary

`verify-inline-tag-preservation.py` started failing on `main` after PR #137 merged. Root cause is HEAD drift in the mi0bot-Thetis upstream — same class of failure PR #120 fixed for ramdor/Thetis, just never applied to the mi0bot clone.

- The verifier opens each cited Thetis file in its upstream clone, scans ±5 lines around the cited range for `//AUTHOR` tags, and requires each one to appear within ±10 lines of the cite in our port.
- CI was cloning mi0bot HEAD with `--depth=1` and no pin. mi0bot has been actively developed since the HL2 IO board epic landed; a new `ANAN_G1` case was inserted at `setup.cs:20238` carrying a `//N1GP G1 added` comment.
- Our cite at `[@c26a8a4]` points at a totally different code block (HermesLite `chkHERCULES`) with no `//N1GP` anywhere nearby. The verifier sees `//N1GP` at the *new* line 20238 and flags four phantom missing tags in `Hl2IoBoardTab.{h,cpp}`.

## Fix

- Drop `--depth=1` from the mi0bot clone (shallow clones can't reliably check out an arbitrary historical sha).
- `git -C ../mi0bot-Thetis checkout c26a8a4c75...` after clone — that's the sha every `From mi0bot ...` cite in the tree is stamped against (`grep -rh '\[@' src/ tests/ | grep mi0bot` → only `[@c26a8a4]`).
- Refresh the comment block in `ci.yml` to document both pins side by side and record the 2026-04-25 incident.

## Verification

Reproduced locally:

```
$ cd /tmp && git clone https://github.com/mi0bot/OpenHPSDR-Thetis.git mi0bot-pinned
$ git -C mi0bot-pinned checkout c26a8a4c7592605039be5f4b5973b33e04e91e54
$ NEREUS_THETIS_DIR=/Users/j.j.boyd/Thetis \
  NEREUS_MI0BOT_DIR=/tmp/mi0bot-pinned \
  python3 scripts/verify-inline-tag-preservation.py
[tag-preservation] scanned 763 cites across 577 files
  WARN  src/core/P1RadioConnection.cpp:1540  RadioConnection.h — upstream-not-found
  WARN  src/gui/AddCustomRadioDialog.cpp:157  Designer.cs — upstream-not-found
  WARN  src/gui/AddCustomRadioDialog.cpp:289  HpsdrModel.h — upstream-not-found
[tag-preservation] OK — no missing tags detected
```

Exit 0. Three pre-existing benign `upstream-not-found` WARNs are unrelated to this drift (cites against generated `Designer.cs` files etc.).

## Test plan

- [ ] CI green on this branch
- [ ] After merge: confirm CI green on `main`

## Refs

- CI failure: run [24940229197](https://github.com/boydsoftprez/NereusSDR/actions/runs/24940229197) on commit dc7b411 (post-#137 merge)
- Related prior incident: PR #120 (ramdor/Thetis pin) — same class of bug

J.J. Boyd ~ KG4VCF