### PR TITLE
fix(#202): deep-fix four code paths to 'PA at full output regardless of slider'

### DIFF
--- a/src/core/HardwareProfile.cpp
+++ b/src/core/HardwareProfile.cpp
@@ -206,9 +206,29 @@ HardwareProfile profileForModel(HPSDRModel model)
 HPSDRModel defaultModelForBoard(HPSDRHW board)
 {
     // Walk HPSDRModel enum, return first match.
+    //
+    // Skip ORIONMKII: Thetis's user-facing comboRadioModel.Items list
+    // intentionally omits "ORIONMKII"
+    // (setup.Designer.cs:8515-8528 [v2.10.3.13] — only ANAN-7000DLE,
+    // ANAN-8000DLE, ANVELINA-PRO3, RED-PITAYA appear for the OrionMKII PCB)
+    // and StringModelToEnum has no string entry for it
+    // (clsHardwareSpecific.cs:316-351 [v2.10.3.13]).  database.cs:10350
+    // [v2.10.3.13] explicitly notes: "not implemented in comboRadioModel
+    // list items".  The bare ORIONMKII enum is kept in code only as a
+    // legacy switch fall-through (its DefaultPAGainsForBands row groups
+    // with FIRST/HERMES/HPSDR at clsHardwareSpecific.cs:471-486 — the
+    // Hermes 41 dB row).  Productized OrionMKII boards (ANAN-7000DLE /
+    // 8000DLE / AnvelinaPro3 / RedPitaya) all have ~50 dB PA gain rather
+    // than 41 dB, so auto-defaulting to ORIONMKII over-drives those PAs.
+    // Skip it on the auto-pick walk to mirror Thetis's user-facing
+    // exclusion; the iteration naturally lands on ANAN7000D for the
+    // OrionMKII boardtype, which carries the correct kAnan7000dRow gains.
     for (int i = static_cast<int>(HPSDRModel::FIRST) + 1;
          i < static_cast<int>(HPSDRModel::LAST); ++i) {
         auto m = static_cast<HPSDRModel>(i);
+        if (m == HPSDRModel::ORIONMKII) {
+            continue;
+        }
         if (boardForModel(m) == board) {
             return m;
         }

--- a/src/core/PaGainProfile.cpp
+++ b/src/core/PaGainProfile.cpp
@@ -391,14 +391,38 @@ float defaultPaGainsForBand(HPSDRModel model, Band band) noexcept {
 
 // --- bypassPaGainsForBand ---------------------------------------------------
 //
-// Returns the all-100.0f sentinel profile used for the "Bypass" factory
-// entry in PaProfileManager. This is the same sentinel value Thetis uses
-// to initialize the gain array (clsHardwareSpecific.cs:466 [v2.10.3.13])
-// before the per-model switch fills it in. Picking this profile turns off
-// the dBm-target compensation entirely — the linear-fallback
-// (gbb >= 99.5) branch in TransmitModel::computeAudioVolume takes over.
-float bypassPaGainsForBand(Band /*band*/) noexcept {
-    return kPaGainSentinel;
+// Returns the gain row Thetis assigns to the "Bypass" factory entry.
+//
+// From Thetis setup.cs:23314 [v2.10.3.13] — initPAProfiles seeds Bypass via
+//   _PAProfiles.Add(_sPA_PROFILE_BYPASS,
+//       new PAProfile(_sPA_PROFILE_BYPASS, HPSDRModel.FIRST, true));
+// The PAProfile constructor calls ResetGainDefaultsForModel(HPSDRModel.FIRST)
+// which calls DefaultPAGainsForBands(HPSDRModel.FIRST).  The clsHardwareSpecific
+// switch at :471-486 [v2.10.3.13] groups
+//   case HPSDRModel.FIRST:
+//   case HPSDRModel.HERMES:
+//   case HPSDRModel.HPSDR:
+//   case HPSDRModel.ORIONMKII:
+// under the same Hermes 41.x dB HF row.  So Thetis's Bypass profile is NOT
+// an "all-100.0f" sentinel — it's the Hermes row.
+//
+// The init loop at clsHardwareSpecific.cs:463-466 [v2.10.3.13] does fill
+// the gain array with 100.0f first ("max them out, these gains are PA
+// attenuations, so 100 is no output power"), but the per-model switch
+// then overwrites those with the actual gains.  In Thetis a residual
+// 100.0f (band not handled by any switch case) means NO output power —
+// the dBm kernel's `target_dbm -= 100` produces audio_volume ≈ 0.
+//
+// NereusSDR previously returned kPaGainSentinel (100.0f) here and combined
+// with a NereusSDR-original `gbb >= 99.5 → linear identity sliderWatts/100`
+// short-circuit in TransmitModel::computeAudioVolume.  That short-circuit
+// inverted the Thetis semantic ("100 = no output") into "100 = full output"
+// and made any user picking the Bypass profile emit wire byte 255 at
+// slider 100.  That short-circuit is being removed concurrently
+// (TransmitModel.cpp), and this function now returns the Thetis-faithful
+// Hermes row by delegating to defaultPaGainsForBand(HPSDRModel::FIRST, band).
+float bypassPaGainsForBand(Band band) noexcept {
+    return defaultPaGainsForBand(HPSDRModel::FIRST, band);
 }
 
 }  // namespace NereusSDR

--- a/src/core/PaProfileManager.cpp
+++ b/src/core/PaProfileManager.cpp
@@ -258,6 +258,58 @@ QStringList PaProfileManager::profileNames() const
     return names;
 }
 
+QStringList PaProfileManager::userVisibleProfileNames(
+    HPSDRModel connectedModel,
+    const QString& currentSelectedName) const
+{
+    // Faithful port of Thetis's combo filter at setup.cs:23335-23344
+    // [v2.10.3.13]:
+    //   if (sSelectProfile == _sPA_PROFILE_BYPASS)
+    //   {
+    //       if (p.ProfileName == _sPA_PROFILE_BYPASS)
+    //           comboPAProfile.Items.Add(p.ProfileName);
+    //   }
+    //   else
+    //   {
+    //       if ((p.IsDefault && p.Model == HardwareSpecific.Model) || !p.IsDefault)
+    //           comboPAProfile.Items.Add(p.ProfileName);
+    //   }
+    QStringList allNames = readManifest();
+    QStringList out;
+
+    const QString bypassName = QString::fromLatin1(kBypassProfileName);
+    const bool bypassMode = (currentSelectedName == bypassName);
+
+    for (const QString& name : allNames) {
+        if (bypassMode) {
+            if (name == bypassName) {
+                out.append(name);
+            }
+            continue;
+        }
+        const PaProfile* p = profileByName(name);
+        if (!p) {
+            // Manifest entry without a loaded blob — shouldn't happen but
+            // skip defensively to avoid emitting ghost names.
+            continue;
+        }
+        const bool isDefault = p->isFactoryDefault();
+        if (isDefault) {
+            if (p->model() == connectedModel) {
+                out.append(name);
+            }
+            // Else: hidden — `Default - <other model>` would apply the
+            // wrong gain row to this radio.
+        } else {
+            // User-customised profile — always visible.
+            out.append(name);
+        }
+    }
+
+    std::sort(out.begin(), out.end());
+    return out;
+}
+
 QString PaProfileManager::activeProfileName() const
 {
     return m_activeProfileName;

--- a/src/core/PaProfileManager.h
+++ b/src/core/PaProfileManager.h
@@ -145,6 +145,26 @@ public:
     /// List all profile names currently in the manager (sorted).
     QStringList profileNames() const;
 
+    /// List profile names filtered for the user-facing PA profile combo.
+    ///
+    /// Mirrors Thetis's filter at setup.cs:23341-23344 [v2.10.3.13]:
+    ///   if ((p.IsDefault && p.Model == HardwareSpecific.Model) || !p.IsDefault)
+    ///       comboPAProfile.Items.Add(p.ProfileName);
+    ///
+    /// i.e. the user sees:
+    ///   - exactly one factory-default entry — `Default - <connectedModel>`,
+    ///   - plus every user-customised (non-default) profile.
+    /// All other `Default - *` entries are hidden.  This prevents a user on
+    /// (e.g.) a 7000DLE from accidentally selecting `Default - HERMES`
+    /// (Hermes 41 dB gain row) and over-driving the actual ~50 dB PA.
+    ///
+    /// The Bypass-mode special case at setup.cs:23335-23339 [v2.10.3.13]
+    /// (when the currently-selected profile is `Bypass`, only `Bypass`
+    /// appears in the combo) is also implemented here: if
+    /// `currentSelectedName == "Bypass"`, only `Bypass` is returned.
+    QStringList userVisibleProfileNames(HPSDRModel connectedModel,
+                                         const QString& currentSelectedName = {}) const;
+
     /// The currently-active profile name, or empty string if no MAC scope
     /// has been set / no load has run yet.
     QString activeProfileName() const;

--- a/src/gui/AddCustomRadioDialog.cpp
+++ b/src/gui/AddCustomRadioDialog.cpp
@@ -494,8 +494,20 @@ void AddCustomRadioDialog::populateModelCombo()
     addSku(HPSDRModel::ANAN200D);        // "ANAN-200D"
 
     // --- Orion MkII (2 ADC · MKII BPF) ---
+    //
+    // ORIONMKII is intentionally NOT user-selectable here.  Mirrors
+    // Thetis's comboRadioModel.Items list at setup.Designer.cs:8515-8528
+    // [v2.10.3.13], which omits "ORIONMKII" entirely — Thetis's
+    // StringModelToEnum (clsHardwareSpecific.cs:316-351 [v2.10.3.13]) has
+    // no string entry for it either, and database.cs:10350 [v2.10.3.13]
+    // confirms: "not implemented in comboRadioModel list items".  The
+    // bare ORIONMKII enum exists only as a code-internal value used in
+    // some PA-gain switch fall-throughs (the Hermes 41.x dB row at
+    // clsHardwareSpecific.cs:471-486).  Productized OrionMKII boards all
+    // have ~50 dB PA gain (kAnan7000dRow / kAnan8000dRow), and letting a
+    // user pick "Orion MkII" produces the same K2GX/issue-#202 over-drive
+    // class as auto-detect did before HardwareProfile.cpp's skip.
     addFamilyHeader(QStringLiteral("Orion MkII (2 ADC · MKII BPF)"));
-    addSku(HPSDRModel::ORIONMKII);       // "Orion MkII"
     addSku(HPSDRModel::ANAN7000D);       // "ANAN-7000DLE"
     addSku(HPSDRModel::ANAN8000D);       // "ANAN-8000DLE"
     addSku(HPSDRModel::ANVELINAPRO3);    // "Anvelina Pro 3"

--- a/src/gui/setup/PaSetupPages.cpp
+++ b/src/gui/setup/PaSetupPages.cpp
@@ -703,6 +703,11 @@ PaGainByBandPage::PaGainByBandPage(RadioModel* model, QWidget* parent)
             this, &PaGainByBandPage::rebuildProfileCombo);
     connect(m_paProfileManager, &PaProfileManager::activeProfileChanged,
             this, [this](const QString& name) {
+                // #202 deep-fix: rebuild the combo whenever the active
+                // profile changes so the Bypass-mode special case can take
+                // effect (when active == "Bypass", combo shows only
+                // Bypass per Thetis setup.cs:23335-23339 [v2.10.3.13]).
+                rebuildProfileCombo();
                 if (m_profileCombo && m_profileCombo->currentText() != name) {
                     QSignalBlocker blocker(m_profileCombo);
                     m_profileCombo->setCurrentText(name);
@@ -905,7 +910,14 @@ void PaGainByBandPage::rebuildProfileCombo()
 
     const QString prevActive = m_paProfileManager->activeProfileName();
     m_profileCombo->clear();
-    const QStringList names = m_paProfileManager->profileNames();
+    // #202 deep-fix: filter to `Default - <connectedModel>` + every
+    // user-customised profile (hide all other `Default - *`).  Mirrors
+    // Thetis setup.cs:23341-23344 [v2.10.3.13].  Bypass-mode special case
+    // (when prevActive == "Bypass", show only "Bypass") is handled inside
+    // userVisibleProfileNames per setup.cs:23335-23339 [v2.10.3.13].
+    const QStringList names =
+        m_paProfileManager->userVisibleProfileNames(m_connectedModel,
+                                                     prevActive);
     for (const QString& n : names) {
         m_profileCombo->addItem(n);
     }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -865,25 +865,31 @@ RadioModel::RadioModel(QObject* parent)
     // accepted into the model but not pushed to the wire, matching
     // Thetis behaviour.
     //
-    // Phase 4 Agent 4A of issue #167 (K2GX safety hotfix) — replaces the
-    // previous linear `wire = clamp(int(255*f*swrProtect),0,255)` formula
-    // (cited to mi0bot NetworkIO.cs:209-211 [v2.10.3.14-beta1] — fork-
-    // specific divergence) with the Thetis-canonical dBm-target chain:
+    // Phase 4 Agent 4A of issue #167 (K2GX safety hotfix) introduced the
+    // Thetis-canonical dBm-target chain (replacing a previous linear
+    // `wire = clamp(int(255*f*swrProtect),0,255)` formula that had no
+    // per-band PA-gain compensation).  Issue #202 deep-fix reverted a
+    // mistaken SWR-topology comment that previously claimed the wire
+    // byte should NOT see SWR foldback.  The actual Thetis topology
+    // (NetworkIO.cs:201-211 [v2.10.3.13]) puts SWR foldback on the
+    // wire byte:
     //
-    //   wire_byte = clamp(int(audio_volume * 1.02 * 255), 0, 255)
-    //               From Thetis audio.cs:262-271 [v2.10.3.13] —
-    //               `NetworkIO.SetOutputPower((float)(value * 1.02))`.
-    //               NO SWR factor on wire byte (MW0LGE-canonical topology).
+    //   wire_byte = (int)(255 * clamp(audio_volume * 1.02, 0, 1) * _swr_protect)
+    //               From Thetis audio.cs:262-271 [v2.10.3.13]
+    //               `NetworkIO.SetOutputPower((float)(value * 1.02))`
+    //               and NetworkIO.cs:201-211 [v2.10.3.13] which clamps
+    //               and applies _swr_protect.
     //
-    //   iq_gain   = audio_volume * swrProtect
-    //               From Thetis cmaster.cs:1115-1119 [v2.10.3.13] —
-    //               `level = RadioVolume * HighSWRScale` ->
-    //               `SetTXFixedGain(0, level, level)`. SWR factor lives HERE.
+    //   iq_gain   = audio_volume * Audio.HighSWRScale
+    //               From Thetis cmaster.cs:1115-1119 [v2.10.3.13].
+    //               HighSWRScale is set to 1.0 once at console.cs:29194
+    //               [v2.10.3.13] and never reassigned anywhere in
+    //               baseline Thetis — IQ-side path is effectively no-op.
     //
-    // The asymmetry is intentional per MW0LGE topology — the wire byte
-    // never sees the SWR foldback, only the IQ scalar fed into the WDSP
-    // TX chain does.  DO NOT "fix" this by adding swrProtect to the wire
-    // byte; doing so reverts the K2GX safety regression.
+    // Wire+IQ composition lives in RadioModel::pumpAudioVolume (one
+    // helper), wired below to TransmitModel::audioVolumeChanged so every
+    // setPowerUsingTargetDbm callsite + future audio_volume mutator
+    // pumps both paths uniformly.
     //
     // Pre-hotfix: ANAN-8000DLE 80m TUN at slider=50 produced wire_byte=127
     // (=> ~300W on a 200W radio).  Post-hotfix: wire_byte=49 (=> ~85W).
@@ -917,21 +923,38 @@ RadioModel::RadioModel(QObject* parent)
             /*bFromTune=*/false, /*bTwoTone=*/false,
             m_hardwareProfile.model);
 
-        // Compose wire byte + IQ scalar per Thetis topology cited above.
-        const float swrProtect =
-            std::clamp(m_transmitModel.swrProtectFactor(), 0.0f, 1.0f);
-        const int wireDrive = std::clamp(
-            int(result.audioVolume * 1.02 * 255.0), 0, 255);
-        const double iqGain =
-            result.audioVolume * static_cast<double>(swrProtect);
+        // Wire byte + IQ scalar pump now happens inside pumpAudioVolume,
+        // wired below to TransmitModel::audioVolumeChanged.  setPowerUsingTargetDbm
+        // emits that signal at TransmitModel.cpp:1129, which fires the
+        // listener synchronously (Qt::AutoConnection on same thread).
+        (void)result;
+    });
 
-        if (m_txChannel) {
-            m_txChannel->setTxFixedGain(iqGain);
-        }
-        auto* conn = m_connection;
-        QMetaObject::invokeMethod(conn, [conn, wireDrive]() {
-            conn->setTxDrive(wireDrive);
-        });
+    // ── #202 deep-fix: Audio.RadioVolume setter analogue ─────────────────────
+    //
+    // Connect TransmitModel::audioVolumeChanged → RadioModel::pumpAudioVolume
+    // so every call to setPowerUsingTargetDbm (drive slider, TUNE-on, TUN-off
+    // restore, two-tone) and any future audio_volume mutator pumps wire byte
+    // + IQ scalar uniformly.  Mirrors Thetis audio.cs:262-271 [v2.10.3.13]
+    // setter side-effects.
+    connect(&m_transmitModel, &TransmitModel::audioVolumeChanged,
+            this, &RadioModel::pumpAudioVolume);
+
+    // Connect TransmitModel::swrProtectFactorChanged → re-pump current
+    // audio_volume through the new SWR factor.  Mirrors Thetis
+    // console.cs:26102-26109 [v2.10.3.13]:
+    //   if (_swr_wind_back_power && swrprotection && old_swr_protect != NetworkIO.SWRProtect)
+    //   {
+    //       // setting SWRProtect does nothing unless power is changed,
+    //       // RadioVolume is the only code that uses SWRProtect using
+    //       // NetworkIO.SetOutputPower.
+    //       Audio.RadioVolume = Audio.RadioVolume;  // self-assign re-emits
+    //   }
+    // The NereusSDR cache (m_lastAudioVolume, updated inside pumpAudioVolume)
+    // stands in for Thetis's `radio_volume` backing field.
+    connect(&m_transmitModel, &TransmitModel::swrProtectFactorChanged,
+            this, [this](float /*factor*/) {
+        pumpAudioVolume(m_lastAudioVolume);
     });
 
     // Bench-reported #167 follow-up: power meters stick after un-key.
@@ -4692,6 +4715,80 @@ void RadioModel::onConnectionStateChanged(ConnectionState state)
     }
 }
 
+// ── #202 deep-fix: pumpAudioVolume — Audio.RadioVolume setter analogue ──────
+//
+// Direct port of the Thetis `Audio.RadioVolume` setter side-effects
+// (audio.cs:262-271 [v2.10.3.13]):
+//   set {
+//       radio_volume = value;
+//       NetworkIO.SetOutputPower((float)(value * 1.02));
+//       cmaster.CMSetTXOutputLevel();
+//   }
+//
+// Wire byte path mirrors NetworkIO.cs:201-211 [v2.10.3.13]:
+//   public static void SetOutputPower(float f) {
+//       if (f < 0.0) f = 0.0F;
+//       if (f >= 1.0) f = 1.0F;
+//       int i = (int)(255 * f * _swr_protect);
+//       SetOutputPowerFactor(i);
+//   }
+// — note `f` is the audio_volume * 1.02 already.  SWR foldback (`_swr_protect`)
+// multiplies the wire byte HERE, NOT the IQ scalar.  This is the opposite of
+// what the prior NereusSDR code did (it placed swrProtect on the IQ scalar).
+// The earlier "MW0LGE-canonical topology" comment was a misreading of the
+// upstream source — Thetis's `Audio.HighSWRScale` (the IQ-side multiplier in
+// cmaster.cs:1117) is set to 1.0 once at console.cs:29194 [v2.10.3.13] and
+// never reassigned anywhere in baseline Thetis, making the IQ-side path a
+// no-op.  Real SWR foldback in Thetis is wire-byte only.
+//
+// IQ scalar path mirrors cmaster.cs:1115-1119 [v2.10.3.13]:
+//   public static void CMSetTXOutputLevel() {
+//       double level = Audio.RadioVolume * Audio.HighSWRScale;
+//       cmaster.SetTXFixedGain(0, level, level);
+//   }
+// With HighSWRScale baseline-1.0, the IQ scalar is just audio_volume.
+//
+// Caches the value into m_lastAudioVolume so a subsequent
+// swrProtectFactorChanged emit can re-pump the same audio_volume through
+// updated SWR protect (mirrors console.cs:26102-26109 [v2.10.3.13]
+// `Audio.RadioVolume = Audio.RadioVolume` re-emit on _swr_protect change).
+void RadioModel::pumpAudioVolume(double audioVolume)
+{
+    if (!m_connection) {
+        // No live connection — cache the value but skip the wire write.
+        // The next setPowerUsingTargetDbm after Connected will re-emit
+        // and reach the wire path.
+        m_lastAudioVolume = audioVolume;
+        return;
+    }
+
+    m_lastAudioVolume = audioVolume;
+
+    const float swrProtect =
+        std::clamp(m_transmitModel.swrProtectFactor(), 0.0f, 1.0f);
+
+    // Byte-for-byte port of NetworkIO.SetOutputPower(float f) at
+    // NetworkIO.cs:201-211 [v2.10.3.13].  `f` is `audioVolume * 1.02`
+    // (audio.cs:268 passes that argument).
+    double f = audioVolume * 1.02;
+    if (f < 0.0) { f = 0.0; }
+    if (f >= 1.0) { f = 1.0; }
+    const int wireDrive = static_cast<int>(255.0 * f
+                                            * static_cast<double>(swrProtect));
+
+    // IQ scalar — Audio.RadioVolume * Audio.HighSWRScale, with
+    // HighSWRScale = 1.0 (baseline Thetis).  No SWR factor.
+    const double iqGain = audioVolume;
+
+    if (m_txChannel) {
+        m_txChannel->setTxFixedGain(iqGain);
+    }
+    auto* conn = m_connection;
+    QMetaObject::invokeMethod(conn, [conn, wireDrive]() {
+        conn->setTxDrive(wireDrive);
+    });
+}
+
 // ── Phase 3M-0 Task 6: Ganymede PA-trip live state ──────────────────────────
 // Porting from Thetis Andromeda/Andromeda.cs:914-948 [v2.10.3.13]
 // (CATHandleAmplifierTripMessage + GanymedeResetPressed).
@@ -4838,6 +4935,16 @@ void RadioModel::setTune(bool on)
         // matches Thetis ordering for future maintainers reading side-by-side.
         m_isTuning = true;
 
+        // #202 deep-fix: propagate TUNE state to TransmitModel so its
+        // m_tune flag (read by SetPowerUsingTargetDBM at TransmitModel.cpp:935-945)
+        // tracks Thetis's `chkTUN.Checked` semantic.  Without this, a
+        // power-slider movement during active TUNE would route through
+        // setPowerUsingTargetDbm's txMode-0 (drive-slider) branch instead
+        // of staying on the tune-power source — sending the wrong drive
+        // byte mid-TUN.  Mirrors Thetis console.cs:46665 [v2.10.3.13]
+        // which reads `chkTUN.Checked` directly.
+        m_transmitModel.setTune(true);
+
         // Issue #177 — cancel any pending TUN-off completion.  If the user
         // double-clicks TUN (off → on within the rxReady + 100 ms settle
         // window) we are mid-walk: the rxReady slot has not yet fired or has
@@ -4889,6 +4996,18 @@ void RadioModel::setTune(bool on)
         //   radio.GetDSPTX(0).TXPostGenMode = 0;
         //   radio.GetDSPTX(0).TXPostGenToneMag = MAX_TONE_MAG;
         //   radio.GetDSPTX(0).TXPostGenRun = 1;
+        //
+        // Tone gen runs by default on TUN-on; the new_pwr==0 path below
+        // (after setPowerUsingTargetDbm) flips TXPostGenRun back to 0 if the
+        // resolved tune power happens to be zero, mirroring Thetis
+        // console.cs:46749-46758 [v2.10.3.13]:
+        //   if (new_pwr == 0) {
+        //       Audio.RadioVolume = 0.0;
+        //       if (chkTUN.Checked) radio.GetDSPTX(0).TXPostGenRun = 0;
+        //   } else {
+        //       if (chkTUN.Checked) radio.GetDSPTX(0).TXPostGenRun = 1;
+        //       Audio.RadioVolume = ...;
+        //   }
         if (m_txChannel) {
             m_txChannel->setTuneTone(true, signedFreq, TxChannel::kMaxToneMag);
         }
@@ -4957,26 +5076,27 @@ void RadioModel::setTune(bool on)
                 // Issue #175 Task 4: thread connected model so HL2
                 // sub-step DSP audio-gain modulation engages on the TUN
                 // path (mi0bot console.cs:47660-47673 [v2.10.3.13-beta2]).
+                //
+                // setPowerUsingTargetDbm emits audioVolumeChanged at
+                // TransmitModel.cpp:1129; the listener wired in the
+                // constructor (RadioModel::pumpAudioVolume) composes the
+                // wire byte + IQ scalar Thetis-faithfully and pushes them.
                 const auto result = m_transmitModel.setPowerUsingTargetDbm(
                     *activeProfile, currentBand, /*bSetPower=*/true,
                     /*bFromTune=*/true, /*bTwoTone=*/false,
                     m_hardwareProfile.model);
 
-                const float swrProtect =
-                    std::clamp(m_transmitModel.swrProtectFactor(), 0.0f, 1.0f);
-                const int wireTuneDrive = std::clamp(
-                    int(result.audioVolume * 1.02 * 255.0), 0, 255);
-                const double iqGain =
-                    result.audioVolume * static_cast<double>(swrProtect);
-
-                if (m_txChannel) {
-                    m_txChannel->setTxFixedGain(iqGain);
-                }
-                if (m_connection) {
-                    auto* conn = m_connection;
-                    QMetaObject::invokeMethod(conn, [conn, wireTuneDrive]() {
-                        conn->setTxDrive(wireTuneDrive);
-                    });
+                // #202 deep-fix: TXPostGenRun=0 case for new_pwr==0 during TUNE.
+                // Mirrors Thetis console.cs:46749-46752 [v2.10.3.13]:
+                //   if (new_pwr == 0) {
+                //       Audio.RadioVolume = 0.0;
+                //       if (chkTUN.Checked) radio.GetDSPTX(0).TXPostGenRun = 0;
+                //   }
+                // setTuneTone(false, ...) maps to TXPostGenRun=0 in NereusSDR's
+                // TxChannel wrapper (sets the run flag while leaving freq/mag).
+                if (result.newPower == 0 && m_txChannel) {
+                    m_txChannel->setTuneTone(false, signedFreq,
+                                             TxChannel::kMaxToneMag);
                 }
             }
             // No active profile loaded -> silently no-op the TUNE power
@@ -5083,6 +5203,16 @@ void RadioModel::setTune(bool on)
         // Until then, the rest of the TUN-off work (gen1 off, mode restore,
         // power restore, VFO un-offset) is deferred.
         m_pendingTuneOff = true;
+
+        // #202 deep-fix: clear TransmitModel's m_tune flag — symmetric with
+        // setTune(true) in the TUN-on branch.  Mirrors Thetis user-click
+        // semantic at console.cs:30106 [v2.10.3.13]: chkTUN.Checked = false
+        // is the user intent that the TUN-off branch responds to.  Cleared
+        // here (synchronously at user click) rather than inside
+        // completeTuneOff (deferred ~130 ms later) so a power-slider event
+        // arriving in the gap correctly routes through txMode-0 (drive-
+        // slider) rather than txMode-1 (TUNE).
+        m_transmitModel.setTune(false);
 
         // Capture MOX state BEFORE calling MoxController::setTune so we can
         // detect the "MOX already RX" path that would otherwise strand the
@@ -5227,25 +5357,16 @@ void RadioModel::completeTuneOff()
             // Issue #175 Task 4: thread connected model so the TUN-off
             // restore (txMode 0 path back to drive slider) is uniform
             // with the TUN-on path; non-HL2 SKUs unaffected.
+            //
+            // setPowerUsingTargetDbm emits audioVolumeChanged at
+            // TransmitModel.cpp:1129; the listener wired in the
+            // constructor (RadioModel::pumpAudioVolume) composes the wire
+            // byte + IQ scalar Thetis-faithfully and pushes them.
             const auto result = m_transmitModel.setPowerUsingTargetDbm(
                 *activeProfile, offBand, /*bSetPower=*/true,
                 /*bFromTune=*/false, /*bTwoTone=*/false,
                 m_hardwareProfile.model);
-            const float swrProtectSaved =
-                std::clamp(m_transmitModel.swrProtectFactor(), 0.0f, 1.0f);
-            const int savedWireDrive = std::clamp(
-                int(result.audioVolume * 1.02 * 255.0), 0, 255);
-            const double iqGain = result.audioVolume
-                                   * static_cast<double>(swrProtectSaved);
-            if (m_txChannel) {
-                m_txChannel->setTxFixedGain(iqGain);
-            }
-            if (m_connection) {
-                auto* conn = m_connection;
-                QMetaObject::invokeMethod(conn, [conn, savedWireDrive]() {
-                    conn->setTxDrive(savedWireDrive);
-                });
-            }
+            (void)result;
         }
     }
 

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -785,6 +785,36 @@ signals:
 private slots:
     void onConnectionStateChanged(NereusSDR::ConnectionState state);
 
+    // ── #202 deep-fix: Audio.RadioVolume setter analogue ─────────────────────
+    //
+    // Mirrors Thetis audio.cs:262-271 [v2.10.3.13]:
+    //   public static double RadioVolume {
+    //       set {
+    //           radio_volume = value;
+    //           NetworkIO.SetOutputPower((float)(value * 1.02));   // wire byte
+    //           cmaster.CMSetTXOutputLevel();                       // IQ scalar
+    //       }
+    //   }
+    //
+    // Connected to TransmitModel::audioVolumeChanged so every call to
+    // setPowerUsingTargetDbm (drive slider, TUNE-on, TUN-off restore,
+    // two-tone) and any future audio_volume mutator pumps the wire byte +
+    // IQ scalar uniformly.  Also re-pumped on TransmitModel::
+    // swrProtectFactorChanged (mirrors console.cs:26102-26109 [v2.10.3.13]
+    // `Audio.RadioVolume = Audio.RadioVolume` re-emission when SWRProtect
+    // changes mid-TX).
+    //
+    // Wire byte composition is byte-for-byte equivalent to Thetis
+    // NetworkIO.cs:201-211 [v2.10.3.13]:
+    //   if (f < 0.0) f = 0.0F;
+    //   if (f >= 1.0) f = 1.0F;
+    //   int i = (int)(255 * f * _swr_protect);
+    // IQ scalar mirrors cmaster.cs:1115-1119 [v2.10.3.13]:
+    //   double level = Audio.RadioVolume * Audio.HighSWRScale;
+    // where HighSWRScale is set to 1.0 once at console.cs:29194 and never
+    // reassigned anywhere in baseline Thetis — effectively no-op.
+    void pumpAudioVolume(double audioVolume);
+
 private:
     // Phase 3Q-1: drives the RadioModel-level connection state machine.
     // Guards against redundant transitions (no emit if state unchanged).
@@ -1099,6 +1129,13 @@ private:
     //   exported for H.3 UI polling.
     //   Cite: Thetis console.cs:30010 [v2.10.3.13] — _tuning = true.
     bool m_isTuning{false};
+
+    // m_lastAudioVolume: cache of the most recent value emitted by
+    //   TransmitModel::audioVolumeChanged.  Used by the swrProtectFactorChanged
+    //   re-pump path (mirrors Thetis console.cs:26108 [v2.10.3.13]
+    //   `Audio.RadioVolume = Audio.RadioVolume` self-assign re-emission when
+    //   SWRProtect changes mid-TX).  Updated only by pumpAudioVolume.
+    double m_lastAudioVolume{0.0};
 
     // ── Issue #177 fix — Thetis-faithful TUN-off ordering ────────────────────
     //

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -706,7 +706,7 @@ bool TransmitModel::pureSignalActive() const noexcept
 // that drives both the wire byte (audio.cs:268) and the IQ gain
 // (cmaster.cs:1117).
 //
-// Two NereusSDR-original safety short-circuits run BEFORE the dBm math:
+// Two short-circuits run BEFORE the dBm math:
 //
 //   1. sliderWatts <= 0 returns 0.0 exactly.  Matches Thetis's
 //      console.cs:46749-46751 branch:
@@ -717,16 +717,21 @@ bool TransmitModel::pureSignalActive() const noexcept
 //      can be called from tests + external callers, so failing-loud-zero is
 //      the safe behavior.
 //
-//   2. gbb >= 99.5 returns clamp(sliderWatts / 100.0, 0, 1) linear fallback.
-//      NereusSDR-original deviation: HL2 PA-bypass sentinel preserves
-//      pre-v0.3.2 transmit behavior.  See mi0bot
-//      clsHardwareSpecific.cs:484 [v2.10.3.13-beta2] "100 is no output power".
-//      The 99.5 threshold catches: (a) HL2 HF bands (gbb=100), (b) NereusSDR
-//      Bypass profile (every band gbb=100), (c) any out-of-range Band cast
-//      (PaProfile::getGainForBand sentinel = 1000).  Without this short-
-//      circuit, HL2 80m at 100 W slider would produce audio_volume ≈ 0.0009
-//      (effectively silent on the air) — a regression from v0.3.1 which
-//      worked for HL2 users by virtue of having no PA-gain compensation.
+//   2. HERMESLITE branch — full mi0bot-Thetis HL2 audio-volume formula
+//      `(hl2Power * gbb/100) / 93.75` (mi0bot-Thetis console.cs:47775-47778
+//      [v2.10.3.13-beta2]).  Runs BEFORE the dBm math because HL2's PA
+//      attenuator topology is fundamentally different (signed dB attenuator
+//      vs. analog PA gain compensation).  Non-HL2 paths fall through to
+//      the canonical Thetis dBm kernel below.
+//
+// Removed in #202 deep-fix: a NereusSDR-original `gbb >= 99.5 → linear
+// identity sliderWatts/100` short-circuit.  It inverted the Thetis semantic
+// "100 = no output power" (clsHardwareSpecific.cs:463-466 [v2.10.3.13])
+// into "100 = full output", which made the Bypass profile and any
+// out-of-range Band cast emit wire byte 255 at slider 100.  The Thetis
+// kernel at console.cs:46720-46758 always runs; with gbb=100 it produces
+// audio_volume ≈ 0.0009 (essentially silent), which is the correct
+// "this band has no PA gain row" behavior.
 //
 // The math itself is the canonical Thetis sequence:
 //
@@ -775,19 +780,25 @@ double TransmitModel::computeAudioVolume(const PaProfile& profile,
         return std::clamp(v, 0.0, 1.0);
     }
 
-    // NereusSDR-original deviation: HL2 PA-bypass sentinel preserves pre-
-    // v0.3.2 transmit behavior. See mi0bot clsHardwareSpecific.cs:484
-    // [v2.10.3.13-beta2] "100 is no output power".
+    // No `gbb >= 99.5` linear-identity short-circuit here.  In Thetis
+    // (clsHardwareSpecific.cs:463-466 [v2.10.3.13]) the gains array is
+    // initialised to 100.0f with the explicit comment:
+    //   "max them out, these gains are PA attenuations, so 100 is no output power"
+    // and SetPowerUsingTargetDBM (console.cs:46720-46758 [v2.10.3.13]) always
+    // runs the dBm kernel — it never short-circuits to a linear identity
+    // path.  With gbb=100 the kernel produces target_dbm = -50 dBm at
+    // sliderWatts=100, target_volts ≈ 0.0007, audio_volume ≈ 0.0009 — i.e.
+    // essentially zero output, which is the correct semantic for the
+    // "this band is not handled by my PA gain row" case.
     //
-    // The 99.5 threshold (vs. exact == 100.0f) handles float-precision noise
-    // from UI round-trips.  Out-of-range Band hits this path via
-    // PaProfile::getGainForBand returning the 1000 sentinel — the safety
-    // net catches programming errors (raw int casts to Band) instead of
-    // silently producing audio_volume = 1.0.
-    if (gbb >= 99.5f) {
-        const double linear = static_cast<double>(sliderWatts) / 100.0;
-        return std::clamp(linear, 0.0, 1.0);
-    }
+    // A previous NereusSDR-original short-circuit
+    //   if (gbb >= 99.5f) return std::clamp(sliderWatts / 100.0, 0.0, 1.0);
+    // inverted that semantic to "100 = full output (linear identity)".
+    // That made the Bypass profile (kPaGainSentinel = 100.0f every band) and
+    // any out-of-range Band emit wire byte 255 at slider 100 — the issue
+    // #202 trapdoor.  Removed; the Thetis kernel below now runs for all
+    // non-HL2 paths.  HL2 retains its mi0bot-Thetis formula above
+    // (TransmitModel.cpp:772-776).
 
     // From Thetis console.cs:46720-46724 [v2.10.3.13]:
     //   double target_dbm = 10 * (double)Math.Log10((double)new_pwr * 1000);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3391,6 +3391,14 @@ nereus_add_test(tst_filter_preset_store)
 #         console.cs:29245-29274 [v2.10.3.13-beta2].
 nereus_add_test(tst_hpsdr_model_pa_constants)
 
+# ── Issue #202 deep-fix: defaultModelForBoard auto-pick regression ──────────
+# Pins the OrionMKII boardtype → HPSDRModel::ANAN7000D mapping (not the bare
+# ORIONMKII enum, which Thetis excludes from its user-facing combo per
+# setup.Designer.cs:8515-8528 [v2.10.3.13]).  Plus coverage for the other
+# board → model auto-defaults so future enum reordering can't silently
+# regress the auto-detect path.
+nereus_add_test(tst_default_model_for_board)
+
 # ── Issue #175 Task 2: TxChannel::setPostGenToneMag WDSP wrapper ──────────────
 # 2 tests asserting round-trip store-and-retrieve for the thin C++ wrapper
 # around SetTXAPostGenToneMag (third_party/wdsp/src/gen.c:800-805 [v2.10.3.13]).

--- a/tests/tst_default_model_for_board.cpp
+++ b/tests/tst_default_model_for_board.cpp
@@ -1,0 +1,87 @@
+// no-port-check: test fixture; cite comments reference upstream
+// setup.Designer.cs / setup.cs / clsHardwareSpecific.cs as documentation of
+// the auto-default behaviour under test.
+//
+// Issue #202 deep-fix regression coverage: defaultModelForBoard() must NOT
+// auto-pick HPSDRModel::ORIONMKII for an OrionMKII boardtype.  The bare
+// ORIONMKII enum is excluded from Thetis's user-facing comboRadioModel.Items
+// list (setup.Designer.cs:8515-8528 [v2.10.3.13]) and from
+// StringModelToEnum (clsHardwareSpecific.cs:316-351 [v2.10.3.13]).  It
+// shares the Hermes 41.x dB PA-gain row at clsHardwareSpecific.cs:471-486
+// [v2.10.3.13]; productized OrionMKII boards (ANAN-7000DLE / 8000DLE /
+// AnvelinaPro3 / RedPitaya) all have ~50 dB PA gain.  Auto-defaulting
+// to ORIONMKII over-drove those PAs — exactly w3ub's "max regardless of
+// slider" report on a 7000DLE Mk II.
+
+#include <QtTest/QtTest>
+#include "core/HardwareProfile.h"
+#include "core/HpsdrModel.h"
+
+using NereusSDR::HPSDRHW;
+using NereusSDR::HPSDRModel;
+using NereusSDR::defaultModelForBoard;
+
+class TestDefaultModelForBoard : public QObject {
+    Q_OBJECT
+private slots:
+
+    // ── Atlas / Hermes / HermesII / Angelia / Orion / Saturn / SaturnMKII ──
+    // These boardtypes have either a single or unambiguous default; the
+    // auto-pick lands on the lowest-enum-value matching HPSDRModel.
+    void atlas_returns_HPSDR() {
+        QCOMPARE(defaultModelForBoard(HPSDRHW::Atlas), HPSDRModel::HPSDR);
+    }
+    void hermes_returns_HERMES() {
+        QCOMPARE(defaultModelForBoard(HPSDRHW::Hermes), HPSDRModel::HERMES);
+    }
+    void hermesII_returns_ANAN10E() {
+        // ANAN10E (idx 3) precedes ANAN100B (idx 5) in enum order.
+        QCOMPARE(defaultModelForBoard(HPSDRHW::HermesII), HPSDRModel::ANAN10E);
+    }
+    void angelia_returns_ANAN100D() {
+        QCOMPARE(defaultModelForBoard(HPSDRHW::Angelia), HPSDRModel::ANAN100D);
+    }
+    void orion_returns_ANAN200D() {
+        QCOMPARE(defaultModelForBoard(HPSDRHW::Orion), HPSDRModel::ANAN200D);
+    }
+    void hermesLite_returns_HERMESLITE() {
+        QCOMPARE(defaultModelForBoard(HPSDRHW::HermesLite),
+                 HPSDRModel::HERMESLITE);
+    }
+    void saturn_returns_ANAN_G2() {
+        QCOMPARE(defaultModelForBoard(HPSDRHW::Saturn), HPSDRModel::ANAN_G2);
+    }
+    void saturnMKII_returns_ANAN_G2_via_specialcase() {
+        // SaturnMKII has no dedicated HPSDRModel — special-cased to ANAN_G2.
+        QCOMPARE(defaultModelForBoard(HPSDRHW::SaturnMKII),
+                 HPSDRModel::ANAN_G2);
+    }
+
+    // ── #202 root cause: OrionMKII must NOT return ORIONMKII ────────────────
+    //
+    // The bare ORIONMKII enum is intentionally skipped in the auto-pick
+    // walk (HardwareProfile.cpp::defaultModelForBoard).  Iteration falls
+    // through to ANAN7000D (idx 9, lowest matching enum after ORIONMKII
+    // is skipped).  Both ANAN7000D and ANAN8000D map to HPSDRHW::OrionMKII
+    // via boardForModel, but ANAN7000D is enum-first.
+    //
+    // Cite (the exclusion rationale):
+    //   - Thetis comboRadioModel.Items at setup.Designer.cs:8515-8528
+    //     [v2.10.3.13] omits "ORIONMKII".
+    //   - StringModelToEnum at clsHardwareSpecific.cs:316-351 [v2.10.3.13]
+    //     has no string entry for "ORIONMKII".
+    //   - database.cs:10350 [v2.10.3.13] notes: "not implemented in
+    //     comboRadioModel list items".
+    //   - DefaultPAGainsForBands(ORIONMKII) at clsHardwareSpecific.cs:
+    //     471-486 [v2.10.3.13] shares the Hermes 41.x dB row, which is
+    //     ~9 dB low for productized OrionMKII PAs (kAnan7000dRow ~50 dB).
+    void orionMKII_returns_ANAN7000D_not_ORIONMKII() {
+        const auto picked = defaultModelForBoard(HPSDRHW::OrionMKII);
+        QCOMPARE(picked, HPSDRModel::ANAN7000D);
+        // Pin: must NOT be ORIONMKII.  Regression guard for #202.
+        QVERIFY(picked != HPSDRModel::ORIONMKII);
+    }
+};
+
+QTEST_MAIN(TestDefaultModelForBoard)
+#include "tst_default_model_for_board.moc"

--- a/tests/tst_pa_gain_by_band_page_editor.cpp
+++ b/tests/tst_pa_gain_by_band_page_editor.cpp
@@ -68,6 +68,12 @@ void primeModelWithProfiles(RadioModel& model)
     Q_ASSERT(mgr != nullptr);  // RadioModel must construct PaProfileManager
     mgr->setMacAddress(testMac());
     mgr->load(HPSDRModel::ANAN8000D);
+    // #202 deep-fix: PaGainByBandPage's combo filter (userVisibleProfileNames)
+    // reads RadioModel::hardwareProfile().model to decide which factory
+    // default is visible.  Sync the test seam so the page sees ANAN8000D
+    // as the connected model (matching PaProfileManager::load(ANAN8000D)
+    // above).
+    model.setHpsdrModelForTest(HPSDRModel::ANAN8000D);
 }
 
 }  // namespace
@@ -113,9 +119,18 @@ private slots:
 };
 
 // ---------------------------------------------------------------------------
-// 1. Combo populates from PaProfileManager profile names. After load(), the
-//    manager seeds 16 Default-<model> + Bypass = 17 entries; combo shows them
-//    all and selects the active one.
+// 1. Combo populates from PaProfileManager filtered profile names.
+//
+//    Issue #202 deep-fix: combo is filtered via
+//    PaProfileManager::userVisibleProfileNames so the user sees:
+//      - exactly one factory-default entry: `Default - <connectedModel>`
+//      - all user-customised (non-default) profiles
+//    Other `Default - *` entries are hidden — mirrors Thetis's filter at
+//    setup.cs:23341-23344 [v2.10.3.13].  PaProfileManager seeds 16 factory
+//    rows + Bypass, but only 1 (`Default - ANAN8000D` for the test radio)
+//    is visible to the user.  Bypass is also a factory-default and gets
+//    hidden when the connected model isn't FIRST — matches Thetis where
+//    Bypass appears only when explicitly selected (setup.cs:23335-23339).
 // ---------------------------------------------------------------------------
 void TstPaGainByBandPageEditor::combo_populates_from_profile_manager()
 {
@@ -127,21 +142,25 @@ void TstPaGainByBandPageEditor::combo_populates_from_profile_manager()
     auto* combo = page.profileComboForTest();
     QVERIFY2(combo != nullptr, "PaGainByBandPage must own a QComboBox profile selector");
 
-    // Default-ANAN8000D + Bypass at minimum, plus the 15 other Default-<model>
-    // factory rows (17 total).
-    QCOMPARE(combo->count(), 17);
+    // Only `Default - ANAN8000D` is visible (Bypass is HPSDRModel::FIRST,
+    // not the connected model, so it's filtered out unless currently
+    // selected per the Thetis-faithful Bypass-mode special case).
+    QCOMPARE(combo->count(), 1);
     QVERIFY(combo->findText(QStringLiteral("Default - ANAN8000D")) >= 0);
-    QVERIFY(combo->findText(QStringLiteral("Bypass")) >= 0);
 
     // Active profile (set by load(ANAN8000D)) must be the current selection.
     QCOMPARE(combo->currentText(), QStringLiteral("Default - ANAN8000D"));
 }
 
 // ---------------------------------------------------------------------------
-// 2. Selecting a different profile via the combo loads its values into the
-//    14 gain spinboxes. Bypass is the all-100.0 sentinel row (per
-//    PaProfileManager::seedFactoryProfile bypass branch); switching to it
-//    must show 100.0 on every band spinbox.
+// 2. Selecting Bypass via the combo loads the Hermes 41.x dB row.
+//
+//    Issue #202 deep-fix: Bypass profile no longer uses the all-100.0f
+//    sentinel.  Per Thetis setup.cs:23314 [v2.10.3.13] Bypass is constructed
+//    with HPSDRModel.FIRST, which falls through to the FIRST/HERMES/HPSDR/
+//    ORIONMKII shared 41.x dB row at clsHardwareSpecific.cs:471-486
+//    [v2.10.3.13].  Switching to Bypass must show those values on the
+//    HF spinboxes.
 // ---------------------------------------------------------------------------
 void TstPaGainByBandPageEditor::selecting_profile_loads_gain_spinbox_values()
 {
@@ -153,17 +172,27 @@ void TstPaGainByBandPageEditor::selecting_profile_loads_gain_spinbox_values()
     auto* combo = page.profileComboForTest();
     QVERIFY(combo != nullptr);
 
-    combo->setCurrentText(QStringLiteral("Bypass"));
+    // Selecting "Bypass" via setCurrentText only works when it's in the
+    // combo's items.  Push it through the manager: setActiveProfile fires
+    // activeProfileChanged which rebuilds the combo with the Bypass-mode
+    // special case (only Bypass visible — Thetis setup.cs:23335-23339
+    // [v2.10.3.13]).
+    auto* mgr = model.paProfileManager();
+    QVERIFY(mgr != nullptr);
+    mgr->setActiveProfile(QStringLiteral("Bypass"));
 
-    // All 11 HF + 6m + GEN + WWV + XVTR spinboxes show the 100.0 sentinel.
-    for (int n = 0; n <= static_cast<int>(Band::XVTR); ++n) {
-        const Band band = static_cast<Band>(n);
-        auto* spin = page.gainSpinForTest(band);
-        QVERIFY2(spin != nullptr,
-                 qPrintable(QStringLiteral("Missing gain spinbox for band %1")
-                                .arg(bandLabel(band))));
-        QCOMPARE(spin->value(), 100.0);
-    }
+    // Hermes 41.x dB row from clsHardwareSpecific.cs:475-485 [v2.10.3.13]:
+    //   B160M=41.0, B80M=41.2, B60M=41.3, B40M=41.3, B30M=41.0,
+    //   B20M=40.5,  B17M=39.9, B15M=38.8, B12M=38.8, B10M=38.8, B6M=38.8
+    QCOMPARE(page.gainSpinForTest(Band::Band160m)->value(), 41.0);
+    QCOMPARE(page.gainSpinForTest(Band::Band80m)->value(),  41.2);
+    QCOMPARE(page.gainSpinForTest(Band::Band20m)->value(),  40.5);
+    QCOMPARE(page.gainSpinForTest(Band::Band6m)->value(),   38.8);
+    // GEN/WWV/XVTR retain the kPaGainSentinel = 100.0f (no Thetis
+    // equivalent in the gain table; lookupHfBand fall-through).
+    QCOMPARE(page.gainSpinForTest(Band::GEN)->value(),  100.0);
+    QCOMPARE(page.gainSpinForTest(Band::WWV)->value(),  100.0);
+    QCOMPARE(page.gainSpinForTest(Band::XVTR)->value(), 100.0);
 }
 
 // ---------------------------------------------------------------------------
@@ -390,7 +419,10 @@ void TstPaGainByBandPageEditor::delete_button_removes_other_profile()
     auto* mgr = model.paProfileManager();
     QVERIFY(mgr != nullptr);
 
-    // Manager dropped from 17 -> 16 and active fell back per its own logic.
+    // Manager-level manifest is unchanged-by-filter (profileNames returns
+    // the full manifest; the page combo uses userVisibleProfileNames for
+    // filtering — Issue #202 deep-fix).  Manifest dropped 17 -> 16 after
+    // the delete.
     QCOMPARE(mgr->profileNames().size(), 16);
     QVERIFY(!mgr->profileNames().contains(QStringLiteral("Default - ANAN8000D")));
     QVERIFY(!mgr->activeProfileName().isEmpty());

--- a/tests/tst_pa_gain_profile.cpp
+++ b/tests/tst_pa_gain_profile.cpp
@@ -241,21 +241,38 @@ private slots:
         QCOMPARE(defaultPaGainsForBand(HPSDRModel::HERMESLITE,   Band::Band6m),   38.8f);
     }
 
-    // ── Bypass profile is all 100.0f sentinel ─────────────────────────────
-    void bypass_returns_100_for_every_ham_band() {
-        QCOMPARE(bypassPaGainsForBand(Band::Band160m), 100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band80m),  100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band60m),  100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band40m),  100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band30m),  100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band20m),  100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band17m),  100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band15m),  100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band12m),  100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band10m),  100.0f);
-        QCOMPARE(bypassPaGainsForBand(Band::Band6m),   100.0f);
+    // ── Bypass profile uses the Hermes 41.x dB row ────────────────────────
+    //
+    // Issue #202 deep-fix: previously NereusSDR returned the all-100.0f
+    // sentinel for Bypass (paired with a NereusSDR-original `gbb >= 99.5`
+    // linear-identity short-circuit in computeAudioVolume).  That combination
+    // inverted the Thetis semantic ("100 = no output power",
+    // clsHardwareSpecific.cs:463-466 [v2.10.3.13]) into "Bypass = full
+    // output".  Bypass now returns the Hermes 41.x dB row, matching Thetis
+    // setup.cs:23314 [v2.10.3.13]:
+    //   _PAProfiles.Add(_sPA_PROFILE_BYPASS,
+    //       new PAProfile(_sPA_PROFILE_BYPASS, HPSDRModel.FIRST, true));
+    // PAProfile constructor calls ResetGainDefaultsForModel(FIRST) which
+    // calls DefaultPAGainsForBands(FIRST) — that switch arm groups
+    // FIRST/HERMES/HPSDR/ORIONMKII under the 41.x dB row at
+    // clsHardwareSpecific.cs:471-486 [v2.10.3.13].
+    void bypass_returns_hermes_row_for_every_ham_band() {
+        QCOMPARE(bypassPaGainsForBand(Band::Band160m), 41.0f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band80m),  41.2f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band60m),  41.3f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band40m),  41.3f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band30m),  41.0f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band20m),  40.5f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band17m),  39.9f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band15m),  38.8f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band12m),  38.8f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band10m),  38.8f);
+        QCOMPARE(bypassPaGainsForBand(Band::Band6m),   38.8f);
     }
-    void bypass_returns_100_for_nereus_specific_slots() {
+    void bypass_returns_sentinel_for_nereus_specific_slots() {
+        // GEN/WWV/XVTR have no Thetis equivalent in the gain table; they
+        // inherit the kPaGainSentinel = 100.0f from the lookupHfBand
+        // fall-through (PaGainProfile.cpp:262-296).
         QCOMPARE(bypassPaGainsForBand(Band::GEN),  100.0f);
         QCOMPARE(bypassPaGainsForBand(Band::WWV),  100.0f);
         QCOMPARE(bypassPaGainsForBand(Band::XVTR), 100.0f);
@@ -263,9 +280,10 @@ private slots:
 
     // ── NereusSDR-specific Band slots (GEN/WWV/XVTR) ──────────────────────
     // No equivalent exists in the Thetis gain table; return the 100.0f
-    // sentinel. Documented divergence — the HL2 sentinel short-circuit
-    // (gbb >= 99.5) in TransmitModel::computeAudioVolume routes these to
-    // the linear-fallback branch downstream.
+    // sentinel.  With the gbb>=99.5 short-circuit removed (#202), the
+    // canonical Thetis dBm kernel runs and gbb=100 produces audio_volume
+    // ≈ 0 — i.e. "no output power", matching the Thetis comment at
+    // clsHardwareSpecific.cs:466 [v2.10.3.13].
     void anan8000d_gen_returns_sentinel() {
         QCOMPARE(defaultPaGainsForBand(HPSDRModel::ANAN8000D, Band::GEN),  100.0f);
     }

--- a/tests/tst_pa_profile_manager.cpp
+++ b/tests/tst_pa_profile_manager.cpp
@@ -480,8 +480,12 @@ private slots:
         const PaProfile* bypass = mgr.activeProfile();
         QVERIFY(bypass != nullptr);
         QCOMPARE(bypass->name(), QStringLiteral("Bypass"));
-        // Bypass row is all-100.0 sentinel.
-        QCOMPARE(bypass->getGainForBand(Band::Band20m), 100.0f);
+        // Issue #202 deep-fix: Bypass profile uses the Hermes 41.x dB row,
+        // matching Thetis setup.cs:23314 [v2.10.3.13] which constructs
+        // Bypass with HPSDRModel.FIRST → DefaultPAGainsForBands(FIRST) →
+        // FIRST/HERMES/HPSDR/ORIONMKII shared 41.x row at
+        // clsHardwareSpecific.cs:471-486 [v2.10.3.13].  20m gbb = 40.5 dB.
+        QCOMPARE(bypass->getGainForBand(Band::Band20m), 40.5f);
     }
 
     // Sanity: profileByName(unknown) returns nullptr.
@@ -491,6 +495,84 @@ private slots:
         mgr.setMacAddress(kMacA);
         mgr.load(HPSDRModel::ANAN8000D);
         QCOMPARE(mgr.profileByName(QStringLiteral("DoesNotExist")), nullptr);
+    }
+
+    // ── #202 deep-fix: userVisibleProfileNames combo filter ──────────────────
+    //
+    // Mirrors Thetis setup.cs:23341-23344 [v2.10.3.13]:
+    //   if ((p.IsDefault && p.Model == HardwareSpecific.Model) || !p.IsDefault)
+    //       comboPAProfile.Items.Add(p.ProfileName);
+    //
+    // The connected radio sees: exactly one factory `Default - <model>` row
+    // + every user-customised (non-default) profile.  All other
+    // `Default - *` rows are hidden so a user on a 7000DLE can't pick
+    // `Default - HERMES` (Hermes 41 dB row) and over-drive their ~50 dB PA.
+    void userVisibleProfileNames_filters_to_connected_model()
+    {
+        PaProfileManager mgr;
+        mgr.setMacAddress(kMacA);
+        mgr.load(HPSDRModel::ANAN8000D);
+
+        // Default behaviour: connected ANAN8000D + no Bypass-mode → only
+        // `Default - ANAN8000D` is visible.
+        const QStringList visible =
+            mgr.userVisibleProfileNames(HPSDRModel::ANAN8000D);
+        QCOMPARE(visible.size(), 1);
+        QCOMPARE(visible.first(), QStringLiteral("Default - ANAN8000D"));
+    }
+
+    void userVisibleProfileNames_includes_user_profiles()
+    {
+        PaProfileManager mgr;
+        mgr.setMacAddress(kMacA);
+        mgr.load(HPSDRModel::ANAN8000D);
+
+        // User saves a non-default profile.
+        PaProfile myProfile(QStringLiteral("MyTune"),
+                            HPSDRModel::ANAN8000D,
+                            /*isFactoryDefault=*/false);
+        mgr.saveProfile(QStringLiteral("MyTune"), myProfile);
+
+        const QStringList visible =
+            mgr.userVisibleProfileNames(HPSDRModel::ANAN8000D);
+        // Both `Default - ANAN8000D` and `MyTune` visible (sorted).
+        QCOMPARE(visible.size(), 2);
+        QVERIFY(visible.contains(QStringLiteral("Default - ANAN8000D")));
+        QVERIFY(visible.contains(QStringLiteral("MyTune")));
+    }
+
+    void userVisibleProfileNames_hides_other_model_defaults()
+    {
+        PaProfileManager mgr;
+        mgr.setMacAddress(kMacA);
+        mgr.load(HPSDRModel::ANAN8000D);
+
+        const QStringList visible =
+            mgr.userVisibleProfileNames(HPSDRModel::ANAN8000D);
+        // Hermes 41 dB row would over-drive an 8000DLE PA — must be hidden.
+        QVERIFY(!visible.contains(QStringLiteral("Default - HERMES")));
+        // ORIONMKII (also 41 dB) hidden too — defence in depth even though
+        // ORIONMKII is no longer auto-pickable per the
+        // HardwareProfile.cpp::defaultModelForBoard #202 fix.
+        QVERIFY(!visible.contains(QStringLiteral("Default - ORIONMKII")));
+    }
+
+    void userVisibleProfileNames_bypass_mode_shows_only_bypass()
+    {
+        PaProfileManager mgr;
+        mgr.setMacAddress(kMacA);
+        mgr.load(HPSDRModel::ANAN8000D);
+
+        // Mirrors Thetis setup.cs:23335-23339 [v2.10.3.13]:
+        //   if (sSelectProfile == _sPA_PROFILE_BYPASS) {
+        //       if (p.ProfileName == _sPA_PROFILE_BYPASS)
+        //           comboPAProfile.Items.Add(p.ProfileName);
+        //   }
+        const QStringList visible =
+            mgr.userVisibleProfileNames(HPSDRModel::ANAN8000D,
+                                         QStringLiteral("Bypass"));
+        QCOMPARE(visible.size(), 1);
+        QCOMPARE(visible.first(), QStringLiteral("Bypass"));
     }
 };
 

--- a/tests/tst_radio_model_drive_path.cpp
+++ b/tests/tst_radio_model_drive_path.cpp
@@ -375,20 +375,37 @@ private slots:
         model.transmitModel().setPower(100);
         pump();
 
-        // Wire byte: same as §2 (~68; SWR factor does NOT affect it).
+        // Issue #202 deep-fix — SWR topology corrected to match Thetis.
+        //
+        // From Thetis NetworkIO.cs:201-211 [v2.10.3.13]:
+        //   int i = (int)(255 * f * _swr_protect);   // WIRE BYTE sees SWR.
+        // From Thetis cmaster.cs:1115-1119 [v2.10.3.13]:
+        //   double level = Audio.RadioVolume * Audio.HighSWRScale;
+        // where HighSWRScale is set to 1.0 once at console.cs:29194 and
+        // never reassigned in baseline Thetis — IQ side is no-op.  So
+        // the SWR factor multiplies the wire byte, NOT the IQ gain.
+        //
+        // For ANAN-8000D 80m @ 100W with swrProtect=0.5:
+        //   audio_volume ≈ 0.2639 (gbb=50.5; computeAudioVolume).
+        //   wire = int(0.2639 * 1.02 * 0.5 * 255) ≈ 34 (HALVED by SWR).
+        //   iqGain = audio_volume = 0.2639 (no SWR factor).
         QVERIFY(!conn->txDriveLog.isEmpty());
         const int wireByte = conn->txDriveLog.last();
-        QVERIFY2(wireByte >= 67 && wireByte <= 69,
-                 qPrintable(QStringLiteral("SWR foldback bled into wire byte: "
-                            "got %1, expected ~68. Topology violation — "
-                            "audio.cs:268 does NOT see SWR factor.")
+        QVERIFY2(wireByte >= 33 && wireByte <= 35,
+                 qPrintable(QStringLiteral("Wire byte %1 outside expected "
+                            "[~34] for ANAN-8000D 80m@100W with SWR=0.5. "
+                            "Thetis NetworkIO.cs:210 puts _swr_protect on "
+                            "the wire byte (audio.cs:268 -> SetOutputPower "
+                            "with the 1.02-scaled value).")
                             .arg(wireByte)));
 
-        // IQ gain: should be ~0.5 * audio_volume (~0.2639 * 0.5 = 0.1319).
+        // IQ gain: pure audio_volume per Thetis cmaster.cs:1117 with
+        // HighSWRScale=1.0 baseline (~0.2639).
         const double iqGain = txCh.lastFixedGainForTest();
-        QVERIFY2(iqGain > 0.12 && iqGain < 0.145,
+        QVERIFY2(iqGain > 0.25 && iqGain < 0.28,
                  qPrintable(QStringLiteral("IQ gain %1 outside expected "
-                            "[~0.13] for ANAN-8000D 80m@100W * SWR=0.5")
+                            "[~0.264] for ANAN-8000D 80m@100W (pure "
+                            "audio_volume; no SWR factor on IQ side).")
                             .arg(iqGain)));
 
         // Detach before scope-exit destroys the TxChannel.

--- a/tests/tst_transmit_model_compute_audio_volume.cpp
+++ b/tests/tst_transmit_model_compute_audio_volume.cpp
@@ -191,40 +191,53 @@ private slots:
     }
 
     // =========================================================================
-    // §3  HL2 sentinel — linear fallback (gbb >= 99.5)
+    // §3  gbb=100 sentinel — Thetis "no output power" path
     // =========================================================================
     //
-    // mi0bot clsHardwareSpecific.cs:484 [v2.10.3.13-beta2] sets HL2 HF gain
-    // rows to 100.0f ("100 is no output power" sentinel).  NereusSDR-original
-    // deviation: gbb >= 99.5 short-circuits to linear fallback
-    // clamp(sliderWatts/100, 0, 1) so HL2 users don't regress on HF transmit
-    // until they calibrate.
-    void hl2_80m_at_100w_linear_fallback_returns_one() {
+    // Issue #202 deep-fix: removed a NereusSDR-original `gbb >= 99.5`
+    // linear-identity short-circuit.  Thetis (clsHardwareSpecific.cs:463-
+    // 466 [v2.10.3.13]) initialises the gain array to 100.0f with the
+    // explicit comment: "100 is no output power".  With the short-circuit
+    // gone, gbb=100 now runs through the dBm kernel and produces
+    // audio_volume ≈ 0 (target_dbm = log10(W*1000)*10 - 100 → very
+    // negative; volts → tiny; audio → ≈ 0).
+    //
+    // These tests use HPSDRModel::FIRST (the default arg) so the HL2
+    // branch is bypassed; the HL2 mi0bot formula has its own coverage
+    // in tst_transmit_model_hl2_audio_volume.
+    void gbb_100_at_100w_thetis_no_output_path() {
         TransmitModel t;
-        const PaProfile p(QStringLiteral("Default - HERMESLITE"),
-                          HPSDRModel::HERMESLITE, true);
-        // gbb @ 80m = 100.0f sentinel → short-circuit hits linear fallback.
-        // 100/100 = 1.0.
+        // Force gbb=100 on every band.
+        PaProfile p(QStringLiteral("AllSentinel"), HPSDRModel::FIRST, true);
+        for (int i = 0; i < PaProfile::kBandCount; ++i) {
+            p.setGainForBand(static_cast<Band>(i), 100.0f);
+        }
         const double v = t.computeAudioVolume(p, Band::Band80m, 100);
-        QCOMPARE(v, 1.0);
+        // target_dbm = 50 - 100 = -50; volts ≈ 7.07e-4; audio ≈ 8.84e-4.
+        // Per Thetis "100 = no output power" — essentially silent.
+        QVERIFY(v < 1.0e-3);
     }
 
-    void hl2_80m_at_50w_linear_fallback_returns_0_5() {
+    void gbb_100_at_50w_thetis_no_output_path() {
         TransmitModel t;
-        const PaProfile p(QStringLiteral("Default - HERMESLITE"),
-                          HPSDRModel::HERMESLITE, true);
-        // 50/100 = 0.5.
+        PaProfile p(QStringLiteral("AllSentinel"), HPSDRModel::FIRST, true);
+        for (int i = 0; i < PaProfile::kBandCount; ++i) {
+            p.setGainForBand(static_cast<Band>(i), 100.0f);
+        }
         const double v = t.computeAudioVolume(p, Band::Band80m, 50);
-        QCOMPARE(v, 0.5);
+        // target_dbm = 47 - 100 = -53; audio ≈ 6.25e-4.
+        QVERIFY(v < 1.0e-3);
     }
 
-    void hl2_80m_at_200w_linear_fallback_clamped_to_one() {
+    void gbb_100_at_200w_thetis_no_output_path() {
         TransmitModel t;
-        const PaProfile p(QStringLiteral("Default - HERMESLITE"),
-                          HPSDRModel::HERMESLITE, true);
-        // 200/100 = 2.0 → clamp to 1.0.
+        PaProfile p(QStringLiteral("AllSentinel"), HPSDRModel::FIRST, true);
+        for (int i = 0; i < PaProfile::kBandCount; ++i) {
+            p.setGainForBand(static_cast<Band>(i), 100.0f);
+        }
         const double v = t.computeAudioVolume(p, Band::Band80m, 200);
-        QCOMPARE(v, 1.0);
+        // target_dbm = 53 - 100 = -47; audio ≈ 1.25e-3.
+        QVERIFY(v < 2.0e-3);
     }
 
     // =========================================================================
@@ -254,25 +267,32 @@ private slots:
     }
 
     // =========================================================================
-    // §5  NereusSDR Bypass profile (all-100.0f) — same linear fallback
+    // §5  NereusSDR Bypass profile — Thetis-faithful Hermes 41.x dB row
     // =========================================================================
     //
-    // The Bypass factory profile has every band at 100.0f — Thetis-
-    // sentinel "no output power".  Same gbb >= 99.5 short-circuit path
-    // as HL2 HF.
-    void bypass_profile_any_band_50w_linear_fallback_returns_0_5() {
+    // Issue #202 deep-fix: bypassPaGainsForBand now returns the Hermes 41.x
+    // dB row (matching Thetis setup.cs:23314 [v2.10.3.13] which constructs
+    // Bypass with HPSDRModel.FIRST → DefaultPAGainsForBands(FIRST) →
+    // FIRST/HERMES/HPSDR/ORIONMKII shared 41.x dB row at
+    // clsHardwareSpecific.cs:471-486 [v2.10.3.13]).
+    //
+    // The previous all-100.0f sentinel + linear-identity short-circuit
+    // produced wire byte 255 at slider 100 on Bypass — exactly the
+    // "max-regardless-of-slider" trapdoor reported in #202.  With Bypass
+    // on the Hermes row, slider 50 on 20m (gbb=40.5) yields a sensible
+    // ~0.55 audio_volume.
+    void bypass_profile_uses_hermes_row() {
         TransmitModel t;
-        // Bypass profile: name doesn't matter, but model FIRST inherits
-        // HERMES values from kHermesRow which would NOT be all-100.
-        // We override via setGainForBand to mirror what
-        // PaProfileManager does for the Bypass slot.
+        // PaProfile constructor with FIRST loads kHermesRow via
+        // resetGainDefaultsForModel(FIRST) — same row Thetis uses for Bypass.
         PaProfile p(QStringLiteral("Bypass"), HPSDRModel::FIRST, true);
-        for (int i = 0; i < PaProfile::kBandCount; ++i) {
-            p.setGainForBand(static_cast<Band>(i), 100.0f);
-        }
-        QCOMPARE(t.computeAudioVolume(p, Band::Band20m, 50), 0.5);
-        QCOMPARE(t.computeAudioVolume(p, Band::Band15m, 75), 0.75);
-        QCOMPARE(t.computeAudioVolume(p, Band::Band6m, 100), 1.0);
+        // 20m gbb = 40.5 dB.  At 50 W slider:
+        //   target_dbm = 47 - 40.5 = 6.5; volts = sqrt(10^0.65 * 0.05) ≈ 0.473
+        //   audio = 0.473 / 0.8 ≈ 0.591.
+        const double v20m_50w = t.computeAudioVolume(p, Band::Band20m, 50);
+        QVERIFY(v20m_50w > 0.55 && v20m_50w < 0.65);
+        // Specifically: NOT 1.0 (the bug).  Pin upper bound.
+        QVERIFY(v20m_50w < 0.99);
     }
 
     // =========================================================================
@@ -359,27 +379,27 @@ private slots:
     }
 
     // =========================================================================
-    // §7  Out-of-range Band hits sentinel
+    // §7  Out-of-range Band hits 1000.0f sentinel — Thetis silent path
     // =========================================================================
     //
     // PaProfile::getGainForBand returns 1000.0f sentinel for Band values
     // outside the 14-band PA window (Band::Band120m and later, plus any
-    // raw int cast outside [0, 14)).  Math kernel sees gbb >= 99.5 and
-    // takes the linear fallback path.
-    void out_of_range_band_hits_sentinel_via_linear_fallback() {
+    // raw int cast outside [0, 14)).  Mirrors Thetis setup.cs:23866
+    // [v2.10.3.13] which returns 1000 for Band ≤ FIRST or ≥ LAST.
+    //
+    // Issue #202 deep-fix: with the gbb>=99.5 short-circuit removed, the
+    // dBm kernel runs.  target_dbm = 50 - 1000 = -950; volts ≈ 0;
+    // audio_volume → 0.  Fail-loud-silent: a programming error (raw int
+    // cast outside Band range) produces no output rather than full-rail.
+    void out_of_range_band_hits_sentinel_silent() {
         TransmitModel t;
         const PaProfile p(QStringLiteral("Default - ANAN8000D"),
                           HPSDRModel::ANAN8000D, true);
-        // Cast raw int to a Band value outside the enum range.  This
-        // would be a programming error, but the kernel must fail-safe
-        // (not produce audio_volume = 1.0 silently — pre-fix behavior).
         const auto badBand = static_cast<Band>(99);
-        // Linear fallback: 50/100 = 0.5.
-        QCOMPARE(t.computeAudioVolume(p, badBand, 50), 0.5);
-        // 100/100 = 1.0.
-        QCOMPARE(t.computeAudioVolume(p, badBand, 100), 1.0);
-        // 200/100 clamped to 1.0.
-        QCOMPARE(t.computeAudioVolume(p, badBand, 200), 1.0);
+        // dBm kernel with gbb=1000 produces audio_volume effectively 0.
+        QVERIFY(t.computeAudioVolume(p, badBand, 50) < 1.0e-30);
+        QVERIFY(t.computeAudioVolume(p, badBand, 100) < 1.0e-30);
+        QVERIFY(t.computeAudioVolume(p, badBand, 200) < 1.0e-30);
     }
 
     // =========================================================================

--- a/tests/tst_transmit_model_hl2_audio_volume.cpp
+++ b/tests/tst_transmit_model_hl2_audio_volume.cpp
@@ -99,18 +99,22 @@ private slots:
     }
 
     // §5 Non-HL2 model — must NOT use the HL2 formula.  ANAN-100 (or any
-    // non-HERMESLITE model) should run through the legacy gbb >= 99.5
-    // sentinel fallback / dBm-target math.  Concretely: assert the result
-    // differs from what the HL2 formula would have returned.
+    // non-HERMESLITE model) runs through the canonical Thetis dBm-target
+    // kernel (console.cs:46720-46758 [v2.10.3.13]).  Concretely: assert
+    // the result differs from what the HL2 formula would have returned.
     //
-    // Build a profile whose 40m gbb=100 (sentinel) so the legacy path
-    // hits the linear fallback (50/100 = 0.5), which differs from the HL2
-    // formula value of (50 * 100/100)/93.75 = 0.5333.
+    // Issue #202 deep-fix: a previous NereusSDR-original short-circuit
+    //   if (gbb >= 99.5f) return clamp(sliderWatts/100.0, 0, 1);
+    // was removed because it inverted the Thetis semantic "100 = no output
+    // power" (clsHardwareSpecific.cs:463-466 [v2.10.3.13]) into "100 =
+    // full output (linear identity)".  With the short-circuit gone, gbb=100
+    // now produces audio_volume ≈ 0.000625 at slider 50 (target_dbm = 47 -
+    // 100 = -53 dBm; volts ≈ 0.0005; audio = 0.000625) — matching Thetis,
+    // which interprets a residual 100 as "no output power".
     void nonHl2_unchanged_path() {
         TransmitModel m;
-        // ANAN100 default profile: kAnan100Row 40m has a real gain entry,
-        // not a sentinel.  Use a Bypass-style construction (FIRST inherits
-        // HERMES values which are NOT all-100; we override via setGain).
+        // Bypass-style construction with explicit gbb=100 on 40m to force
+        // the "no PA gain row" semantic.
         PaProfile p(QStringLiteral("Bypass"), HPSDRModel::FIRST, true);
         p.setGainForBand(Band::Band40m, 100.0f);
         const double vHl2Formula = (50.0 * 100.0 / 100.0) / 93.75;
@@ -118,9 +122,12 @@ private slots:
                                                   Band::Band40m,
                                                   50,
                                                   HPSDRModel::ANAN100);
+        // Different from the HL2 formula value.
         QVERIFY(std::abs(vReal - vHl2Formula) > 1e-6);
-        // And the legacy linear fallback returns 50/100 = 0.5 exactly.
-        QCOMPARE(vReal, 0.5);
+        // gbb=100 with 50 W slider → target_dbm = 10*log10(50000) - 100 ≈ -53.
+        // target_volts = sqrt(10^-5.3 * 0.05) ≈ 0.0005.  audio = 0.000625.
+        // Per Thetis "100 = no output power" semantic — essentially silent.
+        QVERIFY(vReal < 1.0e-3);
     }
 };
 

--- a/tests/tst_transmit_model_set_power_using_dbm.cpp
+++ b/tests/tst_transmit_model_set_power_using_dbm.cpp
@@ -550,8 +550,13 @@ private slots:
             /*bSetPower=*/true, /*bFromTune=*/false, /*bTwoTone=*/false);
 
         QCOMPARE(result.newPower, 50);
-        // XVTR factory gbb=100 (sentinel), so 50/100 = 0.5 linear fallback.
-        QCOMPARE(result.audioVolume, 0.5);
+        // Issue #202 deep-fix: XVTR factory gbb=100 (sentinel) now runs
+        // through the dBm kernel after the gbb>=99.5 short-circuit was
+        // removed (it inverted Thetis's "100 = no output power" semantic
+        // — clsHardwareSpecific.cs:463-466 [v2.10.3.13]).  audio_volume
+        // ≈ 6.25e-4 at slider 50 — i.e. essentially silent, matching
+        // Thetis's "no PA gain row → no output" behavior.
+        QVERIFY(result.audioVolume < 1.0e-3);
         QVERIFY(std::isfinite(result.audioVolume));
     }
 


### PR DESCRIPTION
## Summary

Closes #202.  PR #178 (the K2GX safety hotfix) introduced per-band PA-gain compensation but landed with multiple Thetis-faithfulness gaps in the TX wire-byte / IQ-scalar path.  At least three independent code paths could produce "PA at full output regardless of slider":

1. **Auto-detect picked the wrong model.** OrionMKII boardtype auto-defaulted to `HPSDRModel::ORIONMKII` (Hermes 41 dB row) instead of the productized `ANAN7000D` (~50 dB row).  ~9 dB of undercorrection saturated the radio's PA at most slider positions — w3ub's reported symptom.
2. **Bypass profile was inverted.** NereusSDR seeded Bypass with all-100.0f sentinels.  Combined with a NereusSDR-original `gbb >= 99.5 → linear identity` short-circuit in `computeAudioVolume`, Bypass at slider 100 emitted wire byte 255.  Thetis's `clsHardwareSpecific.cs:463-466` [v2.10.3.13] explicitly comments _"100 is no output power"_ — exactly the opposite semantic.
3. **PA profile combo exposed all 16 factory rows.** A user on a 7000DLE could pick `Default - HERMES` (Hermes 41 dB row) and over-drive their ~50 dB PA.  Thetis filters by `HardwareSpecific.Model` at `setup.cs:23341-23344` [v2.10.3.13].

Plus four adjacent Thetis-faithfulness fixes in the same code paths:

4. **SWR-foldback topology was inverted.**  Comments declared "wire byte never sees SWR foldback, only IQ scalar does. DO NOT 'fix' this by adding swrProtect to the wire byte" — but Thetis `NetworkIO.cs:201-211` [v2.10.3.13] applies `_swr_protect` to the wire byte; the IQ-side `Audio.HighSWRScale` is set to 1.0 once at `console.cs:29194` [v2.10.3.13] and never reassigned, making the IQ path effectively no-op.
5. **`audioVolumeChanged` had no listeners.** Two-tone-Fixed mode and any future audio_volume mutator emitted but no slot pumped wire+IQ.  New `RadioModel::pumpAudioVolume` mirrors Thetis's `Audio.RadioVolume` setter side-effects (`audio.cs:262-271` [v2.10.3.13]); the 3 call sites refactor through it.
6. **`swrProtectFactorChanged` had no listeners.** Mirrors Thetis `console.cs:26102-26109` [v2.10.3.13] re-emit on `_swr_protect` change.
7. **`m_tune` flag was orphan state.** `setTune(true)` was never called; a power-slider event during active TUNE would route through the wrong txMode.  Mirrors Thetis `chkTUN.Checked`.
8. **`TXPostGenRun=0` case for `new_pwr==0` during TUNE.** Mirrors `console.cs:46749-46752` [v2.10.3.13].

All fixes are source-first per Thetis `v2.10.3.13` (commit `501e3f51`).  No invention.

## Commits

- `4dd72d9` — `defaultModelForBoard` skips ORIONMKII; AddCustomRadioDialog drops it; new `tst_default_model_for_board`.
- `535913a` — Bypass profile uses Hermes 41.x dB row; remove `gbb >= 99.5` linear-identity short-circuit; tests updated.
- `428c8be` — SWR factor moves to wire byte; `audioVolumeChanged` + `swrProtectFactorChanged` listeners; `m_tune` wiring; `TXPostGenRun=0` case.
- `6fb3ef0` — `userVisibleProfileNames` filter mirrors Thetis combo at `setup.cs:23341-23344`.

## Test plan

- [x] All 356 ctest tests pass (was 354, +2 new test executables).
- [x] New `tst_default_model_for_board` pins OrionMKII → ANAN7000D (NOT ORIONMKII) plus all other boardtype defaults.
- [x] `tst_pa_profile_manager` gains 4 cases for the combo filter (connected-model defaults visible, user profiles included, other-model defaults hidden, Bypass-mode special case).
- [x] `tst_radio_model_drive_path` updated: SWR factor halves the wire byte (Thetis topology), IQ scalar is pure audio_volume.
- [x] `tst_transmit_model_compute_audio_volume` updated: gbb=100 cases assert the kernel runs (audio_volume ≈ 0) instead of the removed linear-fallback identity.
- [x] `tst_pa_gain_profile`: bypass row asserts Hermes 41.x values byte-for-byte against `clsHardwareSpecific.cs:475-485` [v2.10.3.13].
- [ ] **Bench verification on a 7000DLE Mk II** — the original repro from #202.  Expected: slider 100 → ~200 W; slider 50 → ~50 W; slider 25 → ~12 W; proper scaling across the full range.
- [ ] Bench verification on an 8000DLE confirms the K2GX-class fix from PR #178 still holds (no regression — the math kernel is unchanged for non-sentinel gbb).
- [ ] HL2 user verification confirms HF transmit still uses the mi0bot formula (the HL2 branch at `TransmitModel.cpp:772-776` runs BEFORE the removed short-circuit; behaviour unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)