### PR TITLE
fix(connect): wisdom progress dialog + TX moveToThread regressions on 0.3.0

### DIFF
--- a/src/core/WdspEngine.cpp
+++ b/src/core/WdspEngine.cpp
@@ -472,6 +472,16 @@ TxChannel* WdspEngine::createTxChannel(int channelId,
     // The 31 TXA stages (create_txa()) are live; TxChannel provides the typed
     // C++ facade.  unique_ptr destructor handles cleanup automatically on erase().
     //
+    // Parent argument: nullptr — DO NOT pass `this` here.  RadioModel::
+    // connectToRadio does m_txChannel->moveToThread(workerThread) shortly
+    // after createTxChannel returns, and Qt's invariant is that a QObject
+    // with a parent CANNOT be moved across threads (silent failure with one
+    // warning, then TxWorkerThread::run drains sendPostedEvents on a
+    // wrong-thread channel forever, generating an event-flood storm).
+    // Ownership stays with std::unique_ptr in m_txChannels — the Qt parent
+    // is redundant.  See tst_wdsp_engine_tx_channel.cpp:
+    // createdTxChannelHasNoQtParentForThreadAffinity for the regression test.
+    //
     // Bench fix round 3 (Issue A): pass inputBufferSize and outputBufferSize so
     // TxChannel sizes its fexchange0 buffers correctly.  (3M-1c TX pump v3
     // changed the production callsite from fexchange2 → fexchange0; the
@@ -485,7 +495,7 @@ TxChannel* WdspEngine::createTxChannel(int channelId,
     // From Thetis wdsp/cmaster.c:179-183 [v2.10.3.13] — in_size / ch_outrate.
     // From Thetis wdsp/cmsetup.c:106-110 [v2.10.3.13] — getbuffsize(48000)==64.
     const int outputBufferSize = inputBufferSize * outputSampleRate / inputSampleRate;
-    auto wrapper = std::make_unique<TxChannel>(channelId, inputBufferSize, outputBufferSize, this);
+    auto wrapper = std::make_unique<TxChannel>(channelId, inputBufferSize, outputBufferSize, nullptr);
     TxChannel* raw = wrapper.get();
     m_txChannels.emplace(channelId, std::move(wrapper));
 

--- a/src/core/WdspEngine.cpp
+++ b/src/core/WdspEngine.cpp
@@ -127,49 +127,53 @@ bool WdspEngine::initialize(const QString& configDir)
 
     // Note: Thetis wisdom files are NOT reusable — FFTW wisdom is specific
     // to the exact FFTW build. Copying across builds hangs on import.
-    bool needsGeneration = needsWisdomGeneration(m_configDir);
+    //
+    // Always run wisdom load/regenerate on a worker thread with progress UI.
+    // We previously had a "fast path" that called WDSPwisdom synchronously on
+    // the main thread when wdspWisdom00 already existed, on the assumption
+    // that sync load is instant.  That assumption is wrong: WDSPwisdom
+    // silently regenerates any plans missing from the cached file, which
+    // can take minutes — the main thread freezes (beach ball on macOS) with
+    // no progress dialog because wisdomProgress is never emitted.
+    //
+    // The MainWindow handler at MainWindow.cpp:583 already guards
+    //   if (!m_wisdomDialog && percent < 100) { create dialog; }
+    // so a genuinely cached/fast load that completes before the 250 ms poll
+    // never pops a dialog.  Only sub-poll fast loads stay silent — which is
+    // fine, the user doesn't need feedback for a sub-second operation.
     QByteArray configPath = m_configDir.toUtf8();
 
-    if (!needsGeneration) {
-        // Fast path: wisdom file exists — WDSPwisdom just loads it (instant).
-        // Safe to call on main thread.
-        qCInfo(lcDsp) << "Loading existing WDSP wisdom file...";
-        WDSPwisdom(configPath.data());
-        qCInfo(lcDsp) << "WDSP wisdom loaded";
+    qCInfo(lcDsp) << "Initializing WDSP wisdom on background thread"
+                  << "(load if cached, regenerate any missing plans)";
+
+    auto* wisdomThread = QThread::create([configPath]() {
+        WDSPwisdom(const_cast<char*>(configPath.constData()));
+    });
+    wisdomThread->setObjectName(QStringLiteral("WisdomThread"));
+
+    // Poll wisdom_get_status() for progress updates
+    auto* pollTimer = new QTimer(this);
+    pollTimer->setInterval(250);
+
+    connect(wisdomThread, &QThread::finished, this, [this, wisdomThread, pollTimer]() {
+        pollTimer->stop();
+        pollTimer->deleteLater();
+        wisdomThread->deleteLater();
+        emit wisdomProgress(100, QStringLiteral("FFTW planning complete"));
         finishInitialization();
-    } else {
-        // Slow path: generate wisdom on a background thread with progress.
-        qCInfo(lcDsp) << "Generating WDSP wisdom (first run, may take several minutes)...";
+    });
 
-        auto* wisdomThread = QThread::create([configPath]() {
-            WDSPwisdom(const_cast<char*>(configPath.constData()));
-        });
-        wisdomThread->setObjectName(QStringLiteral("WisdomThread"));
+    connect(pollTimer, &QTimer::timeout, this, [this]() {
+        char* status = wisdom_get_status();
+        if (status && status[0] != '\0') {
+            int pct = estimateWisdomPercent(status);
+            QString msg = QString::fromUtf8(status).trimmed();
+            emit wisdomProgress(pct, msg);
+        }
+    });
 
-        // Poll wisdom_get_status() for progress updates
-        auto* pollTimer = new QTimer(this);
-        pollTimer->setInterval(250);
-
-        connect(wisdomThread, &QThread::finished, this, [this, wisdomThread, pollTimer]() {
-            pollTimer->stop();
-            pollTimer->deleteLater();
-            wisdomThread->deleteLater();
-            emit wisdomProgress(100, QStringLiteral("FFTW planning complete"));
-            finishInitialization();
-        });
-
-        connect(pollTimer, &QTimer::timeout, this, [this]() {
-            char* status = wisdom_get_status();
-            if (status && status[0] != '\0') {
-                int pct = estimateWisdomPercent(status);
-                QString msg = QString::fromUtf8(status).trimmed();
-                emit wisdomProgress(pct, msg);
-            }
-        });
-
-        wisdomThread->start();
-        pollTimer->start();
-    }
+    wisdomThread->start();
+    pollTimer->start();
     return true;
 
 #else

--- a/src/core/WdspEngine.h
+++ b/src/core/WdspEngine.h
@@ -90,6 +90,14 @@ warren@wpratt.com
 #include <map>
 #include <memory>
 
+#ifdef NEREUS_BUILD_TESTS
+// Forward declaration for test-only friend access (see end of class).  The
+// test class lives in the global namespace because it inherits from QObject
+// in tests/tst_wdsp_engine_tx_channel.cpp without a NereusSDR namespace
+// wrapper — friend declarations need the fully-qualified name.
+class TestWdspEngineTxChannel;
+#endif
+
 namespace NereusSDR {
 
 class RxChannel;
@@ -242,6 +250,14 @@ private:
     // pipeline that WDSP constructs when OpenChannel(type=1) is called.
     // destroyTxChannel's erase() runs the unique_ptr destructor automatically.
     std::map<int, std::unique_ptr<TxChannel>> m_txChannels;
+
+#ifdef NEREUS_BUILD_TESTS
+    // Test-only friend: lets unit tests bypass async wisdom load by setting
+    // m_initialized = true directly so they can exercise createTxChannel /
+    // createRxChannel without a running event loop or a real WDSP wisdom
+    // file.  Production builds (without NEREUS_BUILD_TESTS) never see this.
+    friend class ::TestWdspEngineTxChannel;
+#endif
 };
 
 } // namespace NereusSDR

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -267,6 +267,7 @@ warren@wpratt.com
 #include <cmath>
 
 #include <QDateTime>
+#include <QEventLoop>
 #include <QMetaObject>
 #include <QStandardPaths>
 #include <QThread>
@@ -1428,6 +1429,29 @@ void RadioModel::connectToRadio(const RadioInfo& info)
         qCInfo(lcDsp) << "WDSP ready — RX channel 0 active, audio started";
     }, Qt::SingleShotConnection);
     m_wdspEngine->initialize(configDir);
+
+    // WDSP wisdom now ALWAYS runs on a worker thread (WdspEngine::initialize
+    // dropped its sync fast path so the user gets a progress dialog whenever
+    // FFTW regenerates plans).  But the rest of this function — TX channel
+    // creation at line ~1452, the SingleShot lambda above that creates the
+    // RX channel, etc. — was written against the old sync contract where
+    // m_initialized was true by the time initialize() returned.
+    //
+    // Block here while the wisdom worker finishes, pumping the Qt event loop
+    // so the MainWindow wisdom progress dialog (connected to wisdomProgress)
+    // renders and updates.  The dialog is Qt::ApplicationModal (see
+    // MainWindow.cpp:600) so other windows are blocked from interaction
+    // during the wait — no re-entrant Connect-clicks or similar.
+    if (!m_wdspEngine->isInitialized()) {
+        QEventLoop wisdomLoop;
+        QMetaObject::Connection waitConn = QObject::connect(
+            m_wdspEngine, &WdspEngine::initializedChanged,
+            &wisdomLoop, [&wisdomLoop](bool ok) {
+                if (ok) wisdomLoop.quit();
+            });
+        wisdomLoop.exec();
+        QObject::disconnect(waitConn);
+    }
 
     // Factory-create the connection (no parent — will be moved to thread)
     auto conn = RadioConnection::create(info);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1442,16 +1442,23 @@ void RadioModel::connectToRadio(const RadioInfo& info)
     // renders and updates.  The dialog is Qt::ApplicationModal (see
     // MainWindow.cpp:600) so other windows are blocked from interaction
     // during the wait — no re-entrant Connect-clicks or similar.
+    //
+    // Order: register the listener BEFORE checking isInitialized().  Qt's
+    // current threading semantics make the check-then-connect race
+    // theoretically impossible (no event pump between the read and the
+    // connect), but the canonical wait-for-signal idiom is connect → check
+    // → exec — robust against future Qt internals changes and trivially
+    // race-proof regardless of when the worker's QThread::finished posts.
+    QEventLoop wisdomLoop;
+    QMetaObject::Connection waitConn = QObject::connect(
+        m_wdspEngine, &WdspEngine::initializedChanged,
+        &wisdomLoop, [&wisdomLoop](bool ok) {
+            if (ok) wisdomLoop.quit();
+        });
     if (!m_wdspEngine->isInitialized()) {
-        QEventLoop wisdomLoop;
-        QMetaObject::Connection waitConn = QObject::connect(
-            m_wdspEngine, &WdspEngine::initializedChanged,
-            &wisdomLoop, [&wisdomLoop](bool ok) {
-                if (ok) wisdomLoop.quit();
-            });
         wisdomLoop.exec();
-        QObject::disconnect(waitConn);
     }
+    QObject::disconnect(waitConn);
 
     // Factory-create the connection (no parent — will be moved to thread)
     auto conn = RadioConnection::create(info);

--- a/tests/tst_wdsp_engine_tx_channel.cpp
+++ b/tests/tst_wdsp_engine_tx_channel.cpp
@@ -48,6 +48,7 @@ warren@wpratt.com
 
 #include <QtTest/QtTest>
 
+#include "core/TxChannel.h"
 #include "core/WdspEngine.h"
 
 using namespace NereusSDR;
@@ -209,6 +210,42 @@ private slots:
         QVERIFY(kTxChannelId != kRxChannelId);
         QCOMPARE(kTxChannelId, 1);   // TX ID per WDSP.id(1,0) + CMsubrcvr=CMrcvr=1
         QCOMPARE(kRxChannelId, 0);
+    }
+
+    // ── TxChannel created via WdspEngine must have no Qt parent ─────────────
+    //
+    // Regression introduced by Phase 3M-1c TX pump v3 redesign: WdspEngine::
+    // createTxChannel constructed TxChannel with parent=this (the engine —
+    // main-thread-affined), but RadioModel::connectToRadio then does
+    // m_txChannel->moveToThread(workerThread).  Qt invariant: a QObject with
+    // a parent CANNOT be moved across threads.  moveToThread silently fails
+    // (one warning), TxChannel stays on the main thread, and TxWorkerThread::
+    // run drains QCoreApplication::sendPostedEvents(m_txChannel) from the
+    // worker thread — producing tens of thousands to millions of "Cannot send
+    // posted events for objects in another thread" warnings per session and
+    // starving the main thread.
+    //
+    // Ownership of TxChannel is held by std::unique_ptr in
+    // WdspEngine::m_txChannels — a Qt parent on top of that is redundant and
+    // breaks moveToThread.
+    //
+    // We use the test-only friend access (WdspEngine.h, gated on
+    // NEREUS_BUILD_TESTS) to set m_initialized = true synchronously, bypassing
+    // the async wisdom path which would otherwise need a running event loop
+    // and a real WDSP wisdom file to complete.
+    void createdTxChannelHasNoQtParentForThreadAffinity() {
+        WdspEngine engine;
+        engine.m_initialized = true;   // friend access, test-only path
+
+        TxChannel* tx = engine.createTxChannel(kTxChannelId);
+        QVERIFY(tx != nullptr);
+        QVERIFY2(tx->parent() == nullptr,
+                 "TxChannel created via WdspEngine::createTxChannel must "
+                 "have no Qt parent so RadioModel::connectToRadio can move "
+                 "it onto TxWorkerThread without tripping Qt's "
+                 "'cannot move objects with a parent' invariant");
+
+        engine.destroyTxChannel(kTxChannelId);
     }
 };
 


### PR DESCRIPTION
## Summary

Two distinct regressions surface as "connecting to a radio on 0.3.0 hangs the app." Both fixed here, in two GPG-signed commits (one per bug).

### Bug 1 — wisdom progress dialog disappeared

`WdspEngine::initialize` had a fast path that called `WDSPwisdom` synchronously on the main thread when `wdspWisdom00` already existed, on the assumption that load is instant. That assumption is wrong: `WDSPwisdom` silently regenerates any plans missing from the cached file, which can take minutes — main thread freezes (beach ball on macOS) with no progress dialog because `wisdomProgress` is never emitted along the fast path.

**Field repro:** my cached `wdspWisdom00` was 38 KB after a settings purge. `WDSPwisdom()` blocked the main thread for 2 min 39 s on Connect with no dialog. Indistinguishable from a hung app.

**Fix:** drop the fast/slow branch, always run wisdom on a worker thread with the existing `pollTimer` + `wisdomProgress` signal. `MainWindow` already guards `if (!m_wisdomDialog && percent < 100)`, so genuinely cached fast loads (sub-250-ms) still don't pop a dialog. Add a local `QEventLoop` wait in `RadioModel::connectToRadio` right after `initialize()` so downstream code (TX channel creation, slice config) keeps its sync contract — events pump during the wait so the dialog renders.

### Bug 2 — TX cross-thread event flood

Phase 3M-1c TX pump v3 introduced `m_txChannel->moveToThread(workerThread)` in `connectToRadio`, but `WdspEngine::createTxChannel` was still constructing `TxChannel` with `parent=this` (engine, main-thread-affined). Qt invariant: a `QObject` with a parent CANNOT be moved across threads. `moveToThread` silently failed with one warning per connect, `TxChannel` stayed on the main thread, and `TxWorkerThread::run` then drained `QCoreApplication::sendPostedEvents(m_txChannel)` from the worker every loop iteration — producing tens of thousands to millions of *"Cannot send posted events for objects in another thread"* warnings per session and starving the main thread in a repaint storm.

**Field repro:** 40,623 spam warnings in one short session, **17,535,574 in a longer one**.

**Fix:** `nullptr` parent in `createTxChannel`. Ownership stays with `std::unique_ptr` in `m_txChannels`. Added a regression test (`createdTxChannelHasNoQtParentForThreadAffinity`) via a test-only `friend` declaration so the test can flip `m_initialized` and exercise `createTxChannel` without a running event loop or real wisdom file.

## Verification

- Live test on macOS 26.4 / HL2: TX pump starts, radio connects, audio + I/Q flow, **0** moveToThread warnings, **0** sendPostedEvents spam.
- Wisdom regen took ~7 min on this branch — progress dialog rendered the entire time, no beach ball.
- Full test suite: 282/284 pass. The two failures (`tst_radio_model_set_tune` SEGFAULT, `tst_p1_mic_ptt_wire` HL2 codec PTT bit) reproduce identically on baseline `baf34bb` without these changes — pre-existing, unrelated.

## Test plan

- [ ] Connect to ANAN-G2 (P2) — verify no freeze, no spam in log
- [ ] Connect to HL2 (P1) — verify no freeze, no spam in log
- [ ] Force a wisdom regen (delete `~/Library/Preferences/NereusSDR/NereusSDR/wdspWisdom00` on macOS, equivalent on Linux/Windows) — verify the wisdom progress dialog appears with live status updates and closes cleanly
- [ ] Disconnect + reconnect — verify cleanup is clean (no dangling TxChannel, no warnings)
- [ ] CI green

## Files

| File | Commit | Change |
|------|--------|--------|
| `src/core/WdspEngine.cpp` | both | wisdom branch collapse + `nullptr` parent for TxChannel |
| `src/core/WdspEngine.h` | TX | forward declaration + `friend class ::TestWdspEngineTxChannel` (gated on `NEREUS_BUILD_TESTS`) |
| `src/models/RadioModel.cpp` | wisdom | local `QEventLoop` wait after `initialize()` + `#include <QEventLoop>` |
| `tests/tst_wdsp_engine_tx_channel.cpp` | TX | regression test |

J.J. Boyd ~ KG4VCF