### PR TITLE
fix(main-window): persist geometry + maximized state across launches (#206)

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -308,6 +308,8 @@ warren@wpratt.com
 #include "core/audio/VirtualCableDetector.h"
 
 #include <QApplication>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QSlider>
 #include <QCloseEvent>
 #include <QResizeEvent>
@@ -679,11 +681,59 @@ MainWindow::MainWindow(QWidget* parent)
         if (m_containerManager) {
             m_containerManager->saveState();
         }
+        // Issue #206 — also flush window geometry on signal-based
+        // shutdown (SIGTERM / force-quit). Idempotent with the
+        // closeEvent path above.
+        saveMainWindowGeometry();
         AppSettings::instance().save();
     });
 }
 
 MainWindow::~MainWindow() = default;
+
+// Issue #206 — main-window geometry persistence. Qt's saveGeometry()
+// returns a versioned QByteArray that already encodes position, size,
+// AND window state (Normal/Maximized/FullScreen) plus screen identity
+// for multi-monitor setups. We base64-encode it so AppSettings (which
+// stores QString values) can round-trip the blob unmodified.
+void MainWindow::saveMainWindowGeometry()
+{
+    auto& s = AppSettings::instance();
+    s.setValue(QStringLiteral("MainWindowGeometry"),
+               QString::fromLatin1(saveGeometry().toBase64()));
+}
+
+bool MainWindow::restoreMainWindowGeometry()
+{
+    auto& s = AppSettings::instance();
+    const QString blob = s.value(QStringLiteral("MainWindowGeometry")).toString();
+    if (blob.isEmpty()) {
+        return false;
+    }
+    const QByteArray bytes = QByteArray::fromBase64(blob.toLatin1());
+    if (bytes.isEmpty() || !restoreGeometry(bytes)) {
+        return false;
+    }
+
+    // Multi-screen safety: if the restored frame's center sits outside
+    // every connected screen (monitor disconnected since last save),
+    // fall back to the centered 1280×800 default rather than parking
+    // the window offscreen where the user can't reach it.
+    const QPoint center = frameGeometry().center();
+    if (!QGuiApplication::screenAt(center)) {
+        resize(1280, 800);
+        if (auto* primary = QGuiApplication::primaryScreen()) {
+            const QRect avail = primary->availableGeometry();
+            move(avail.center() - QPoint(width() / 2, height() / 2));
+        }
+        // Drop any saved Maximized/FullScreen bit so we don't immediately
+        // re-maximize onto a screen layout that no longer matches.
+        setWindowState(Qt::WindowNoState);
+        return false;
+    }
+
+    return true;
+}
 
 void MainWindow::buildUI()
 {
@@ -699,6 +749,13 @@ void MainWindow::buildUI()
     }
     setMinimumSize(800, 600);
     resize(1280, 800);
+
+    // Issue #206 — restore last session's window position, size, and
+    // maximized/fullscreen state. The 1280×800 above stays as the
+    // first-launch fallback; restoreMainWindowGeometry() returns false
+    // when no saved blob exists or the blob is corrupted, in which
+    // case Qt centers the default size on the primary screen as before.
+    restoreMainWindowGeometry();
 
     // --- Main QSplitter: spectrum (left) + container panel (right) ---
     // AetherSDR pattern: right panel is a proper layout element, not an overlay.
@@ -4709,6 +4766,11 @@ void MainWindow::closeEvent(QCloseEvent* event)
     if (m_containerManager) {
         m_containerManager->saveState();
     }
+
+    // Issue #206 — persist window geometry + maximized/fullscreen
+    // state. Captured BEFORE close so the saved blob reflects the
+    // user-visible state, not Qt's mid-teardown geometry.
+    saveMainWindowGeometry();
 
     AppSettings::instance().save();
     event->accept();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -157,6 +157,19 @@ private:
     void tryAutoReconnect();
     void wireSliceToSpectrum();
 
+    // Issue #206 — persist the main window's position, size, and
+    // maximized/fullscreen state across launches. Stored in AppSettings
+    // under MainWindowGeometry / MainWindowState (base64 of Qt's native
+    // QByteArray blobs). restoreMainWindowGeometry() returns true if a
+    // valid saved geometry was applied, false otherwise (first launch
+    // or corrupted blob); buildUI() uses the return to decide whether
+    // to keep the 1280×800 default. Multi-screen safety clamp: if the
+    // restored geometry sits entirely outside every connected screen
+    // (monitor disconnected since last save), fall back to centering
+    // on the primary screen at the default size.
+    void saveMainWindowGeometry();
+    bool restoreMainWindowGeometry();
+
     // Re-runs the right-side strip's progressive-drop logic per design
     // §286-294. Restores all drop candidates first (in case the window
     // grew), then walks the priority order — PA OK → CAT/TCI →


### PR DESCRIPTION
## Summary
- Fixes #206 — the main window opened at a fixed 1280×800 centered on every launch and never remembered position, size, or maximize state.
- Adds `saveMainWindowGeometry` / `restoreMainWindowGeometry` using Qt's native `saveGeometry()` / `restoreGeometry()` byte blob, base64-encoded into `AppSettings` under `MainWindowGeometry`. Wired into `closeEvent` and the `aboutToQuit` signal-shutdown path.
- The Qt blob already encodes position, size, AND `windowState` (Normal / Maximized / FullScreen) plus screen identity, so all three states round-trip without separate keys.
- Multi-screen safety: if the saved geometry's center sits outside every connected screen (monitor disconnected since last save), fall back to the centered 1280×800 default.
- The 1280×800 default still applies on first launch when no saved blob exists.

## Test plan
- [x] Launch fresh (no saved blob) → window opens at default 1280×800
- [x] Resize to 1100×750 at (200,150), Cmd+Q
- [x] Verify `MainWindowGeometry` key written to `~/Library/Preferences/NereusSDR/NereusSDR.settings`
- [x] Relaunch → window restored at exactly (200,150) size 1100×750
- [x] `ctest` full suite: 353/353 passed
- [ ] Manual test on Linux (per OP's Arch/Manjaro environment)
- [ ] Manual test on Windows
- [ ] Manual test of maximize round-trip (covered by Qt's documented `saveGeometry` semantics; relies on `restoreState` re-applying the bitmask)

J.J. Boyd ~ KG4VCF