### PR TITLE
fix(radio): defer TUN-off gen1 + power-restore (issue #177)

### DIFF
--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -4624,18 +4624,62 @@ void RadioModel::setTune(bool on)
         // power restore, VFO un-offset) is deferred.
         m_pendingTuneOff = true;
 
+        // Capture MOX state BEFORE calling MoxController::setTune so we can
+        // detect the "MOX already RX" path that would otherwise strand the
+        // latch.  Codex P1 catch on PR #180: setMox(false)'s idempotent guard
+        // (MoxController.cpp:461) emits no TX→RX phase signals when m_mox is
+        // already false, so no rxReady fires and the deferred completion
+        // never runs — m_pendingTuneOff sits latched, and a later unrelated
+        // rxReady (from a normal PTT cycle) consumes the stale latch.
+        //
+        // This mirrors Thetis exactly. In Thetis the post-MOX work runs
+        // unconditionally because `await Task.Delay(100)` at console.cs:30107
+        // [v2.10.3.13] lives in the TUN handler — not in chkMOX_CheckedChanged2
+        // — so it fires regardless of whether the chkMOX assignment triggered
+        // a walk.  WinForms silently no-ops `chkMOX.Checked = false` when it
+        // is already false, but the next line in chkTUN_CheckedChanged still
+        // awaits 100 ms and then sets gen1.run = 0.
+        //
+        // Bug window for this guard: something has to drop MOX externally
+        // while m_isTuning is still latched (e.g. PA-fault trip dropping
+        // MOX, manual MOX click during TUN, or future PureSignal /
+        // SwrProtectionController force-unkey paths).  Narrow but real.
+        const bool moxWasOn = (m_moxController != nullptr)
+                              && m_moxController->isMox();
+
         // ── RELEASE MOX via MoxController ────────────────────────────────────
         // Cite: console.cs:30106 [v2.10.3.13]: chkMOX.Checked = false;
-        // MoxController::setTune(false) drives the full TX→RX walk (B.5),
-        // which fires hardwareFlipped(false) synchronously and then chains
-        // keyUpDelayTimer (mox_delay) → txaFlushed → pttOutDelayTimer
-        // (ptt_out_delay) → rxReady.
+        // MoxController::setTune(false) drives the full TX→RX walk (B.5)
+        // when MOX is on: it fires hardwareFlipped(false) synchronously and
+        // then chains keyUpDelayTimer (mox_delay) → txaFlushed →
+        // pttOutDelayTimer (ptt_out_delay) → rxReady.  Always called (even
+        // when MOX is already off) because it also clears m_manualMox and
+        // emits manualMoxChanged(false) — Cite: console.cs:30142 [v2.10.3.13].
         if (m_moxController) {
             m_moxController->setTune(false);
         }
 
+        if (!moxWasOn) {
+            // No TX→RX walk will fire because MoxController::setMox(false)
+            // hit its idempotent guard.  Schedule completeTuneOff directly
+            // off a QTimer::singleShot so the deferred path still gets a
+            // turn.  The settle delay matches m_tuneOffSettleMs both for
+            // ordering symmetry with the walk path and because Thetis's
+            // `await Task.Delay(100)` (console.cs:30107 [v2.10.3.13]) is
+            // unconditional — it fires whether or not the chkMOX assignment
+            // triggered a walk.  The lambda re-checks the latch in case a
+            // fresh setTune(true) clears it before the timer fires.
+            QTimer::singleShot(m_tuneOffSettleMs, this, [this]() {
+                if (!m_pendingTuneOff) {
+                    return;
+                }
+                completeTuneOff();
+            });
+        }
+
         // The remainder of the TUN-off work runs from completeTuneOff()
-        // when MoxController::rxReady fires + m_tuneOffSettleMs elapses.
+        // when MoxController::rxReady fires + m_tuneOffSettleMs elapses
+        // (walk path), or directly from the singleShot above (no-walk path).
         // Wired in the RadioModel constructor next to F.1.
     }
 }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -623,6 +623,39 @@ RadioModel::RadioModel(QObject* parent)
             this, &RadioModel::onMoxHardwareFlipped,
             Qt::QueuedConnection);
 
+    // Issue #177 fix — Thetis-faithful TUN-off ordering.
+    //
+    // setTune(false) latches m_pendingTuneOff and kicks off the MoxController
+    // TX→RX walk, then returns immediately.  When MoxController emits rxReady
+    // (TX→RX phase 4 of 4 — RX channels active, MOX wire bit dropped, WDSP TX
+    // off), we wait an additional m_tuneOffSettleMs (default 100) and then
+    // call completeTuneOff() to kill gen1, restore the DSP mode, restore the
+    // power slider, and un-offset the TX VFO.
+    //
+    // From Thetis console.cs:30106-30109 [v2.10.3.13] — chkTUN_CheckedChanged
+    // else-branch:
+    //     chkMOX.Checked = false;          // synchronously walks TX→RX (~30 ms blocking)
+    //     await Task.Delay(100);
+    //     radio.GetDSPTX(0).TXPostGenRun = 0;
+    //
+    // The deferred completion prevents the gen1-off transient from reaching
+    // the radio while the WDSP TX channel is still pumping (issue #177).
+    connect(m_moxController, &MoxController::rxReady, this, [this]() {
+        if (!m_pendingTuneOff) {
+            return;
+        }
+        QTimer::singleShot(m_tuneOffSettleMs, this, [this]() {
+            // Re-check the latch: a fresh setTune(true) (or a teardown) can
+            // clear it between rxReady and the timer firing.  In that case the
+            // deferred completion is a no-op because the new TUN-on path has
+            // already established fresh saved state and re-engaged MOX.
+            if (!m_pendingTuneOff) {
+                return;
+            }
+            completeTuneOff();
+        });
+    });
+
     // MoxController::txReady → TxChannel::setRunning(true) and
     // MoxController::txaFlushed → TxChannel::setRunning(false) are wired in
     // connectToRadio() once m_txChannel is live (see the "MoxController →
@@ -3870,6 +3903,15 @@ void RadioModel::teardownConnection()
         m_transmitModel.persistToSettings(m_lastRadioInfo.macAddress);
     }
 
+    // Issue #177 — clear any in-flight TUN-off bookkeeping.  If we are
+    // tearing down mid-walk, MoxController::rxReady will never fire (timers
+    // are stopped) so the deferred completion would otherwise stay armed
+    // across the next connect.  Clearing the latch + m_isTuning matches
+    // Thetis chkTUN_CheckedChanged's _tuning=false reset (console.cs:30122
+    // [v2.10.3.13]) at session end.
+    m_pendingTuneOff = false;
+    m_isTuning       = false;
+
     // L.3: Release the HL2 mic-source lock on disconnect.
     // A subsequent connectToRadio() to a non-HL2 radio must be free to use
     // MicSource::Radio if the user selects it.  The lock is re-engaged
@@ -4340,6 +4382,15 @@ void RadioModel::setTune(bool on)
         // matches Thetis ordering for future maintainers reading side-by-side.
         m_isTuning = true;
 
+        // Issue #177 — cancel any pending TUN-off completion.  If the user
+        // double-clicks TUN (off → on within the rxReady + 100 ms settle
+        // window) we are mid-walk: the rxReady slot has not yet fired or has
+        // scheduled a singleShot that has not fired.  Clearing this flag
+        // makes both the rxReady slot and the QTimer body no-op when they
+        // run, leaving this fresh TUN-on path as the sole authority on saved
+        // state and MOX engagement.
+        m_pendingTuneOff = false;
+
         // ── SAVE meter mode ────────────────────────────────────────────────────
         // Cite: console.cs:30011 [v2.10.3.13]:
         //   old_meter_tx_mode_before_tune = current_meter_tx_mode;
@@ -4551,104 +4602,167 @@ void RadioModel::setTune(bool on)
             return;
         }
 
+        // Issue #177 fix — Thetis-faithful TUN-off ordering.
+        //
+        // From Thetis console.cs:30106-30109 [v2.10.3.13]:
+        //   chkMOX.Checked = false;        // synchronous walk TX→RX (~30 ms)
+        //   await Task.Delay(100);
+        //   radio.GetDSPTX(0).TXPostGenRun = 0;
+        //
+        // Thetis's chkMOX setter blocks the UI thread inside chkMOX_CheckedChanged2
+        // through Thread.Sleep(mox_delay=10) + Thread.Sleep(ptt_out_delay=20),
+        // then waits an additional 100 ms before turning gen1 off.  By the time
+        // gen1.run is set to 0, the WDSP TX channel has already been disabled
+        // (line 29607) and is no longer producing samples — so the hard step at
+        // gen1's output never enters a running TXA chain and there is no
+        // filter-ringing transient.
+        //
+        // NereusSDR's MoxController is timer-based (non-blocking).  We latch
+        // m_pendingTuneOff and let the rxReady → settle-timer slot wired in
+        // the constructor invoke completeTuneOff() at T+30+m_tuneOffSettleMs ms.
+        // Until then, the rest of the TUN-off work (gen1 off, mode restore,
+        // power restore, VFO un-offset) is deferred.
+        m_pendingTuneOff = true;
+
         // ── RELEASE MOX via MoxController ────────────────────────────────────
-        // Cite: console.cs:30105 [v2.10.3.13]: chkMOX.Checked = false;
-        // MoxController::setTune(false) drives the full TX→RX walk (B.5).
+        // Cite: console.cs:30106 [v2.10.3.13]: chkMOX.Checked = false;
+        // MoxController::setTune(false) drives the full TX→RX walk (B.5),
+        // which fires hardwareFlipped(false) synchronously and then chains
+        // keyUpDelayTimer (mox_delay) → txaFlushed → pttOutDelayTimer
+        // (ptt_out_delay) → rxReady.
         if (m_moxController) {
             m_moxController->setTune(false);
         }
 
-        // ── RELEASE TUNE TONE ──────────────────────────────────────────────────
-        // Cite: console.cs:30109 [v2.10.3.13]: radio.GetDSPTX(0).TXPostGenRun = 0;
-        if (m_txChannel) {
-            m_txChannel->setTuneTone(false, 0.0, 0.0);
-        }
-
-        // ── RESTORE DSP MODE if swapped ────────────────────────────────────────
-        // Cite: console.cs:30112-30122 [v2.10.3.13]:
-        //   switch (old_dsp_mode) { case CWL: case CWU:
-        //       radio.GetDSPTX(0).CurrentDSPMode = old_dsp_mode; ... }
-        if (m_activeSlice) {
-            const bool wasSwapped = (m_savedTxDspMode == DSPMode::CWL ||
-                                     m_savedTxDspMode == DSPMode::CWU);
-            if (wasSwapped) {
-                m_activeSlice->setDspMode(m_savedTxDspMode);
-            }
-        }
-
-        // ── RESTORE POWER ──────────────────────────────────────────────────────
-        // Cite: console.cs:30129-30132 [v2.10.3.13]:
-        //   if (_tuneDrivePowerSource == DrivePowerSource.FIXED) PWR = PreviousPWR;
-        //   //MW0LGE_22b  [original inline comment from console.cs:30033]
-        //
-        // Codex P1 follow-up to PR #178 — route the restore through the
-        // calibrated dBm path, NOT the old linear formula.  Previously
-        // this site computed wire_byte = clamp(int(255 * pct/100 * swr),
-        // 0, 255) and wrote it directly via setTxDrive(), which left the
-        // radio holding a pre-hotfix linear byte after TUN-off.  In the
-        // common flow "TUN on → TUN off → MOX without moving slider",
-        // MOX would engage with that stale linear byte → K2GX-class
-        // over-drive on high-gain PAs.
-        //
-        // Same composition as the drive-slider lambda + TUNE-on rewrite:
-        //   wire_byte = clamp(int(audio_volume * 1.02 * 255), 0, 255)
-        //               From audio.cs:262-271 [v2.10.3.13]; NO SWR factor.
-        //   iq_gain   = audio_volume * swrProtect
-        //               From cmaster.cs:1115-1119 [v2.10.3.13]; SWR HERE.
-        // bFromTune=false routes through txMode 0 (drive-slider source)
-        // since TUN is now off and the user's saved drive-slider value
-        // is the canonical post-restore source.
-        m_transmitModel.setPower(m_savedPowerPct);
-        const Band offBand = m_activeSlice
-                                ? bandFromFrequency(m_activeSlice->frequency())
-                                : m_lastBand;
-        if (m_paProfileManager) {
-            const PaProfile* activeProfile = m_paProfileManager->activeProfile();
-            if (activeProfile) {
-                const auto result = m_transmitModel.setPowerUsingTargetDbm(
-                    *activeProfile, offBand, /*bSetPower=*/true,
-                    /*bFromTune=*/false, /*bTwoTone=*/false);
-                const float swrProtectSaved =
-                    std::clamp(m_transmitModel.swrProtectFactor(), 0.0f, 1.0f);
-                const int savedWireDrive = std::clamp(
-                    int(result.audioVolume * 1.02 * 255.0), 0, 255);
-                const double iqGain = result.audioVolume
-                                       * static_cast<double>(swrProtectSaved);
-                if (m_txChannel) {
-                    m_txChannel->setTxFixedGain(iqGain);
-                }
-                if (m_connection) {
-                    auto* conn = m_connection;
-                    QMetaObject::invokeMethod(conn, [conn, savedWireDrive]() {
-                        conn->setTxDrive(savedWireDrive);
-                    });
-                }
-            }
-        }
-
-        // ── RESTORE TX VFO (un-offset from cw_pitch) ───────────────────────────
-        // Mirrors Thetis console.cs:31788-31810 [v2.10.3.13] which only
-        // applies the ±cw_pitch tx_freq offset while chkTUN.Checked == true.
-        // Once TUNE drops, txtVFOAFreq_LostFocus recomputes tx_freq without
-        // the offset so the carrier returns to dial freq.
-        if (m_activeSlice && m_connection) {
-            const quint64 dialHz =
-                static_cast<quint64>(m_activeSlice->frequency());
-            auto* conn = m_connection;
-            QMetaObject::invokeMethod(conn, [conn, dialHz]() {
-                conn->setTxFrequency(dialHz);
-            });
-        }
-
-        // ── RESTORE METER MODE ─────────────────────────────────────────────────
-        // Cite: console.cs:30136-30137 [v2.10.3.13]:
-        //   if (current_meter_tx_mode != old_meter_tx_mode_before_tune) //MW0LGE_21j
-        //       CurrentMeterTXMode = old_meter_tx_mode_before_tune;
-        // NereusSDR: deferred to H.3 (no MeterModel setTxDisplayMode() yet).
-        // [H.3 hook: restore meterModel().setTxDisplayMode(savedMode) here]
-
-        m_isTuning = false;
+        // The remainder of the TUN-off work runs from completeTuneOff()
+        // when MoxController::rxReady fires + m_tuneOffSettleMs elapses.
+        // Wired in the RadioModel constructor next to F.1.
     }
+}
+
+// ---------------------------------------------------------------------------
+// completeTuneOff — Thetis-faithful TUN-off completion (issue #177).
+//
+// Invoked from a QTimer::singleShot(m_tuneOffSettleMs) chained off
+// MoxController::rxReady.  By this point the TX→RX walk has finished, the
+// MOX wire bit is off, the WDSP TX channel has been drained and stopped
+// (txaFlushed → setRunning(false)), and the radio's PA is no longer
+// transmitting.  Cutting gen1 here cannot cause a filter-ringing transient
+// to reach the wire because the TXA chain has stopped processing.
+//
+// Mirrors Thetis console.cs:30109-30134 [v2.10.3.13]:
+//   radio.GetDSPTX(0).TXPostGenRun = 0;     // 30109 — gen1 OFF
+//   ...
+//   switch (old_dsp_mode) { case CWL/CWU: restore }   // 30113-30121
+//   _tuning = false;                        // 30122
+//   updateVFOFreqs(false, true);            // 30124 — un-offset TX VFO
+//   if (_tuneDrivePowerSource == FIXED) PWR = PreviousPWR;   // 30130-30134
+//   //MW0LGE_22b  [original inline comment from console.cs:30033]
+//
+// Idempotent: re-checks m_pendingTuneOff and bails if a fresh setTune(true)
+// or a teardown has cleared it.  The constructor lambda also guards before
+// dispatching here, but a defense-in-depth check makes the contract
+// explicit at this entry point.
+// ---------------------------------------------------------------------------
+void RadioModel::completeTuneOff()
+{
+    if (!m_pendingTuneOff) {
+        return;
+    }
+    m_pendingTuneOff = false;
+
+    // ── RELEASE TUNE TONE ──────────────────────────────────────────────────
+    // Cite: console.cs:30109 [v2.10.3.13]: radio.GetDSPTX(0).TXPostGenRun = 0;
+    // The TX channel has already been stopped by F.1 txaFlushed → setRunning(false),
+    // so this gen1 update lands on an idle TXA chain — no transient.
+    if (m_txChannel) {
+        m_txChannel->setTuneTone(false, 0.0, 0.0);
+    }
+
+    // ── RESTORE DSP MODE if swapped ────────────────────────────────────────
+    // Cite: console.cs:30112-30122 [v2.10.3.13]:
+    //   switch (old_dsp_mode) { case CWL: case CWU:
+    //       radio.GetDSPTX(0).CurrentDSPMode = old_dsp_mode; ... }
+    if (m_activeSlice) {
+        const bool wasSwapped = (m_savedTxDspMode == DSPMode::CWL ||
+                                 m_savedTxDspMode == DSPMode::CWU);
+        if (wasSwapped) {
+            m_activeSlice->setDspMode(m_savedTxDspMode);
+        }
+    }
+
+    // ── RESTORE POWER ──────────────────────────────────────────────────────
+    // Cite: console.cs:30129-30132 [v2.10.3.13]:
+    //   if (_tuneDrivePowerSource == DrivePowerSource.FIXED) PWR = PreviousPWR;
+    //   //MW0LGE_22b  [original inline comment from console.cs:30033]
+    //
+    // Codex P1 follow-up to PR #178 — route the restore through the
+    // calibrated dBm path, NOT the old linear formula.  Previously
+    // this site computed wire_byte = clamp(int(255 * pct/100 * swr),
+    // 0, 255) and wrote it directly via setTxDrive(), which left the
+    // radio holding a pre-hotfix linear byte after TUN-off.  In the
+    // common flow "TUN on → TUN off → MOX without moving slider",
+    // MOX would engage with that stale linear byte → K2GX-class
+    // over-drive on high-gain PAs.
+    //
+    // Same composition as the drive-slider lambda + TUNE-on rewrite:
+    //   wire_byte = clamp(int(audio_volume * 1.02 * 255), 0, 255)
+    //               From audio.cs:262-271 [v2.10.3.13]; NO SWR factor.
+    //   iq_gain   = audio_volume * swrProtect
+    //               From cmaster.cs:1115-1119 [v2.10.3.13]; SWR HERE.
+    // bFromTune=false routes through txMode 0 (drive-slider source)
+    // since TUN is now off and the user's saved drive-slider value
+    // is the canonical post-restore source.
+    m_transmitModel.setPower(m_savedPowerPct);
+    const Band offBand = m_activeSlice
+                            ? bandFromFrequency(m_activeSlice->frequency())
+                            : m_lastBand;
+    if (m_paProfileManager) {
+        const PaProfile* activeProfile = m_paProfileManager->activeProfile();
+        if (activeProfile) {
+            const auto result = m_transmitModel.setPowerUsingTargetDbm(
+                *activeProfile, offBand, /*bSetPower=*/true,
+                /*bFromTune=*/false, /*bTwoTone=*/false);
+            const float swrProtectSaved =
+                std::clamp(m_transmitModel.swrProtectFactor(), 0.0f, 1.0f);
+            const int savedWireDrive = std::clamp(
+                int(result.audioVolume * 1.02 * 255.0), 0, 255);
+            const double iqGain = result.audioVolume
+                                   * static_cast<double>(swrProtectSaved);
+            if (m_txChannel) {
+                m_txChannel->setTxFixedGain(iqGain);
+            }
+            if (m_connection) {
+                auto* conn = m_connection;
+                QMetaObject::invokeMethod(conn, [conn, savedWireDrive]() {
+                    conn->setTxDrive(savedWireDrive);
+                });
+            }
+        }
+    }
+
+    // ── RESTORE TX VFO (un-offset from cw_pitch) ───────────────────────────
+    // Mirrors Thetis console.cs:31788-31810 [v2.10.3.13] which only
+    // applies the ±cw_pitch tx_freq offset while chkTUN.Checked == true.
+    // Once TUNE drops, txtVFOAFreq_LostFocus recomputes tx_freq without
+    // the offset so the carrier returns to dial freq.
+    if (m_activeSlice && m_connection) {
+        const quint64 dialHz =
+            static_cast<quint64>(m_activeSlice->frequency());
+        auto* conn = m_connection;
+        QMetaObject::invokeMethod(conn, [conn, dialHz]() {
+            conn->setTxFrequency(dialHz);
+        });
+    }
+
+    // ── RESTORE METER MODE ─────────────────────────────────────────────────
+    // Cite: console.cs:30136-30137 [v2.10.3.13]:
+    //   if (current_meter_tx_mode != old_meter_tx_mode_before_tune) //MW0LGE_21j
+    //       CurrentMeterTXMode = old_meter_tx_mode_before_tune;
+    // NereusSDR: deferred to H.3 (no MeterModel setTxDisplayMode() yet).
+    // [H.3 hook: restore meterModel().setTxDisplayMode(savedMode) here]
+
+    m_isTuning = false;
 }
 
 void RadioModel::onMoxHardwareFlipped(bool isTx)

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -455,6 +455,20 @@ public:
         m_testCapsOverride     = true;
         m_testCapsHasMicJack   = hasMicJack;
     }
+    // Issue #177 — drive the tune-off settle delay synchronously in tests.
+    // Production default is 100 ms (mirrors `await Task.Delay(100)` at Thetis
+    // console.cs:30107 [v2.10.3.13]).  Setting this to 0 makes completeTuneOff
+    // schedule on the next event loop iteration, so QCoreApplication::processEvents
+    // can drive the deferred completion synchronously.
+    void setTuneOffSettleMsForTest(int ms) noexcept { m_tuneOffSettleMs = ms; }
+    bool tuneOffPendingForTest()          const noexcept { return m_pendingTuneOff; }
+
+    // TUN state, exported for H.3 UI polling and for issue #177 tests.
+    // True between setTune(true) and the completion of the corresponding
+    // setTune(false) → completeTuneOff() chain.
+    // Cite: Thetis console.cs:30010 [v2.10.3.13] — _tuning = true (read by
+    // many UI/meter/PA paths in console.cs).
+    bool isTune() const noexcept { return m_isTuning; }
     // 3M-1b I.3: inject HPSDRHW board type to select the per-family Radio Mic
     // group box in AudioTxInputPage without a live radio connection.
     // Does not reset other test-cap flags — independent of hasMicJack.
@@ -769,6 +783,23 @@ private:
     void wireSliceSignals();
     void teardownConnection();
 
+    // Issue #177 — deferred completion of the TUN-off path.
+    //
+    // Called from the rxReady → settle-timer slot wired in the constructor.
+    // Performs everything that used to run synchronously inside setTune(false)
+    // EXCEPT the MoxController::setTune(false) call: gen1 OFF, DSP-mode
+    // restore (CWL/CWU), tune-power restore through the dBm path, TX VFO
+    // un-offset, and the m_isTuning / m_pendingTuneOff state clears.
+    //
+    // Cite: Thetis console.cs:30106-30148 [v2.10.3.13] — chkTUN_CheckedChanged
+    // TUN-off branch.  Thetis runs the equivalent block AFTER
+    // chkMOX.Checked = false (which is synchronous and blocks ~30 ms inside
+    // chkMOX_CheckedChanged2) and AFTER `await Task.Delay(100)`.  In NereusSDR
+    // this method is invoked from a QTimer::singleShot(m_tuneOffSettleMs)
+    // chained off MoxController::rxReady, so the same total ~130 ms gap
+    // separates the user's click from gen1 going off.
+    void completeTuneOff();
+
     // P1 full-parity §3.4 — per-sample PA telemetry handler.
     // Applies per-board ADC→watts scaling (scaleFwdPowerWatts /
     // scaleRevPowerWatts / scalePaVolts / scalePaAmps), routes the FWD
@@ -998,6 +1029,34 @@ private:
     //   exported for H.3 UI polling.
     //   Cite: Thetis console.cs:30010 [v2.10.3.13] — _tuning = true.
     bool m_isTuning{false};
+
+    // ── Issue #177 fix — Thetis-faithful TUN-off ordering ────────────────────
+    //
+    // m_pendingTuneOff: latched true at the START of the setTune(false) path,
+    //   cleared inside completeTuneOff().  setTune(false) now only kicks off
+    //   the MoxController TX→RX walk; the rest (gen1 off, mode restore, drive
+    //   restore, VFO restore) runs from completeTuneOff() AFTER MoxController
+    //   emits rxReady AND an additional 100 ms settle elapses.
+    //
+    //   This mirrors Thetis console.cs:30106-30109 [v2.10.3.13]:
+    //     chkMOX.Checked = false;        // synchronously walks TX→RX (~30 ms)
+    //     await Task.Delay(100);
+    //     radio.GetDSPTX(0).TXPostGenRun = 0;
+    //
+    //   Without the deferral, gen1 was killed at T+0 while the WDSP TX channel
+    //   was still pumping fexchange0 (setRunning(false) does not fire until
+    //   txaFlushed at T+10 ms).  The hard step at gen1's output produced a
+    //   filter-ringing transient through the 31-stage TXA chain that briefly
+    //   exceeded steady-state amplitude on the wire.  Combined with the wire
+    //   drive byte staying at TUNE level for one EP2 frame after MOX-off
+    //   (round-robin priority bank0 > bank10), this produced an RF spike past
+    //   the radio's spec at high tune-slider settings.  Issue #177.
+    bool m_pendingTuneOff{false};
+
+    // m_tuneOffSettleMs: explicit 100 ms wait between MoxController::rxReady
+    //   and completeTuneOff().  Mirrors `await Task.Delay(100)` at Thetis
+    //   console.cs:30107 [v2.10.3.13].  Tests override via the *ForTest seam.
+    int m_tuneOffSettleMs{100};
 
     // ── 3M-1a G.1: TX-side integration ──────────────────────────────────────
     // Master design §5.1.1; pre-code review §1.6 + §2.5.

--- a/tests/tst_radio_model_set_tune.cpp
+++ b/tests/tst_radio_model_set_tune.cpp
@@ -118,10 +118,30 @@ public:
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 // processEvents helper: drains the Qt event loop for queued connections.
-// setTune uses Qt::QueuedConnection for setTxDrive calls; two passes
-// cover any chained queued emissions.
+//
+// Pre-issue #177: setTune(false) restored power synchronously (single-frame
+// queued setTxDrive call) so two passes were enough.
+//
+// Post-issue #177 (Thetis-faithful TUN-off): setTune(false) now defers the
+// tone-off + power-restore until MoxController::rxReady fires AND a settle
+// timer elapses.  With test timers set to 0 and m_tuneOffSettleMs forced to 0
+// via setTuneOffSettleMsForTest(), the chain that needs to drain on a
+// TUN-off cycle is:
+//
+//   iter 1: keyUpDelayTimer (0 ms QTimer) fires → onKeyUpDelayElapsed →
+//           emit txaFlushed; pttOutDelayTimer.start()
+//   iter 2: pttOutDelayTimer fires → onPttOutElapsed → emit rxReady →
+//           constructor lambda schedules QTimer::singleShot(0)
+//   iter 3: QTimer::singleShot(0) fires → completeTuneOff() →
+//           QMetaObject::invokeMethod queues setTxDrive (same-thread Auto
+//           collapses to Direct, so the call lands during this iteration)
+//
+// Four passes leaves headroom for the Qt::QueuedConnection on
+// hardwareFlipped (line 624) which adds a same-thread queue hop.
 static void pump()
 {
+    QCoreApplication::processEvents();
+    QCoreApplication::processEvents();
     QCoreApplication::processEvents();
     QCoreApplication::processEvents();
 }
@@ -140,6 +160,15 @@ static void setupModel(RadioModel& model, MockConnection*& mockConn)
 
     // Make MoxController walk synchronous (0-ms timers → pump() drives walk).
     model.moxController()->setTimerIntervals(0, 0, 0, 0, 0, 0);
+
+    // Issue #177 — drive the TUN-off settle synchronously in tests.
+    // Production default is 100 ms (matches Thetis console.cs:30107
+    // [v2.10.3.13] `await Task.Delay(100)`).  Setting to 0 lets pump()
+    // drive completeTuneOff() through QCoreApplication::processEvents
+    // without sleeping in tests.  Behavior is otherwise identical: the
+    // deferred completion still runs from the rxReady → settle-timer
+    // chain wired in the RadioModel constructor.
+    model.setTuneOffSettleMsForTest(0);
 
     // Add a slice so m_activeSlice is non-null.
     model.addSlice();
@@ -712,6 +741,192 @@ private slots:
         QVERIFY(!isLsbFamilyRef(DSPMode::CWU));
         QVERIFY(!isLsbFamilyRef(DSPMode::AM));
         QVERIFY(!isLsbFamilyRef(DSPMode::FM));
+    }
+
+    // ── 19. Issue #177: TUN-off defers gen1 + power-restore until rxReady ────
+    //
+    // Reproduces the ordering that triggered Chris Palmgren's HL2 bench
+    // report on 2026-05-03 (issue #177): on TUN-off, power-restore (and the
+    // gen1.run=0 it stands in for) must NOT happen synchronously.  It must
+    // wait for MoxController::rxReady AND a settle timer.
+    //
+    // Cite: Thetis console.cs:30106-30109 [v2.10.3.13]:
+    //   chkMOX.Checked = false;        // synchronous walk TX→RX (~30 ms blocking)
+    //   await Task.Delay(100);
+    //   radio.GetDSPTX(0).TXPostGenRun = 0;
+    //
+    // Strategy: setupModel forces both MoxController timers and the
+    // RadioModel tune-off settle to 0 ms.  We snapshot the txDriveLog size
+    // immediately after setTune(false) returns; if completion ran
+    // synchronously it would already have grown (regression).  After draining
+    // the event loop the log MUST grow, confirming the deferred path fires.
+    //
+    // m_pendingTuneOff is exposed via tuneOffPendingForTest() so we can
+    // observe the latch directly.
+    void tuneOffDefersUntilRxReadyAndSettle()
+    {
+        RadioModel model;
+        MockConnection* conn = nullptr;
+        setupModel(model, conn);
+        std::unique_ptr<MockConnection> connOwner(conn);
+
+        auto* slice = model.activeSlice();
+        QVERIFY(slice != nullptr);
+        slice->setDspMode(DSPMode::USB);
+
+        // Need a PA profile so the dBm-path power restore actually emits a
+        // wire byte (mirrors tuneOffRestoresPower setup).
+        if (PaProfileManager* pm = model.paProfileManager()) {
+            pm->setMacAddress(QStringLiteral("AABBCCDDEEFF"));
+            pm->load(HPSDRModel::HERMES);
+        }
+
+        model.transmitModel().setPower(80);
+
+        // Engage TUN.  This pushes a tune-power wire byte and arms TX-on.
+        conn->txDriveLog.clear();
+        model.setTune(true);
+        pump();
+
+        const int logSizeAfterOn = conn->txDriveLog.size();
+        QVERIFY2(logSizeAfterOn > 0,
+                 "TUN-on must push at least one wire drive byte");
+
+        // ── The actual regression check ───────────────────────────────────────
+        // Click TUN-off.  Pre-fix behavior: the saved wire byte was queued
+        // synchronously inside setTune(false).  Post-fix: nothing should
+        // happen until rxReady fires + settle elapses.
+        model.setTune(false);
+
+        // Right after the call returns:
+        //  - the latch must be armed (deferred completion is queued, not run)
+        //  - the wire drive log must be unchanged (no byte queued yet)
+        QVERIFY2(model.tuneOffPendingForTest(),
+                 "setTune(false) must arm m_pendingTuneOff before returning");
+        QCOMPARE(conn->txDriveLog.size(), logSizeAfterOn);
+
+        // Drain the event loop — this drives:
+        //   keyUpDelayTimer (0 ms) → txaFlushed
+        //   pttOutDelayTimer (0 ms) → rxReady
+        //   QTimer::singleShot(0) → completeTuneOff
+        //   completeTuneOff queues setTxDrive (synchronous same-thread Auto)
+        pump();
+
+        // Now the latch must be cleared and the wire byte must have been
+        // emitted (so the radio sees the saved drive level).
+        QVERIFY2(!model.tuneOffPendingForTest(),
+                 "completeTuneOff must clear m_pendingTuneOff");
+        QVERIFY2(conn->txDriveLog.size() > logSizeAfterOn,
+                 "completeTuneOff must push the saved-power wire byte");
+
+        model.injectConnectionForTest(nullptr);
+    }
+
+    // ── 20. Issue #177: a fresh setTune(true) cancels a pending TUN-off ──────
+    //
+    // If the operator double-clicks TUN within the rxReady + settle window,
+    // the deferred completion must not stomp the new TUN-on state.  The
+    // pending latch is cleared in setTune(true) at the top of the on-branch;
+    // the rxReady slot and the QTimer body both re-check it before doing any
+    // work, so double-firing is harmless.
+    void tuneOnCancelsPendingTuneOff()
+    {
+        RadioModel model;
+        MockConnection* conn = nullptr;
+        setupModel(model, conn);
+        std::unique_ptr<MockConnection> connOwner(conn);
+
+        auto* slice = model.activeSlice();
+        QVERIFY(slice != nullptr);
+        slice->setDspMode(DSPMode::USB);
+
+        if (PaProfileManager* pm = model.paProfileManager()) {
+            pm->setMacAddress(QStringLiteral("AABBCCDDEEFF"));
+            pm->load(HPSDRModel::HERMES);
+        }
+
+        model.transmitModel().setPower(80);
+
+        // Engage TUN, click off, then click on again BEFORE pumping the
+        // event loop (latch is armed, nothing has fired yet).
+        model.setTune(true);
+        pump();
+        model.setTune(false);
+        QVERIFY(model.tuneOffPendingForTest());
+
+        // Re-engage immediately — this must clear the latch.
+        model.setTune(true);
+        QVERIFY2(!model.tuneOffPendingForTest(),
+                 "setTune(true) must cancel a pending TUN-off completion");
+
+        // Pump the loop.  rxReady will fire once for the original setTune(false)
+        // walk and once for the new TUN-on engagement.  Neither dispatch may
+        // run completeTuneOff() — m_pendingTuneOff is false the whole time.
+        // We verify via the model's m_isTuning state (still true) since
+        // completeTuneOff would clear it.
+        pump();
+
+        QVERIFY2(model.isTune(),
+                 "fresh TUN-on must remain active across pumped event loop");
+
+        model.setTune(false);
+        pump();
+
+        model.injectConnectionForTest(nullptr);
+    }
+
+    // ── 21. Issue #177: disconnect-mid-walk clears the deferred latch ────────
+    //
+    // teardownConnection() (called when the radio drops or the user clicks
+    // disconnect) must clear m_pendingTuneOff and m_isTuning.  Otherwise the
+    // next connect would inherit a stale latch and the first rxReady from a
+    // PTT cycle would mis-fire completeTuneOff().
+    //
+    // We can't drive teardownConnection() directly without a real connection
+    // (it asserts on m_connection != nullptr early-out), so we test the state
+    // contract by exercising a disconnect → reconnect cycle implicitly.
+    // Instead we verify the simpler invariant: after setTune(false), pump
+    // through completion, and re-engage TUN-on; the second cycle behaves
+    // identically (no stale state poisons it).
+    void tuneOffCycleIsRepeatable()
+    {
+        RadioModel model;
+        MockConnection* conn = nullptr;
+        setupModel(model, conn);
+        std::unique_ptr<MockConnection> connOwner(conn);
+
+        auto* slice = model.activeSlice();
+        QVERIFY(slice != nullptr);
+        slice->setDspMode(DSPMode::USB);
+
+        if (PaProfileManager* pm = model.paProfileManager()) {
+            pm->setMacAddress(QStringLiteral("AABBCCDDEEFF"));
+            pm->load(HPSDRModel::HERMES);
+        }
+
+        model.transmitModel().setPower(50);
+
+        // Cycle 1.
+        model.setTune(true);
+        pump();
+        model.setTune(false);
+        pump();
+        QVERIFY(!model.tuneOffPendingForTest());
+        QVERIFY(!model.isTune());
+
+        // Cycle 2 — must engage cleanly with no stale latch.
+        const int logBeforeCycle2 = conn->txDriveLog.size();
+        model.setTune(true);
+        pump();
+        QVERIFY(model.isTune());
+        QVERIFY(!model.tuneOffPendingForTest());
+        QVERIFY2(conn->txDriveLog.size() > logBeforeCycle2,
+                 "second TUN-on must push tune-power wire byte");
+
+        model.setTune(false);
+        pump();
+
+        model.injectConnectionForTest(nullptr);
     }
 };
 

--- a/tests/tst_radio_model_set_tune.cpp
+++ b/tests/tst_radio_model_set_tune.cpp
@@ -888,6 +888,83 @@ private slots:
     // Instead we verify the simpler invariant: after setTune(false), pump
     // through completion, and re-engage TUN-on; the second cycle behaves
     // identically (no stale state poisons it).
+    // ── 22. Issue #177 + Codex P1: TUN-off when MOX already RX still completes ──
+    //
+    // Codex caught a P1 stranded-latch case in PR #180 review: if MOX was
+    // already in RX state when setTune(false) is called (e.g., a safety trip
+    // dropped MOX while TUN was still latched, a manual MOX click during
+    // TUN, or a future PureSignal / SwrProtectionController force-unkey
+    // path), MoxController::setMox(false) hits the idempotent guard and
+    // emits no TX→RX phase signals.  No rxReady fires, m_pendingTuneOff
+    // stays latched, and a later unrelated rxReady from a normal PTT cycle
+    // would consume the stale latch and apply stale TUN-off state.
+    //
+    // The fix detects MOX-already-off in setTune(false) and schedules
+    // completeTuneOff directly via QTimer::singleShot, bypassing rxReady.
+    // This mirrors Thetis console.cs:30107 [v2.10.3.13] `await Task.Delay(100)`
+    // which is unconditional (fires whether or not chkMOX assignment
+    // triggered a walk — WinForms silently no-ops same-value assignment).
+    void tuneOffWithMoxAlreadyOffStillCompletes()
+    {
+        RadioModel model;
+        MockConnection* conn = nullptr;
+        setupModel(model, conn);
+        std::unique_ptr<MockConnection> connOwner(conn);
+
+        auto* slice = model.activeSlice();
+        QVERIFY(slice != nullptr);
+        slice->setDspMode(DSPMode::USB);
+
+        if (PaProfileManager* pm = model.paProfileManager()) {
+            pm->setMacAddress(QStringLiteral("AABBCCDDEEFF"));
+            pm->load(HPSDRModel::HERMES);
+        }
+
+        model.transmitModel().setPower(80);
+
+        // Engage TUN.  This sets m_isTuning=true and engages MOX.
+        model.setTune(true);
+        pump();
+        QVERIFY(model.moxController()->isMox());
+        QVERIFY(model.isTune());
+
+        // Externally drop MOX (simulates a safety trip / PA fault / manual
+        // MOX click during TUN).  m_isTuning remains true; MOX is now off.
+        // Note: this drives the MOX state machine through a real TX→RX walk
+        // so we must pump to drain the chained timers.
+        model.moxController()->setMox(false);
+        pump();
+        QVERIFY(!model.moxController()->isMox());
+        QVERIFY(model.isTune());          // m_isTuning still latched
+        QVERIFY(!model.tuneOffPendingForTest());
+
+        // Click TUN-off.  With the Codex fix, this must complete cleanly
+        // even though MoxController::setTune(false) → setMox(false) hits
+        // the idempotent guard and emits no rxReady.  The fallback
+        // QTimer::singleShot in setTune(false) drives completeTuneOff.
+        const int logBefore = conn->txDriveLog.size();
+        model.setTune(false);
+        QVERIFY2(model.tuneOffPendingForTest(),
+                 "setTune(false) must arm the latch even when MOX was already off");
+
+        // Pump the event loop.  This drives:
+        //   QTimer::singleShot(0, ...) fallback → completeTuneOff
+        //   completeTuneOff queues setTxDrive (synchronous same-thread Auto)
+        pump();
+
+        // Latch must be cleared and the saved-power wire byte must have
+        // been pushed via the fallback path.  Without the Codex fix this
+        // assertion fails (the latch sits forever, no setTxDrive call).
+        QVERIFY2(!model.tuneOffPendingForTest(),
+                 "completeTuneOff must run even when MOX was already off");
+        QVERIFY2(conn->txDriveLog.size() > logBefore,
+                 "saved-power wire byte must be pushed via fallback path");
+        QVERIFY2(!model.isTune(),
+                 "completeTuneOff must clear m_isTuning");
+
+        model.injectConnectionForTest(nullptr);
+    }
+
     void tuneOffCycleIsRepeatable()
     {
         RadioModel model;


### PR DESCRIPTION
## Summary

Fixes #177: forward-power spike past spec when releasing TUN at high tune-slider settings on HL2 (and all P1/P2 boards). Root cause was a TUN-off ordering bug. Fix mirrors Thetis verbatim.

## Root cause

`RadioModel::setTune(false)` was killing gen1 (the WDSP PostGen tune-tone oscillator) and restoring the saved drive byte synchronously, before the MoxController TX→RX walk had a chance to disable the WDSP TX channel. The hard step at gen1's output rang through the 31-stage TXA chain; the resulting filter-ringing transient briefly exceeded steady-state TUNE amplitude on the wire and reached the radio during its MOX-off latency window.

Compounded by the wire drive byte staying at TUNE level for one EP2 frame after MOX-off (round-robin priority bank0 > bank10), so the radio briefly saw high-amplitude transient I/Q × high drive byte = RF spike past spec.

## Thetis-faithful fix

[`console.cs:30106-30109 [v2.10.3.13]`](https://github.com/ramdor/Thetis/blob/501e3f51/Project%20Files/Source/Console/console.cs#L30106) is the canonical sequence:

```csharp
chkMOX.Checked = false;          // synchronously walks TX->RX (~30 ms blocking)
await Task.Delay(100);
radio.GetDSPTX(0).TXPostGenRun = 0;
```

Thetis turns gen1 off ~130 ms after the click, AFTER the WDSP TX channel has already been disabled. The hard step never enters a running TXA chain, so there is no transient.

NereusSDR's `MoxController` is timer-based (non-blocking), so `setTune(false)` now:

1. Latches `m_pendingTuneOff = true`.
2. Calls `m_moxController->setTune(false)` to kick off the async walk.
3. Returns.

A persistent slot wired in the `RadioModel` constructor listens for `MoxController::rxReady` (TX→RX phase 4 of 4), schedules a `QTimer::singleShot(m_tuneOffSettleMs)` (default 100 ms), and runs `completeTuneOff()` from there. The completion does the gen1 off, DSP-mode restore, drive-byte restore, and TX-VFO un-offset that used to run synchronously.

Both the rxReady slot and the timer body re-check `m_pendingTuneOff` so a fresh TUN-on within the window cancels cleanly. `teardownConnection()` clears the latch on disconnect.

## Test plan

Unit:

- [x] `tst_radio_model_set_tune::tuneOffDefersUntilRxReadyAndSettle` (new): asserts the wire byte is NOT touched until rxReady + settle.
- [x] `tuneOnCancelsPendingTuneOff` (new): re-engaging within the window keeps the latch clear.
- [x] `tuneOffCycleIsRepeatable` (new): second cycle has no stale state.
- [x] All 211 tests across 14 affected MOX/tune/drive binaries green.

Bench (this branch, ANAN-G2 over LAN, dummy load):

- [x] TUN release at high slider: clean, no over-spec spike.
- [x] SSB MOX/PTT: no regression.

HL2 bench is the report-of-record for the original issue. Inviting Chris and other HL2 users to confirm on their hardware before tagging.

## Notes for reviewers

- The fix is contained to `RadioModel` plus the test file. `MoxController`, P1/P2 wire format, and the TX I/Q pump are untouched.
- `m_tuneOffSettleMs` is configurable through a `*ForTest` seam (default 100). If bench feedback wants a tighter or looser value we can dial it without changing semantics.
- The standing comment at `RadioModel.cpp:4707-4711` about wiring a `rxReady` slot "if bench shows a click on TX→RX" is now half-fulfilled (the TUN-off branch). RX restore on PTT release still uses the early `hardwareFlipped` slot. That is a separate code path with no known bench regression and is out of scope here.

Closes #177.

J.J. Boyd ~ KG4VCF