### PR TITLE
fix(oc-matrix): persist OC pins per band across restart (#191)

### DIFF
--- a/src/core/OcMatrix.cpp
+++ b/src/core/OcMatrix.cpp
@@ -81,6 +81,10 @@ void OcMatrix::setPin(Band band, int pin, bool tx, bool enabled)
         if (slot == enabled) { return; }
         slot = enabled;
     }
+    // Issue #191: persist immediately. The HF / SWL OC tab toggle handlers
+    // call setPin() directly and don't follow up with save(); without this,
+    // user edits never reach AppSettings and are lost on app restart.
+    save();
     emit changed();
 }
 
@@ -116,6 +120,10 @@ void OcMatrix::setPinAction(int pin, TXPinAction action)
         if (m_pinActions[pin] == action) { return; }
         m_pinActions[pin] = action;
     }
+    // Issue #191: persist immediately. The HF tab pin-action lambda calls
+    // setPinAction() directly without an explicit save(); without this,
+    // user edits never reach AppSettings and are lost on app restart.
+    save();
     emit changed();
 }
 
@@ -229,6 +237,9 @@ void OcMatrix::resetDefaults()
         }
         m_pinActions.fill(TXPinAction::MoxTuneTwoTone);
     }
+    // Issue #191: persist immediately. Reset OC defaults button calls
+    // resetDefaults() with no follow-up save().
+    save();
     emit changed();
 }
 

--- a/tests/tst_oc_matrix.cpp
+++ b/tests/tst_oc_matrix.cpp
@@ -112,6 +112,75 @@ private slots:
         m.setPinAction(0, OcMatrix::TXPinAction::Mox);
         QCOMPARE(spy.count(), 1);
     }
+
+    // Issue #191 regression: setPin must persist immediately (no explicit
+    // save() needed). The HF/SWL OC tab toggle handlers only call
+    // setPin(); they don't follow up with save(). Before the fix, user
+    // edits never reached AppSettings and were lost on app restart.
+    void setPin_persists_without_explicit_save() {
+        const QString mac = QStringLiteral("11:22:33:44:55:66");
+
+        OcMatrix m1;
+        m1.setMacAddress(mac);
+        m1.setPin(Band::Band20m, 3, /*tx=*/false, true);
+        m1.setPin(Band::Band40m, 1, /*tx=*/true,  true);
+        // No m1.save() — mimics the OcOutputsHfTab / OcOutputsSwlTab
+        // checkbox toggle paths.
+
+        OcMatrix m2;
+        m2.setMacAddress(mac);
+        m2.load();
+        QVERIFY(m2.pinEnabled(Band::Band20m, 3, /*tx=*/false));
+        QVERIFY(m2.pinEnabled(Band::Band40m, 1, /*tx=*/true));
+        QVERIFY(!m2.pinEnabled(Band::Band20m, 3, /*tx=*/true));
+    }
+
+    // Issue #191 regression: setPinAction must persist immediately.
+    void setPinAction_persists_without_explicit_save() {
+        const QString mac = QStringLiteral("22:33:44:55:66:77");
+
+        OcMatrix m1;
+        m1.setMacAddress(mac);
+        m1.setPinAction(2, OcMatrix::TXPinAction::Mox);
+        m1.setPinAction(5, OcMatrix::TXPinAction::TuneTwoTone);
+        // No explicit save() — mimics the HF tab pin-action lambda.
+
+        OcMatrix m2;
+        m2.setMacAddress(mac);
+        m2.load();
+        QCOMPARE(m2.pinAction(2), OcMatrix::TXPinAction::Mox);
+        QCOMPARE(m2.pinAction(5), OcMatrix::TXPinAction::TuneTwoTone);
+    }
+
+    // Issue #191 regression: resetDefaults must persist immediately so
+    // that the user-visible "Reset OC defaults" button survives restart.
+    // Establish a non-default baseline via an explicit save() first, so
+    // that the post-reset cleared state is observably different from the
+    // pre-reset baseline (otherwise an unpersisted reset looks identical
+    // to the baseline-default-everywhere case and the test passes
+    // coincidentally).
+    void resetDefaults_persists_without_explicit_save() {
+        const QString mac = QStringLiteral("33:44:55:66:77:88");
+
+        OcMatrix m1;
+        m1.setMacAddress(mac);
+        m1.setPin(Band::Band20m, 0, /*tx=*/false, true);
+        m1.setPinAction(0, OcMatrix::TXPinAction::Mox);
+        m1.save();  // explicit save → baseline is durable
+
+        OcMatrix m2;
+        m2.setMacAddress(mac);
+        m2.load();
+        QVERIFY(m2.pinEnabled(Band::Band20m, 0, /*tx=*/false));  // baseline visible
+        m2.resetDefaults();
+        // No explicit save() — mimics OcOutputsHfTab::onResetClicked().
+
+        OcMatrix m3;
+        m3.setMacAddress(mac);
+        m3.load();
+        QVERIFY(!m3.pinEnabled(Band::Band20m, 0, /*tx=*/false));
+        QCOMPARE(m3.pinAction(0), OcMatrix::TXPinAction::MoxTuneTwoTone);
+    }
 };
 
 QTEST_APPLESS_MAIN(TestOcMatrix)


### PR DESCRIPTION
## Summary

- Closes #191 (OC pins per band not memorized across restart on HL1, reported by Pascal F6EHP)
- `OcMatrix::setPin()`, `setPinAction()`, and `resetDefaults()` now persist immediately to `AppSettings` after the in-memory mutation. Previously the OC HF / SWL tab checkbox handlers and the Reset button called these setters with no follow-up `save()`, so user edits never reached `~/.config/NereusSDR/NereusSDR.settings` and were lost on app shutdown.
- Affected every HPSDR board, not just HL1 / HL2.

## Root cause

The only `OcMatrix::save()` call site was the N2ADR connect-time reconcile in [RadioModel::startConnection](src/models/RadioModel.cpp:1280), gated on `hasIoBoardHl2`. User edits anywhere else (HF tab, SWL tab, Reset button) were dropped on quit because `save()` was never called for them.

## Fix locus

- [src/core/OcMatrix.cpp](src/core/OcMatrix.cpp): each setter now calls `save()` after releasing the write lock.
- The existing `m_ocMatrix.save()` after `applyN2adrPreset` in [RadioModel::startConnection](src/models/RadioModel.cpp:1280) is now redundant but harmless; left in as a defensive checkpoint after bulk preset application.

## Test plan

- [x] `tst_oc_matrix` adds 3 regression cases (`setPin_persists_without_explicit_save`, `setPinAction_persists_without_explicit_save`, `resetDefaults_persists_without_explicit_save`); all 3 fail before the fix (red) and pass after (green).
- [x] Full local `ctest`: 353 / 353 passing.
- [ ] Manual verification on real radio (Pascal HL1 or any HPSDR board): toggle a few OC pins per band in Setup → Hardware → OC Outputs → HF, quit, relaunch, confirm checkboxes survive.

J.J. Boyd ~ KG4VCF