### PR TITLE
fix(macos): trigger mic-permission dialog deterministically at launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,8 +445,16 @@ set(CORE_SOURCES
 # NereusSDRVAX HAL plugin via POSIX shared memory. The header is
 # cross-platform-safe (falls through to error stubs off macOS) but the .cpp
 # pulls in <sys/mman.h> / shm_open, so only compile it on Apple targets.
+#
+# MacMicPermission — Objective-C++ helper that calls
+# AVCaptureDevice.requestAccessForMediaType:AVMediaTypeAudio at app launch so
+# macOS surfaces the microphone permission dialog deterministically (issue
+# #203). Without it, the prompt only fires as a side effect of opening a
+# hardware mic, which silently fails on Mac mini / Mac Studio rigs and on
+# machines whose only inputs are audio interfaces.
 if(APPLE)
     list(APPEND CORE_SOURCES src/core/audio/CoreAudioHalBus.cpp)
+    list(APPEND CORE_SOURCES src/core/MacMicPermission.mm)
 endif()
 
 # LinuxPipeBus — Linux-only IAudioBus implementation bridging to PulseAudio /
@@ -769,6 +777,12 @@ target_link_libraries(NereusSDRObjs PUBLIC
 if(WIN32)
     # Needed by RadioDiscovery.cpp's setsockopt() call for SO_BROADCAST.
     target_link_libraries(NereusSDR PRIVATE ws2_32)
+endif()
+
+if(APPLE)
+    # AVFoundation provides AVCaptureDevice for the launch-time mic-permission
+    # prompt (src/core/MacMicPermission.mm, issue #203).
+    target_link_libraries(NereusSDRObjs PUBLIC "-framework AVFoundation")
 endif()
 
 if(Qt6SerialPort_FOUND)

--- a/src/core/MacMicPermission.h
+++ b/src/core/MacMicPermission.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// Request microphone permission on macOS at app startup.
+//
+// Hardened-Runtime + Developer-ID signed apps with NSMicrophoneUsageDescription
+// in Info.plist will normally surface the system permission dialog the first
+// time something opens an input audio unit. In practice that's unreliable for
+// us: AudioEngine::ensureTxInputOpen() drives Pa_OpenStream through PortAudio's
+// CoreAudio backend, and the device resolver silently returns paNoDevice on
+// machines that lack a built-in mic (Mac mini / Mac Studio) or whose only
+// inputs are audio interfaces with names that don't match the hardware-mic
+// regex. When that happens, AVCaptureDevice never sees an access attempt and
+// macOS has no reason to show the prompt.
+//
+// Calling AVCaptureDevice's requestAccess(forMediaType:AVMediaTypeAudio) at
+// app launch deterministically engages TCC regardless of what audio hardware
+// is attached, so the user gets the prompt on first launch and the answer is
+// cached for every subsequent mic open. No-op on non-macOS platforms.
+#ifdef Q_OS_MAC
+namespace NereusSDR { void requestMicrophonePermission(); }
+#else
+namespace NereusSDR { inline void requestMicrophonePermission() {} }
+#endif

--- a/src/core/MacMicPermission.mm
+++ b/src/core/MacMicPermission.mm
@@ -1,0 +1,46 @@
+#import <AVFoundation/AVFoundation.h>
+
+#include "core/LogCategories.h"
+#include <QLoggingCategory>
+
+namespace NereusSDR {
+
+void requestMicrophonePermission()
+{
+    AVAuthorizationStatus status =
+        [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+
+    const char* statusName = "unknown";
+    switch (status) {
+    case AVAuthorizationStatusNotDetermined: statusName = "NotDetermined"; break;
+    case AVAuthorizationStatusRestricted:    statusName = "Restricted";    break;
+    case AVAuthorizationStatusDenied:        statusName = "Denied";        break;
+    case AVAuthorizationStatusAuthorized:    statusName = "Authorized";    break;
+    }
+    qCInfo(lcAudio) << "Microphone TCC status on launch:" << statusName;
+
+    switch (status) {
+    case AVAuthorizationStatusNotDetermined:
+        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
+                                 completionHandler:^(BOOL granted) {
+            if (granted) {
+                qCInfo(lcAudio) << "Microphone access granted";
+            } else {
+                qCWarning(lcAudio) << "Microphone access denied by user";
+            }
+        }];
+        break;
+
+    case AVAuthorizationStatusAuthorized:
+        break;
+
+    case AVAuthorizationStatusDenied:
+    case AVAuthorizationStatusRestricted:
+        qCWarning(lcAudio)
+            << "Microphone access denied/restricted. Open System Settings → "
+               "Privacy & Security → Microphone and enable access for NereusSDR.";
+        break;
+    }
+}
+
+} // namespace NereusSDR

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "gui/styles/AppTheme.h"
 #include "core/AppSettings.h"
 #include "core/AudioDeviceConfig.h"
+#include "core/MacMicPermission.h"
 #include "core/RadioConnection.h"
 #include "core/mmio/ExternalVariableEngine.h"
 #include "core/LogCategories.h"
@@ -134,6 +135,12 @@ int main(int argc, char* argv[])
     app.setApplicationVersion(NEREUSSDR_VERSION);
     app.setOrganizationName("NereusSDR");
     app.setWindowIcon(QIcon(":/icons/NereusSDR.png"));
+
+    // Trigger the macOS microphone permission dialog deterministically
+    // (issue #203). The OS only prompts when something actually engages
+    // TCC; relying on PortAudio's CoreAudio backend to do so is unreliable
+    // on machines without a built-in mic, so call AVCaptureDevice directly.
+    NereusSDR::requestMicrophonePermission();
 
     // Re-parse properly so --help / --version / unknown options surface
     // via Qt's standard machinery. The earlyProfile pass above already


### PR DESCRIPTION
## Summary

- Add `src/core/MacMicPermission.{h,mm}` — calls `AVCaptureDevice.requestAccessForMediaType:AVMediaTypeAudio` once at app launch so the macOS permission prompt fires on first run regardless of what audio hardware is attached.
- Wire into [src/main.cpp](src/main.cpp:140) right after `QApplication` construction.
- Link `-framework AVFoundation` on Apple targets.

## Why

Issue #203: w3ub reported and JJ confirmed that fresh installs of v0.3.1 / v0.3.2 do not request microphone permission on Apple Silicon. Build-side gate is correct (`NSMicrophoneUsageDescription` is in the released bundle, Hardened Runtime + Developer ID signed). The bug is downstream: the only path that engaged TCC was `AudioEngine::ensureTxInputOpen()` -> `Pa_OpenStream`, and [PortAudioBus::resolveDevice()](src/core/audio/PortAudioBus.cpp:60) silently returns `paNoDevice` when nothing matches the hardware-mic name regex. That happens on:

- Mac mini / Mac Studio (no built-in mic)
- Macs whose only inputs are audio interfaces (RME, MOTU, Focusrite, etc.)
- Macs where the system default has been hijacked by a virtual mic

When that happens, `Pa_OpenStream` is never called and TCC never engages. Mirrors AetherSDR's MacMicPermission helper.

## Test plan

- [x] Local build on Apple Silicon (`cmake --build build`)
- [x] Verified `MacMicPermission.mm` compiles, AVFoundation linked into bundle (`otool -L`)
- [x] Verified helper runs at startup via diagnostic log line: `nereus.audio: Microphone TCC status on launch: Authorized` (status reflects current TCC state on this machine; on a fresh install it would be `NotDetermined` -> dialog fires)
- [x] Full ctest suite: 353/353 passed
- [ ] Field verification on a Mac that has never run NereusSDR before (w3ub or another tester)

Fixes #203

J.J. Boyd ~ KG4VCF