### PR TITLE
fix(p1): adc_overload byte offset (issue #176)

### DIFF
--- a/src/core/P1RadioConnection.cpp
+++ b/src/core/P1RadioConnection.cpp
@@ -2372,9 +2372,12 @@ void P1RadioConnection::parseEp6Frame(const QByteArray& pkt)
         return;
     }
 
-    //[2.10.3.13]MW0LGE adc_overload accumulated (or'd) across EP6 frames, cleared only by reader [Thetis networkproto1.c:335]
-    // From Thetis networkproto1.c — ADC overflow in C&C status bytes.
-    // C0[0] bit 0 = LT2208 overflow (ADC0).
+    // Cache each subframe's C0 byte for the mic_ptt extraction below.
+    // ADC overflow does NOT live in C0 — per Thetis networkproto1.c:332-355
+    // [v2.10.3.13] it lives in C1 bit 0 of case-0x00 frames and in
+    // C1/C2/C3 bit 0 of case-0x20 frames.  See the C0-type switch lower
+    // in this function.
+    //
     // Phase 3P-E Task 2: C0 bit 7 = I2C response frame (HL2 only).
     // Source: mi0bot networkproto1.c:478-493 [@c26a8a4]
     const quint8 c0_sub0 = frame[11];
@@ -2391,10 +2394,6 @@ void P1RadioConnection::parseEp6Frame(const QByteArray& pkt)
             parseI2cResponse(c0, frame[base + 4], frame[base + 5],
                              frame[base + 6], frame[base + 7]);
         }
-    }
-
-    if ((c0_sub0 & 0x01) || (c0_sub1 & 0x01)) {
-        emit adcOverflow(0);
     }
 
     // H.5: mic_ptt extraction — P1 status frame C0 bit 0 (PTT from radio).
@@ -2452,12 +2451,24 @@ void P1RadioConnection::parseEp6Frame(const QByteArray& pkt)
             continue;
         }
         // Source: networkproto1.c:332 — switch (ControlBytesIn[0] & 0xf8)
-        // Adjacent upstream cases 0x00/0x20 (networkproto1.c:335/353/354/355)
-        // each preserve `// only cleared by getAndResetADC_Overload(), or'ed
-        // with existing state //[2.10.3.13]MW0LGE` — inline attribution that
-        // survives verbatim in the port even though ADC-overload extraction
-        // happens in parseEp6Frame(), not here.
+        // Cases 0x00/0x20 carry ADC-overload bits (one per ADC); the
+        // `//[2.10.3.13]MW0LGE only cleared by getAndResetADC_Overload(),
+        // or'ed with existing state` inline attributions are preserved
+        // verbatim within each case body below.  In NereusSDR the SAC
+        // hysteresis state machine (StepAttenuatorController) plays the
+        // role of `getAndResetADC_Overload()` — it OR-accumulates every
+        // adcOverflow() emission until its 100 ms tick consumes them.
         switch (c0 & 0xF8) {
+        case 0x00: {
+            // Issue #176 fix — ADC0 overload reported in C1 bit 0.
+            // From Thetis networkproto1.c:335 [v2.10.3.13]:
+            //   prn->adc[0].adc_overload = prn->adc[0].adc_overload || ControlBytesIn[1] & 0x01;
+            //   // only cleared by getAndResetADC_Overload(), or'ed with existing state //[2.10.3.13]MW0LGE
+            if (c1 & 0x01) {
+                emit adcOverflow(0);
+            }
+            break;
+        }
         case 0x08: {
             // From Thetis networkproto1.c:339 [@501e3f5] — exciter_power AIN5
             const quint16 exciter = static_cast<quint16>((c1 << 8) | c2);
@@ -2506,6 +2517,17 @@ void P1RadioConnection::parseEp6Frame(const QByteArray& pkt)
             // Shell-chrome sub-PR-2 B.3: emit supplyVoltsChanged for all radios.
             // From Thetis networkproto1.c:350 [@501e3f5] — supply_volts AIN6 Hermes Volts //[2.10.3.13]MW0LGE
             handleSupplyRaw(supply);
+            break;
+        }
+        case 0x20: {
+            // Issue #176 fix — multi-ADC overload report (Orion / ANAN-8000 class).
+            // From Thetis networkproto1.c:353-355 [v2.10.3.13]:
+            //   prn->adc[0].adc_overload = prn->adc[0].adc_overload || ControlBytesIn[1] & 1;        // only cleared by getAndResetADC_Overload(), or'ed with existing state //[2.10.3.13]MW0LGE
+            //   prn->adc[1].adc_overload = prn->adc[1].adc_overload || (ControlBytesIn[2] & 1) << 1; // only cleared by getAndResetADC_Overload(), or'ed with existing state //[2.10.3.13]MW0LGE
+            //   prn->adc[2].adc_overload = prn->adc[2].adc_overload || (ControlBytesIn[3] & 1) << 2; // only cleared by getAndResetADC_Overload(), or'ed with existing state //[2.10.3.13]MW0LGE
+            if (c1 & 0x01) { emit adcOverflow(0); }
+            if (c2 & 0x01) { emit adcOverflow(1); }
+            if (c3 & 0x01) { emit adcOverflow(2); }
             break;
         }
         default:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1017,6 +1017,17 @@ nereus_add_test(tst_p1_status_telemetry)
 nereus_add_test(tst_p2_status_telemetry)
 nereus_add_test(tst_radio_model_status_wiring)
 
+# ── Issue #176: P1 EP6 status-frame parser was reading C0 bit 0 (mic_PTT)
+# and emitting it as adcOverflow, causing the OVL badge to fire on every
+# footswitch press while real ADC saturations went unreported.  This test
+# constructs hand-crafted ep6 frames and verifies adcOverflow / micPttFromRadio
+# fire from independent bytes per Thetis networkproto1.c:329 + 332-355
+# [v2.10.3.13]:
+#   ptt_in   = ControlBytesIn[0] & 0x1               (C0 bit 0)
+#   case 0x00: adc[0] = ControlBytesIn[1] & 0x01     (C1 bit 0)
+#   case 0x20: adc[0..2] = ControlBytesIn[1..3] & 0x01
+nereus_add_test(tst_p1_adc_overflow_extraction)
+
 # ── Phase 3P-G commit 1: CalibrationController model ─────────────────────────
 # Verifies defaults (freqFactor=1.0, all offsets=0), setter signal emission
 # (idempotent no-fire), effectiveFreqCorrectionFactor() toggle between normal

--- a/tests/tst_p1_adc_overflow_extraction.cpp
+++ b/tests/tst_p1_adc_overflow_extraction.cpp
@@ -1,0 +1,223 @@
+// no-port-check: test harness citing Thetis networkproto1.c offsets as the
+// behavioural spec it asserts against; contains no ported logic of its own.
+// =================================================================
+// tests/tst_p1_adc_overflow_extraction.cpp  (NereusSDR)
+// =================================================================
+//
+// Regression tests for issue #176 — the P1 EP6 status-frame parser was
+// reading C0 bit 0 (which is mic_PTT) and emitting it as adcOverflow.
+// That meant:
+//   1. Closing the footswitch fired a false ADC-overload every frame
+//      while held — the badge ramped yellow→red and tailed back through
+//      yellow on release.
+//   2. UI MOX (which never closes the PTT input pin) never saw any OVL
+//      indication.
+//   3. A genuine LT2208 saturation, reported by the radio in C1 bit 0,
+//      was invisible — the parser was looking at the wrong byte.
+//
+// The correct extraction per Thetis is:
+//
+//   networkproto1.c:329 [v2.10.3.13]:
+//     prn->ptt_in = ControlBytesIn[0] & 0x1;            // C0 bit 0
+//
+//   networkproto1.c:332-335 [v2.10.3.13]:
+//     switch (ControlBytesIn[0] & 0xf8)
+//       case 0x00:
+//         prn->adc[0].adc_overload = ... ControlBytesIn[1] & 0x01;
+//                                          // C1 bit 0 — type 0x00 only
+//
+//   networkproto1.c:353-355 [v2.10.3.13]:
+//     case 0x20:
+//       prn->adc[0].adc_overload = ... ControlBytesIn[1] & 1;
+//       prn->adc[1].adc_overload = ... (ControlBytesIn[2] & 1) << 1;
+//       prn->adc[2].adc_overload = ... (ControlBytesIn[3] & 1) << 2;
+//
+// This test feeds 1032-byte EP6 datagrams that exercise each of:
+//   - PTT bit set, OVL bit clear  → adcOverflow MUST NOT fire
+//   - OVL bit set in case 0x00    → adcOverflow(0) fires once
+//   - C1 bit 0 in non-OVL case    → adcOverflow MUST NOT fire (gated by C0 type)
+//   - Multi-ADC case 0x20         → adcOverflow(0), (1), (2) each fire
+//   - PTT + OVL set together      → both signals fire independently
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-05-04 — Issue #176 regression — J.J. Boyd (KG4VCF),
+//                 with AI-assisted authoring via Anthropic Claude Code.
+// =================================================================
+
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include <QByteArray>
+
+#include "core/P1RadioConnection.h"
+
+using namespace NereusSDR;
+
+namespace {
+
+// Build a 1032-byte EP6 datagram with both subframes' sync words +
+// caller-supplied 5-byte C&C (C0..C4) per subframe.  Sample bytes are
+// zero — parseEp6Frame() accepts the frame because magic + sync are
+// present.  Layout per Thetis networkproto1.c:320-357 [v2.10.3.13].
+QByteArray makeEp6Frame(const quint8 sub0[5], const quint8 sub1[5])
+{
+    QByteArray pkt(1032, '\0');
+    auto* p = reinterpret_cast<quint8*>(pkt.data());
+
+    // Metis EP6 magic — networkproto1.c:326-327 [v2.10.3.13]
+    p[0] = 0xEF; p[1] = 0xFE; p[2] = 0x01; p[3] = 0x06;
+
+    // Subframe 0: sync at [8..10], C&C at [11..15]
+    p[8] = 0x7F; p[9] = 0x7F; p[10] = 0x7F;
+    for (int i = 0; i < 5; ++i) { p[11 + i] = sub0[i]; }
+
+    // Subframe 1: sync at [520..522], C&C at [523..527]
+    p[520] = 0x7F; p[521] = 0x7F; p[522] = 0x7F;
+    for (int i = 0; i < 5; ++i) { p[523 + i] = sub1[i]; }
+
+    return pkt;
+}
+
+} // anonymous namespace
+
+class TestP1AdcOverflowExtraction : public QObject {
+    Q_OBJECT
+private slots:
+
+    // ── Headline regression for #176 ──────────────────────────────────────
+    // PTT bit set in C0, no OVL bit anywhere → adcOverflow MUST NOT fire.
+    //
+    // Without the fix: the parser reads C0 bit 0 as the OVL source, so
+    //   pressing the footswitch sends an unbroken stream of fake OVLs.
+    //
+    // From Thetis networkproto1.c:329 [v2.10.3.13]:
+    //   prn->ptt_in = ControlBytesIn[0] & 0x1;            // C0 bit 0
+    // From Thetis networkproto1.c:335 [v2.10.3.13]:
+    //   prn->adc[0].adc_overload = ... ControlBytesIn[1] & 0x01;
+    //   // only cleared by getAndResetADC_Overload() //[2.10.3.13]MW0LGE
+    void pttHeldNoOverload_doesNotEmitAdcOverflow()
+    {
+        // Sub 0: C0 = 0x01 (type=0x00, ptt_in=1), C1 = 0x00 (no OVL)
+        // Sub 1: C0 = 0x00 (no PTT), C1 = 0x00
+        const quint8 sub0[5] = {0x01, 0x00, 0x00, 0x00, 0x00};
+        const quint8 sub1[5] = {0x00, 0x00, 0x00, 0x00, 0x00};
+        const QByteArray pkt = makeEp6Frame(sub0, sub1);
+
+        P1RadioConnection conn;
+        conn.init();
+        QSignalSpy ovlSpy(&conn, &P1RadioConnection::adcOverflow);
+        QSignalSpy pttSpy(&conn, &P1RadioConnection::micPttFromRadio);
+
+        conn.parseEp6FrameForTest(pkt);
+
+        // PTT must reach MoxController so the footswitch still works.
+        QCOMPARE(pttSpy.count(), 1);
+        QCOMPARE(pttSpy.at(0).at(0).toBool(), true);
+        // OVL must NOT fire — no overload was reported by the radio.
+        QCOMPARE(ovlSpy.count(), 0);
+    }
+
+    // ── Real OVL in case 0x00 fires on the right ADC ───────────────────────
+    // From Thetis networkproto1.c:332-335 [v2.10.3.13]:
+    //   switch (ControlBytesIn[0] & 0xf8) case 0x00:
+    //     prn->adc[0].adc_overload = ... ControlBytesIn[1] & 0x01;
+    //   // only cleared by getAndResetADC_Overload() //[2.10.3.13]MW0LGE
+    void overloadInCase00_emitsAdcOverflowZero()
+    {
+        // Sub 0: C0 = 0x00 (type=0x00, ptt=0), C1 = 0x01 (OVL bit set)
+        // Sub 1: C0 = 0x00, C1 = 0x00 (quiet — only one report)
+        const quint8 sub0[5] = {0x00, 0x01, 0x00, 0x00, 0x00};
+        const quint8 sub1[5] = {0x00, 0x00, 0x00, 0x00, 0x00};
+        const QByteArray pkt = makeEp6Frame(sub0, sub1);
+
+        P1RadioConnection conn;
+        conn.init();
+        QSignalSpy ovlSpy(&conn, &P1RadioConnection::adcOverflow);
+
+        conn.parseEp6FrameForTest(pkt);
+
+        QCOMPARE(ovlSpy.count(), 1);
+        QCOMPARE(ovlSpy.at(0).at(0).toInt(), 0);
+    }
+
+    // ── C1 bit 0 in a non-OVL case must NOT fire OVL ───────────────────────
+    // Type 0x08 carries exciter_power MSB in C1 — bit 0 of C1 there is the
+    // top byte's LSB, NOT an overload report.  This test guards the type
+    // gate so the fix can't over-fire.
+    //
+    // From Thetis networkproto1.c:339 [v2.10.3.13]:
+    //   case 0x08:
+    //     prn->tx[0].exciter_power = ((ControlBytesIn[1] << 8) ...) ...
+    // (Adjacent upstream :335 OVL line carries //[2.10.3.13]MW0LGE — preserved
+    //  in the case 0x00 body of the port; no OVL semantics in case 0x08.)
+    void c1Bit0InCase08_doesNotEmitAdcOverflow()
+    {
+        // Sub 0: C0 = 0x08 (PA telemetry case), C1 = 0x01 (exciter MSB lsb)
+        // Sub 1: C0 = 0x00, C1 = 0x00 (no OVL anywhere)
+        const quint8 sub0[5] = {0x08, 0x01, 0x00, 0x00, 0x00};
+        const quint8 sub1[5] = {0x00, 0x00, 0x00, 0x00, 0x00};
+        const QByteArray pkt = makeEp6Frame(sub0, sub1);
+
+        P1RadioConnection conn;
+        conn.init();
+        QSignalSpy ovlSpy(&conn, &P1RadioConnection::adcOverflow);
+
+        conn.parseEp6FrameForTest(pkt);
+
+        QCOMPARE(ovlSpy.count(), 0);
+    }
+
+    // ── Multi-ADC case 0x20 fires ADC0 / ADC1 / ADC2 independently ─────────
+    // From Thetis networkproto1.c:353-355 [v2.10.3.13]:
+    //   case 0x20:
+    //     prn->adc[0].adc_overload = ... ControlBytesIn[1] & 1;        //[2.10.3.13]MW0LGE
+    //     prn->adc[1].adc_overload = ... (ControlBytesIn[2] & 1) << 1; //[2.10.3.13]MW0LGE
+    //     prn->adc[2].adc_overload = ... (ControlBytesIn[3] & 1) << 2; //[2.10.3.13]MW0LGE
+    void overloadInCase20_emitsAllThreeAdcs()
+    {
+        // Sub 0: C0 = 0x20 (multi-ADC OVL case), C1=C2=C3 each bit 0 set
+        // Sub 1: C0 = 0x00 (quiet)
+        const quint8 sub0[5] = {0x20, 0x01, 0x01, 0x01, 0x00};
+        const quint8 sub1[5] = {0x00, 0x00, 0x00, 0x00, 0x00};
+        const QByteArray pkt = makeEp6Frame(sub0, sub1);
+
+        P1RadioConnection conn;
+        conn.init();
+        QSignalSpy ovlSpy(&conn, &P1RadioConnection::adcOverflow);
+
+        conn.parseEp6FrameForTest(pkt);
+
+        // Three independent ADC reports in this single frame.  Order of
+        // emission follows the Thetis switch body (ADC0 → ADC1 → ADC2).
+        QCOMPARE(ovlSpy.count(), 3);
+        QCOMPARE(ovlSpy.at(0).at(0).toInt(), 0);
+        QCOMPARE(ovlSpy.at(1).at(0).toInt(), 1);
+        QCOMPARE(ovlSpy.at(2).at(0).toInt(), 2);
+    }
+
+    // ── PTT and OVL fire independently when both bits are set ──────────────
+    // Confirms the two paths are wired to different bytes after the fix.
+    void pttAndOverloadTogether_fireIndependently()
+    {
+        // Sub 0: C0 = 0x01 (ptt_in=1, type=0x00), C1 = 0x01 (OVL bit set)
+        // Sub 1: C0 = 0x00, C1 = 0x00
+        const quint8 sub0[5] = {0x01, 0x01, 0x00, 0x00, 0x00};
+        const quint8 sub1[5] = {0x00, 0x00, 0x00, 0x00, 0x00};
+        const QByteArray pkt = makeEp6Frame(sub0, sub1);
+
+        P1RadioConnection conn;
+        conn.init();
+        QSignalSpy ovlSpy(&conn, &P1RadioConnection::adcOverflow);
+        QSignalSpy pttSpy(&conn, &P1RadioConnection::micPttFromRadio);
+
+        conn.parseEp6FrameForTest(pkt);
+
+        QCOMPARE(pttSpy.count(), 1);
+        QCOMPARE(pttSpy.at(0).at(0).toBool(), true);
+        QCOMPARE(ovlSpy.count(), 1);
+        QCOMPARE(ovlSpy.at(0).at(0).toInt(), 0);
+    }
+};
+
+QTEST_GUILESS_MAIN(TestP1AdcOverflowExtraction)
+#include "tst_p1_adc_overflow_extraction.moc"


### PR DESCRIPTION
## Summary

- The P1 EP6 status-frame parser was reading **C0 bit 0** (which is `mic_PTT`) and emitting it as `adcOverflow`. Closing the footswitch fired a fake ADC-overload every frame while held; UI MOX (which never closes the PTT pin) saw nothing.
- Real LT2208 saturations, reported by the radio in **C1 bit 0** of case-0x00 frames, were invisible.
- Fix moves OVL extraction into the existing C0-type switch alongside PA-telemetry cases, per Thetis `networkproto1.c:332-355 [v2.10.3.13]`.

## What changed

- `src/core/P1RadioConnection.cpp` — removed the buggy `frame[11]/frame[523] & 0x01` block that was reading the PTT bit as OVL. Added `case 0x00:` (single-ADC, C1 bit 0) and `case 0x20:` (multi-ADC, C1/C2/C3 bit 0) to the existing C0-type switch. mic_PTT extraction stays put on C0 bit 0. P2 path was already correct (`P2RadioConnection.cpp:2168-2180`).
- `tests/tst_p1_adc_overflow_extraction.cpp` — new regression test, 5 slots:
  - PTT held without OVL must NOT emit `adcOverflow` (the headline regression)
  - C1 bit 0 in case 0x00 emits `adcOverflow(0)`
  - C1 bit 0 in a non-OVL case (0x08, exciter) must NOT emit (type-gating guard)
  - case 0x20 emits `adcOverflow(0/1/2)` independently
  - PTT and OVL fire from independent bytes when both bits set
- `tests/CMakeLists.txt` — registered `tst_p1_adc_overflow_extraction`.

## Why it shipped (regression timeline)

Introduced 2026-04-16 in commit `25f81e88` when the OVL plumbing was added. The parser comment incorrectly said "C0[0] bit 0 = LT2208 overflow"; the cited Thetis line (`networkproto1.c:335`) actually reads `ControlBytesIn[1] & 0x01` (C1, not C0). No test ever synthesized an inbound EP6 frame and asserted `adcOverflow` independently from `micPttFromRadio` until now, so the off-by-one was invisible to CI. Released in v0.3.1 (2026-05-03) -- still on main.

## Scope

- **P1 only.** HL2, Atlas, Hermes, Hermes-II, Angelia, Orion. P2 (ANAN-line) was always correct.
- The "MOX-button-needs-TUNE-first" quirk that the same reporter mentions is a separate bug (deferred Task G.3 in MoxController) and is out of scope.

## Test plan

- [x] `ctest -R tst_p1_adc_overflow_extraction` -- 5/5 pass.
- [x] `ctest -R "tst_p1_status_telemetry|tst_mox_controller_mic_ptt_extraction|tst_pa_values_page|tst_step_attenuator_controller"` -- all green (no regressions in adjacent suites).
- [x] `verify-inline-tag-preservation.py` clean (`//[2.10.3.13]MW0LGE` preserved verbatim).
- [x] `verify-inline-cites.py`, `check-new-ports.py`, `verify-thetis-headers.py` all clean.
- [ ] Bench verification on HL2: footswitch press should leave the OVL badge clean (only fires when the radio actually reports an overload). UI MOX behaviour unchanged.

Closes #176.

J.J. Boyd ~ KG4VCF