### PR TITLE
fix(setup): clamp PA Gain spinbox minimum to 38.8 dB (#199)

### DIFF
--- a/src/gui/setup/PaSetupPages.cpp
+++ b/src/gui/setup/PaSetupPages.cpp
@@ -544,8 +544,15 @@ PaGainByBandPage::PaGainByBandPage(RadioModel* model, QWidget* parent)
         bandLbl->setFixedWidth(kBandLabelWidth);
         grid->addWidget(bandLbl, row, kColBand);
 
-        // Per-band gain spinbox (0..100 dB, 0.1 step, 1 decimal).
-        m_gainSpins[n] = buildSpin(0.0, 100.0, 0.1, 1, gainGroup);
+        // Per-band gain spinbox (38.8..100 dB, 0.1 step, 1 decimal).
+        // Issue #199: Thetis hard-clamps the minimum at 38.8 across all 25
+        // PA-gain spinboxes (11 HF nud<Band>M + 14 nudVHF<n>) — values below
+        // 38.8 saturate computeAudioVolume's drive byte at 1.0 with no
+        // further effect on RF output (funsutton field report on ANAN-10E:
+        // 30.8 produced same RF as 38.8 on 80m).
+        // From Thetis setup.designer.cs:48537-48546 [v2.10.3.13] — nudVHF1
+        // (`Maximum = 100`, `Minimum = 38.8`) and 24 sibling sites match.
+        m_gainSpins[n] = buildSpin(38.8, 100.0, 0.1, 1, gainGroup);
         m_gainSpins[n]->setFixedWidth(kGainSpinWidth);
         m_gainSpins[n]->setToolTip(QStringLiteral(
             "PA gain compensation for %1 in dB.  Subtracted from the "

--- a/tests/tst_pa_gain_by_band_page_editor.cpp
+++ b/tests/tst_pa_gain_by_band_page_editor.cpp
@@ -109,6 +109,7 @@ private slots:
     void reset_defaults_regenerates_canonical_values();
     void auto_cal_checkbox_present_and_toggleable();
     void warning_label_visible_when_profile_diverges();
+    void gain_spinbox_bounds_match_thetis_minimum_38_8();  // issue #199
 };
 
 // ---------------------------------------------------------------------------
@@ -465,10 +466,12 @@ void TstPaGainByBandPageEditor::warning_label_visible_when_profile_diverges()
                  || !warningLabel->isVisibleTo(&page),
              "Warning label should be hidden for canonical factory profile");
 
-    // Mutate a gain value so the active profile no longer matches canonical.
+    // Mutate a gain value so the active profile no longer matches canonical
+    // (ANAN8000D 80m default = 50.5; 45.0 is in-range per #199 spinbox
+    // bounds [38.8, 100.0] and still divergent).
     auto* spin = page.gainSpinForTest(Band::Band80m);
     QVERIFY(spin != nullptr);
-    spin->setValue(10.0);
+    spin->setValue(45.0);
 
     // The warning should now be visible (page recomputes on every spinbox edit).
     QVERIFY2(warningLabel->isVisibleTo(&page),
@@ -482,6 +485,34 @@ void TstPaGainByBandPageEditor::warning_label_visible_when_profile_diverges()
 
     QVERIFY2(!warningLabel->isVisibleTo(&page),
              "Warning label must be hidden after Reset Defaults");
+}
+
+// ---------------------------------------------------------------------------
+// 14. Per-band gain spinbox bounds match Thetis (issue #199). Thetis
+//     hard-clamps every nud<Band>M / nudVHF<n> spinbox at minimum 38.8 dB
+//     and maximum 100.0 dB (setup.designer.cs:48537-48546 [v2.10.3.13] for
+//     nudVHF1, with 24 sibling sites configured identically). The
+//     pre-#199 NereusSDR port used minimum 0.0, which let users enter
+//     values where computeAudioVolume saturates the drive byte at 1.0 with
+//     no further effect on RF power output (funsutton field report:
+//     ANAN-10E 80m, value 30.8 produced same RF as 38.8).
+// ---------------------------------------------------------------------------
+void TstPaGainByBandPageEditor::gain_spinbox_bounds_match_thetis_minimum_38_8()
+{
+    RadioModel model;
+    primeModelWithProfiles(model);
+
+    PaGainByBandPage page(&model);
+
+    for (int n = 0; n < PaGainByBandPage::kPaBandCount; ++n) {
+        const Band band = static_cast<Band>(n);
+        auto* spin = page.gainSpinForTest(band);
+        QVERIFY2(spin != nullptr,
+                 qPrintable(QStringLiteral("Missing gain spinbox for band %1")
+                                .arg(bandLabel(band))));
+        QCOMPARE(spin->minimum(), 38.8);
+        QCOMPARE(spin->maximum(), 100.0);
+    }
 }
 
 QTEST_MAIN(TstPaGainByBandPageEditor)


### PR DESCRIPTION
## Summary
- Issue #199: ANAN-10E user could drop Setup -> PA -> PA Gain values
  below 38.8 dB with no effect on RF output past that point.
- Root cause: NereusSDR's PaSetupPages port used buildSpin(0.0, 100.0)
  for the per-band gain spinboxes. Thetis hard-clamps all 25 of these
  spinboxes (11 HF + 14 VHF, setup.designer.cs:48537-48546 [v2.10.3.13])
  at minimum 38.8.
- Below 38.8 the dBm-target math in TransmitModel::computeAudioVolume
  saturates the drive byte at 1.0, so reductions below that floor are
  inert. The original user (funsutton) reproduced this on 80m: 30.8
  produced the same RF power as 38.8.

## Changes
- src/gui/setup/PaSetupPages.cpp:548 — minimum 0.0 -> 38.8 with Thetis cite
- tests/tst_pa_gain_by_band_page_editor.cpp — new test
  `gain_spinbox_bounds_match_thetis_minimum_38_8` asserts min=38.8
  and max=100.0 across all 14 PA-editable band spinboxes
- tests/tst_pa_gain_by_band_page_editor.cpp — existing
  `warning_label_visible_when_profile_diverges` switched from
  setValue(10.0) to 45.0 so it no longer relies on Qt's silent
  display clamp

## Migration
Existing user profiles persisted below 38.8 are silently display-clamped
to 38.8 by Qt and committed back to PaProfile on first edit. No
over-drive risk: computeAudioVolume was already saturating drive at 1.0
for those values.

## Test plan
- [x] New test added; ran red->green TDD locally on macOS (Apple Silicon)
- [x] ctest -R "pa_|transmit_model": 44/44 pass
- [ ] Funsutton verify on ANAN-10E once a build is posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)