### PR TITLE
fix(nr3): probe <exe>/../third_party for dev-build rnnoise model

### DIFF
--- a/src/core/ModelPaths.cpp
+++ b/src/core/ModelPaths.cpp
@@ -65,14 +65,17 @@ QString probeModel(const QString& subdir, const QString& filename)
         if (!p.isEmpty()) { return p; }
     }
 
-    // 5-7. Dev build — binary is inside the build tree, source is a few levels up.
-    //    macOS:  build/NereusSDR.app/Contents/MacOS/NereusSDR
-    //    Linux:  build/NereusSDR  (or build/bin/NereusSDR)
+    // 5-8. Dev build — binary is inside the build tree, source is a few levels up.
+    //    Windows: build/NereusSDR.exe                              (1 level)
+    //    Linux:   build/NereusSDR                                  (1 level)
+    //    Linux:   build/bin/NereusSDR                              (2 levels)
+    //    macOS:   build/NereusSDR.app/Contents/MacOS/NereusSDR     (4 levels)
     //    The third_party/<libname>/models/ path is relative to the repo root.
     const QString libname = (subdir == QStringLiteral("dfnet3"))
         ? QStringLiteral("deepfilter")
         : QStringLiteral("rnnoise");
     for (const char* rel : {
+             "/../third_party/",
              "/../../third_party/",
              "/../../../third_party/",
              "/../../../../third_party/",


### PR DESCRIPTION
## Summary

- One-line probe addition in `src/core/ModelPaths.cpp` so dev-build runs of NereusSDR find the bundled rnnoise model on Windows MinGW (and bare-`build/` Linux) without a manual copy.
- Without this, clicking **NR3** on the VFO flag in a fresh dev build hard-crashes the process the moment audio frames hit `rnnoise_process_frame`.

## Background

`ModelPaths::probeModel` already had four "dev build" fallbacks (2/3/4 levels up from `<exeDir>` for `build/bin/NereusSDR`, `build/NereusSDR.app/...`). Windows MinGW outputs `build/NereusSDR.exe` directly — only **1** level deep — so every dev fallback resolved outside the repo and the probe returned an empty `QString`.

`RadioModel::initializedChanged` lambda then logged

```
WRN: NR3 model not found at expected paths; NR3 will be disabled until a model is loaded.
```

and skipped `RNNRloadModel` entirely. But `create_rnnr` (third_party/wdsp/src/rnnr.c:225) had **already** run during channel creation with `_rnnr_model = NULL`. Because the vendored rnnoise is built with `USE_WEIGHTS_FILE` (third_party/rnnoise/CMakeLists.txt — and the `// rnnoise_create(NULL) is never called` comment that pinned the invariant), `rnnoise_create(NULL)` returns a `DenoiseState*` whose model fields are zeroed but reports success. Clicking NR3 toggles `SetRXARNNRRun(channel, 1)` and the next audio block segfaults inside `rnn_compute_generic_conv1d → memmove(NULL, …)`.

GDB confirmed it under MinGW with full RelWithDebInfo symbols on Hermes Lite 2 / Protocol 1 (the same chain reproduces on every WDSP-using radio because the failure is in the rnnoise wrapper, not protocol code):

```
Thread 27 received signal SIGSEGV
#0  msvcrt!memmove
#1  rnn_compute_generic_conv1d ()
#2  0x0000000000000000 in ?? ()
```

After the patch, the probe finds `<exeDir>/../third_party/rnnoise/models/Default_large.bin`, the model loads (`INF: NR3: loading rnnoise model from "…/third_party/rnnoise/models/Default_large.bin"`), and NR3 toggles cleanly.

## Audit — strictly additive across every supported layout

The change adds **one** new entry (`"/../third_party/"`) at the front of the dev-fallback list. `probeModel` returns the first hit, so installed/bundle/XDG layouts never reach the new probe. I walked every layout the project supports:

| Layout | New probe resolves to | Outcome |
|---|---|---|
| Windows installed (NSIS to `C:\Program Files\NereusSDR\`) | `C:\Program Files\third_party\…` (doesn't exist) | empty — probe 1 (`<exe>/models/…`) wins, identical |
| Windows portable (extracted ZIP) | `<extractDir>/../third_party/…` (doesn't exist) | empty — probe 1 wins, identical |
| **Windows MinGW dev** | `<repo>\third_party\rnnoise\models\Default_large.bin` | **wins** — fix kicks in here |
| macOS .app bundle (release) | `…/Contents/third_party/…` (doesn't exist) | empty — probe 2 (`…/Contents/Resources/models/…`) wins, identical |
| macOS dev (`build/NereusSDR.app/...`) | `…/Contents/third_party/…` (doesn't exist) | empty — probe 8 (4 levels up) wins, identical |
| Linux installed (`/usr/local/`) | `/usr/local/third_party/…` (doesn't exist) | empty — probe 3 (`…/share/NereusSDR/…`) wins, identical |
| Linux user/XDG | doesn't exist | empty — probe 4 wins, identical |
| **Linux dev** (`build/NereusSDR`) | `<repo>/third_party/rnnoise/models/Default_large.bin` | **wins** — fix kicks in here too |
| Linux dev (`build/bin/NereusSDR`) | `build/third_party/…` (doesn't exist) | empty — probe 6 (2 levels up) wins, identical |

Per-protocol / per-radio: the rnnoise probe has exactly one call site (`RadioModel.cpp:1502`, inside the `WdspEngine::initializedChanged` lambda) which fires once per WDSP init with no protocol or radio-model branching. P1 (HL2 / Atlas / Hermes / Hermes II / Angelia / Orion) and P2 (ANAN line) all hit the same code path. The `dfnrModelTarball()` helper for DFNR (NR4) shares the same `probeModel` and gets the same dev-build benefit for free.

## Test plan

- [x] Reproduce NR3 segfault on Windows MinGW dev build (HL2 P1, fresh `build/` with no manual model copy) — `gdb --batch` captures `rnn_compute_generic_conv1d` segfault on click.
- [x] Apply patch, rebuild, repeat — Qt log shows `INF: NR3: loading rnnoise model from "…/third_party/rnnoise/models/Default_large.bin"` and NR3 toggles cleanly.
- [x] Static audit of all 9 packaging layouts (table above) — new probe is strictly additive.
- [ ] Maintainer: confirm Linux installed / macOS .app behavior unchanged on respective platforms (probes 1-4 still fire first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)