### PR TITLE
fix(audio): drop spurious bus reconfigure on Settings open (#172)

### DIFF
--- a/src/gui/setup/DeviceCard.cpp
+++ b/src/gui/setup/DeviceCard.cpp
@@ -352,7 +352,10 @@ void DeviceCard::buildLayout()
         connect(m_bufferSizeDebounceTimer, &QTimer::timeout,
                 this, &DeviceCard::onAnyControlChanged);
         connect(m_bufferSizeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
-                this, [this](int) { m_bufferSizeDebounceTimer->start(); });
+                this, [this](int) {
+                    if (m_suppressSignals) { return; }
+                    m_bufferSizeDebounceTimer->start();
+                });
     }
 
     // Device combo fires populateDeviceCombo on driver-API change, then

--- a/tests/tst_device_card.cpp
+++ b/tests/tst_device_card.cpp
@@ -221,6 +221,39 @@ private slots:
 
         QVERIFY2(spy.count() >= 1, "enabledChanged not emitted on toggle");
     }
+
+    // ── 11. configChanged stays silent during loadFromSettings (issue #172) ───
+    //
+    // Regression for the "audio gets stuck opening File - Settings" bug.
+    // The buffer-size combo uses a 200 ms debounce timer.  loadFromSettings()
+    // calls setCurrentIndex on the combo, which fires currentIndexChanged.
+    // Before the fix the start-timer lambda ignored m_suppressSignals, so the
+    // timer was scheduled during load and fired ~200 ms after construction —
+    // emitting a spurious configChanged that triggered AudioEngine::setXxxConfig
+    // and tore down/rebuilt the bus on every Settings dialog open.
+
+    void configChangedDoesNotEmitDuringLoad() {
+        // Seed AppSettings with a non-default buffer size so setCurrentIndex
+        // during loadFromSettings actually changes the index (otherwise Qt
+        // suppresses currentIndexChanged when the value is already current).
+        // kBufferSizes = {64, 128, 256, 512, 1024, 2048}; default index in
+        // loadFromSettings is 2 (256). Pick 1024 (index 4) to force a change.
+        AppSettings::instance().setValue(
+            QStringLiteral("audio/Speakers/BufferSamples"),
+            QStringLiteral("1024"));
+
+        DeviceCard card(QStringLiteral("audio/Speakers"),
+                        DeviceCard::Role::Output,
+                        false);
+
+        QSignalSpy spy(&card, &DeviceCard::configChanged);
+
+        // Buffer-size debounce timer is 200 ms. Wait long enough that any
+        // timer scheduled during loadFromSettings has had time to fire.
+        QTest::qWait(300);
+
+        QCOMPARE(spy.count(), 0);
+    }
 };
 
 QTEST_MAIN(TstDeviceCard)


### PR DESCRIPTION
## Summary

- Closes #172. Opening File > Settings tore down and reopened all 7 audio
  buses (Speakers, Headphones, TX Input, VAX 1-4), stalling the GUI
  thread for 150-700 ms on Windows MME/DirectSound and causing the audio
  buffer to repeat while the dialog opened.
- Root cause: DeviceCard's buffer-size combo wires a 200 ms debounce
  timer (so rapid scrubbing of the dropdown doesn't rebuild the bus on
  every step). The lambda that *starts* that timer was missing the
  `m_suppressSignals` guard the other combos use, so `loadFromSettings`
  scheduled the timer, and 200 ms after each card finished constructing
  the timer fired `onAnyControlChanged` and emitted `configChanged`.
- Fix is a 3-line guard on the lambda. Adds a regression test that seeds
  a non-default BufferSamples, constructs a DeviceCard, waits 300 ms,
  and asserts `configChanged` stays silent.

## Test plan

- [x] New test `configChangedDoesNotEmitDuringLoad` fails on unfixed code
      (`spy.count() = 1`), passes with the guard.
- [x] All 32 audio + setup tests pass, incl.
      `tst_audio_engine_speakers_live_reconfig` (covers the legitimate
      user-driven buffer-size scrub path the debounce was added for).
- [ ] Bench on ANAN-G2 + macOS: open File > Settings several times while
      RX audio is flowing, confirm no stutter / repeat.
- [ ] Chris (W4ORS) bench on HL2 + Windows 11 (the original report
      environment).

J.J. Boyd ~ KG4VCF