### PR TITLE
fix(persistence/shutdown): restore last band, persist all slice changes, eliminate ⌘Q beach ball

### DIFF
--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -153,6 +153,7 @@ void RadioDiscovery::startDiscovery()
     // main's cross-platform socket header fix (b3c2961) is preserved at
     // the top of this file, which is what scanAllNics() needs when it
     // does its own setsockopt(SO_BROADCAST) per NIC.
+    m_stopRequested.store(false, std::memory_order_release);
     emit discoveryStarted();
     scanAllNics();                              // one-shot NIC walk
     if (!m_staleTimer.isActive()) {
@@ -165,6 +166,14 @@ void RadioDiscovery::startDiscovery()
 
 void RadioDiscovery::stopDiscovery()
 {
+    // Cooperative cancel for any scanAllNics() currently in flight (or
+    // queued via a recently-fired m_staleTimer). Without this flip the
+    // SafeDefault profile blocks shutdown for ~4.5 s on a 2-NIC machine
+    // while the scan completes its attempts × pollTimeoutMs walk; with
+    // it the scan exits within one pollTimeoutMs window. m_staleTimer.stop()
+    // alone isn't enough — already-queued QTimer events still execute
+    // after the close path returns to the event loop.
+    m_stopRequested.store(true, std::memory_order_release);
     m_staleTimer.stop();
     emit discoveryFinished();
 }
@@ -361,6 +370,12 @@ void RadioDiscovery::scanAllNics()
 
     const auto interfaces = QNetworkInterface::allInterfaces();
     for (const QNetworkInterface& iface : interfaces) {
+        // Cooperative cancel — see stopDiscovery(). Bail before touching
+        // a new NIC if a shutdown was requested. (Inner loop also checks.)
+        if (m_stopRequested.load(std::memory_order_acquire)) {
+            return;
+        }
+
         // From Thetis isNicCandidate(): Up/Running, not loopback
         if (!(iface.flags() & QNetworkInterface::IsUp)
             || !(iface.flags() & QNetworkInterface::IsRunning)
@@ -422,6 +437,13 @@ void RadioDiscovery::scanAllNics()
 
             int quietPolls = 0;
             while (quietPolls < quietBeforeStop) {
+                // Cooperative cancel — see stopDiscovery(). Checked after
+                // each waitForReadyRead window so shutdown latency is at
+                // most one pollTimeoutMs (~150 ms on SafeDefault).
+                if (m_stopRequested.load(std::memory_order_acquire)) {
+                    sock.close();
+                    return;
+                }
                 // From Thetis: s.Poll(pollMs * 1000, SelectMode.SelectRead)
                 bool readable = sock.waitForReadyRead(pollMs);
                 if (!readable) {

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -67,6 +67,7 @@ mw0lge@grange-lane.co.uk
 #include <QSet>
 #include <QStringList>
 
+#include <atomic>
 #include <chrono>
 
 namespace NereusSDR {
@@ -262,6 +263,16 @@ private:
     QMap<QString, qint64> m_lastSeen;    // MAC -> timestamp
     QString m_connectedMac;              // MAC currently in use by a RadioConnection; exempt from stale-removal
     QSet<QString>  m_savedMacs;          // Design §7.4: MACs that are saved in AppSettings; exempt from stale-removal
+
+    // Cooperative cancel for scanAllNics(). The synchronous NIC walk does
+    // attemptsPerNic × quietPollsBeforeResend × pollTimeoutMs of blocking
+    // waitForReadyRead per NIC — up to ~4.5 s for the SafeDefault profile
+    // on a 2-NIC machine. stopDiscovery() flips this flag so an in-flight
+    // (or queued-by-timer) scan exits within one pollTimeoutMs window
+    // instead of blocking shutdown for several seconds. Atomic because
+    // stopDiscovery may run from any thread context (main, in practice,
+    // but cheap defense-in-depth).
+    std::atomic<bool> m_stopRequested{false};
 };
 
 } // namespace NereusSDR

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -669,6 +669,12 @@ MainWindow::MainWindow(QWidget* parent)
     // harmless. (Preserved from main PR #13 alongside Phase 3I's
     // singleShot auto-reconnect above.)
     connect(qApp, &QCoreApplication::aboutToQuit, this, [this]() {
+        // Same flush as closeEvent — covers the signal-shutdown path
+        // (SIGTERM, force-quit, debugger detach) where closeEvent
+        // doesn't run. Idempotent when closeEvent already flushed.
+        if (m_radioModel) {
+            m_radioModel->flushPendingSettingsSave();
+        }
         if (m_containerManager) {
             m_containerManager->saveState();
         }
@@ -4454,6 +4460,13 @@ void MainWindow::checkVaxFirstRun()
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
+    // Force-run any pending coalesced slice save BEFORE we tear anything
+    // down. The 500 ms debounce in RadioModel::scheduleSettingsSave can't
+    // fire while this handler runs synchronously (event loop blocked on
+    // QThread::wait below); without this flush the user's last AF / step /
+    // freq / lock / RIT change is silently dropped on close.
+    m_radioModel->flushPendingSettingsSave();
+
     // Stop discovery to prevent new signals during shutdown
     m_radioModel->discovery()->stopDiscovery();
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -672,6 +672,7 @@ MainWindow::MainWindow(QWidget* parent)
         // Same flush as closeEvent — covers the signal-shutdown path
         // (SIGTERM, force-quit, debugger detach) where closeEvent
         // doesn't run. Idempotent when closeEvent already flushed.
+        m_shuttingDown = true;
         if (m_radioModel) {
             m_radioModel->flushPendingSettingsSave();
         }
@@ -4113,10 +4114,14 @@ void MainWindow::onConnectionStateChanged()
         // Phase 3Q Task 5 — auto-open: on disconnect (after having been connected),
         // open the ConnectionPanel so the user can reconnect.
         // Guard: m_autoReconnectInProgress suppresses the panel during background
-        // auto-reconnect (Task 17), and the very first state read at startup is
-        // Disconnected which should not open the panel.
+        // auto-reconnect (Task 17); m_shuttingDown suppresses it during ⌘Q so
+        // ConnectionPanel's ctor doesn't restart discovery mid-close (would
+        // beach-ball the close path for the full SafeDefault scan window — see
+        // [shutdown-trace] log analysis 2026-05-02). The very first state read
+        // at startup is Disconnected which should not open the panel either —
+        // the radio-name check below handles that case.
         // The panel itself is non-modal (show/raise), matching the current pattern.
-        if (!m_autoReconnectInProgress) {
+        if (!m_autoReconnectInProgress && !m_shuttingDown) {
             // Only open if we were previously connected (transition from Connected,
             // not the initial Disconnected state at startup). We detect this by
             // checking if the model has ever reported a radio name — set on connect.
@@ -4460,6 +4465,11 @@ void MainWindow::checkVaxFirstRun()
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
+    // Mark shutting-down BEFORE anything else so the "auto-open
+    // ConnectionPanel on Disconnect" slot below doesn't re-trigger
+    // discovery via ConnectionPanel's ctor while teardown runs.
+    m_shuttingDown = true;
+
     // Force-run any pending coalesced slice save BEFORE we tear anything
     // down. The 500 ms debounce in RadioModel::scheduleSettingsSave can't
     // fire while this handler runs synchronously (event loop blocked on

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -287,6 +287,14 @@ private:
     // interfering with a subsequent user-initiated Start Discovery.
     bool m_autoReconnectInProgress{false};
 
+    // Set true at the top of closeEvent (and aboutToQuit). Gates the
+    // "auto-open ConnectionPanel on Disconnect" slot — without this,
+    // closeEvent's disconnectFromRadio fires connectionStateChanged →
+    // ConnectionPanel ctor → startDiscovery, which clears the discovery
+    // stop flag and runs a fresh ~5 s NIC walk on the main thread mid-
+    // close. Symptom: ⌘Q beach-balls for the full SafeDefault scan time.
+    bool m_shuttingDown{false};
+
     // Container infrastructure (Phase 3G-1)
     ContainerManager* m_containerManager{nullptr};
     QSplitter* m_mainSplitter{nullptr};

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3156,6 +3156,22 @@ void RadioModel::wireSliceSignals()
     connect(slice, &SliceModel::rttyMarkHzChanged,  this, updateRttyFilter);
     connect(slice, &SliceModel::rttyShiftHzChanged, this, updateRttyFilter);
 
+    // Persistence-only wires — slice properties whose only side-effect is
+    // "save the new value." Without these, changes are stored on the in-
+    // memory slice but never written to AppSettings until something else
+    // (a band crossing, an antenna change, etc.) happens to trigger
+    // scheduleSettingsSave(). User-visible bug: tweak step (or lock, or
+    // RIT, or XIT) and close the app — value reverts on next launch.
+    // The dspModeChanged / filterChanged / agcModeChanged etc. handlers
+    // above already call scheduleSettingsSave() as part of their main
+    // job; this block covers the gaps.
+    connect(slice, &SliceModel::stepHzChanged,    this, [this](int) { scheduleSettingsSave(); });
+    connect(slice, &SliceModel::lockedChanged,    this, [this](bool) { scheduleSettingsSave(); });
+    connect(slice, &SliceModel::ritEnabledChanged, this, [this](bool) { scheduleSettingsSave(); });
+    connect(slice, &SliceModel::ritHzChanged,     this, [this](int) { scheduleSettingsSave(); });
+    connect(slice, &SliceModel::xitEnabledChanged, this, [this](bool) { scheduleSettingsSave(); });
+    connect(slice, &SliceModel::xitHzChanged,     this, [this](int) { scheduleSettingsSave(); });
+
     // XIT stored for 3M-1 (TX phase) to consume on keydown. No RX effect in 3G-10.
 
     // AF gain → AudioEngine volume
@@ -3408,6 +3424,22 @@ void RadioModel::scheduleSettingsSave()
     });
 }
 
+// Force-run any pending coalesced slice save synchronously. Without this,
+// the 500 ms QTimer in scheduleSettingsSave() can't fire while the main
+// thread is inside MainWindow::closeEvent → teardownConnection (synchronous,
+// blocks on QThread::wait calls), so the user's last AF / step / freq /
+// lock / RIT change before close gets dropped on the floor. The pending
+// QTimer is left in place; if it fires after this it will redundantly
+// re-save the same state, which is harmless.
+void RadioModel::flushPendingSettingsSave()
+{
+    if (!m_settingsSaveScheduled) {
+        return;
+    }
+    m_settingsSaveScheduled = false;
+    saveSliceState(m_activeSlice);
+}
+
 // Persist current slice state to AppSettings (per-band + session state).
 // Also flushes AlexController persistence if the dirty flag was set —
 // see the antennaChanged / blockTxChanged handlers in wireSliceSignals.
@@ -3438,6 +3470,14 @@ void RadioModel::teardownConnection()
     if (!m_connection) {
         return;
     }
+
+    // Flush any pending coalesced slice save FIRST so the user's last
+    // AF / step / freq / lock / RIT tweak isn't lost to the 500 ms
+    // debounce in scheduleSettingsSave(). The QTimer there can't fire
+    // while teardown is running on the main thread, so without this an
+    // immediate close-after-tweak silently drops the change. Cheap and
+    // idempotent — no-op when nothing's pending.
+    flushPendingSettingsSave();
 
     // 3M-1a G.1 fixup: drop any prior WdspEngine::initializedChanged subscribers
     // we registered in connectToRadio(). Without this, each reconnect cycle

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3225,8 +3225,8 @@ void RadioModel::wireSliceSignals()
 
 // Load persisted VFO state from AppSettings into a slice.
 // Migrates legacy flat keys first, then restores per-band state for the
-// current band (derived from the panadapter center frequency or the slice
-// default frequency).
+// last-used band (or, when no LastBand marker exists, falls back to the
+// panadapter's center frequency band, then to the slice's default freq).
 void RadioModel::loadSliceState(SliceModel* slice)
 {
     if (!slice) {
@@ -3236,10 +3236,18 @@ void RadioModel::loadSliceState(SliceModel* slice)
     // One-shot migration of legacy Vfo* flat keys. No-op if already migrated.
     SliceModel::migrateLegacyKeys();
 
-    // Derive current band. Use the first panadapter's band if available;
-    // otherwise fall back to bandFromFrequency on the slice's default freq.
+    // Pick the band to restore. Priority order:
+    //   1. Slice<N>/LastBand — written by saveToSettings on every save, so
+    //      this lands on the user's actual last-used band/frequency.
+    //   2. Panadapter band — only useful if the panadapter's center freq
+    //      is itself restored from somewhere; today it defaults to
+    //      14.225 MHz so this branch reduces to "always 20m" without (1).
+    //   3. bandFromFrequency on the slice's default freq — startup fallback
+    //      when neither (1) nor (2) is available (fresh install).
     Band currentBand = Band::Band20m;
-    if (!m_panadapters.isEmpty()) {
+    if (auto lastBand = SliceModel::loadLastBandFromSettings(slice->sliceIndex())) {
+        currentBand = *lastBand;
+    } else if (!m_panadapters.isEmpty()) {
         currentBand = m_panadapters.first()->band();
     } else {
         currentBand = bandFromFrequency(slice->frequency());
@@ -3247,6 +3255,15 @@ void RadioModel::loadSliceState(SliceModel* slice)
     m_lastBand = currentBand;
 
     slice->restoreFromSettings(currentBand);
+
+    // Push restored frequency to the panadapter so the spectrum display
+    // lands on the same band as the slice. Without this the panadapter
+    // stays parked at its 14.225 MHz default and the user sees the slice
+    // jump to (say) 7.236 MHz on a panadapter still rendering 20m.
+    // SpectrumWidget center freq follows from the panadapter on startup.
+    if (!m_panadapters.isEmpty()) {
+        m_panadapters.first()->setCenterFrequency(slice->frequency());
+    }
 
     qCInfo(lcDsp) << "Loaded slice state for band:"
                   << bandKeyName(currentBand)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -667,6 +667,16 @@ private:
     void saveSliceState(SliceModel* slice);
     void scheduleSettingsSave();
 
+public:
+    // Force-run any pending coalesced slice save synchronously. Call this
+    // from app-quit paths (MainWindow::closeEvent, aboutToQuit) and at the
+    // top of teardownConnection() so the 500 ms debounce in
+    // scheduleSettingsSave() can't swallow the user's last AF / step / freq
+    // tweak when they immediately close the app. No-op when nothing's
+    // pending. Idempotent — calling repeatedly is safe.
+    void flushPendingSettingsSave();
+
+private:
     // Sub-components (owned, main thread)
     RadioDiscovery*  m_discovery{nullptr};
     ReceiverManager* m_receiverManager{nullptr};

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -1083,6 +1083,12 @@ void SliceModel::saveToSettings(Band band)
     s.setValue(sp + QStringLiteral("RxAntenna"),  m_rxAntenna);
     s.setValue(sp + QStringLiteral("TxAntenna"),  m_txAntenna);
 
+    // Track the most recently saved band so RadioModel::loadSliceState() on
+    // the next launch can land on the user's actual last-used frequency,
+    // not the panadapter's 14.225 MHz default. Per-band Frequency keys
+    // already store the per-band freq; this just records "which band was
+    // active last." Read via SliceModel::loadLastBandFromSettings().
+    s.setValue(sp + QStringLiteral("LastBand"), bandKeyName(band));
 }
 
 void SliceModel::restoreFromSettings(Band band)
@@ -1380,6 +1386,31 @@ void SliceModel::migrateLegacyKeys()
     s.remove(QStringLiteral("VfoRfGain"));
     s.remove(QStringLiteral("VfoRxAntenna"));
     s.remove(QStringLiteral("VfoTxAntenna"));
+}
+
+// Reads Slice<N>/LastBand and parses it back to a Band. Returns
+// std::nullopt on missing key (fresh install / pre-LastBand settings)
+// or unparseable values. Static so RadioModel can call this before
+// constructing any slice.
+std::optional<Band> SliceModel::loadLastBandFromSettings(int sliceIndex)
+{
+    auto& s = AppSettings::instance();
+    const QString key = slicePrefix(sliceIndex) + QStringLiteral("LastBand");
+    if (!s.contains(key)) {
+        return std::nullopt;
+    }
+    const QString name = s.value(key).toString();
+    if (name.isEmpty()) {
+        return std::nullopt;
+    }
+    // bandFromName handles both label form ("20m") and short form ("20"),
+    // plus GEN/WWV/XVTR. Falls back to Band::GEN on unknown input — guard
+    // against that so a corrupted key doesn't silently land on GEN.
+    const Band parsed = bandFromName(name);
+    if (parsed == Band::GEN && name != QLatin1String("GEN")) {
+        return std::nullopt;
+    }
+    return parsed;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -124,6 +124,7 @@
 #include <QString>
 
 #include <atomic>
+#include <optional>
 #include <utility>
 
 namespace NereusSDR {
@@ -616,6 +617,15 @@ public:
     void saveToSettings(NereusSDR::Band band);
     void restoreFromSettings(NereusSDR::Band band);
     static void migrateLegacyKeys();
+
+    // Reads the persisted "last band" marker for this slice index from
+    // AppSettings (Slice<N>/LastBand). saveToSettings(band) writes this
+    // every time it runs, so on next startup the caller can restore the
+    // user's actual last-used band rather than falling back to the
+    // panadapter's default. Returns std::nullopt when the key is absent
+    // (fresh install, or pre-LastBand settings file). Static so RadioModel
+    // can read it before any SliceModel exists.
+    static std::optional<NereusSDR::Band> loadLastBandFromSettings(int sliceIndex);
 
     // Load band-agnostic slice settings (e.g. VAX channel) from AppSettings.
     // Called on startup when no specific band context is needed. Does NOT

--- a/tests/tst_slice_persistence_per_band.cpp
+++ b/tests/tst_slice_persistence_per_band.cpp
@@ -64,15 +64,25 @@ private:
     // Remove all Slice0/* and legacy Vfo* keys from the singleton.
     static void resetSingleton() {
         auto& s = AppSettings::instance();
-        // Per-band keys for bands we use in tests (20m, 40m).
-        for (const QString& band : {QStringLiteral("20m"), QStringLiteral("40m")}) {
+        // Per-band keys for every band any test touches. lastBandRoundTrips*
+        // walks the full HF set + GEN/WWV/XVTR, so we have to clean those
+        // too or ctest run-order leaks pollute later tests.
+        const QString bands[] = {
+            QStringLiteral("160m"), QStringLiteral("80m"),  QStringLiteral("60m"),
+            QStringLiteral("40m"),  QStringLiteral("30m"),  QStringLiteral("20m"),
+            QStringLiteral("17m"),  QStringLiteral("15m"),  QStringLiteral("12m"),
+            QStringLiteral("10m"),  QStringLiteral("6m"),
+            QStringLiteral("GEN"),  QStringLiteral("WWV"),  QStringLiteral("XVTR"),
+        };
+        for (const QString& band : bands) {
             const QString bp = QStringLiteral("Slice0/Band") + band + QStringLiteral("/");
             for (const QString& field : {
                      QStringLiteral("AgcThreshold"), QStringLiteral("AgcHang"),
                      QStringLiteral("AgcSlope"),     QStringLiteral("AgcAttack"),
                      QStringLiteral("AgcDecay"),     QStringLiteral("FilterLow"),
                      QStringLiteral("FilterHigh"),   QStringLiteral("DspMode"),
-                     QStringLiteral("AgcMode"),      QStringLiteral("StepHz") }) {
+                     QStringLiteral("AgcMode"),      QStringLiteral("StepHz"),
+                     QStringLiteral("Frequency"),   QStringLiteral("NbMode") }) {
                 s.remove(bp + field);
             }
         }
@@ -83,7 +93,8 @@ private:
                  QStringLiteral("RitEnabled"), QStringLiteral("RitHz"),
                  QStringLiteral("XitEnabled"), QStringLiteral("XitHz"),
                  QStringLiteral("AfGain"),     QStringLiteral("RfGain"),
-                 QStringLiteral("RxAntenna"),  QStringLiteral("TxAntenna") }) {
+                 QStringLiteral("RxAntenna"),  QStringLiteral("TxAntenna"),
+                 QStringLiteral("LastBand") }) {
             s.remove(sp + field);
         }
         // Legacy keys.
@@ -298,6 +309,90 @@ private slots:
         // No keys exist for 40m — restore must be a no-op.
         slice.restoreFromSettings(Band::Band40m);
         QCOMPARE(slice.agcThreshold(), defaultThreshold);
+    }
+
+    // ── LastBand: persist + reload last-used band marker ──────────────────────
+
+    void lastBandIsPersistedOnSave() {
+        // saveToSettings(band) must write Slice<N>/LastBand = bandKeyName(band)
+        // every call. This is what RadioModel::loadSliceState reads on the
+        // next launch to land on the user's last-used band, instead of
+        // falling back to the panadapter's 14.225 MHz default → always 20m.
+        SliceModel slice;
+        slice.setSliceIndex(0);
+
+        // No marker before any save — fresh install / pre-LastBand settings.
+        QCOMPARE(SliceModel::loadLastBandFromSettings(0), std::nullopt);
+
+        slice.saveToSettings(Band::Band40m);
+        auto after40 = SliceModel::loadLastBandFromSettings(0);
+        QVERIFY(after40.has_value());
+        QCOMPARE(*after40, Band::Band40m);
+
+        // Subsequent save on a different band must overwrite, not stack.
+        slice.saveToSettings(Band::Band20m);
+        auto after20 = SliceModel::loadLastBandFromSettings(0);
+        QVERIFY(after20.has_value());
+        QCOMPARE(*after20, Band::Band20m);
+    }
+
+    void lastBandRoundTripsAcrossEveryHfBand() {
+        // Sanity check that bandKeyName/bandFromName round-trip through
+        // AppSettings cleanly for the full HF band set the user can land on.
+        // Prevents a future label rename from silently breaking persistence
+        // for one specific band while leaving others working.
+        const Band bands[] = {
+            Band::Band160m, Band::Band80m,  Band::Band60m, Band::Band40m,
+            Band::Band30m,  Band::Band20m,  Band::Band17m, Band::Band15m,
+            Band::Band12m,  Band::Band10m,  Band::Band6m,
+            Band::GEN,      Band::WWV,      Band::XVTR,
+        };
+        SliceModel slice;
+        slice.setSliceIndex(0);
+
+        for (Band b : bands) {
+            slice.saveToSettings(b);
+            auto loaded = SliceModel::loadLastBandFromSettings(0);
+            QVERIFY2(loaded.has_value(),
+                     qPrintable(QStringLiteral("LastBand missing after saving %1")
+                                .arg(bandKeyName(b))));
+            QCOMPARE(*loaded, b);
+        }
+    }
+
+    void lastBandReturnsNulloptOnUnparseableValue() {
+        // Belt-and-suspenders: if a corrupted settings file holds a non-band
+        // string under Slice0/LastBand, the loader must NOT silently land on
+        // Band::GEN — it should return nullopt so RadioModel falls back to
+        // the panadapter / default-frequency path.
+        auto& s = AppSettings::instance();
+        s.setValue(QStringLiteral("Slice0/LastBand"), QStringLiteral("not-a-band"));
+        QCOMPARE(SliceModel::loadLastBandFromSettings(0), std::nullopt);
+
+        // GEN itself, however, is a valid persisted value.
+        s.setValue(QStringLiteral("Slice0/LastBand"), QStringLiteral("GEN"));
+        auto loaded = SliceModel::loadLastBandFromSettings(0);
+        QVERIFY(loaded.has_value());
+        QCOMPARE(*loaded, Band::GEN);
+    }
+
+    // ── Step persists across save/restore (gap-fill regression test) ─────────
+
+    void stepHzPersistsAcrossSaveRestore() {
+        // tst_slice_persistence_per_band already covers stepHz round-trip
+        // alongside the other DSP keys, but call it out explicitly here as
+        // a regression guard for the close-race fix: with the wire from
+        // stepHzChanged → scheduleSettingsSave in place, the per-band
+        // StepHz key must survive a save+restore on a single band.
+        SliceModel writer;
+        writer.setSliceIndex(0);
+        writer.setStepHz(2500);  // non-default value
+        writer.saveToSettings(Band::Band20m);
+
+        SliceModel reader;
+        reader.setSliceIndex(0);
+        reader.restoreFromSettings(Band::Band20m);
+        QCOMPARE(reader.stepHz(), 2500);
     }
 };
 


### PR DESCRIPTION
## Summary

Three coupled bugs surfaced together while user-testing v0.3.0 on macOS — all in the persistence + shutdown path. One PR, three commits for review-readability.

## Bug 1 — frequency doesn't return to last-used band on launch

Per-band `Frequency` keys were saved correctly, but `RadioModel::loadSliceState()` derived the startup band from `PanadapterModel::centerFrequency`, which defaults to 14.225 MHz → `Band20m` and is never persisted. Result: every launch landed on whatever was saved for 20m, regardless of where the user was last operating.

**Fix:** new `Slice<N>/LastBand` session-level marker, written by `SliceModel::saveToSettings` on every save and read by `loadSliceState` before falling back to the panadapter band. Restored frequency is then pushed into the panadapter so the spectrum lines up. Includes corruption guard — `loadLastBandFromSettings` returns `nullopt` on unparseable input rather than silently landing on `Band::GEN`.

Commit: `6fa2350` — fix(persistence): restore last-used band/frequency on launch

## Bug 2 — AF / step / lock / RIT / XIT changes don't stick

Two separate root causes here, fixed together because they exhibit identically:

- **Close-path race:** `scheduleSettingsSave()` debounces 500 ms via a main-thread `QTimer`. `closeEvent` blocks on `QThread::wait` calls, so the timer can't fire before `AppSettings.save()` writes the in-memory map to XML. Anything tweaked in the last ~500 ms before close was lost.
- **Six unwired signals:** `stepHzChanged`, `lockedChanged`, `ritEnabledChanged`, `ritHzChanged`, `xitEnabledChanged`, `xitHzChanged` had UI/DSP wires but no `scheduleSettingsSave` hook. Changes hit the in-memory slice but never reached AppSettings until something else (band crossing, antenna change) incidentally triggered a save.

**Fix:** new `RadioModel::flushPendingSettingsSave()` synchronously runs the coalesced save when one is pending. Called from `MainWindow::closeEvent`, `aboutToQuit` (catches SIGTERM/force-quit), and the top of `teardownConnection` (catches mid-session disconnects). Plus the six missing signal wires.

Commit: `4e78dee` — fix(persistence): flush coalesced slice save on close, wire missing signals

## Bug 3 — ⌘Q beach-balls for ~5 s

Two coupled root causes blocked the main thread for the full SafeDefault NIC-walk (~4.5 s on a 2-NIC machine):

- **Uncancellable scan:** `scanAllNics()` is a synchronous main-thread walk doing `attemptsPerNic × quietPollsBeforeResend × pollTimeoutMs` of blocking `QUdpSocket::waitForReadyRead` per NIC. `stopDiscovery()` only stopped the stale-timer — it had no way to interrupt an in-flight scan.
- **Auto-reopen restarting discovery during close:** the Phase 3Q Task 5 "auto-open ConnectionPanel on Disconnect" slot fired during `closeEvent`'s `disconnectFromRadio`. ConnectionPanel's ctor called `disc->startDiscovery()`, which cleared the stop flag and ran a fresh full scan on the way out.

**Fix:** added `std::atomic<bool> m_stopRequested` to `RadioDiscovery`, checked at the NIC-loop boundary and after every `waitForReadyRead` window — in-flight scans now exit within one `pollTimeoutMs` (~150 ms). Plus `MainWindow::m_shuttingDown`, set true at the top of `closeEvent` / `aboutToQuit`, gating the auto-open slot so it doesn't run during quit. User-initiated Disconnect is unaffected.

Result confirmed via instrumentation: **close path 414 ms total** (was ~5215 ms), and the slow leg is now just the legitimate WDSP/audio thread joins.

Commit: `e925288` — fix(shutdown): eliminate ~5 s ⌘Q beach ball

## Test plan

- [x] `tst_slice_persistence_per_band` — 11/11 pass (4 new tests: LastBand persist-on-save, full HF round-trip across 14 bands incl. GEN/WWV/XVTR, corruption guard, step-Hz round-trip)
- [x] All persistence + discovery + app-settings tests — 17/17 pass
- [x] Manual: connect to ANAN-G2 on 40m at 7.236 MHz, change step to 100 Hz, ⌘Q, relaunch — comes back at 7.236 MHz on 40m with step 100 Hz
- [x] Manual: ⌘Q while connected — close path measured 414 ms via `[shutdown-trace]` logging
- [ ] Manual on Linux (PipeWire bridge) — not bench-tested by this branch
- [ ] Manual on Windows — not bench-tested by this branch

J.J. Boyd ~ KG4VCF