### PR TITLE
fix(audio): flush speakers ring on master mute (#201)

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -92,6 +92,15 @@
 //                 returns to a pure drain (no accumulator side effects).
 //                 TX pump now lives in src/core/TxWorkerThread.{h,cpp}.
 //                 Plan: docs/architecture/phase3m-1c-tx-pump-architecture-plan.md
+//   2026-05-07 — Issue #201 (master-mute echo tail) by J.J. Boyd (KG4VCF),
+//                 AI-assisted via Anthropic Claude Code.  setMasterMuted(true)
+//                 now calls m_speakersBus->flush() under m_speakersBusMutex on
+//                 the false→true transition so already-queued samples in the
+//                 PortAudio output ring don't keep draining out the device
+//                 after the mute click — surfaced as a ~1 s "echo" tail on
+//                 macOS Intel / Core Audio.  Pairs with new IAudioBus::flush()
+//                 (default no-op) and PortAudioBus::flush() (atomic
+//                 ringRead := ringWrite).
 // =================================================================
 
 #include "AudioEngine.h"
@@ -968,7 +977,11 @@ void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
     // accumulate() above and the VAX tap earlier in this method run
     // unconditionally, so 3rd-party apps consuming a VAX channel keep
     // receiving audio while the local monitor is muted. No alloc, no
-    // logging — RT-safety preserved.
+    // logging — RT-safety preserved.  setMasterMuted(true) also flushes
+    // the speakers bus's queued samples (issue #201) so already-buffered
+    // pre-mute audio doesn't keep draining out the device after the
+    // gate engages — see PortAudioBus::flush() and the call site in
+    // setMasterMuted().
     //
     // Sub-Phase 12 live-reconfig: try_lock the speakers bus mutex only
     // around the push itself.  Previously this was held for the entire
@@ -1090,9 +1103,36 @@ void AudioEngine::setMasterMuted(bool muted)
     // would not synchronize the read-side observation order on weak
     // memory models.
     const bool prev = m_masterMuted.exchange(muted, std::memory_order_acq_rel);
-    if (prev != muted) {
-        emit masterMutedChanged(muted);
+    if (prev == muted) {
+        return;
     }
+
+    // Issue #201 (macOS Intel / Core Audio): on the false→true
+    // transition, drop any samples already queued in the speakers bus's
+    // internal ring.  rxBlockReady's mute gate stops NEW pushes, but
+    // the PortAudio output ring (1 s capacity — see PortAudioBus.cpp)
+    // can hold up to a second of pre-mute audio that would otherwise
+    // keep playing out the device after the click, surfacing as a
+    // ~1 s "echo" tail.  The flush atomically equalizes the ring's
+    // read/write cursors so the next paCallback iteration sees no
+    // unread samples and outputs silence.  No flush on unmute — the
+    // DSP thread resuming pushes is enough, and a flush there would
+    // create an audible click.
+    //
+    // Hold m_speakersBusMutex around the flush so a concurrent
+    // setSpeakersConfig (which tears down + rebuilds m_speakersBus)
+    // can't free the bus out from under us.  rxBlockReady try_locks
+    // this same mutex; ≤1 ms of dropped speakers-push from contention
+    // here is inaudible (and only happens on the rare race of mute +
+    // device-reconfigure simultaneously).
+    if (muted) {
+        std::lock_guard<std::mutex> lk(m_speakersBusMutex);
+        if (m_speakersBus) {
+            m_speakersBus->flush();
+        }
+    }
+
+    emit masterMutedChanged(muted);
 }
 
 // Plan: 3M-1b E.4. Pre-code review §10.3 + §10.4.

--- a/src/core/IAudioBus.h
+++ b/src/core/IAudioBus.h
@@ -42,6 +42,15 @@ public:
     // Consumer side (TX). Returns bytes read, or -1 on error. Audio-thread safe.
     virtual qint64 pull(char* data, qint64 maxBytes) = 0;
 
+    // Drop any samples queued in the bus's internal buffer that have been
+    // pushed but not yet consumed (or pulled but not yet read).  Used by
+    // AudioEngine::setMasterMuted to stop already-buffered pre-mute audio
+    // from draining out the speakers device after the mute click — see
+    // issue #201.  Default no-op for buses without an internal ring (HAL
+    // shm, PipeWire, FIFO).  PortAudioBus overrides to atomically equalize
+    // its ring read/write cursors.  Safe to call from any thread.
+    virtual void flush() {}
+
     // Metering (RMS of last block). 0.0–1.0. Published atomically for UI.
     virtual float rxLevel() const = 0;
     virtual float txLevel() const = 0;

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -320,6 +320,37 @@ qint64 PortAudioBus::push(const char* data, qint64 bytes) {
     return bytes;
 }
 
+void PortAudioBus::flush() {
+    // Issue #201: drop any unread samples queued in the ring so they
+    // don't keep draining out the device after a mute click.  Output
+    // mode: callers (AudioEngine on mute) want unread samples dropped.
+    // Input mode: callers (a future Setup → Audio "drop stale capture"
+    // path) want unread captured samples dropped.  In both modes the
+    // operation is the same: equalize read/write cursors atomically.
+    //
+    // Race with the audio thread:
+    //  - Output mode: paCallback advances m_ringRead; push() advances
+    //    m_ringWrite.  If we set ringRead := ringWrite atomically, the
+    //    callback may have JUST advanced ringRead one tick before our
+    //    store; the store still leaves r ≤ w, so the next callback
+    //    iteration reads `r < w` as false and outputs silence.  No
+    //    torn-read window.
+    //  - Input mode: paCallback advances m_ringWrite; pull() advances
+    //    m_ringRead.  Symmetric reasoning applies.
+    //
+    // No mutex needed — the cursors are std::atomic<qint64> and the
+    // single store is sequenced after the load by acquire/release
+    // ordering.  The PortAudio device's own internal output buffer
+    // (~5–20 ms latency on Core Audio / WASAPI) still plays its
+    // already-handed-off samples; that's below the threshold of
+    // perception and outside this layer's reach.
+    if (!m_stream) {
+        return;
+    }
+    const qint64 w = m_ringWrite.load(std::memory_order_acquire);
+    m_ringRead.store(w, std::memory_order_release);
+}
+
 qint64 PortAudioBus::pull(char* data, qint64 maxBytes) {
     if (!m_stream) { return 0; }
     if (m_cfg.direction != AudioDirection::Input) { return 0; }

--- a/src/core/audio/PortAudioBus.h
+++ b/src/core/audio/PortAudioBus.h
@@ -76,6 +76,7 @@ public:
 
     qint64 push(const char* data, qint64 bytes) override;
     qint64 pull(char* data, qint64 maxBytes) override;
+    void   flush() override;
 
     float rxLevel() const override { return m_rxLevel.load(std::memory_order_acquire); }
     float txLevel() const override { return m_txLevel.load(std::memory_order_acquire); }

--- a/tests/fakes/FakeAudioBus.h
+++ b/tests/fakes/FakeAudioBus.h
@@ -52,6 +52,10 @@ public:
         return bytes;
     }
 
+    void flush() override {
+        ++m_flushes;
+    }
+
     qint64 pull(char* data, qint64 maxBytes) override {
         if (!m_open || data == nullptr || maxBytes <= 0) {
             return 0;
@@ -83,6 +87,7 @@ public:
     const QByteArray& buffer() const { return m_buffer; }
 
     int pullCount() const { return m_pulls; }
+    int flushCount() const { return m_flushes; }
 
     // Force-toggle isOpen() to false so AudioEngine::rxBlockReady's
     // isOpen() guard skips the push.
@@ -116,6 +121,7 @@ private:
     QByteArray  m_buffer;
     int         m_pushes{0};
     qint64      m_lastPushBytes{0};
+    int         m_flushes{0};
 
     // Pull-side state
     QByteArray  m_pullData;

--- a/tests/tst_audio_engine_master_mute.cpp
+++ b/tests/tst_audio_engine_master_mute.cpp
@@ -153,6 +153,50 @@ private slots:
         QCOMPARE(h.speakers->pushCount(), 1);
     }
 
+    // ── 7. setMasterMuted(true) flushes the speakers bus's queued samples
+    //      so any pre-mute audio already in the output ring stops draining
+    //      out the device.  Issue #201 (macOS Intel / Core Audio): without
+    //      the flush, the PortAudio ring (1 s capacity) keeps playing its
+    //      buffered tail after the mute click — surfaced as a "repeating
+    //      echo" before silence took over.  Skipping pushes alone (test
+    //      #2 above) is necessary but not sufficient; the flush drops the
+    //      already-queued samples so the gate is audibly instant. ─────────
+
+    void setMutedFlushesSpeakers() {
+        Harness h = makeHarness();
+        const int s = h.addSlice(/*vaxChannel=*/0);
+
+        // Simulate steady-state operation: a few audio blocks have been
+        // pushed before the user clicks mute.  These leave samples queued
+        // in the (real) PortAudio ring; with the FakeAudioBus they show up
+        // as accumulated push count.
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+        h.engine->rxBlockReady(s, kTestSamples.data(), kTestFrames);
+        const int pushesBeforeMute = h.speakers->pushCount();
+
+        // Reset the flush counter so we observe ONLY the mute-driven
+        // flush, not any incidental flushes from earlier setup.
+        const int flushesBeforeMute = h.speakers->flushCount();
+
+        h.engine->setMasterMuted(true);
+
+        // The mute transition must call flush() on the speakers bus
+        // exactly once.  Pushes are unaffected by flush — this is purely
+        // a "drop already-queued samples" signal.
+        QCOMPARE(h.speakers->flushCount(), flushesBeforeMute + 1);
+        QCOMPARE(h.speakers->pushCount(), pushesBeforeMute);
+
+        // Redundant set to true — same value, no second flush.
+        h.engine->setMasterMuted(true);
+        QCOMPARE(h.speakers->flushCount(), flushesBeforeMute + 1);
+
+        // Unmute must NOT flush — the writer resuming pushes is enough,
+        // and a flush on unmute would create an audible click by dropping
+        // any already-pushed-but-not-yet-played zero tail.
+        h.engine->setMasterMuted(false);
+        QCOMPARE(h.speakers->flushCount(), flushesBeforeMute + 1);
+    }
+
     // ── 5. masterMutedChanged emits once per distinct state change ─────────
 
     void emitsSignalOnChange() {


### PR DESCRIPTION
## Summary
- Issue #201: master mute on macOS Intel / Core Audio surfaced as a ~1 s "echo" tail before the speakers actually went silent. The mute path skipped new pushes to the speakers bus but did not drop samples already queued in `PortAudioBus`'s 1 s output ring (`PortAudioBus.cpp:214`); the PortAudio callback kept draining that backlog until `r` caught up to `w`.
- Fix: add `IAudioBus::flush()` (default no-op) and override in `PortAudioBus` to atomically equalize `m_ringRead := m_ringWrite`. `AudioEngine::setMasterMuted` calls `m_speakersBus->flush()` under `m_speakersBusMutex` on the false→true transition only.
- New regression test `setMutedFlushesSpeakers` verifies the flush count behavior; existing mute/VAX/unmute contracts are preserved.

## Test plan
- [x] `tst_audio_engine_master_mute` (9/9 — adds `setMutedFlushesSpeakers`)
- [x] `tst_audio_engine_speakers_live_reconfig` (9/9 — mutex contract preserved)
- [x] `tst_audio_engine_vax_tee` (9/9)
- [x] `tst_audio_engine_rx_leak_during_mox` (8/8)
- [x] `tst_port_audio_bus` (12/12)
- [x] Full app build + cold-start auto-launch on macOS (Apple Silicon dev box)
- [ ] Manual on macOS Intel / Core Audio (issue reporter): connect to ANAN-10E, click master mute, verify mute is audibly instant on the first mute of session
- [ ] Manual: unmute does not click

🤖 Generated with [Claude Code](https://claude.com/claude-code)