### PR TITLE
fix(hardware): wire Radio Info live-apply (codex P2)

### DIFF
--- a/src/gui/setup/hardware/RadioInfoTab.cpp
+++ b/src/gui/setup/hardware/RadioInfoTab.cpp
@@ -338,6 +338,17 @@ void RadioInfoTab::onSampleRateChanged(int index)
         // Mirror into RX2 stub visually.
         QSignalBlocker blocker(m_sampleRateRx2Combo);
         m_sampleRateRx2Combo->setCurrentIndex(index);
+        // Apply live via the RadioModel coordinator (Task 1.6) when a
+        // radio is connected.  Returns >= 0 ms on success — the banner
+        // then hides itself once wireSampleRateChanged fires from the
+        // updated connection — or -1 when no active connection / WDSP
+        // not ready (banner stays up; setting still persists for next
+        // connect via settingChanged above).  Without this call the
+        // live-apply infrastructure added in PR #219 (Task 1.6) was
+        // unreachable from the UI; codex post-merge review flagged as P2.
+        if (m_model) {
+            m_model->setSampleRateLive(rate);
+        }
         updateReconnectBanner();
     }
 }
@@ -346,6 +357,12 @@ void RadioInfoTab::onActiveRxCountChanged(int count)
 {
     if (count < 1) { return; }
     emit settingChanged(QStringLiteral("radioInfo/activeRxCount"), count);
+    // Apply live via the RadioModel coordinator (Task 1.7).  Same
+    // negative-return-means-disconnected contract as setSampleRateLive
+    // above; setting persists either way for next connect.
+    if (m_model) {
+        m_model->setActiveRxCountLive(count);
+    }
 }
 
 void RadioInfoTab::onWireSampleRateChanged(double hz)


### PR DESCRIPTION
## Summary

Wires `Setup → Hardware → Radio Info` sample-rate and active-RX-count combos to the live-apply coordinators (`RadioModel::setSampleRateLive` / `setActiveRxCountLive`) added in PR #219. Previously the combos only emitted `settingChanged` — which `HardwarePage` persisted — but never reached the live-apply coordinators, so changing the rate left the connection running on the OLD rate until the user manually reconnected. The reconnect banner kept advising "reconnect to apply" even though the infrastructure could have done it for them.

The coordinators are no-ops when disconnected (return -1), so the banner gracefully falls back to its previous behaviour in those cases via the existing `wireSampleRateChanged` auto-update. When connected, the rate switch / RX-count toggle now happens live and the banner hides itself.

Codex post-merge review on PR #219 flagged this as P2.

## Test plan

- [ ] Connect ANAN-G2; change sample rate combo (48k → 96k → 192k) — banner clears, audio stays connected, no reconnect prompt
- [ ] Toggle RX2 active-count up/down — happens without disconnect
- [ ] Disconnected: change combos — setting persists, banner stays up advising reconnect, behaviour unchanged from before
- [ ] Repeated identical-rate selection: idempotent (no spurious connection churn)

J.J. Boyd ~ KG4VCF