### PR TITLE
fix: HL2 connect init parity (Bug 1 + #153 cold-start + SSB MOX)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -877,6 +877,49 @@ void MainWindow::buildUI()
         }
     });
 
+    // Push restored slice state into spectrum + VFO views once
+    // RadioModel::loadSliceState() completes.
+    //
+    // wireSliceToSpectrum() above runs at sliceAdded() time — BEFORE
+    // loadSliceState() runs inside connectToRadio.  At that earlier moment
+    // the slice still holds its pre-restore default values, so the
+    // spectrum widget's m_ddcCenterHz, center freq, and VFO freq were
+    // seeded with the default (typically 14.225 MHz / 20m).  After
+    // loadSliceState() restores the persisted band/freq/mode/filter,
+    // SliceModel::frequencyChanged is gated by qFuzzyCompare and by the
+    // CTUN-shift branch in wireSliceToSpectrum's frequencyChanged lambda
+    // (the offScreen path that calls setDdcCenterFrequency only fires
+    // when persisted freq is OUTSIDE default ±halfBw).  Without an
+    // explicit re-push, m_ddcCenterHz stays at the default and spectrum
+    // bin labels point to the wrong band of RF until the first dial-
+    // tune crosses the offScreen threshold.
+    //
+    // Mirrors Thetis txtVFOAFreq_LostFocus's unconditional Display.VFOA
+    // / Display.CentreFreqRX1 push at console.cs:31272 + 15378
+    // [v2.10.3.13], invoked from chkPower_CheckedChanged at
+    // console.cs:27204 [v2.10.3.13] as the explicit "push state to
+    // display" step on power-on.
+    connect(m_radioModel, &RadioModel::sliceStateRestored, this,
+            [this](int index) {
+        if (index != 0 || !m_spectrumWidget) {
+            return;
+        }
+        SliceModel* slice = m_radioModel->activeSlice();
+        if (!slice) {
+            return;
+        }
+        const double freq = slice->frequency();
+        m_spectrumWidget->setCenterFrequency(freq);
+        m_spectrumWidget->setDdcCenterFrequency(freq);
+        m_spectrumWidget->setVfoFrequency(freq);
+        m_spectrumWidget->setFilterOffset(slice->filterLow(), slice->filterHigh());
+        if (m_vfoWidget) {
+            m_vfoWidget->setFrequency(freq);
+            m_vfoWidget->setMode(slice->dspMode());
+            m_vfoWidget->setFilter(slice->filterLow(), slice->filterHigh());
+        }
+    });
+
     // Phase 3Q Sub-PR-6 (F.1): bind RxDashboard to slice(0) once it exists.
     // buildStatusBar() runs before connectToRadio() so slices().isEmpty() at
     // construction time; defer binding to sliceAdded.

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3993,19 +3993,30 @@ void RadioModel::loadSliceState(SliceModel* slice)
     emit sliceStateRestored(slice->sliceIndex());
 }
 
-// Issue #153 sub-bug 2 — push the active slice's DSPMode + audio-space
-// filter cutoffs to TxChannel.  See header comment for the wire targets
-// and source-of-truth Thetis cites.  This is the helper called by all
-// three triggers (createTxChannel post-create, SliceModel::dspModeChanged,
+// Issue #153 sub-bug 2 — push the active slice's DSPMode + the user's
+// configured TX bandpass to TxChannel.  See header comment for wire
+// targets and Thetis source-of-truth cites.  Called by all three
+// triggers (createTxChannel post-create, SliceModel::dspModeChanged,
 // MoxController::txAboutToBegin).
+//
+// Filter source is m_transmitModel (NOT m_activeSlice).  TransmitModel
+// stores audio-space TX cutoffs (positive, low <= high enforced by
+// setFilterLow/High swap-on-commit at TransmitModel.cpp:2526-2549),
+// which is what TxChannel::requestFilterChange + applyTxFilterForMode
+// expect.  SliceModel::filterLow/High are RX-passband IQ-space values
+// (negative for LSB-family modes); routing those through
+// applyTxFilterForMode would double-negate on LSB and silently
+// overwrite any user-configured TX bandwidth on every connect/MOX.
+// Mirrors the canonical wire at RadioModel.cpp:2550-2560 which reads
+// audioLow/audioHigh straight from TransmitModel::filterChanged.
 void RadioModel::pushTxModeAndBandpass()
 {
     if (!m_activeSlice) {
         return;
     }
     const DSPMode mode      = m_activeSlice->dspMode();
-    const int     audioLow  = m_activeSlice->filterLow();
-    const int     audioHigh = m_activeSlice->filterHigh();
+    const int     audioLow  = m_transmitModel.filterLow();
+    const int     audioHigh = m_transmitModel.filterHigh();
 
     // Diagnostic / test-observation hook fires unconditionally (m_txChannel
     // can be null during odd lifecycle moments — addSlice before

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -1665,13 +1665,38 @@ void RadioModel::connectToRadio(const RadioInfo& info)
         // getbuffsize(48000) at cmsetup.c:106-110 [v2.10.3.13] exactly.
         // Output buffer = 64 * txOutRate / 48000 — at 48 kHz out: 64; at
         // 192 kHz out (P2 G2): 256.
-        m_txChannel = m_wdspEngine->createTxChannel(/*channelId=*/1,
-                                                    /*inputBufferSize=*/64,
-                                                    /*dspBufferSize=*/WdspEngine::kTxDspBufferSize,
-                                                    /*inputSampleRate=*/48000,
-                                                    /*dspSampleRate=*/WdspEngine::kTxDspSampleRate,
-                                                    /*outputSampleRate=*/txOutRate);
-        if (m_txChannel) {
+        //
+        // Issue #153 sub-bug 1 — cold-start TxChannel race fix.
+        //
+        // On cold start (no cached FFTW wisdom), WdspEngine::initialize
+        // runs async and only emits initializedChanged(true) AFTER wisdom
+        // is generated (~15 min on a fresh install).  connectToRadio()
+        // runs synchronously, so the immediate createTxChannel attempt
+        // returns nullptr and the previous code logged a warning and
+        // gave up — TUN and MOX both produced silence for the rest of
+        // the session until reconnect.
+        //
+        // Wrap the entire create+wire body in a captured lambda so the
+        // exact same code path can run later when WdspEngine becomes
+        // initialized.  Hot-cache (wisdom present): txSetup() runs and
+        // succeeds inline.  Cold-start: txSetup() returns early at the
+        // createTxChannel-returns-nullptr guard, the retry registration
+        // below fires the same lambda once initializedChanged(true)
+        // lands, and the body runs verbatim.
+        auto txSetup = [this, txOutRate]() {
+            if (m_txChannel) {
+                return;
+            }
+            m_txChannel = m_wdspEngine->createTxChannel(
+                /*channelId=*/1,
+                /*inputBufferSize=*/64,
+                /*dspBufferSize=*/WdspEngine::kTxDspBufferSize,
+                /*inputSampleRate=*/48000,
+                /*dspSampleRate=*/WdspEngine::kTxDspSampleRate,
+                /*outputSampleRate=*/txOutRate);
+            if (!m_txChannel) {
+                return;
+            }
             m_txChannel->setConnection(m_connection);
 
             // ── L.1: construct Pc + Radio mic sources + composite router ──────────
@@ -1965,6 +1990,23 @@ void RadioModel::connectToRadio(const RadioInfo& info)
                     m_txChannel, [this](bool run) {
                 m_txChannel->setVoxRun(run);
             });
+
+            // Issue #153 sub-bug 2 — txAboutToBegin → pushTxModeAndBandpass.
+            //
+            // MoxController phase-1 signal fires synchronously BEFORE the
+            // rfDelay timer that gates txReady (MoxController.cpp:505-507
+            // [@501e3f5]).  pushTxModeAndBandpass dispatches setTxMode +
+            // requestFilterChange to TxWorkerThread; the queued setters
+            // settle well before rfDelay completes (~50 ms typical) and
+            // txReady → setRunning(true) above starts the channel.
+            //
+            // Belt-and-suspenders re-seed at MOX-engage even though the
+            // initial seed below + the dspModeChanged seed in
+            // wireSliceSignals already cover the no-mode-change case.
+            // Defends against any state desync caused by other code
+            // paths writing TXA mode/bp0 (TUN, future PureSignal, etc.).
+            connect(m_moxController, &MoxController::txAboutToBegin,
+                    this, &RadioModel::pushTxModeAndBandpass);
 
             // ── Phase 3M-3a-iii Task 17 (bench fix) ───────────────────────────
             //
@@ -2619,9 +2661,57 @@ void RadioModel::connectToRadio(const RadioInfo& info)
             qCInfo(lcDsp) << "G.1: TX channel 1 created (deferred until conn live)"
                           << "outRate=" << txOutRate
                           << "— SSB voice path ready (L.1 composite router wired).";
-        } else {
-            qCWarning(lcDsp) << "G.1: deferred createTxChannel(1) returned nullptr —"
-                                " TUNE will be unavailable until next reconnect.";
+
+            // Issue #153 sub-bug 2 — initial TXA mode/bandpass seed.
+            //
+            // m_txChannel is alive, m_activeSlice is non-null (loadSliceState
+            // ran earlier in connectToRadio at line ~1377 and restored the
+            // persisted dspMode + filterLow/filterHigh).  Push them now so
+            // SSB MOX no longer requires a prior TUN press to seed TXA
+            // mode (default LSB) and bp0 cutoffs (default -5000..-100).
+            //
+            // Source: Thetis SetTXFilters at console.cs:8091 [v2.10.3.13]
+            // + CurrentDSPMode setter at radio.cs:2670-2696 [v2.10.3.13];
+            // Thetis seeds at mode-change (console.cs:33937) + at
+            // chkPower → txtVFOAFreq_LostFocus path indirectly via the
+            // SetupTxFilters() preamble.  NereusSDR consolidates into
+            // one helper called at three triggers (this is trigger #1 of 3).
+            pushTxModeAndBandpass();
+        };  // end of txSetup lambda
+        txSetup();
+
+        if (!m_txChannel) {
+            // Issue #153 sub-bug 1 — cold-start retry hook.
+            //
+            // WDSP not yet initialized at connectToRadio time (typical
+            // first-launch case with no cached FFTW wisdom — async wisdom
+            // build can take ~15 minutes on a fresh install).  Register a
+            // one-shot connect to WdspEngine::initializedChanged(true)
+            // that re-runs the captured txSetup lambda.  receiver=this so
+            // the slot runs on RadioModel's main thread; QMetaObject
+            // disconnects automatically when this RadioModel is destroyed.
+            //
+            // The retry self-disconnects on first successful run.  If WDSP
+            // never initializes (e.g. wisdom build aborted) the connection
+            // remains harmlessly attached until RadioModel teardown.
+            auto retry = std::make_shared<QMetaObject::Connection>();
+            *retry = connect(m_wdspEngine, &WdspEngine::initializedChanged,
+                             this,
+                             [this, retry, txSetup = std::move(txSetup)](bool ready) {
+                if (!ready || m_txChannel) {
+                    return;
+                }
+                txSetup();
+                if (m_txChannel) {
+                    QObject::disconnect(*retry);
+                    qCInfo(lcDsp) << "Issue #153 sub-bug 1: TxChannel deferred-create "
+                                     "succeeded after WdspEngine::initializedChanged(true).";
+                }
+            }, Qt::UniqueConnection);
+            qCWarning(lcDsp) << "Issue #153 sub-bug 1: createTxChannel(1) returned nullptr "
+                                "at connect-time (WDSP not yet initialized — likely cold-"
+                                "start with no cached wisdom).  Registered one-shot retry "
+                                "on WdspEngine::initializedChanged.";
         }
     }
 
@@ -3120,6 +3210,13 @@ void RadioModel::wireSliceSignals()
         if (rxCh) {
             rxCh->setMode(mode);
         }
+        // Issue #153 sub-bug 2 — TX-side mode + bandpass push (trigger #2
+        // of 3).  Mirrors Thetis console.cs:33937 [v2.10.3.13] mode-change
+        // handler calling SetTXFilters + (CurrentDSPMode setter) →
+        // SetTXAMode.  Without this, the user can change slice mode while
+        // not transmitting and the next MOX would still use the previous
+        // mode's TXA setup.
+        pushTxModeAndBandpass();
         scheduleSettingsSave();
     });
 
@@ -3873,6 +3970,64 @@ void RadioModel::loadSliceState(SliceModel* slice)
                   << slice->frequency() / 1e6 << "MHz"
                   << "AGC:" << static_cast<int>(slice->agcMode())
                   << "AF:" << slice->afGain() << "RF:" << slice->rfGain();
+
+    // Unconditional state-restored hook for view layer.
+    //
+    // wireSliceToSpectrum() runs at sliceAdded() time — BEFORE this function —
+    // so it seeds m_spectrumWidget->setDdcCenterFrequency() / setCenterFrequency
+    // / setVfoFrequency with the slice's PRE-restore default values.  After
+    // restoreFromSettings() above, the slice now holds the persisted values,
+    // but the spectrum widget will only learn about them via
+    // SliceModel::frequencyChanged, which is gated:
+    //   (a) qFuzzyCompare guard at SliceModel.cpp:145 — no emit if equal;
+    //   (b) MainWindow::wireSliceToSpectrum lambda's offScreen test — with
+    //       CTUN=true (default) and persisted freq within ±halfBw of the
+    //       default seed, the lambda hits the CTUN-shift branch and never
+    //       calls setDdcCenterFrequency.
+    //
+    // This unconditional emit gives MainWindow an explicit hook to push the
+    // now-correct slice freq/mode/filter into the spectrum widget and VFO
+    // flag — mirroring Thetis chkPower_CheckedChanged calling
+    // txtVFOAFreq_LostFocus() unconditionally at console.cs:27204
+    // [v2.10.3.13] as the explicit "push state to display" step at power-on.
+    emit sliceStateRestored(slice->sliceIndex());
+}
+
+// Issue #153 sub-bug 2 — push the active slice's DSPMode + audio-space
+// filter cutoffs to TxChannel.  See header comment for the wire targets
+// and source-of-truth Thetis cites.  This is the helper called by all
+// three triggers (createTxChannel post-create, SliceModel::dspModeChanged,
+// MoxController::txAboutToBegin).
+void RadioModel::pushTxModeAndBandpass()
+{
+    if (!m_activeSlice) {
+        return;
+    }
+    const DSPMode mode      = m_activeSlice->dspMode();
+    const int     audioLow  = m_activeSlice->filterLow();
+    const int     audioHigh = m_activeSlice->filterHigh();
+
+    // Diagnostic / test-observation hook fires unconditionally (m_txChannel
+    // can be null during odd lifecycle moments — addSlice before
+    // connectToRadio's WDSP-init lambda runs — and tests rely on the
+    // emit to verify the trigger pipeline without standing up the full
+    // TX pipeline).
+    emit txModeAndBandpassPushed(mode, audioLow, audioHigh);
+
+    if (!m_txChannel) {
+        return;
+    }
+
+    // Queue the WDSP setter call to TxWorkerThread.  receiver=m_txChannel
+    // routes via auto-queued connection; the lambda body runs on the
+    // worker thread, where setTxMode / requestFilterChange are then
+    // same-thread direct calls.  Mirrors the F.1 / F.2 / H.1 wires inside
+    // connectToRadio's txSetup lambda (RadioModel.cpp ~1957).
+    QMetaObject::invokeMethod(m_txChannel,
+                              [tx = m_txChannel, mode, audioLow, audioHigh]() {
+        tx->setTxMode(mode);
+        tx->requestFilterChange(audioLow, audioHigh, mode);
+    });
 }
 
 // Apply AlexController state to the wire. Called from three triggers:

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -849,8 +849,19 @@ public:
     // sliceStateRestored(index) on completion (see comment on the signal).
     void loadSliceState(SliceModel* slice);
 
-    // Issue #153 sub-bug 2 — push the active slice's DSPMode +
-    // audio-space filter cutoffs to TxChannel.  No-op if no active slice.
+    // Issue #153 sub-bug 2 — push the active slice's DSPMode + the
+    // user's configured TX bandpass (TransmitModel::filterLow/High) to
+    // TxChannel.  No-op if no active slice.
+    //
+    // Filter source is TransmitModel, NOT SliceModel.  TransmitModel
+    // stores audio-space TX cutoffs (positive, low<=high invariant),
+    // which is what TxChannel::requestFilterChange + applyTxFilterForMode
+    // expect.  SliceModel filter values are RX-passband IQ-space
+    // (negative for LSB-family); routing them through
+    // applyTxFilterForMode would double-negate on LSB and clobber
+    // any user-configured TX bandwidth on every connect/MOX.  Mirrors
+    // the canonical wire at RadioModel.cpp:2550-2560 which sources
+    // audio cutoffs from TransmitModel::filterChanged.
     //
     // Read happens on RadioModel's main thread; the TxChannel setter
     // call is queued to TxWorkerThread via QMetaObject::invokeMethod

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -695,6 +695,22 @@ signals:
     void sliceAdded(int index);
     void sliceRemoved(int index);
     void activeSliceChanged(int index);
+    // Emitted once at the end of loadSliceState() after the slice has been
+    // restored from AppSettings. Mirrors Thetis console.cs:27204 [v2.10.3.13]
+    // chkPower_CheckedChanged calling txtVFOAFreq_LostFocus() as the
+    // explicit "push state to display" step at power-on. Listeners
+    // (MainWindow, SpectrumWidget bridge) push the now-correct slice
+    // freq/mode/filter into views, since the wireSliceToSpectrum() seed
+    // ran with the slice's pre-restore default values.
+    void sliceStateRestored(int index);
+    // Issue #153 sub-bug 2 — diagnostic + test observation hook.
+    // Emitted by pushTxModeAndBandpass() when an active slice exists,
+    // BEFORE the queued setter dispatch to TxWorkerThread.  Carries the
+    // slice's current DSPMode + audio-space filter cutoffs.  Tests use
+    // it as a proxy for "push helper triggered with X"; production code
+    // can wire it into diagnostic logging.
+    void txModeAndBandpassPushed(NereusSDR::DSPMode mode,
+                                 int audioLowHz, int audioHighHz);
     void panadapterAdded(int index);
     void panadapterRemoved(int index);
 
@@ -814,7 +830,6 @@ private:
     void handlePaTelemetry(quint16 fwdRaw, quint16 revRaw, quint16 exciterRaw,
                            quint16 userAdc0Raw, quint16 userAdc1Raw,
                            quint16 supplyRaw);
-    void loadSliceState(SliceModel* slice);
     void saveSliceState(SliceModel* slice);
     void scheduleSettingsSave();
 
@@ -826,6 +841,38 @@ public:
     // tweak when they immediately close the app. No-op when nothing's
     // pending. Idempotent — calling repeatedly is safe.
     void flushPendingSettingsSave();
+
+    // Restore a slice's persisted state from AppSettings.  Public so unit
+    // tests can drive it without spinning up the full connectToRadio()
+    // pipeline.  Production callers: connectToRadio() at RadioModel.cpp
+    // line ~1377 — fires once per session per slice on Connected. Emits
+    // sliceStateRestored(index) on completion (see comment on the signal).
+    void loadSliceState(SliceModel* slice);
+
+    // Issue #153 sub-bug 2 — push the active slice's DSPMode +
+    // audio-space filter cutoffs to TxChannel.  No-op if no active slice.
+    //
+    // Read happens on RadioModel's main thread; the TxChannel setter
+    // call is queued to TxWorkerThread via QMetaObject::invokeMethod
+    // (receiver=m_txChannel) so the receiver-thread invariant holds —
+    // mirrors the F.1 / F.2 / H.1 wires inside connectToRadio's txSetup
+    // lambda.  Emits txModeAndBandpassPushed(mode, audioLow, audioHigh)
+    // before the queued dispatch as a test/diagnostic observation hook
+    // (fires even when m_txChannel is null so test fixtures can drive
+    // the helper without standing up the full TX pipeline).
+    //
+    // Wire targets (set up inside the txSetup lambda + wireSliceSignals):
+    //   - createTxChannel success → pushTxModeAndBandpass (initial seed)
+    //   - SliceModel::dspModeChanged → pushTxModeAndBandpass
+    //   - MoxController::txAboutToBegin → pushTxModeAndBandpass
+    //
+    // Source-of-truth: Thetis SetTXFilters at console.cs:8091 +
+    // CurrentDSPMode setter at radio.cs:2670-2696 [v2.10.3.13], wired
+    // into the mode-change handler at console.cs:33937 [v2.10.3.13].
+    // The MOX-engage trigger is NereusSDR's belt-and-suspenders re-seed
+    // (Thetis seeds at mode-change only; we additionally re-seed at
+    // MOX-engage so prior TUN-state desync cannot starve SSB MOX).
+    void pushTxModeAndBandpass();
 
 private:
     // Sub-components (owned, main thread)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,22 @@ nereus_add_test(tst_smoke)
 
 # ── Issue #75: receiver leak across disconnect/reconnect ──────────────────
 nereus_add_test(tst_receiver_manager_reconnect)
+
+# ── HL2 connect-init parity: spectrum DDC center push (Bug 1) ─────────────
+# Pins the contract that RadioModel::loadSliceState() emits
+# sliceStateRestored(idx) at completion, mirroring Thetis
+# txtVFOAFreq_LostFocus's unconditional state push at power-on
+# (console.cs:27204 [v2.10.3.13]).  Without this hook the spectrum widget's
+# m_ddcCenterHz stays at the slice's pre-restore default in CTUN mode.
+nereus_add_test(tst_radio_model_slice_state_restored)
+
+# ── Issue #153 sub-bug 2: SSB MOX TXA seeding ────────────────────────────
+# Pins the contract that RadioModel::pushTxModeAndBandpass() emits
+# txModeAndBandpassPushed(mode, audioLow, audioHigh) with the active
+# slice's current DSPMode + filter cutoffs.  Wired into createTxChannel,
+# SliceModel::dspModeChanged, and MoxController::txAboutToBegin so SSB
+# MOX no longer requires a prior TUN press to seed TXA mode + bp0.
+nereus_add_test(tst_radio_model_push_tx_mode_and_bandpass)
 nereus_add_test(tst_container_persistence)
 nereus_add_test(tst_meter_item_bar)
 nereus_add_test(tst_reading_name)

--- a/tests/tst_radio_model_push_tx_mode_and_bandpass.cpp
+++ b/tests/tst_radio_model_push_tx_mode_and_bandpass.cpp
@@ -1,3 +1,8 @@
+// no-port-check: NereusSDR-original test for the pushTxModeAndBandpass
+// helper.  The TXA.c reference below is a Thetis source-of-truth cite
+// for design context (the WDSP defaults that make the bug visible),
+// not a port — no Thetis code is translated in this file.
+//
 // tst_radio_model_push_tx_mode_and_bandpass.cpp
 //
 // Issue #153 sub-bug 2 — SSB MOX TXA seeding.
@@ -23,6 +28,7 @@
 #include <QtTest/QtTest>
 #include "models/RadioModel.h"
 #include "models/SliceModel.h"
+#include "models/TransmitModel.h"
 #include "core/WdspTypes.h"
 
 using namespace NereusSDR;
@@ -32,9 +38,13 @@ class TestRadioModelPushTxModeAndBandpass : public QObject
     Q_OBJECT
 
 private slots:
-    // ── Contract: helper emits signal with current slice mode/filter ────────
+    // ── Contract: helper emits signal with slice mode + TransmitModel filter ──
+    //
+    // TX bandpass source is TransmitModel (audio-space, low<=high), NOT
+    // SliceModel (RX-passband IQ-space, negative for LSB).  See
+    // RadioModel::pushTxModeAndBandpass header comment for why.
 
-    void pushEmitsSignalWithCurrentSliceState()
+    void pushEmitsSignalWithSliceModeAndTransmitFilter()
     {
         RadioModel model;
         const int idx = model.addSlice();
@@ -43,7 +53,8 @@ private slots:
         QVERIFY(slice != nullptr);
 
         slice->setDspMode(DSPMode::USB);
-        slice->setFilter(150, 2850);  // audio-space USB voice cutoffs
+        model.transmitModel().setFilterLow(150);
+        model.transmitModel().setFilterHigh(2850);
 
         QSignalSpy spy(&model, &RadioModel::txModeAndBandpassPushed);
         model.pushTxModeAndBandpass();
@@ -54,30 +65,37 @@ private slots:
         QCOMPARE(spy.at(0).at(2).toInt(), 2850);
     }
 
-    // ── Contract: helper picks up freshly-restored slice values ─────────────
+    // ── Contract: cutoffs stay audio-space across LSB↔USB mode changes ──────
     //
-    // Mirrors the connect-time path: loadSliceState restores the slice's
-    // dspMode + filter, then the txSetup wiring runs pushTxModeAndBandpass
-    // as the initial seed.  Verifies the helper reads CURRENT slice state
-    // each call (no stale cache).
+    // Verifies the bug Codex flagged on PR #189: prior implementation read
+    // cutoffs from SliceModel::filterLow/High, which are negative on LSB.
+    // applyTxFilterForMode would then double-negate, producing a
+    // wrong-sided TXA bandpass on first MOX after an LSB selection.
+    // Reading from TransmitModel keeps cutoffs positive across all modes;
+    // the mode parameter alone drives the IQ-space sign mapping inside
+    // applyTxFilterForMode.
 
-    void pushReflectsModeChanges()
+    void pushKeepsCutoffsPositiveAcrossModeChanges()
     {
         RadioModel model;
         model.addSlice();
         SliceModel* slice = model.activeSlice();
         QVERIFY(slice != nullptr);
 
-        slice->setDspMode(DSPMode::LSB);
-        slice->setFilter(-2850, -150);
+        // User-configured TX BW stays the same regardless of slice mode.
+        model.transmitModel().setFilterLow(150);
+        model.transmitModel().setFilterHigh(2850);
 
         QSignalSpy spy(&model, &RadioModel::txModeAndBandpassPushed);
+
+        slice->setDspMode(DSPMode::LSB);
         model.pushTxModeAndBandpass();
         QCOMPARE(spy.count(), 1);
         QCOMPARE(spy.at(0).at(0).value<DSPMode>(), DSPMode::LSB);
+        QCOMPARE(spy.at(0).at(1).toInt(), 150);   // audio-space, NOT -2850
+        QCOMPARE(spy.at(0).at(2).toInt(), 2850);  // audio-space, NOT -150
 
         slice->setDspMode(DSPMode::USB);
-        slice->setFilter(150, 2850);
         model.pushTxModeAndBandpass();
         QCOMPARE(spy.count(), 2);
         QCOMPARE(spy.at(1).at(0).value<DSPMode>(), DSPMode::USB);

--- a/tests/tst_radio_model_push_tx_mode_and_bandpass.cpp
+++ b/tests/tst_radio_model_push_tx_mode_and_bandpass.cpp
@@ -1,0 +1,106 @@
+// tst_radio_model_push_tx_mode_and_bandpass.cpp
+//
+// Issue #153 sub-bug 2 — SSB MOX TXA seeding.
+//
+// Bug being guarded: the SSB voice TX path never calls SetTXAMode or
+// SetTXABandpassFreqs.  Only TUN does, via TxChannel::setTuneTone
+// (TxChannel.cpp:861-916 [v2.10.3.13]).  Without TUN, WDSP TXA defaults
+// from create_txa apply: mode=TXA_LSB, f_low=-5000, f_high=-100
+// (TXA.c:33-35 [v2.10.3.13]).  Works by accident on LSB; silent on
+// USB / AM / FM / DSB / DIGU / DIGL until TUN is hit once.
+//
+// Fix: RadioModel::pushTxModeAndBandpass() reads the active slice's
+// DSPMode + audio-space filter cutoffs and dispatches them to TxChannel.
+// Wired on three triggers (verified at integration layer / bench):
+//   - createTxChannel success (initial seed)
+//   - SliceModel::dspModeChanged (re-seed after user changes mode)
+//   - MoxController::txAboutToBegin (belt-and-suspenders pre-MOX seed)
+//
+// This test pins the helper-level contract: when called with an active
+// slice, it emits txModeAndBandpassPushed(mode, audioLow, audioHigh)
+// carrying the slice's current state.
+
+#include <QtTest/QtTest>
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+#include "core/WdspTypes.h"
+
+using namespace NereusSDR;
+
+class TestRadioModelPushTxModeAndBandpass : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // ── Contract: helper emits signal with current slice mode/filter ────────
+
+    void pushEmitsSignalWithCurrentSliceState()
+    {
+        RadioModel model;
+        const int idx = model.addSlice();
+        QCOMPARE(idx, 0);
+        SliceModel* slice = model.activeSlice();
+        QVERIFY(slice != nullptr);
+
+        slice->setDspMode(DSPMode::USB);
+        slice->setFilter(150, 2850);  // audio-space USB voice cutoffs
+
+        QSignalSpy spy(&model, &RadioModel::txModeAndBandpassPushed);
+        model.pushTxModeAndBandpass();
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).value<DSPMode>(), DSPMode::USB);
+        QCOMPARE(spy.at(0).at(1).toInt(), 150);
+        QCOMPARE(spy.at(0).at(2).toInt(), 2850);
+    }
+
+    // ── Contract: helper picks up freshly-restored slice values ─────────────
+    //
+    // Mirrors the connect-time path: loadSliceState restores the slice's
+    // dspMode + filter, then the txSetup wiring runs pushTxModeAndBandpass
+    // as the initial seed.  Verifies the helper reads CURRENT slice state
+    // each call (no stale cache).
+
+    void pushReflectsModeChanges()
+    {
+        RadioModel model;
+        model.addSlice();
+        SliceModel* slice = model.activeSlice();
+        QVERIFY(slice != nullptr);
+
+        slice->setDspMode(DSPMode::LSB);
+        slice->setFilter(-2850, -150);
+
+        QSignalSpy spy(&model, &RadioModel::txModeAndBandpassPushed);
+        model.pushTxModeAndBandpass();
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).value<DSPMode>(), DSPMode::LSB);
+
+        slice->setDspMode(DSPMode::USB);
+        slice->setFilter(150, 2850);
+        model.pushTxModeAndBandpass();
+        QCOMPARE(spy.count(), 2);
+        QCOMPARE(spy.at(1).at(0).value<DSPMode>(), DSPMode::USB);
+        QCOMPARE(spy.at(1).at(1).toInt(), 150);
+        QCOMPARE(spy.at(1).at(2).toInt(), 2850);
+    }
+
+    // ── Contract: no emit without an active slice ────────────────────────────
+    //
+    // pushTxModeAndBandpass must early-return when no slice exists.  Without
+    // this guard, dispatching with default-constructed slice values could
+    // push junk to TxChannel during odd lifecycle moments (RadioModel
+    // construction before connectToRadio runs).
+
+    void pushIsNoOpWhenNoActiveSlice()
+    {
+        RadioModel model;
+        // Intentionally NOT calling addSlice — m_activeSlice is null.
+        QSignalSpy spy(&model, &RadioModel::txModeAndBandpassPushed);
+        model.pushTxModeAndBandpass();
+        QCOMPARE(spy.count(), 0);
+    }
+};
+
+QTEST_MAIN(TestRadioModelPushTxModeAndBandpass)
+#include "tst_radio_model_push_tx_mode_and_bandpass.moc"

--- a/tests/tst_radio_model_slice_state_restored.cpp
+++ b/tests/tst_radio_model_slice_state_restored.cpp
@@ -1,3 +1,8 @@
+// no-port-check: NereusSDR-original test for the sliceStateRestored
+// emit contract on RadioModel::loadSliceState.  The console.cs reference
+// in the body comment is a Thetis source-of-truth cite for design
+// context, not a port — no Thetis code is translated in this file.
+//
 // tst_radio_model_slice_state_restored.cpp
 //
 // Verifies RadioModel::sliceStateRestored(int) is emitted at the end of

--- a/tests/tst_radio_model_slice_state_restored.cpp
+++ b/tests/tst_radio_model_slice_state_restored.cpp
@@ -1,0 +1,84 @@
+// tst_radio_model_slice_state_restored.cpp
+//
+// Verifies RadioModel::sliceStateRestored(int) is emitted at the end of
+// loadSliceState() so MainWindow can push the now-correct slice state into
+// the spectrum widget on connect (DDC center, VFO marker, filter offset).
+//
+// Bug being guarded: on initial HL2 connect, MainWindow::wireSliceToSpectrum
+// runs at sliceAdded() time and seeds m_spectrumWidget->setDdcCenterFrequency()
+// with the slice's *pre-restore* default frequency.  loadSliceState() then
+// calls slice->restoreFromSettings() which conditionally emits frequencyChanged.
+// In CTUN mode (default true), the MainWindow lambda's offScreen guard skips
+// setDdcCenterFrequency() when the persisted freq sits within +/- halfBw of
+// the default seed.  Result: spectrum bin labels point to the wrong band of
+// RF until the first dial-tune crosses the offScreen threshold.
+//
+// This test pins the contract that loadSliceState() ALWAYS emits
+// sliceStateRestored(idx) at completion, giving listeners an unconditional
+// hook to push final state into views — mirroring the unconditional state
+// push Thetis performs from chkPower_CheckedChanged via txtVFOAFreq_LostFocus
+// (console.cs:27204 [v2.10.3.13]).
+
+#include <QtTest/QtTest>
+#include "models/RadioModel.h"
+#include "models/SliceModel.h"
+
+using namespace NereusSDR;
+
+class TestRadioModelSliceStateRestored : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // ── Contract: emit fires once per loadSliceState call ────────────────────
+
+    void emitsSliceStateRestoredAfterLoadSliceState()
+    {
+        RadioModel model;
+        const int idx = model.addSlice();
+        QCOMPARE(idx, 0);
+        SliceModel* slice = model.activeSlice();
+        QVERIFY(slice != nullptr);
+
+        QSignalSpy spy(&model, &RadioModel::sliceStateRestored);
+        model.loadSliceState(slice);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toInt(), idx);
+    }
+
+    // ── Contract: emit carries the slice index that was restored ─────────────
+
+    void emitCarriesSliceIndex()
+    {
+        RadioModel model;
+        const int idx0 = model.addSlice();
+        QCOMPARE(idx0, 0);
+
+        QSignalSpy spy(&model, &RadioModel::sliceStateRestored);
+        model.loadSliceState(model.slices().at(idx0));
+
+        QVERIFY(!spy.isEmpty());
+        QCOMPARE(spy.last().at(0).toInt(), idx0);
+    }
+
+    // ── Contract: addSlice() alone does NOT emit ─────────────────────────────
+    //
+    // This is what wireSliceToSpectrum's seed-with-default behaviour relies
+    // on — sliceStateRestored is the loadSliceState completion signal, not
+    // the slice creation signal.  sliceAdded covers creation.
+
+    void addSliceDoesNotEmitSliceStateRestored()
+    {
+        RadioModel model;
+        QSignalSpy spy(&model, &RadioModel::sliceStateRestored);
+
+        const int idx = model.addSlice();
+        QCOMPARE(idx, 0);
+
+        QCOMPARE(spy.count(), 0);
+    }
+};
+
+QTEST_MAIN(TestRadioModelSliceStateRestored)
+#include "tst_radio_model_slice_state_restored.moc"


### PR DESCRIPTION
## Summary

Three connect-time init bugs in the same family. State not pushed to all
subsystems on initial connect; first user action carried it forward,
masking the gap.

1. **Spectrum vs dial freq misalignment on initial HL2 connect.**
   `wireSliceToSpectrum` runs at `sliceAdded` time, BEFORE
   `loadSliceState`, so the spectrum widget seeds `m_ddcCenterHz` with
   the slice's pre-restore default freq. CTUN-mode (default true) +
   persisted freq within +/-halfBw of the default seed = the
   `frequencyChanged` lambda hits the CTUN-shift branch and never
   re-pushes DDC center. Fix: emit `sliceStateRestored(idx)` at end of
   `loadSliceState`; MainWindow listens and pushes spectrum + VFO
   state unconditionally. Mirrors Thetis `chkPower_CheckedChanged`
   calling `txtVFOAFreq_LostFocus()` unconditionally at
   `console.cs:27204` [v2.10.3.13].

2. **#153 sub-bug 1: cold-start `createTxChannel` race.** On first
   launch with no cached FFTW wisdom, WdspEngine's async wisdom build
   completes after `connectToRadio` runs synchronously, so
   `createTxChannel(1)` returns nullptr and TX is unavailable for the
   rest of the session. Fix: wrap entire create+wire body in a
   captured `txSetup` lambda; on cold-start failure, register a
   one-shot connect to `WdspEngine::initializedChanged(true)` that
   re-runs the same lambda. Self-disconnects on first success.
   Hot-cache path is unchanged.

3. **#153 sub-bug 2: SSB MOX requires prior TUN.** SSB voice TX path
   never calls `SetTXAMode` or `SetTXABandpassFreqs`. Only TUN does.
   WDSP TXA defaults from `create_txa` (mode=TXA_LSB, f_low=-5000,
   f_high=-100) leak into MOX; SSB MOX is silent on USB / AM / FM /
   DSB / DIGU / DIGL until TUN is hit once. Fix:
   `RadioModel::pushTxModeAndBandpass()` reads slice state on main
   thread, queues setters to TxWorkerThread via
   `QMetaObject::invokeMethod` (mirrors F.1 / F.2 / H.1 wires).
   Wired on three triggers: createTxChannel post-create (initial
   seed), `SliceModel::dspModeChanged`, `MoxController::txAboutToBegin`.
   Mirrors Thetis `SetTXFilters` at `console.cs:8091` + `CurrentDSPMode`
   setter at `radio.cs:2670-2696` [v2.10.3.13]. Cross-thread safety
   via receiver=m_txChannel auto-queued connection (defends against
   the prior `wip-tx-bandpass-pre-rollback` race).

Source-first audit: each fix is cited to specific Thetis lines in
v2.10.3.13. No new ports introduced (no PROVENANCE table additions).

Closes #153.

## Test plan

- [x] `tst_radio_model_slice_state_restored` (3 contract assertions)
- [x] `tst_radio_model_push_tx_mode_and_bandpass` (3 contract assertions)
- [x] Full ctest 340/340 green on RelWithDebInfo + macOS arm64
- [ ] Bench: HL2 connect, spectrum visually aligned with dial freq on
      first paint (no waterfall drag needed)
- [ ] Bench: HL2 connect, switch slice to USB, first MOX press
      produces audio (no TUN required)
- [ ] Bench: cold-start (`rm -rf ~/Library/Preferences/NereusSDR ~/.config/NereusSDR/wisdom*`)
      then connect on first attempt, TUN works without disconnect/reconnect

## Notes for reviewer

- The 950-line TX setup body inside `connectToRadio` is now wrapped in
  a captured `txSetup` lambda (#153 sub-bug 1). Diff looks deceptively
  large but the body content is unchanged; only prelude / closing
  brace are modified. `git diff -W` confirms.
- A separate, related parity gap surfaced during the audit (no
  `setTxFrequency` push at connect-time; first dial-tune writes the
  TX NCO). Filing as a separate issue.

J.J. Boyd ~ KG4VCF