### PR TITLE
docs(build): document missing Linux deps (qt6-svg, jack, alsa, pipewire)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,7 @@ cmake --build build -j$(nproc)
 ./build/NereusSDR
 ```
 
-Dependencies (Arch): `qt6-base qt6-multimedia qt6-svg cmake ninja pkgconf fftw alsa-lib jack2 libpipewire`
+Dependencies (Arch): `qt6-base qt6-multimedia qt6-svg cmake ninja pkgconf fftw alsa-lib jack2 pipewire`
 Dependencies (Ubuntu/Debian): `qt6-base-dev qt6-base-private-dev qt6-multimedia-dev qt6-shadertools-dev qt6-svg-dev cmake ninja-build pkg-config libfftw3-dev libgl1-mesa-dev libasound2-dev libjack-jackd2-dev libpipewire-0.3-dev`
 Notes:
 * `qt6-svg` / `qt6-svg-dev` is hard-required (`find_package(Qt6 REQUIRED COMPONENTS Svg)`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,11 +290,12 @@ cmake --build build -j$(nproc)
 ./build/NereusSDR
 ```
 
-Dependencies: `qt6-base qt6-multimedia cmake ninja pkgconf fftw`
-Optional (Linux only): `libpipewire-0.3-dev` ≥ 0.3.50 — enables the
-PipeWire-native audio bridge (Phase 3O). Without it the build still
-works and the Linux audio path falls back to the existing pactl /
-LinuxPipeBus FIFO route.
+Dependencies (Arch): `qt6-base qt6-multimedia qt6-svg cmake ninja pkgconf fftw alsa-lib jack2 libpipewire`
+Dependencies (Ubuntu/Debian): `qt6-base-dev qt6-base-private-dev qt6-multimedia-dev qt6-shadertools-dev qt6-svg-dev cmake ninja-build pkg-config libfftw3-dev libgl1-mesa-dev libasound2-dev libjack-jackd2-dev libpipewire-0.3-dev`
+Notes:
+* `qt6-svg` / `qt6-svg-dev` is hard-required (`find_package(Qt6 REQUIRED COMPONENTS Svg)`).
+* `alsa-lib` / `libasound2-dev` and `jack2` / `libjack-jackd2-dev` are hard-required on Linux because PortAudio is built with `PA_USE_ALSA=ON` and `PA_USE_JACK=ON FORCE`; without them the static libportaudio links with zero host APIs.
+* `libpipewire-0.3-dev` ≥ 0.3.50 enables the native PipeWire audio bridge (Phase 3O). Build still succeeds without it; the Linux audio path falls back to the existing pactl / LinuxPipeBus FIFO route.
 
 WDSP source is in `third_party/wdsp/` (TAPR v1.29 + linux_port.h for cross-platform).
 FFTW3: system package on Linux/macOS, pre-built DLL on Windows (`third_party/fftw3/`).

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ sudo apt install qt6-base-dev qt6-base-private-dev \
 # Arch / CachyOS / Manjaro
 sudo pacman -S qt6-base qt6-multimedia qt6-svg \
   cmake ninja pkgconf fftw \
-  alsa-lib jack2 libpipewire
+  alsa-lib jack2 pipewire
 
 # macOS (Homebrew)
 brew install qt@6 ninja cmake pkgconf fftw

--- a/README.md
+++ b/README.md
@@ -203,16 +203,27 @@ See [docs/MASTER-PLAN.md](docs/MASTER-PLAN.md) for the full implementation plan.
 ```bash
 # Ubuntu 24.04+ / Debian
 sudo apt install qt6-base-dev qt6-base-private-dev \
-  qt6-multimedia-dev qt6-shadertools-dev \
+  qt6-multimedia-dev qt6-shadertools-dev qt6-svg-dev \
   cmake ninja-build pkg-config \
-  libfftw3-dev libgl1-mesa-dev
+  libfftw3-dev libgl1-mesa-dev \
+  libasound2-dev libjack-jackd2-dev \
+  libpipewire-0.3-dev
 
 # Arch / CachyOS / Manjaro
-sudo pacman -S qt6-base qt6-multimedia cmake ninja pkgconf fftw
+sudo pacman -S qt6-base qt6-multimedia qt6-svg \
+  cmake ninja pkgconf fftw \
+  alsa-lib jack2 libpipewire
 
 # macOS (Homebrew)
 brew install qt@6 ninja cmake pkgconf fftw
 ```
+
+The bundled PortAudio is built with `PA_USE_ALSA=ON` and `PA_USE_JACK=ON` on Linux,
+so the ALSA and JACK development headers are required at compile time even if you
+don't use those audio backends at runtime. `libpipewire-0.3-dev` (≥ 0.3.50) is
+strongly recommended on PipeWire-default distributions (Ubuntu 24.04+, Fedora 39+,
+Arch) — without it the Linux audio path falls back from the native libpipewire-0.3
+bridge to the older pactl route.
 
 ### Windows (FFTW3 Setup)
 


### PR DESCRIPTION
## Summary

- README.md and CLAUDE.md were missing four Linux build dependencies that the build either hard-requires or strongly recommends. CI installs all four, so workflow runners built clean while fresh local clones tripped.
- Adds `qt6-svg-dev`, `libjack-jackd2-dev`, `libasound2-dev`, `libpipewire-0.3-dev` to the Ubuntu/Debian install line.
- Brings the Arch line to parity (`qt6-svg`, `alsa-lib`, `jack2`, `libpipewire`).
- Adds a short explanatory paragraph below the Ubuntu block so the `PA_USE_ALSA=ON` / `PA_USE_JACK=ON FORCE` PortAudio config isn't a mystery.

## Why each dep

| Package | Status | Source |
|---|---|---|
| `qt6-svg-dev` | hard-required | `find_package(Qt6 REQUIRED COMPONENTS Svg)` at [CMakeLists.txt:33](CMakeLists.txt#L33) |
| `libjack-jackd2-dev` | hard-required on Linux | `PA_USE_JACK=ON FORCE` at [CMakeLists.txt:81](CMakeLists.txt#L81) — static libportaudio links with zero host APIs without it |
| `libasound2-dev` | hard-required on Linux | `PA_USE_ALSA=ON FORCE` at [CMakeLists.txt:80](CMakeLists.txt#L80) — same reason |
| `libpipewire-0.3-dev` | optional, recommended | [CMakeLists.txt:199](CMakeLists.txt#L199); without it Linux audio falls back from the native libpipewire-0.3 bridge to pactl |

CI installs all four ([ci.yml:194-200](.github/workflows/ci.yml#L194), [codeql.yml:30-36](.github/workflows/codeql.yml#L30), [release.yml:118-135](.github/workflows/release.yml#L118)).

No CMake changes — `PA_USE_JACK ON FORCE` is justified per the existing comment at [CMakeLists.txt:73-78](CMakeLists.txt#L73). Better to fix the docs than weaken the build.

Fixes #142. Reported by John Melton G0ORX.

## Test plan

- [ ] Fresh Ubuntu 24.04+ container: `apt install` the new line, `cmake -B build -G Ninja`, build succeeds.
- [ ] Fresh Arch container: `pacman -S` the new line, build succeeds.
- [ ] Existing macOS / Windows build paths unchanged (no Linux-only edits affect them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)