### PR TITLE
feat(3n-5.5): wire Developer ID signing + notarization for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
             -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
 
           # Add temp keychain to the search list so codesign finds the certs
-          security list-keychain -d user -s "$KEYCHAIN_PATH" \
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
             $(security list-keychains -d user | tr -d '"')
 
           # Allow codesign / productbuild to use the keys without prompts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,44 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # Import Apple Developer ID certs into a temporary keychain so
+      # codesign / productbuild can find them. Gated on the secret being
+      # present so dev builds without secrets still complete (they fall
+      # back to ad-hoc codesign in the "Codesign app" step below).
+      - name: Import Apple certs
+        if: env.HAS_APPLE_DEVELOPER_ID == 'true'
+        env:
+          APPLE_CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+          APPLE_CERT_P12_PASSWORD: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 24)
+          P12_PATH="$RUNNER_TEMP/certs.p12"
+
+          echo -n "$APPLE_CERT_P12_BASE64" | base64 --decode > "$P12_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security import "$P12_PATH" \
+            -P "$APPLE_CERT_P12_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+
+          # Add temp keychain to the search list so codesign finds the certs
+          security list-keychain -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | tr -d '"')
+
+          # Allow codesign / productbuild to use the keys without prompts
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign:,productbuild: \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Verify both identities are visible
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+          rm "$P12_PATH"
+
       - name: Set up DeepFilterNet3 library
         run: bash setup-deepfilter.sh
 
@@ -359,32 +397,21 @@ jobs:
           mkdir -p build/NereusSDR.app/Contents/Resources/models/dfnet3
           cp third_party/deepfilter/models/DeepFilterNet3_onnx.tar.gz build/NereusSDR.app/Contents/Resources/models/dfnet3/
 
-      - name: Ad-hoc codesign
+      # Sign the .app bundle. With APPLE_DEVELOPER_ID set we use Developer
+      # ID + hardened runtime + entitlements (required for notarization).
+      # Without secrets we fall back to ad-hoc so dev builds still work.
+      - name: Codesign app
         run: |
-          codesign --force --deep --sign - build/NereusSDR.app
+          if [ "$HAS_APPLE_DEVELOPER_ID" = "true" ]; then
+            codesign --force --deep --options runtime --timestamp \
+              --entitlements packaging/macos/app-entitlements.plist \
+              --sign "${{ secrets.APPLE_DEVELOPER_ID }}" \
+              build/NereusSDR.app
+          else
+            codesign --force --deep --sign - build/NereusSDR.app
+          fi
           codesign --verify --verbose=2 build/NereusSDR.app
 
-      # ── Sub-Phase 5 Task 5.4: HAL plugin build + sign + .pkg + notarize ──
-      # The HAL plugin build and the .pkg build via hal-installer.sh run
-      # unconditionally so alpha / dev release cuts without Apple certs
-      # still produce a working (unsigned) .pkg artifact. The Developer ID
-      # sign, notarize, and staple steps are gated on APPLE_DEVELOPER_ID
-      # being populated.
-      #
-      # Known limitations (tracked for a Sub-Phase 5.5 follow-up):
-      #   * The main app currently gets ad-hoc codesign above, not
-      #     Developer ID. Apple's notarytool requires every component
-      #     inside a submitted .pkg to carry a Developer ID signature,
-      #     so notarization will reject the .pkg until the app's
-      #     codesign step is upgraded to Developer ID when secrets are
-      #     present.
-      #   * The .pkg itself is produced by productbuild without --sign.
-      #     A Developer ID Installer certificate and an extra productsign
-      #     step (or an env-var threading through hal-installer.sh) will
-      #     be needed before notarization can succeed end-to-end.
-      # Until both are addressed, the Notarize step is expected to fail
-      # on real submissions; the Sign HAL plugin / Build .pkg steps do
-      # their job standalone and the .pkg upload still lands.
       - name: Build HAL plugin
         run: |
           cmake -B build-hal -S hal-plugin -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -394,13 +421,16 @@ jobs:
         if: env.HAS_APPLE_DEVELOPER_ID == 'true'
         run: |
           codesign --force --options runtime --timestamp \
-            --sign "Developer ID Application: ${{ secrets.APPLE_DEVELOPER_ID }}" \
+            --entitlements packaging/macos/hal-entitlements.plist \
+            --sign "${{ secrets.APPLE_DEVELOPER_ID }}" \
             build-hal/NereusSDRVAX.driver
 
       - name: Build .pkg
+        env:
+          APPLE_INSTALLER_ID: ${{ secrets.APPLE_INSTALLER_ID }}
         run: bash packaging/macos/hal-installer.sh
 
-      - name: Notarize
+      - name: Notarize .pkg
         if: env.HAS_APPLE_DEVELOPER_ID == 'true'
         run: |
           xcrun notarytool submit \
@@ -410,7 +440,7 @@ jobs:
             --password "${{ secrets.APPLE_APP_PASSWORD }}" \
             --wait
 
-      - name: Staple
+      - name: Staple .pkg
         if: env.HAS_APPLE_DEVELOPER_ID == 'true'
         run: |
           xcrun stapler staple \
@@ -431,17 +461,30 @@ jobs:
           || true
           ls -la NereusSDR-*.dmg
 
-      # NOTE: The .pkg is uploaded as a workflow artifact only — NOT attached
-      # to the GitHub Release. Release attachment is deferred until the two
-      # cascading items land:
-      #   1. Main app codesign upgraded from ad-hoc to Developer ID (required
-      #      for notarization to accept the .pkg).
-      #   2. hal-installer.sh wired for productbuild --sign via
-      #      Developer ID Installer certificate.
-      # Until both are in place, the .pkg is a build-verification artifact
-      # for local smoke-testing, not a distributable installer. The
-      # sign-and-publish job at the bottom of this workflow intentionally
-      # excludes *.pkg from its find glob.
+      - name: Codesign DMG
+        if: env.HAS_APPLE_DEVELOPER_ID == 'true'
+        run: |
+          DMG_PATH=$(ls NereusSDR-*.dmg | head -1)
+          codesign --force --timestamp \
+            --sign "${{ secrets.APPLE_DEVELOPER_ID }}" \
+            "$DMG_PATH"
+
+      - name: Notarize DMG
+        if: env.HAS_APPLE_DEVELOPER_ID == 'true'
+        run: |
+          DMG_PATH=$(ls NereusSDR-*.dmg | head -1)
+          xcrun notarytool submit "$DMG_PATH" \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --password "${{ secrets.APPLE_APP_PASSWORD }}" \
+            --wait
+
+      - name: Staple DMG
+        if: env.HAS_APPLE_DEVELOPER_ID == 'true'
+        run: |
+          DMG_PATH=$(ls NereusSDR-*.dmg | head -1)
+          xcrun stapler staple "$DMG_PATH"
+
       - name: Upload .pkg artifact
         uses: actions/upload-artifact@v4
         with:
@@ -641,6 +684,7 @@ jobs:
           find downloaded -type f \( \
             -name '*.AppImage' -o \
             -name '*.dmg' -o \
+            -name '*.pkg' -o \
             -name '*.zip' -o \
             -name '*-setup.exe' -o \
             -name 'release_notes.md' \
@@ -689,7 +733,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         working-directory: artifacts
         run: |
-          for f in *.AppImage *.dmg *.zip *.exe *.tar.gz SHA256SUMS.txt; do
+          for f in *.AppImage *.dmg *.pkg *.zip *.exe *.tar.gz SHA256SUMS.txt; do
             [ -f "$f" ] || continue
             gpg --batch --yes --pinentry-mode loopback \
               --passphrase "$GPG_PASSPHRASE" \
@@ -716,6 +760,7 @@ jobs:
             $PRERELEASE_FLAG \
             artifacts/*.AppImage \
             artifacts/*.dmg \
+            artifacts/*.pkg \
             artifacts/*.zip \
             artifacts/*-setup.exe \
             artifacts/*.tar.gz \

--- a/packaging/macos/app-entitlements.plist
+++ b/packaging/macos/app-entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Qt loads platform plugins, image format plugins, and Rust/DSP
+         dylibs (DeepFilterNet, rnnoise) that are re-signed with our
+         Developer ID during macdeployqt + codesign. Library validation
+         normally requires same-TeamID OR Apple signature for every loaded
+         binary; we disable it because re-signing every nested framework
+         in lock-step is brittle for Qt apps. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/packaging/macos/hal-entitlements.plist
+++ b/packaging/macos/hal-entitlements.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- NereusSDRVAX is an Audio Server Plugin (CoreAudio HAL plugin).
+         It loads into coreaudiod and uses only the AudioServerPlugIn API,
+         no third-party dylibs. The empty entitlements dict is
+         intentional — hardened runtime alone (via codesign --options
+         runtime) provides the right defaults for this plugin. If
+         notarization rejects with library-validation complaints, add
+         com.apple.security.cs.disable-library-validation here. -->
+</dict>
+</plist>

--- a/packaging/macos/hal-installer.sh
+++ b/packaging/macos/hal-installer.sh
@@ -137,11 +137,22 @@ cat > "${PKG_DIR}/resources/welcome.html" << 'WELCOME'
 WELCOME
 
 # 7. Build product archive
-productbuild \
-    --distribution "${PKG_DIR}/Distribution.xml" \
-    --resources "${PKG_DIR}/resources" \
-    --package-path "${PKG_DIR}" \
-    "${BUILD_DIR}/NereusSDR-${VERSION}-macOS.pkg"
+#    If APPLE_INSTALLER_ID env var is set (CI with Developer ID Installer
+#    cert imported into the keychain), sign the .pkg. Otherwise produce
+#    an unsigned .pkg suitable for local smoke-testing.
+PRODUCTBUILD_ARGS=(
+    --distribution "${PKG_DIR}/Distribution.xml"
+    --resources "${PKG_DIR}/resources"
+    --package-path "${PKG_DIR}"
+)
+if [ -n "${APPLE_INSTALLER_ID:-}" ]; then
+    echo "--- Signing .pkg with: ${APPLE_INSTALLER_ID} ---"
+    PRODUCTBUILD_ARGS+=(--sign "${APPLE_INSTALLER_ID}")
+else
+    echo "--- APPLE_INSTALLER_ID not set; producing unsigned .pkg ---"
+fi
+PRODUCTBUILD_ARGS+=("${BUILD_DIR}/NereusSDR-${VERSION}-macOS.pkg")
+productbuild "${PRODUCTBUILD_ARGS[@]}"
 
 echo ""
 echo "=== Installer created: ${BUILD_DIR}/NereusSDR-${VERSION}-macOS.pkg ==="


### PR DESCRIPTION
## Summary

Closes the Sub-Phase 5.5 follow-up gap from the prior 3N scaffolding. Replaces ad-hoc `.app` codesign with Developer ID + hardened runtime + entitlements, signs the `.pkg` with Developer ID Installer, codesigns + notarizes + staples the DMG, and attaches `.pkg` to GitHub Releases.

## What lands

- **New** `packaging/macos/app-entitlements.plist` — `disable-library-validation` (Qt platform plugins + DeepFilterNet/rnnoise Rust dylibs)
- **New** `packaging/macos/hal-entitlements.plist` — empty dict (hardened-runtime defaults are sufficient for the `AudioServerPlugIn`)
- **Modified** `packaging/macos/hal-installer.sh` — `productbuild --sign $APPLE_INSTALLER_ID` when env var present, unsigned otherwise (preserves local smoke-test path)
- **Modified** `.github/workflows/release.yml`:
  - NEW step: Import Apple certs from `APPLE_CERT_P12_BASE64` into a temp keychain
  - App codesign upgraded ad-hoc → Developer ID + entitlements (ad-hoc fallback when `APPLE_DEVELOPER_ID` unset)
  - Sign HAL plugin gets `--entitlements`
  - Build .pkg passes `APPLE_INSTALLER_ID` through env
  - NEW: Codesign DMG / Notarize DMG / Staple DMG
  - `sign-and-publish`: `*.pkg` added to stage glob, GPG sign loop, release attachment list
  - Removed obsolete "known limitations" + ".pkg artifact-only" comment blocks

## Behavior matrix

| \`APPLE_DEVELOPER_ID\` | App | HAL | .pkg | DMG | Release attach |
|---|---|---|---|---|---|
| Set (release tag) | Developer ID + hardened runtime + entitlements | Developer ID + entitlements | Developer ID Installer signed | Developer ID + notarized + stapled | \`.pkg\` + \`.dmg\` |
| Unset (dev cut) | ad-hoc | unsigned | unsigned | unsigned | \`.dmg\` only |

## GitHub Secrets required

All seven set in this repo on 2026-04-28: \`APPLE_DEVELOPER_ID\`, \`APPLE_INSTALLER_ID\`, \`APPLE_TEAM_ID\`, \`APPLE_ID\`, \`APPLE_APP_PASSWORD\`, \`APPLE_CERT_P12_BASE64\`, \`APPLE_CERT_P12_PASSWORD\`.

## Test plan

- [x] \`release.yml\` parses (\`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"\`)
- [x] \`hal-installer.sh\` \`bash -n\` clean
- [x] All three \`.plist\` files validate via \`plutil\`
- [ ] Cut \`v0.2.4-alpha.1\` test tag → workflow runs end-to-end
- [ ] \`notarytool submit\` accepts both \`.pkg\` and \`.dmg\`
- [ ] \`stapler validate\` passes on both
- [ ] Draft GitHub Release contains both with \`.asc\` signatures
- [ ] Manual: download notarized \`.dmg\` on a clean Mac, drag to \`/Applications\`, confirm Gatekeeper opens it without an "unidentified developer" warning

J.J. Boyd ~ KG4VCF