### PR TITLE
feat(phone,tx): wire VAX button as quick TX-source toggle

### DIFF
--- a/docs/architecture/2026-05-10-vax-tx-source-toggle-design.md
+++ b/docs/architecture/2026-05-10-vax-tx-source-toggle-design.md
@@ -1,0 +1,134 @@
+# VAX TX-Source Toggle Button (PhoneCwApplet)
+
+**Status:** Approved 2026-05-10. Pending implementation plan + bench.
+**Scope:** Wire the existing-but-NYI VAX button on PhoneCwApplet so that left-click toggles `MicSource::Vax` as the TX audio source, and right-click jumps to Setup → Audio → TX Input. Lets the operator swap quickly between mic input and VAX without paging through Setup.
+**Out of scope:** Wiring the Phone-tab `m_micSourceCombo` (Control #4, still NYI), any new Setup pages, any change to the underlying VAX TX shared-memory route or `CompositeTxMicRouter` dispatch logic.
+**Source-first:** Not applicable. VAX is NereusSDR-native (see memory `feedback_vax_not_vac_port`); no Thetis equivalent to port.
+
+## Problem
+
+The VAX button on PhoneCwApplet (Phone/CW tab, Control #9) was added in Phase 3-VAX skeletal work and immediately marked NYI via `NyiOverlay::markNyi(m_vaxBtn, kNyiVax)` at [PhoneCwApplet.cpp:541](../../src/gui/applets/PhoneCwApplet.cpp:541). The TX pipeline already routes correctly when `MicSource::Vax` is selected (see [RadioModel.cpp:2952](../../src/models/RadioModel.cpp:2952), [AudioEngine.h:411](../../src/core/AudioEngine.h:411)), and the value already auto-persists per-MAC under `hardware/<mac>/tx/Mic_Source` ([TransmitModel.cpp:1411-1430](../../src/models/TransmitModel.cpp:1411)). The remaining gap is purely the click handler plus a way to remember which non-VAX source the user came from so the toggle-off is non-destructive.
+
+## Goals
+
+1. Left-click on the VAX button toggles `TransmitModel::micSource()` between `Vax` and the user's previously-selected non-VAX source (`Pc` or `Radio`).
+2. Right-click opens Setup → Audio → TX Input.
+3. The "previous non-VAX source" survives an app restart.
+4. The button checked-state mirrors model state, so external changes (profile load, future combo wiring, MMIO) keep it in sync.
+
+## Non-goals
+
+- Adding any new Setup page.
+- Changing the existing `Mic_Source` persistence key, schema version, or migration.
+- Wiring `m_micSourceCombo` (Phone Control #4), which stays NYI.
+- HL2 lock changes. The existing `setMicSourceLocked(true)` Radio→Pc clamp covers the HL2 case automatically.
+
+## Design
+
+### 1. `TransmitModel`: previous-source tracking + persistence
+
+Add a tracked, persisted "last non-VAX source" alongside the existing `m_micSource`:
+
+```cpp
+// New member
+MicSource m_previousNonVaxMicSource{MicSource::Pc};
+
+// New getter
+MicSource previousNonVaxMicSource() const noexcept;
+
+// New slot
+public slots:
+void toggleVaxSource(bool on);
+```
+
+Behavior:
+
+- Inside `setMicSource(source)` ([TransmitModel.cpp:2329](../../src/models/TransmitModel.cpp:2329)): after the existing lock clamp + idempotent guard, when the resulting source is non-Vax and differs from the previously tracked value, update `m_previousNonVaxMicSource` and persist it. This single hook covers every entry point (combo, profile load, pre-connect path, future MMIO) automatically.
+- `toggleVaxSource(bool on)`: when `on`, calls `setMicSource(MicSource::Vax)`. When `!on`, calls `setMicSource(previousNonVaxMicSource())`. The lock guard already coerces Radio→Pc on HL2, so this works on every SKU without special-casing.
+
+Persistence keys mirror the existing `Mic_Source` two-key pattern:
+
+| Scope | Key |
+| --- | --- |
+| Per-MAC | `hardware/<mac>/tx/Mic_Source_PreVax` |
+| Pre-connect global | `tx/preconnect/Mic_Source_PreVax` |
+
+Default on first load: `Pc`. No schema migration required (absent key falls back to default).
+
+Load is added to the same block as `Mic_Source` near [TransmitModel.cpp:1411-1430](../../src/models/TransmitModel.cpp:1411). Save mirrors the existing `setValue(pfx + "Mic_Source", ...)` and `tx/preconnect/Mic_Source` writes around [TransmitModel.cpp:1717-1723](../../src/models/TransmitModel.cpp:1717) and [:2355-2363](../../src/models/TransmitModel.cpp:2355).
+
+### 2. `PhoneCwApplet`: wire the VAX button
+
+In `buildUI()` at [PhoneCwApplet.cpp:541](../../src/gui/applets/PhoneCwApplet.cpp:541): remove the `NyiOverlay::markNyi(m_vaxBtn, kNyiVax)` call.
+
+In `wireControls()`, add bindings consistent with the file's existing `m_updatingFromModel` pattern (DEXP, PROC, MON):
+
+- `connect(m_vaxBtn, &QPushButton::toggled, &tx, &TransmitModel::toggleVaxSource)`, gated by `m_updatingFromModel`.
+- `connect(&tx, &TransmitModel::micSourceChanged, this, [this](MicSource src) { ... })` to sync `m_vaxBtn->setChecked(src == MicSource::Vax)` under a `QSignalBlocker`.
+- `m_vaxBtn->setContextMenuPolicy(Qt::CustomContextMenu)` plus `connect(m_vaxBtn, &QWidget::customContextMenuRequested, this, [this] { emit openSetupRequested("Audio", "TX Input"); })`. The existing `openSetupRequested` signal is reused unchanged.
+
+Tooltip update:
+
+> VAX digital audio input.
+> Left-click: toggle VAX as the TX audio source.
+> Right-click: open Setup → Audio → TX Input.
+
+`syncFromModel()` adds `m_vaxBtn->setChecked(tx.micSource() == MicSource::Vax)` under the existing guard so initial state is correct after profile load or reconnect.
+
+### 3. `TxApplet`: extend mic-source badge to a 3-way
+
+The badge at [TxApplet.cpp:1300-1310](../../src/gui/applets/TxApplet.cpp:1300) and the matching block in `syncFromModel()` near [:1551](../../src/gui/applets/TxApplet.cpp:1551) currently switches binary on `Radio` vs not. Extend to a 3-way:
+
+| `MicSource` | Badge text |
+| --- | --- |
+| `Pc` | `PC mic` |
+| `Radio` | `Radio mic` |
+| `Vax` | `VAX` |
+
+No styling change. Tooltip stays the same.
+
+### 4. `MainWindow`: no change
+
+The existing `PhoneCwApplet::openSetupRequested` lambda at [MainWindow.cpp:4234-4243](../../src/gui/MainWindow.cpp:4234) already does `dialog->selectPage(page)` against the leaf-page label. `selectPage("TX Input")` resolves to the `AudioTxInputPage` registered at [SetupDialog.cpp:323](../../src/gui/SetupDialog.cpp:323).
+
+## Edge cases
+
+| Case | Behavior |
+| --- | --- |
+| HL2 connect (locked to Pc) | Lock blocks Radio at the model level. `previousNonVaxMicSource` updates to `Pc` whenever the lock coerces Radio→Pc. Toggle-off after Vax lands on `Pc`. |
+| Profile load while Vax active | `MicProfileManager::applyProfile` calls `setMicSource(...)` ([MicProfileManager.cpp:1337](../../src/core/MicProfileManager.cpp:1337)). The `micSourceChanged` signal updates the button checked-state; if the loaded source is non-Vax, `previousNonVaxMicSource` advances. |
+| Pre-connect VAX click | Pre-connect path persists to `tx/preconnect/Mic_Source` today; the new key follows the same path so the previous source survives the first connect. |
+| Disconnect → reconnect different MAC | New per-MAC keys load. `Mic_Source_PreVax` defaults to `Pc` if unset. |
+| External change to Vax via combo (future) | The single `setMicSource` hook picks it up. The button checked-state mirrors the model. No combo-specific code needed. |
+
+## Tests
+
+Unit tests on `TransmitModel` (new file `tests/models/test_TransmitModel_VaxToggle.cpp`):
+
+1. From `Pc`: `toggleVaxSource(true)` → `Vax`; `toggleVaxSource(false)` → `Pc`.
+2. From `Radio`: `setMicSource(Radio); toggleVaxSource(true)` → `Vax`, `previousNonVaxMicSource() == Radio`; `toggleVaxSource(false)` → `Radio`.
+3. HL2 lock: `setMicSourceLocked(true); setMicSource(Radio)` clamps to `Pc`; `toggleVaxSource(true); toggleVaxSource(false)` lands on `Pc`.
+4. Persistence round-trip: `Mic_Source_PreVax = "Radio"`, reload, `previousNonVaxMicSource() == Radio`.
+5. Combo-style external write: `setMicSource(Radio); setMicSource(Vax); setMicSource(Pc)` advances `previousNonVaxMicSource` to `Pc` (each non-Vax write feeds the tracker).
+
+Widget test on `PhoneCwApplet` (extends existing PhoneCwApplet test fixture):
+
+6. Click VAX → `tx.micSource() == Vax` and button checked.
+7. Click VAX again → `tx.micSource()` returns to the previous source and button unchecked.
+8. Right-click → `openSetupRequested("Audio", "TX Input")` emitted exactly once.
+
+## Risks
+
+- **Profile XML round-trip:** `MicProfileManager` already writes `Mic_Source` into profile XML. Profiles do **not** need to carry `Mic_Source_PreVax`; it is per-installation user state, not per-profile state. Verify the profile loader does not stomp the new key.
+- **Test fixtures that construct `TransmitModel` without an `AppSettings`:** the new persistence path must use the same `s.contains(...)` guard the existing `Mic_Source` block uses, so headless tests stay clean.
+
+## Verification
+
+- `cmake --build build` clean.
+- `ctest` green incl. the 5 new TransmitModel cases and 3 new PhoneCwApplet cases.
+- Manual on Linux + ANAN-G2:
+  1. Connect, click VAX on PhoneCwApplet → TxApplet badge reads `VAX`, mic input audible via `pavucontrol` on the VAX TX virtual sink.
+  2. Click VAX off → badge returns to `PC mic` (or `Radio mic` if Radio was active first).
+  3. Right-click VAX → Setup opens at Audio → TX Input.
+  4. App restart with VAX on → button still reflects model state, click off restores prior source.
+- Manual on HL2: VAX toggle works, off lands on `Pc` regardless of prior state.

--- a/docs/architecture/2026-05-10-vax-tx-source-toggle-plan.md
+++ b/docs/architecture/2026-05-10-vax-tx-source-toggle-plan.md
@@ -1,0 +1,923 @@
+# VAX TX-Source Toggle Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing-but-NYI VAX button on PhoneCwApplet so left-click toggles `MicSource::Vax` as the TX audio source and right-click jumps to Setup → Audio → TX Input. Toggle-off restores the user's previous non-VAX source.
+
+**Architecture:** `TransmitModel` gains a tracked, per-MAC-persisted "previous non-VAX source" plus a `toggleVaxSource(bool)` slot. The PhoneCwApplet button binds to that slot bidirectionally with `m_updatingFromModel` echo guards (matching the existing PROC/DEXP pattern). The TxApplet mic-source badge extends from a 2-way to a 3-way switch.
+
+**Tech Stack:** C++20, Qt6 (QPushButton, QSignalBlocker, customContextMenuRequested), AppSettings (NereusSDR XML persistence, NOT QSettings), QtTest.
+
+**Spec:** [docs/architecture/2026-05-10-vax-tx-source-toggle-design.md](2026-05-10-vax-tx-source-toggle-design.md)
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+| --- | --- | --- |
+| Modify | `src/models/TransmitModel.h` | Declare `previousNonVaxMicSource()` getter, `toggleVaxSource(bool)` slot, `m_previousNonVaxMicSource` member |
+| Modify | `src/models/TransmitModel.cpp` | Implement slot, capture-on-set hook in `setMicSource`, load + save `Mic_Source_PreVax` per-MAC + preconnect keys |
+| Modify | `src/gui/applets/PhoneCwApplet.cpp` | Remove `NyiOverlay::markNyi(m_vaxBtn, kNyiVax)`; wire toggle + right-click; tooltip; `syncFromModel` initial state |
+| Modify | `src/gui/applets/TxApplet.cpp` | Extend mic-source badge to 3-way (Pc/Radio/VAX) at the `micSourceChanged` lambda + `syncFromModel` block |
+| Create | `tests/tst_transmit_model_vax_toggle.cpp` | Unit-test toggle behavior, previous-tracking, HL2 lock interaction, persistence round-trip |
+| Create | `tests/tst_phone_applet_vax_toggle.cpp` | Widget test: click VAX, click again, right-click signal |
+| Modify | `tests/CMakeLists.txt` | Register both new tests via `nereus_add_test(...)` |
+
+No new headers, no new files in `src/`. The `openSetupRequested(category, page)` signal already exists on PhoneCwApplet and is already routed by MainWindow's existing lambda at [MainWindow.cpp:4234](../../src/gui/MainWindow.cpp:4234), so no MainWindow change is needed.
+
+---
+
+## Task 1: TransmitModel state, tracking, persistence, and toggle slot
+
+**Files:**
+- Modify: `src/models/TransmitModel.h` (add slot, getter, member; near the existing `setMicSource` declaration around line 1783)
+- Modify: `src/models/TransmitModel.cpp` (extend `setMicSource` near 2329, extend load near 1408, extend save near 1714)
+- Create: `tests/tst_transmit_model_vax_toggle.cpp`
+- Modify: `tests/CMakeLists.txt` (register test, near the existing `tst_transmit_model_mic_source_preconnect` block at line 2949)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tst_transmit_model_vax_toggle.cpp` with the full content below. Patterned on `tests/tst_transmit_model_mic_source_preconnect.cpp` (same `clearState` shape, unique MAC per case).
+
+```cpp
+// =================================================================
+// tests/tst_transmit_model_vax_toggle.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original test file. No Thetis port at this layer.
+//
+// Verifies the PhoneCwApplet VAX-button toggle plumbing on
+// TransmitModel: previous non-VAX source tracking, toggleVaxSource
+// slot, HL2 lock interaction, and Mic_Source_PreVax persistence
+// (per-MAC + preconnect fallback).
+//
+// Coverage:
+//   defaults_previousIsPc                - cold construct -> Pc default
+//   setMicSource_radioTracksPrevious     - explicit Radio captured as previous
+//   setMicSource_vaxDoesNotTrackPrevious - Vax write does NOT clobber previous
+//   toggleOn_setsVax                     - toggleVaxSource(true) -> Vax
+//   toggleOff_restoresPrevious           - toggleVaxSource(false) -> previous
+//   toggleOff_hl2LockedRestoresPc        - lock active, previous=Radio coerced
+//   persistence_perMacRoundTrip          - PreVax key round-trips per-MAC
+//   persistence_preconnectFallback       - missing per-MAC falls back to preconnect
+// =================================================================
+//
+// Modification history (NereusSDR):
+//   2026-05-10 - Original test for NereusSDR by J.J. Boyd (KG4VCF),
+//                 with AI-assisted implementation via Anthropic Claude
+//                 Code.
+// =================================================================
+
+// no-port-check: NereusSDR-original test file.
+
+#include <QtTest/QtTest>
+
+#include "models/TransmitModel.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstTransmitModelVaxToggle : public QObject {
+    Q_OBJECT
+
+private:
+    static QString preconnectMicKey()
+    {
+        return QStringLiteral("tx/preconnect/Mic_Source");
+    }
+    static QString preconnectPreVaxKey()
+    {
+        return QStringLiteral("tx/preconnect/Mic_Source_PreVax");
+    }
+    static QString perMacMicKey(const QString& mac)
+    {
+        return QStringLiteral("hardware/%1/tx/Mic_Source").arg(mac);
+    }
+    static QString perMacPreVaxKey(const QString& mac)
+    {
+        return QStringLiteral("hardware/%1/tx/Mic_Source_PreVax").arg(mac);
+    }
+
+    void clearState(const QString& mac)
+    {
+        auto& s = AppSettings::instance();
+        s.remove(preconnectMicKey());
+        s.remove(preconnectPreVaxKey());
+        s.remove(perMacMicKey(mac));
+        s.remove(perMacPreVaxKey(mac));
+    }
+
+private slots:
+
+    void defaults_previousIsPc()
+    {
+        TransmitModel m;
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Pc);
+    }
+
+    void setMicSource_radioTracksPrevious()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-01");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        m.setMicSource(MicSource::Radio);
+
+        QCOMPARE(m.micSource(), MicSource::Radio);
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+    }
+
+    void setMicSource_vaxDoesNotTrackPrevious()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-02");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        m.setMicSource(MicSource::Radio);
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+
+        m.setMicSource(MicSource::Vax);
+        // Previous stays Radio. Toggling off should land back on Radio.
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+    }
+
+    void toggleOn_setsVax()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-03");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        m.toggleVaxSource(true);
+        QCOMPARE(m.micSource(), MicSource::Vax);
+    }
+
+    void toggleOff_restoresPrevious()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-04");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        m.setMicSource(MicSource::Radio);
+        m.toggleVaxSource(true);
+        QCOMPARE(m.micSource(), MicSource::Vax);
+
+        m.toggleVaxSource(false);
+        QCOMPARE(m.micSource(), MicSource::Radio);
+    }
+
+    void toggleOff_hl2LockedRestoresPc()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-05");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        // Pretend Radio was the previous source on a non-HL2 radio.
+        m.setMicSource(MicSource::Radio);
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+
+        // Switch to HL2: lock engages, current Radio coerces to Pc.
+        m.setMicSourceLocked(true);
+        QCOMPARE(m.micSource(), MicSource::Pc);
+        // The lock-coerce write also updated previous to Pc.
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Pc);
+
+        m.toggleVaxSource(true);
+        QCOMPARE(m.micSource(), MicSource::Vax);
+        m.toggleVaxSource(false);
+        QCOMPARE(m.micSource(), MicSource::Pc);
+    }
+
+    void persistence_perMacRoundTrip()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-06");
+        clearState(mac);
+
+        {
+            TransmitModel m;
+            m.loadFromSettings(mac);
+            m.setMicSource(MicSource::Radio);  // captures Radio as previous + persists
+            QCOMPARE(AppSettings::instance().value(perMacPreVaxKey(mac)).toString(),
+                     QStringLiteral("Radio"));
+        }
+
+        {
+            TransmitModel m;
+            m.loadFromSettings(mac);
+            QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+        }
+    }
+
+    void persistence_preconnectFallback()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-07");
+        clearState(mac);
+
+        // User picks Radio in Setup before connecting (no MAC bound).
+        TransmitModel pre;
+        pre.setMicSource(MicSource::Radio);
+        QCOMPARE(AppSettings::instance().value(preconnectPreVaxKey()).toString(),
+                 QStringLiteral("Radio"));
+
+        // First connect to this radio: per-MAC PreVax absent, fall back to preconnect.
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstTransmitModelVaxToggle)
+#include "tst_transmit_model_vax_toggle.moc"
+```
+
+Add the registration in `tests/CMakeLists.txt` immediately after the `tst_transmit_model_mic_source_preconnect` block at line 2949:
+
+```cmake
+# ── Phase 3M-VAX-toggle: TransmitModel previousNonVaxMicSource + toggleVaxSource ──
+# Verifies the model-layer plumbing for the PhoneCwApplet VAX button:
+# previous-source tracking on every non-VAX setMicSource write, toggleVaxSource
+# slot (Vax on -> sets Vax; off -> restores previous), HL2 lock interaction
+# (Radio previous coerces to Pc), and Mic_Source_PreVax persistence (per-MAC
+# + preconnect fallback, mirroring the existing Mic_Source two-key pattern).
+nereus_add_test(tst_transmit_model_vax_toggle)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cmake --build build --target tst_transmit_model_vax_toggle
+```
+
+Expected: FAIL with "no member named 'previousNonVaxMicSource' in 'NereusSDR::TransmitModel'" or "no member named 'toggleVaxSource'". Compile error is acceptable.
+
+- [ ] **Step 3: Add header declarations**
+
+In `src/models/TransmitModel.h`, locate the `setMicSource` declaration (around line 1783). Add immediately after it:
+
+```cpp
+    /// Returns the most recent non-VAX source the user has selected.
+    /// Tracked automatically by setMicSource() whenever a non-VAX source
+    /// is written. Default Pc on first run.
+    MicSource previousNonVaxMicSource() const noexcept { return m_previousNonVaxMicSource; }
+```
+
+In the `public slots:` block (locate the existing setter slots, e.g. `setMicSource`), add:
+
+```cpp
+    /// Quick toggle wired to the PhoneCwApplet VAX button. on=true sets
+    /// MicSource::Vax. on=false restores previousNonVaxMicSource() (which
+    /// the lock guard in setMicSource will coerce to Pc on HL2).
+    void toggleVaxSource(bool on);
+```
+
+In the private member section (locate `MicSource m_micSource{MicSource::Pc};` near line 2253), add immediately below it:
+
+```cpp
+    MicSource m_previousNonVaxMicSource{MicSource::Pc};
+```
+
+- [ ] **Step 4: Implement the slot, the tracking hook, and persistence in TransmitModel.cpp**
+
+Edit `src/models/TransmitModel.cpp::setMicSource` (line 2329-2366) to capture non-Vax writes BEFORE the existing persistence block. Replace the function body with:
+
+```cpp
+void TransmitModel::setMicSource(MicSource source)
+{
+    if (source == MicSource::Radio && m_micSourceLocked) {
+        source = MicSource::Pc;
+    }
+
+    if (source == m_micSource) { return; }
+    m_micSource = source;
+
+    // Capture every non-Vax write as the "previous" source so toggling
+    // VAX off restores the user's most recent explicit choice. Updates
+    // both the per-MAC and preconnect persistence keys to mirror the
+    // Mic_Source two-key pattern.
+    if (source != MicSource::Vax && source != m_previousNonVaxMicSource) {
+        m_previousNonVaxMicSource = source;
+        QString preVaxStr = (source == MicSource::Radio)
+                                ? QStringLiteral("Radio")
+                                : QStringLiteral("Pc");
+        if (m_persistMac.isEmpty()) {
+            AppSettings::instance().setValue(
+                QStringLiteral("tx/preconnect/Mic_Source_PreVax"), preVaxStr);
+        } else {
+            persistOne(QStringLiteral("Mic_Source_PreVax"), preVaxStr);
+        }
+    }
+
+    QString persistStr;
+    switch (source) {
+        case MicSource::Radio: persistStr = QStringLiteral("Radio"); break;
+        case MicSource::Vax:   persistStr = QStringLiteral("Vax");   break;
+        case MicSource::Pc:
+        default:               persistStr = QStringLiteral("Pc");    break;
+    }
+    if (m_persistMac.isEmpty()) {
+        AppSettings::instance().setValue(
+            QStringLiteral("tx/preconnect/Mic_Source"), persistStr);
+    } else {
+        persistOne(QStringLiteral("Mic_Source"), persistStr);
+    }
+    emit micSourceChanged(source);
+}
+```
+
+Add the slot implementation immediately below `setMicSource`:
+
+```cpp
+void TransmitModel::toggleVaxSource(bool on)
+{
+    if (on) {
+        setMicSource(MicSource::Vax);
+    } else {
+        setMicSource(m_previousNonVaxMicSource);
+    }
+}
+```
+
+In the load block at `loadFromSettings` (line 1408-1438), add the PreVax read immediately after the existing Mic_Source block (around line 1438). Use the same per-MAC-then-preconnect-fallback shape:
+
+```cpp
+    // ── Mic source previous (PhoneCwApplet VAX-toggle restore target) ─────
+    // Lookup order matches Mic_Source: per-MAC -> preconnect -> default Pc.
+    const QString perMacPreVaxStr = s.value(pfx + QLatin1String("Mic_Source_PreVax"),
+                                             QString()).toString();
+    QString preVaxStr;
+    if (perMacPreVaxStr.isEmpty()) {
+        preVaxStr = AppSettings::instance().value(
+            QStringLiteral("tx/preconnect/Mic_Source_PreVax"),
+            QStringLiteral("Pc")).toString();
+    } else {
+        preVaxStr = perMacPreVaxStr;
+    }
+    m_previousNonVaxMicSource = (preVaxStr == QLatin1String("Radio"))
+                                    ? MicSource::Radio
+                                    : MicSource::Pc;
+```
+
+In the save block at `saveToSettings` (the `Mic_Source` write at line 1714-1724), add directly below it:
+
+```cpp
+    // Mic_Source_PreVax mirrors Mic_Source persistence; tracked by setMicSource.
+    {
+        QString preVaxStr = (m_previousNonVaxMicSource == MicSource::Radio)
+                                ? QStringLiteral("Radio")
+                                : QStringLiteral("Pc");
+        s.setValue(pfx + QLatin1String("Mic_Source_PreVax"), preVaxStr);
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cmake --build build --target tst_transmit_model_vax_toggle && ctest --test-dir build -R "^tst_transmit_model_vax_toggle$" --output-on-failure
+```
+
+Expected: PASS, all 8 cases.
+
+- [ ] **Step 6: Commit (GPG-signed)**
+
+```bash
+git add src/models/TransmitModel.h src/models/TransmitModel.cpp tests/tst_transmit_model_vax_toggle.cpp tests/CMakeLists.txt
+git commit -m "$(cat <<'EOF'
+feat(tx): TransmitModel previousNonVaxMicSource + toggleVaxSource slot
+
+Adds the model-layer plumbing for the PhoneCwApplet VAX button. Every
+non-Vax write to setMicSource captures the source as previous, persisted
+per-MAC (Mic_Source_PreVax) with a preconnect fallback that mirrors the
+existing Mic_Source two-key pattern. toggleVaxSource(bool) is the slot
+the button binds to.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: PhoneCwApplet wires the VAX button
+
+**Files:**
+- Modify: `src/gui/applets/PhoneCwApplet.cpp` (remove NYI mark at line 541; add wiring + right-click; tooltip; syncFromModel update)
+- Create: `tests/tst_phone_applet_vax_toggle.cpp`
+- Modify: `tests/CMakeLists.txt` (register test)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tst_phone_applet_vax_toggle.cpp`:
+
+```cpp
+// =================================================================
+// tests/tst_phone_applet_vax_toggle.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original test file. No Thetis port at this layer.
+//
+// Verifies the PhoneCwApplet VAX button:
+//   click_setsVax              - left-click toggles MicSource to Vax
+//   secondClick_restoresPrevious - second click reverts to previous source
+//   modelChange_syncsButton    - external micSource change updates checked state
+//   rightClick_emitsSetupReq   - right-click emits openSetupRequested("Audio", "TX Input")
+//   nyiMark_absent             - the NyiOverlay mark removed
+// =================================================================
+//
+// Modification history (NereusSDR):
+//   2026-05-10 - Original test for NereusSDR by J.J. Boyd (KG4VCF),
+//                 with AI-assisted implementation via Anthropic Claude
+//                 Code.
+// =================================================================
+
+// no-port-check: NereusSDR-original test file.
+
+#include <QtTest/QtTest>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QApplication>
+
+#include "gui/applets/PhoneCwApplet.h"
+#include "models/RadioModel.h"
+#include "models/TransmitModel.h"
+
+using namespace NereusSDR;
+
+namespace {
+QPushButton* findVaxButton(PhoneCwApplet* applet)
+{
+    // Locate by accessibleName set in PhoneCwApplet::buildUI (line 401).
+    const auto buttons = applet->findChildren<QPushButton*>();
+    for (auto* b : buttons) {
+        if (b->accessibleName() == QStringLiteral("VAX digital audio")) {
+            return b;
+        }
+    }
+    return nullptr;
+}
+}
+
+class TstPhoneAppletVaxToggle : public QObject {
+    Q_OBJECT
+
+private slots:
+
+    void click_setsVax()
+    {
+        RadioModel model;
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+
+        QVERIFY(!btn->isChecked());
+        btn->click();
+        QCOMPARE(model.transmitModel().micSource(), MicSource::Vax);
+        QVERIFY(btn->isChecked());
+    }
+
+    void secondClick_restoresPrevious()
+    {
+        RadioModel model;
+        model.transmitModel().setMicSource(MicSource::Radio);
+
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+
+        btn->click();  // -> Vax
+        QCOMPARE(model.transmitModel().micSource(), MicSource::Vax);
+
+        btn->click();  // -> Radio (previous)
+        QCOMPARE(model.transmitModel().micSource(), MicSource::Radio);
+        QVERIFY(!btn->isChecked());
+    }
+
+    void modelChange_syncsButton()
+    {
+        RadioModel model;
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+
+        QVERIFY(!btn->isChecked());
+        model.transmitModel().setMicSource(MicSource::Vax);
+        QVERIFY(btn->isChecked());
+        model.transmitModel().setMicSource(MicSource::Pc);
+        QVERIFY(!btn->isChecked());
+    }
+
+    void rightClick_emitsSetupReq()
+    {
+        RadioModel model;
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+
+        QSignalSpy spy(&applet, &PhoneCwApplet::openSetupRequested);
+
+        // Trigger the customContextMenuRequested handler directly.
+        emit btn->customContextMenuRequested(QPoint(0, 0));
+
+        QCOMPARE(spy.count(), 1);
+        const auto args = spy.takeFirst();
+        QCOMPARE(args.at(0).toString(), QStringLiteral("Audio"));
+        QCOMPARE(args.at(1).toString(), QStringLiteral("TX Input"));
+    }
+
+    void nyiMark_absent()
+    {
+        RadioModel model;
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+        // NyiOverlay sets the property "nyiOverlay" on marked widgets;
+        // the absence of the overlay is sufficient verification.
+        QVERIFY(btn->property("nyiOverlay").isNull()
+                || !btn->property("nyiOverlay").toBool());
+    }
+};
+
+QTEST_MAIN(TstPhoneAppletVaxToggle)
+#include "tst_phone_applet_vax_toggle.moc"
+```
+
+Register in `tests/CMakeLists.txt` near the existing `nereus_add_test(tst_phone_applet_proc)` at line 1831:
+
+```cmake
+# ── Phase 3M-VAX-toggle: PhoneCwApplet VAX button wiring ────────────────────
+# Verifies the [VAX] button on the Phone tab now drives MicSource via
+# TransmitModel::toggleVaxSource: left-click toggles Vax, second click
+# restores the previous non-VAX source, external model changes sync the
+# checked state, and right-click emits openSetupRequested("Audio", "TX Input")
+# so MainWindow opens Setup -> Audio -> TX Input.
+nereus_add_test(tst_phone_applet_vax_toggle)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cmake --build build --target tst_phone_applet_vax_toggle && ctest --test-dir build -R "^tst_phone_applet_vax_toggle$" --output-on-failure
+```
+
+Expected: FAIL on `click_setsVax` (button is NYI-marked and has no signal binding) and `nyiMark_absent` (NYI property still set).
+
+- [ ] **Step 3: Remove the NYI mark in PhoneCwApplet.cpp**
+
+In `src/gui/applets/PhoneCwApplet.cpp` at line 541, delete this single line:
+
+```cpp
+    NyiOverlay::markNyi(m_vaxBtn,           kNyiVax);     // #8 — Phase 3-VAX
+```
+
+Replace with a one-line comment so the surrounding NYI-marker block stays readable:
+
+```cpp
+    // #8 m_vaxBtn: wired (Phase 3M-VAX-toggle)
+```
+
+- [ ] **Step 4: Add the button wiring in `wireControls()`**
+
+Locate the PROC button wiring around line 893-912 in `src/gui/applets/PhoneCwApplet.cpp`. Immediately AFTER that block (before the DEXP block), add:
+
+```cpp
+    // ── #8 VAX button ↔ TransmitModel::toggleVaxSource ─────────────────────
+    // Left-click toggles MicSource between Vax and the user's previous
+    // non-VAX source (tracked by TransmitModel::previousNonVaxMicSource,
+    // persisted per-MAC). Right-click opens Setup -> Audio -> TX Input.
+    if (m_vaxBtn) {
+        m_vaxBtn->setToolTip(QStringLiteral(
+            "VAX digital audio input.\n"
+            "Left-click: toggle VAX as the TX audio source.\n"
+            "Right-click: open Setup → Audio → TX Input."));
+        {
+            QSignalBlocker b(m_vaxBtn);
+            m_vaxBtn->setChecked(tx.micSource() == MicSource::Vax);
+        }
+        // UI → Model
+        connect(m_vaxBtn, &QPushButton::toggled, this, [this, &tx](bool on) {
+            if (m_updatingFromModel) { return; }
+            tx.toggleVaxSource(on);
+        });
+        // Model → UI (mirrors button to model so external changes - profile
+        // load, future combo wiring, MMIO - keep the checked state honest).
+        connect(&tx, &TransmitModel::micSourceChanged, this, [this](MicSource src) {
+            m_updatingFromModel = true;
+            {
+                QSignalBlocker b(m_vaxBtn);
+                m_vaxBtn->setChecked(src == MicSource::Vax);
+            }
+            m_updatingFromModel = false;
+        });
+        // Right-click → Setup → Audio → TX Input.
+        m_vaxBtn->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(m_vaxBtn, &QPushButton::customContextMenuRequested, this,
+                [this](const QPoint&) {
+            emit openSetupRequested(QStringLiteral("Audio"),
+                                    QStringLiteral("TX Input"));
+        });
+    }
+```
+
+- [ ] **Step 5: Update `syncFromModel()`**
+
+Locate `PhoneCwApplet::syncFromModel()` (search for the function). Inside it, add the VAX button initial-state line in the same style as the existing `m_procBtn->setChecked(tx.cpdrOn())` mirror:
+
+```cpp
+    if (m_vaxBtn) {
+        QSignalBlocker b(m_vaxBtn);
+        m_vaxBtn->setChecked(tx.micSource() == MicSource::Vax);
+    }
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+cmake --build build --target tst_phone_applet_vax_toggle && ctest --test-dir build -R "^tst_phone_applet_vax_toggle$" --output-on-failure
+```
+
+Expected: PASS, all 5 cases.
+
+- [ ] **Step 7: Commit (GPG-signed)**
+
+```bash
+git add src/gui/applets/PhoneCwApplet.cpp tests/tst_phone_applet_vax_toggle.cpp tests/CMakeLists.txt
+git commit -m "$(cat <<'EOF'
+feat(phone): wire VAX button to TransmitModel.toggleVaxSource
+
+Removes the Phase 3-VAX NyiOverlay mark and binds the [VAX] button:
+left-click toggles MicSource between Vax and the previous non-VAX
+source, right-click emits openSetupRequested("Audio", "TX Input")
+which MainWindow's existing lambda routes to Setup -> Audio -> TX Input.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: TxApplet mic-source badge gains the VAX case
+
+**Files:**
+- Modify: `src/gui/applets/TxApplet.cpp` (extend the `micSourceChanged` lambda at 1303-1309 and the `syncFromModel` block at 1549-1555)
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the existing `tst_phone_applet_vax_toggle.cpp` with a new badge-only check, OR create a thin sibling test. Use the sibling pattern to keep concerns separate. Append to `tests/tst_phone_applet_vax_toggle.cpp` an additional `private slots:` case is wrong because the badge lives on TxApplet, not PhoneCwApplet. Instead, create `tests/tst_tx_applet_mic_source_badge.cpp`:
+
+```cpp
+// =================================================================
+// tests/tst_tx_applet_mic_source_badge.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original test file. No Thetis port at this layer.
+//
+// Verifies the TxApplet mic-source badge text for all three MicSource
+// values: Pc -> "PC mic", Radio -> "Radio mic", Vax -> "VAX". Covers
+// both the live micSourceChanged path and the syncFromModel path.
+// =================================================================
+//
+// Modification history (NereusSDR):
+//   2026-05-10 - Original test for NereusSDR by J.J. Boyd (KG4VCF),
+//                 with AI-assisted implementation via Anthropic Claude
+//                 Code.
+// =================================================================
+
+// no-port-check: NereusSDR-original test file.
+
+#include <QtTest/QtTest>
+#include <QLabel>
+
+#include "gui/applets/TxApplet.h"
+#include "models/RadioModel.h"
+#include "models/TransmitModel.h"
+
+using namespace NereusSDR;
+
+namespace {
+QLabel* findBadge(TxApplet* applet)
+{
+    const auto labels = applet->findChildren<QLabel*>();
+    for (auto* l : labels) {
+        if (l->accessibleName() == QStringLiteral("Mic source indicator")) {
+            return l;
+        }
+    }
+    return nullptr;
+}
+}
+
+class TstTxAppletMicSourceBadge : public QObject {
+    Q_OBJECT
+
+private slots:
+
+    void liveChange_Pc()
+    {
+        RadioModel model;
+        TxApplet applet(&model);
+        auto* badge = findBadge(&applet);
+        QVERIFY(badge != nullptr);
+
+        model.transmitModel().setMicSource(MicSource::Radio);
+        QCOMPARE(badge->text(), QStringLiteral("Radio mic"));
+        model.transmitModel().setMicSource(MicSource::Pc);
+        QCOMPARE(badge->text(), QStringLiteral("PC mic"));
+    }
+
+    void liveChange_Vax()
+    {
+        RadioModel model;
+        TxApplet applet(&model);
+        auto* badge = findBadge(&applet);
+        QVERIFY(badge != nullptr);
+
+        model.transmitModel().setMicSource(MicSource::Vax);
+        QCOMPARE(badge->text(), QStringLiteral("VAX"));
+    }
+
+    void syncFromModel_Vax()
+    {
+        RadioModel model;
+        model.transmitModel().setMicSource(MicSource::Vax);
+
+        TxApplet applet(&model);
+        auto* badge = findBadge(&applet);
+        QVERIFY(badge != nullptr);
+        applet.syncFromModel();
+        QCOMPARE(badge->text(), QStringLiteral("VAX"));
+    }
+};
+
+QTEST_MAIN(TstTxAppletMicSourceBadge)
+#include "tst_tx_applet_mic_source_badge.moc"
+```
+
+Register in `tests/CMakeLists.txt` near the other TxApplet tests (search for `nereus_add_test(tst_tx_applet_lev_eq_cfc)` and add immediately after):
+
+```cmake
+# ── Phase 3M-VAX-toggle: TxApplet mic-source badge 3-way ────────────────────
+# The badge above the gauges previously read "PC mic" or "Radio mic".
+# Phase 3M-VAX-toggle extends it to a 3-way switch so MicSource::Vax
+# renders "VAX" both on micSourceChanged and on syncFromModel.
+nereus_add_test(tst_tx_applet_mic_source_badge)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cmake --build build --target tst_tx_applet_mic_source_badge && ctest --test-dir build -R "^tst_tx_applet_mic_source_badge$" --output-on-failure
+```
+
+Expected: `liveChange_Vax` and `syncFromModel_Vax` FAIL. The current 2-way switch returns "PC mic" for Vax (the default branch).
+
+- [ ] **Step 3: Extend the live-change lambda**
+
+In `src/gui/applets/TxApplet.cpp` at lines 1303-1309, replace:
+
+```cpp
+    connect(&tx, &TransmitModel::micSourceChanged,
+            this, [this](MicSource source) {
+        m_micSourceBadge->setText(
+            source == MicSource::Radio
+                ? QStringLiteral("Radio mic")
+                : QStringLiteral("PC mic"));
+    });
+```
+
+with:
+
+```cpp
+    connect(&tx, &TransmitModel::micSourceChanged,
+            this, [this](MicSource source) {
+        QString text;
+        switch (source) {
+            case MicSource::Radio: text = QStringLiteral("Radio mic"); break;
+            case MicSource::Vax:   text = QStringLiteral("VAX");       break;
+            case MicSource::Pc:
+            default:               text = QStringLiteral("PC mic");    break;
+        }
+        m_micSourceBadge->setText(text);
+    });
+```
+
+- [ ] **Step 4: Extend `syncFromModel` block**
+
+In `src/gui/applets/TxApplet.cpp` at lines 1549-1555, replace:
+
+```cpp
+    if (m_micSourceBadge) {
+        m_micSourceBadge->setText(
+            tx.micSource() == MicSource::Radio
+                ? QStringLiteral("Radio mic")
+                : QStringLiteral("PC mic"));
+    }
+```
+
+with:
+
+```cpp
+    if (m_micSourceBadge) {
+        QString text;
+        switch (tx.micSource()) {
+            case MicSource::Radio: text = QStringLiteral("Radio mic"); break;
+            case MicSource::Vax:   text = QStringLiteral("VAX");       break;
+            case MicSource::Pc:
+            default:               text = QStringLiteral("PC mic");    break;
+        }
+        m_micSourceBadge->setText(text);
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cmake --build build --target tst_tx_applet_mic_source_badge && ctest --test-dir build -R "^tst_tx_applet_mic_source_badge$" --output-on-failure
+```
+
+Expected: PASS, all 3 cases.
+
+- [ ] **Step 6: Commit (GPG-signed)**
+
+```bash
+git add src/gui/applets/TxApplet.cpp tests/tst_tx_applet_mic_source_badge.cpp tests/CMakeLists.txt
+git commit -m "$(cat <<'EOF'
+feat(tx): mic-source badge renders VAX as third state
+
+Extends the TxApplet mic-source badge from a 2-way (Radio/Pc) to a
+3-way switch. MicSource::Vax now reads "VAX" both on the live
+micSourceChanged path and via syncFromModel.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Final verification + manual bench
+
+- [ ] **Step 1: Run the full test suite to catch regressions**
+
+```bash
+cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Expected: PASS. No new failures elsewhere. Any pre-existing flakes are unrelated to this change.
+
+- [ ] **Step 2: Build and launch the app**
+
+```bash
+cmake --build build && pkill -f NereusSDR 2>/dev/null; sleep 1; ./build/NereusSDR &
+```
+
+Expected: app launches cleanly.
+
+- [ ] **Step 3: Manual bench checklist (Linux + ANAN-G2 if available)**
+
+Walk through the spec §Verification matrix:
+
+1. Connect to a radio. PhoneCwApplet [VAX] button is no longer overlaid with the NYI badge.
+2. Click [VAX]. TxApplet mic-source badge changes to `VAX`. Mic input audio should reach the VAX TX virtual sink (verify via `pavucontrol` on Linux, Audio MIDI Setup on macOS, Loopback on Windows).
+3. Click [VAX] again. Badge returns to `PC mic` (or `Radio mic` if Radio was the prior state).
+4. Right-click [VAX]. Setup dialog opens at Audio → TX Input.
+5. Quit and relaunch the app. The button reflects the persisted `Mic_Source`. Click [VAX] off (if it loaded on) and verify it lands on the persisted `Mic_Source_PreVax` value.
+6. On HL2 (or with `setMicSourceLocked(true)` simulated): VAX still toggles on; toggle-off lands on `Pc` regardless of any prior Radio state.
+
+Take screenshots of states 2, 3, and 4 for the PR description.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin claude/hungry-rubin-bec84a
+gh pr create --title "feat(phone,tx): wire VAX button as quick TX-source toggle" --body "$(cat <<'EOF'
+## Summary
+- PhoneCwApplet [VAX] button left-click toggles `MicSource::Vax`; second click restores the previous non-VAX source (Pc or Radio).
+- Right-click [VAX] opens Setup → Audio → TX Input.
+- TxApplet mic-source badge gains a `VAX` state.
+- New per-MAC + preconnect persistence key `Mic_Source_PreVax` survives app restart.
+
+## Test plan
+- [ ] `ctest --test-dir build --output-on-failure` green (incl. 3 new test executables: `tst_transmit_model_vax_toggle`, `tst_phone_applet_vax_toggle`, `tst_tx_applet_mic_source_badge`).
+- [ ] Manual bench on Linux + ANAN-G2: clicks 1→4 from the design spec §Verification matrix.
+- [ ] App restart with VAX on: button reflects model, toggle-off restores prior source.
+- [ ] HL2 (or simulated lock): toggle-off lands on Pc regardless.
+
+Spec: `docs/architecture/2026-05-10-vax-tx-source-toggle-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review (post-write)
+
+- **Spec coverage:** Goals 1-4 from the spec are covered by Tasks 1-3 (toggle, right-click, persistence, button-state mirror). Tests for every case in spec §Tests rows 1-8 are split between `tst_transmit_model_vax_toggle` (8 cases) and `tst_phone_applet_vax_toggle` (5 cases). Spec §Edge Cases entries map to test cases: HL2 lock → `toggleOff_hl2LockedRestoresPc`; profile load → `modelChange_syncsButton`; pre-connect → `persistence_preconnectFallback`; multi-MAC → unique MACs per test. The "External change to Vax via combo (future)" case is covered by `modelChange_syncsButton`.
+- **Placeholder scan:** No TBDs, no "implement later", no "similar to Task N", no "appropriate error handling". All code blocks contain real code; all bash commands are concrete.
+- **Type consistency:** `previousNonVaxMicSource()` getter, `toggleVaxSource(bool)` slot, `m_previousNonVaxMicSource` member, `Mic_Source_PreVax` AppSettings key (per-MAC + preconnect) used identically across header, .cpp, and tests. The badge accessibleName lookup `"Mic source indicator"` matches the existing `setAccessibleName` call at [TxApplet.cpp:239](../../src/gui/applets/TxApplet.cpp:239). The button accessibleName `"VAX digital audio"` matches the existing `setAccessibleName` at [PhoneCwApplet.cpp:401](../../src/gui/applets/PhoneCwApplet.cpp:401).

--- a/src/gui/applets/PhoneCwApplet.cpp
+++ b/src/gui/applets/PhoneCwApplet.cpp
@@ -538,7 +538,7 @@ void PhoneCwApplet::buildPhonePage(QWidget* page)
     NyiOverlay::markNyi(m_micProfileCombo,  kNyiPhone);   // #3
     NyiOverlay::markNyi(m_micSourceCombo,   kNyiPhone);   // #4
     NyiOverlay::markNyi(m_accBtn,           kNyiPhone);   // #6
-    NyiOverlay::markNyi(m_vaxBtn,           kNyiVax);     // #8 — Phase 3-VAX
+    // #8 m_vaxBtn: wired (Phase 3M-VAX-toggle)
     NyiOverlay::markNyi(m_monBtn,           kNyiPhone);   // #9
     NyiOverlay::markNyi(m_monSlider,        kNyiPhone);   // #9 slider
     NyiOverlay::markNyi(m_amCarSlider,      kNyiProc);    // #13 — Phase 3I-3
@@ -941,6 +941,43 @@ void PhoneCwApplet::wireControls()
         });
     }
 
+    // ── #8 VAX button bidirectional with TransmitModel::toggleVaxSource ────
+    // Left-click toggles MicSource between Vax and the user's previous
+    // non-VAX source (tracked by TransmitModel::previousNonVaxMicSource,
+    // persisted per-MAC). Right-click opens Setup -> Audio -> TX Input.
+    if (m_vaxBtn) {
+        m_vaxBtn->setToolTip(QStringLiteral(
+            "VAX digital audio input.\n"
+            "Left-click: toggle VAX as the TX audio source.\n"
+            "Right-click: open Setup > Audio > TX Input."));
+        {
+            QSignalBlocker b(m_vaxBtn);
+            m_vaxBtn->setChecked(tx.micSource() == MicSource::Vax);
+        }
+        // UI -> Model
+        connect(m_vaxBtn, &QPushButton::toggled, this, [this, &tx](bool on) {
+            if (m_updatingFromModel) { return; }
+            tx.toggleVaxSource(on);
+        });
+        // Model -> UI (mirrors button to model so external changes - profile
+        // load, future combo wiring, MMIO - keep the checked state honest).
+        connect(&tx, &TransmitModel::micSourceChanged, this, [this](MicSource src) {
+            m_updatingFromModel = true;
+            {
+                QSignalBlocker b(m_vaxBtn);
+                m_vaxBtn->setChecked(src == MicSource::Vax);
+            }
+            m_updatingFromModel = false;
+        });
+        // Right-click goes to Setup > Audio > TX Input.
+        m_vaxBtn->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(m_vaxBtn, &QPushButton::customContextMenuRequested, this,
+                [this](const QPoint&) {
+            emit openSetupRequested(QStringLiteral("Audio"),
+                                    QStringLiteral("TX Input"));
+        });
+    }
+
     // ─────────────────────────────────────────────────────────────────────────
     // Phase 3M-3a-iii Task 15: DEXP (#11) row wiring.
     //
@@ -1140,6 +1177,14 @@ void PhoneCwApplet::syncFromModel()
         QSignalBlocker b(m_dexpBtn);
         m_dexpBtn->setChecked(tx.dexpEnabled());
         m_updatingFromModel = false;
+    }
+
+    // VAX button (Phase 3M-VAX-toggle) — bidirectional sync to
+    // TransmitModel::micSource.
+    if (m_vaxBtn) {
+        TransmitModel& tx = m_model->transmitModel();
+        QSignalBlocker b(m_vaxBtn);
+        m_vaxBtn->setChecked(tx.micSource() == MicSource::Vax);
     }
 
     // Other controls wired in Phase 3I-1 (Phone/FM) / Phase 3I-2 (CW)

--- a/src/gui/applets/PhoneCwApplet.cpp
+++ b/src/gui/applets/PhoneCwApplet.cpp
@@ -1179,7 +1179,7 @@ void PhoneCwApplet::syncFromModel()
         m_updatingFromModel = false;
     }
 
-    // VAX button (Phase 3M-VAX-toggle) — bidirectional sync to
+    // VAX button (Phase 3M-VAX-toggle): bidirectional sync to
     // TransmitModel::micSource.
     if (m_vaxBtn) {
         TransmitModel& tx = m_model->transmitModel();

--- a/src/gui/applets/TxApplet.cpp
+++ b/src/gui/applets/TxApplet.cpp
@@ -1299,13 +1299,17 @@ void TxApplet::wireControls()
 
     // ── Mic-source badge ← TransmitModel::micSourceChanged ───────────────────
     // Phase 3M-1b J.3. Read-only: updates badge text on signal, no user interaction.
-    // "PC mic" for MicSource::Pc, "Radio mic" for MicSource::Radio.
+    // "PC mic" for MicSource::Pc, "Radio mic" for MicSource::Radio, "VAX" for MicSource::Vax.
     connect(&tx, &TransmitModel::micSourceChanged,
             this, [this](MicSource source) {
-        m_micSourceBadge->setText(
-            source == MicSource::Radio
-                ? QStringLiteral("Radio mic")
-                : QStringLiteral("PC mic"));
+        QString text;
+        switch (source) {
+            case MicSource::Radio: text = QStringLiteral("Radio mic"); break;
+            case MicSource::Vax:   text = QStringLiteral("VAX");       break;
+            case MicSource::Pc:
+            default:               text = QStringLiteral("PC mic");    break;
+        }
+        m_micSourceBadge->setText(text);
     });
 
     // ── Phase 3M-1c J.1 ─ TX Profile combo wiring ────────────────────────────
@@ -1546,12 +1550,16 @@ void TxApplet::syncFromModel()
         m_txFilterStatusLabel->setText(tx.filterDisplayText(mode));
     }
 
-    // Mic-source badge (J.3 Phase 3M-1b)
+    // Mic-source badge (J.3 Phase 3M-1b; extended to 3-way in Phase 3M-VAX-toggle)
     if (m_micSourceBadge) {
-        m_micSourceBadge->setText(
-            tx.micSource() == MicSource::Radio
-                ? QStringLiteral("Radio mic")
-                : QStringLiteral("PC mic"));
+        QString text;
+        switch (tx.micSource()) {
+            case MicSource::Radio: text = QStringLiteral("Radio mic"); break;
+            case MicSource::Vax:   text = QStringLiteral("VAX");       break;
+            case MicSource::Pc:
+            default:               text = QStringLiteral("PC mic");    break;
+        }
+        m_micSourceBadge->setText(text);
     }
 
     // MOX / TUNE button state

--- a/src/models/TransmitModel.cpp
+++ b/src/models/TransmitModel.cpp
@@ -1438,6 +1438,22 @@ void TransmitModel::loadFromSettings(const QString& mac)
     }
     setMicSource(micSource);
 
+    // ── Mic source previous (PhoneCwApplet VAX-toggle restore target) ─────
+    // Lookup order matches Mic_Source: per-MAC -> preconnect -> default Pc.
+    const QString perMacPreVaxStr = s.value(pfx + QLatin1String("Mic_Source_PreVax"),
+                                             QString()).toString();
+    QString preVaxStr;
+    if (perMacPreVaxStr.isEmpty()) {
+        preVaxStr = AppSettings::instance().value(
+            QStringLiteral("tx/preconnect/Mic_Source_PreVax"),
+            QStringLiteral("Pc")).toString();
+    } else {
+        preVaxStr = perMacPreVaxStr;
+    }
+    m_previousNonVaxMicSource = (preVaxStr == QLatin1String("Radio"))
+                                    ? MicSource::Radio
+                                    : MicSource::Pc;
+
     // ── Two-tone test properties (3M-1c B.2) ──────────────────────────────
     // Defaults per design spec §4.4 (option C):
     //   Freq1=700, Freq2=1900 — match Thetis Designer + btnTwoToneF_defaults.
@@ -1721,6 +1737,14 @@ void TransmitModel::persistToSettings(const QString& mac) const
             default:               micSourceStr = QStringLiteral("Pc");    break;
         }
         s.setValue(pfx + QLatin1String("Mic_Source"), micSourceStr);
+    }
+
+    // Mic_Source_PreVax mirrors Mic_Source persistence; tracked by setMicSource.
+    {
+        QString preVaxStr = (m_previousNonVaxMicSource == MicSource::Radio)
+                                ? QStringLiteral("Radio")
+                                : QStringLiteral("Pc");
+        s.setValue(pfx + QLatin1String("Mic_Source_PreVax"), preVaxStr);
     }
 
     // ── Two-tone test properties (3M-1c B.2) ──────────────────────────────
@@ -2340,6 +2364,24 @@ void TransmitModel::setMicSource(MicSource source)
 
     if (source == m_micSource) { return; }  // idempotent guard
     m_micSource = source;
+
+    // Capture every non-Vax write as the "previous" source so toggling
+    // VAX off restores the user's most recent explicit choice. Updates
+    // both the per-MAC and preconnect persistence keys to mirror the
+    // Mic_Source two-key pattern.
+    if (source != MicSource::Vax && source != m_previousNonVaxMicSource) {
+        m_previousNonVaxMicSource = source;
+        QString preVaxStr = (source == MicSource::Radio)
+                                ? QStringLiteral("Radio")
+                                : QStringLiteral("Pc");
+        if (m_persistMac.isEmpty()) {
+            AppSettings::instance().setValue(
+                QStringLiteral("tx/preconnect/Mic_Source_PreVax"), preVaxStr);
+        } else {
+            persistOne(QStringLiteral("Mic_Source_PreVax"), preVaxStr);
+        }
+    }
+
     QString persistStr;
     switch (source) {
         case MicSource::Radio: persistStr = QStringLiteral("Radio"); break;
@@ -2348,14 +2390,14 @@ void TransmitModel::setMicSource(MicSource source)
         default:               persistStr = QStringLiteral("Pc");    break;
     }
     if (m_persistMac.isEmpty()) {
-        // Pre-connect fallback (eager-borg-d64bed, 2026-05-06).  When the
+        // Pre-connect fallback (eager-borg-d64bed, 2026-05-06). When the
         // user clicks the radio button in Setup -> Audio -> TX Input
         // before connecting to a radio, persistOne early-returns (no MAC
         // bound yet) so the choice would normally be lost on app restart.
         // Write to a global "tx/preconnect/Mic_Source" key instead;
         // loadFromSettings reads it as a fallback when the per-MAC key is
         // absent so the choice carries forward to whatever radio they
-        // connect next.  Per-MAC values always take precedence over the
+        // connect next. Per-MAC values always take precedence over the
         // preconnect key once written.
         AppSettings::instance().setValue(
             QStringLiteral("tx/preconnect/Mic_Source"), persistStr);
@@ -2363,6 +2405,15 @@ void TransmitModel::setMicSource(MicSource source)
         persistOne(QStringLiteral("Mic_Source"), persistStr);  // L.2 auto-persist
     }
     emit micSourceChanged(source);
+}
+
+void TransmitModel::toggleVaxSource(bool on)
+{
+    if (on) {
+        setMicSource(MicSource::Vax);
+    } else {
+        setMicSource(m_previousNonVaxMicSource);
+    }
 }
 
 // ── Mic source lock guard (3M-1b L.3) ────────────────────────────────────────

--- a/src/models/TransmitModel.h
+++ b/src/models/TransmitModel.h
@@ -1782,6 +1782,11 @@ public slots:
     /// must never be active on that board.
     void setMicSource(MicSource source);
 
+    /// Returns the most recent non-VAX source the user has selected.
+    /// Tracked automatically by setMicSource() whenever a non-VAX source
+    /// is written. Default Pc on first run.
+    MicSource previousNonVaxMicSource() const noexcept { return m_previousNonVaxMicSource; }
+
     // ── Mic source lock guard (3M-1b L.3) ────────────────────────────────────
     //
     // NereusSDR-native. When lock is true, setMicSource(MicSource::Radio)
@@ -1806,6 +1811,11 @@ public slots:
 
     /// Return true when the mic-source lock is active (hasMicJack == false).
     bool isMicSourceLocked() const noexcept { return m_micSourceLocked; }
+
+    /// Quick toggle wired to the PhoneCwApplet VAX button. on=true sets
+    /// MicSource::Vax. on=false restores previousNonVaxMicSource() (which
+    /// the lock guard in setMicSource will coerce to Pc on HL2).
+    void toggleVaxSource(bool on);
 
     // ── PC Mic session-state setters (3M-1b I.2) ─────────────────────────────
     /// Set the PortAudio host API index for PC Mic capture.  Idempotent.
@@ -2252,6 +2262,7 @@ private:
     // silently coerces to Pc.  Runtime capability constraint; not persisted.
     MicSource m_micSource{MicSource::Pc};
     bool      m_micSourceLocked{false};  // L.3: set by RadioModel per hasMicJack
+    MicSource m_previousNonVaxMicSource{MicSource::Pc};
 
     // ── PC Mic session state (3M-1b I.2) ─────────────────────────────────
     // NereusSDR-native transient session state. AppSettings persistence

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2948,6 +2948,14 @@ target_compile_definitions(tst_vax_tx_mic_source PRIVATE NEREUS_BUILD_TESTS)
 # post-connect writes don't touch preconnect, first-run defaults to Pc.
 nereus_add_test(tst_transmit_model_mic_source_preconnect)
 
+# ── Phase 3M-VAX-toggle: TransmitModel previousNonVaxMicSource + toggleVaxSource ──
+# Verifies the model-layer plumbing for the PhoneCwApplet VAX button:
+# previous-source tracking on every non-VAX setMicSource write, toggleVaxSource
+# slot (Vax on -> sets Vax; off -> restores previous), HL2 lock interaction
+# (Radio previous coerces to Pc), and Mic_Source_PreVax persistence (per-MAC
+# + preconnect fallback, mirroring the existing Mic_Source two-key pattern).
+nereus_add_test(tst_transmit_model_vax_toggle)
+
 # ── Phase 3M-1b Task F.4: RadioConnection::micFrameDecoded signal ─────────────
 # Verifies the micFrameDecoded Qt signal added to the RadioConnection base class.
 # Uses TestRadioConnection minimal concrete subclass (stubs all pure-virtuals).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1822,6 +1822,12 @@ nereus_add_test(tst_tx_applet_vox_toggle)
 # (Renamed from tst_tx_applet_lev_eq_proc.cpp during the post-bench cleanup.)
 nereus_add_test(tst_tx_applet_lev_eq_cfc)
 
+# ── Phase 3M-VAX-toggle: TxApplet mic-source badge 3-way ────────────────────
+# The badge above the gauges previously read "PC mic" or "Radio mic".
+# Phase 3M-VAX-toggle extends it to a 3-way switch so MicSource::Vax
+# renders "VAX" both on micSourceChanged and on syncFromModel.
+nereus_add_test(tst_tx_applet_mic_source_badge)
+
 # ── Phase 3M-3a-ii post-bench cleanup: PhoneCwApplet PROC button + slider ──
 # Verifies the PROC controls inherited un-wired from 3I-3 (NyiOverlay-marked):
 # PhoneCwProcButton bidirectional with TransmitModel.cpdrOn; PhoneCwProcSlider

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1830,6 +1830,14 @@ nereus_add_test(tst_tx_applet_lev_eq_cfc)
 # label mirrors slider; NyiOverlay markers absent.
 nereus_add_test(tst_phone_applet_proc)
 
+# ── Phase 3M-VAX-toggle: PhoneCwApplet VAX button wiring ────────────────────
+# Verifies the [VAX] button on the Phone tab now drives MicSource via
+# TransmitModel::toggleVaxSource: left-click toggles Vax, second click
+# restores the previous non-VAX source, external model changes sync the
+# checked state, and right-click emits openSetupRequested("Audio", "TX Input")
+# so MainWindow opens Setup -> Audio -> TX Input.
+nereus_add_test(tst_phone_applet_vax_toggle)
+
 # ── Phase 3M-3a-i Batch 3 Task A.1: TxEqDialog scaffold ───────────────────
 # Verifies the modeless 10-band TX EQ dialog launched from the [EQ]
 # right-click and Tools → TX Equalizer menu.  Confirms construction,

--- a/tests/tst_phone_applet_vax_toggle.cpp
+++ b/tests/tst_phone_applet_vax_toggle.cpp
@@ -1,0 +1,129 @@
+// =================================================================
+// tests/tst_phone_applet_vax_toggle.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original test file. No Thetis port at this layer.
+//
+// Verifies the PhoneCwApplet VAX button:
+//   click_setsVax              - left-click toggles MicSource to Vax
+//   secondClick_restoresPrevious - second click reverts to previous source
+//   modelChange_syncsButton    - external micSource change updates checked state
+//   rightClick_emitsSetupReq   - right-click emits openSetupRequested("Audio", "TX Input")
+//   nyiMark_absent             - the NyiOverlay mark removed
+// =================================================================
+//
+// Modification history (NereusSDR):
+//   2026-05-10 - Original test for NereusSDR by J.J. Boyd (KG4VCF),
+//                 with AI-assisted implementation via Anthropic Claude
+//                 Code.
+// =================================================================
+
+// no-port-check: NereusSDR-original test file.
+
+#include <QtTest/QtTest>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QApplication>
+
+#include "gui/applets/PhoneCwApplet.h"
+#include "models/RadioModel.h"
+#include "models/TransmitModel.h"
+
+using namespace NereusSDR;
+
+namespace {
+QPushButton* findVaxButton(PhoneCwApplet* applet)
+{
+    // Locate by accessibleName set in PhoneCwApplet::buildUI.
+    const auto buttons = applet->findChildren<QPushButton*>();
+    for (auto* b : buttons) {
+        if (b->accessibleName() == QStringLiteral("VAX digital audio")) {
+            return b;
+        }
+    }
+    return nullptr;
+}
+}
+
+class TstPhoneAppletVaxToggle : public QObject {
+    Q_OBJECT
+
+private slots:
+
+    void click_setsVax()
+    {
+        RadioModel model;
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+
+        QVERIFY(!btn->isChecked());
+        btn->click();
+        QCOMPARE(model.transmitModel().micSource(), MicSource::Vax);
+        QVERIFY(btn->isChecked());
+    }
+
+    void secondClick_restoresPrevious()
+    {
+        RadioModel model;
+        model.transmitModel().setMicSource(MicSource::Radio);
+
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+
+        btn->click();  // -> Vax
+        QCOMPARE(model.transmitModel().micSource(), MicSource::Vax);
+
+        btn->click();  // -> Radio (previous)
+        QCOMPARE(model.transmitModel().micSource(), MicSource::Radio);
+        QVERIFY(!btn->isChecked());
+    }
+
+    void modelChange_syncsButton()
+    {
+        RadioModel model;
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+
+        QVERIFY(!btn->isChecked());
+        model.transmitModel().setMicSource(MicSource::Vax);
+        QVERIFY(btn->isChecked());
+        model.transmitModel().setMicSource(MicSource::Pc);
+        QVERIFY(!btn->isChecked());
+    }
+
+    void rightClick_emitsSetupReq()
+    {
+        RadioModel model;
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+
+        QSignalSpy spy(&applet, &PhoneCwApplet::openSetupRequested);
+
+        // Trigger the customContextMenuRequested handler directly.
+        emit btn->customContextMenuRequested(QPoint(0, 0));
+
+        QCOMPARE(spy.count(), 1);
+        const auto args = spy.takeFirst();
+        QCOMPARE(args.at(0).toString(), QStringLiteral("Audio"));
+        QCOMPARE(args.at(1).toString(), QStringLiteral("TX Input"));
+    }
+
+    void nyiMark_absent()
+    {
+        RadioModel model;
+        PhoneCwApplet applet(&model);
+        auto* btn = findVaxButton(&applet);
+        QVERIFY(btn != nullptr);
+        // NyiOverlay sets the property "nyiOverlay" on marked widgets;
+        // the absence of the overlay is sufficient verification.
+        QVERIFY(btn->property("nyiOverlay").isNull()
+                || !btn->property("nyiOverlay").toBool());
+    }
+};
+
+QTEST_MAIN(TstPhoneAppletVaxToggle)
+#include "tst_phone_applet_vax_toggle.moc"

--- a/tests/tst_transmit_model_vax_toggle.cpp
+++ b/tests/tst_transmit_model_vax_toggle.cpp
@@ -1,0 +1,192 @@
+// =================================================================
+// tests/tst_transmit_model_vax_toggle.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original test file. No Thetis port at this layer.
+//
+// Verifies the PhoneCwApplet VAX-button toggle plumbing on
+// TransmitModel: previous non-VAX source tracking, toggleVaxSource
+// slot, HL2 lock interaction, and Mic_Source_PreVax persistence
+// (per-MAC + preconnect fallback).
+//
+// Coverage:
+//   defaults_previousIsPc                - cold construct -> Pc default
+//   setMicSource_radioTracksPrevious     - explicit Radio captured as previous
+//   setMicSource_vaxDoesNotTrackPrevious - Vax write does NOT clobber previous
+//   toggleOn_setsVax                     - toggleVaxSource(true) -> Vax
+//   toggleOff_restoresPrevious           - toggleVaxSource(false) -> previous
+//   toggleOff_hl2LockedRestoresPc        - lock active, previous=Radio coerced
+//   persistence_perMacRoundTrip          - PreVax key round-trips per-MAC
+//   persistence_preconnectFallback       - missing per-MAC falls back to preconnect
+// =================================================================
+//
+// Modification history (NereusSDR):
+//   2026-05-10 - Original test for NereusSDR by J.J. Boyd (KG4VCF),
+//                 with AI-assisted implementation via Anthropic Claude
+//                 Code.
+// =================================================================
+
+// no-port-check: NereusSDR-original test file.
+
+#include <QtTest/QtTest>
+
+#include "models/TransmitModel.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstTransmitModelVaxToggle : public QObject {
+    Q_OBJECT
+
+private:
+    static QString preconnectMicKey()
+    {
+        return QStringLiteral("tx/preconnect/Mic_Source");
+    }
+    static QString preconnectPreVaxKey()
+    {
+        return QStringLiteral("tx/preconnect/Mic_Source_PreVax");
+    }
+    static QString perMacMicKey(const QString& mac)
+    {
+        return QStringLiteral("hardware/%1/tx/Mic_Source").arg(mac);
+    }
+    static QString perMacPreVaxKey(const QString& mac)
+    {
+        return QStringLiteral("hardware/%1/tx/Mic_Source_PreVax").arg(mac);
+    }
+
+    void clearState(const QString& mac)
+    {
+        auto& s = AppSettings::instance();
+        s.remove(preconnectMicKey());
+        s.remove(preconnectPreVaxKey());
+        s.remove(perMacMicKey(mac));
+        s.remove(perMacPreVaxKey(mac));
+    }
+
+private slots:
+
+    void defaults_previousIsPc()
+    {
+        TransmitModel m;
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Pc);
+    }
+
+    void setMicSource_radioTracksPrevious()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-01");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        m.setMicSource(MicSource::Radio);
+
+        QCOMPARE(m.micSource(), MicSource::Radio);
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+    }
+
+    void setMicSource_vaxDoesNotTrackPrevious()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-02");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        m.setMicSource(MicSource::Radio);
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+
+        m.setMicSource(MicSource::Vax);
+        // Previous stays Radio. Toggling off should land back on Radio.
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+    }
+
+    void toggleOn_setsVax()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-03");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        m.toggleVaxSource(true);
+        QCOMPARE(m.micSource(), MicSource::Vax);
+    }
+
+    void toggleOff_restoresPrevious()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-04");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        m.setMicSource(MicSource::Radio);
+        m.toggleVaxSource(true);
+        QCOMPARE(m.micSource(), MicSource::Vax);
+
+        m.toggleVaxSource(false);
+        QCOMPARE(m.micSource(), MicSource::Radio);
+    }
+
+    void toggleOff_hl2LockedRestoresPc()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-05");
+        clearState(mac);
+
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        // Pretend Radio was the previous source on a non-HL2 radio.
+        m.setMicSource(MicSource::Radio);
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+
+        // Switch to HL2: lock engages, current Radio coerces to Pc.
+        m.setMicSourceLocked(true);
+        QCOMPARE(m.micSource(), MicSource::Pc);
+        // The lock-coerce write also updated previous to Pc.
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Pc);
+
+        m.toggleVaxSource(true);
+        QCOMPARE(m.micSource(), MicSource::Vax);
+        m.toggleVaxSource(false);
+        QCOMPARE(m.micSource(), MicSource::Pc);
+    }
+
+    void persistence_perMacRoundTrip()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-06");
+        clearState(mac);
+
+        {
+            TransmitModel m;
+            m.loadFromSettings(mac);
+            m.setMicSource(MicSource::Radio);  // captures Radio as previous + persists
+            QCOMPARE(AppSettings::instance().value(perMacPreVaxKey(mac)).toString(),
+                     QStringLiteral("Radio"));
+        }
+
+        {
+            TransmitModel m;
+            m.loadFromSettings(mac);
+            QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+        }
+    }
+
+    void persistence_preconnectFallback()
+    {
+        const QString mac = QStringLiteral("tst-vaxtog-aa-bb-cc-dd-ee-07");
+        clearState(mac);
+
+        // User picks Radio in Setup before connecting (no MAC bound).
+        TransmitModel pre;
+        pre.setMicSource(MicSource::Radio);
+        QCOMPARE(AppSettings::instance().value(preconnectPreVaxKey()).toString(),
+                 QStringLiteral("Radio"));
+
+        // First connect to this radio: per-MAC PreVax absent, fall back to preconnect.
+        TransmitModel m;
+        m.loadFromSettings(mac);
+        QCOMPARE(m.previousNonVaxMicSource(), MicSource::Radio);
+    }
+};
+
+QTEST_APPLESS_MAIN(TstTransmitModelVaxToggle)
+#include "tst_transmit_model_vax_toggle.moc"

--- a/tests/tst_tx_applet_mic_source_badge.cpp
+++ b/tests/tst_tx_applet_mic_source_badge.cpp
@@ -1,0 +1,85 @@
+// =================================================================
+// tests/tst_tx_applet_mic_source_badge.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original test file. No Thetis port at this layer.
+//
+// Verifies the TxApplet mic-source badge text for all three MicSource
+// values: Pc -> "PC mic", Radio -> "Radio mic", Vax -> "VAX". Covers
+// both the live micSourceChanged path and the syncFromModel path.
+// =================================================================
+//
+// Modification history (NereusSDR):
+//   2026-05-10 - Original test for NereusSDR by J.J. Boyd (KG4VCF),
+//                 with AI-assisted implementation via Anthropic Claude
+//                 Code.
+// =================================================================
+
+// no-port-check: NereusSDR-original test file.
+
+#include <QtTest/QtTest>
+#include <QLabel>
+
+#include "gui/applets/TxApplet.h"
+#include "models/RadioModel.h"
+#include "models/TransmitModel.h"
+
+using namespace NereusSDR;
+
+namespace {
+QLabel* findBadge(TxApplet* applet)
+{
+    const auto labels = applet->findChildren<QLabel*>();
+    for (auto* l : labels) {
+        if (l->accessibleName() == QStringLiteral("Mic source indicator")) {
+            return l;
+        }
+    }
+    return nullptr;
+}
+}
+
+class TstTxAppletMicSourceBadge : public QObject {
+    Q_OBJECT
+
+private slots:
+
+    void liveChange_Pc()
+    {
+        RadioModel model;
+        TxApplet applet(&model);
+        auto* badge = findBadge(&applet);
+        QVERIFY(badge != nullptr);
+
+        model.transmitModel().setMicSource(MicSource::Radio);
+        QCOMPARE(badge->text(), QStringLiteral("Radio mic"));
+        model.transmitModel().setMicSource(MicSource::Pc);
+        QCOMPARE(badge->text(), QStringLiteral("PC mic"));
+    }
+
+    void liveChange_Vax()
+    {
+        RadioModel model;
+        TxApplet applet(&model);
+        auto* badge = findBadge(&applet);
+        QVERIFY(badge != nullptr);
+
+        model.transmitModel().setMicSource(MicSource::Vax);
+        QCOMPARE(badge->text(), QStringLiteral("VAX"));
+    }
+
+    void syncFromModel_Vax()
+    {
+        RadioModel model;
+        model.transmitModel().setMicSource(MicSource::Vax);
+
+        TxApplet applet(&model);
+        auto* badge = findBadge(&applet);
+        QVERIFY(badge != nullptr);
+        applet.syncFromModel();
+        QCOMPARE(badge->text(), QStringLiteral("VAX"));
+    }
+};
+
+QTEST_MAIN(TstTxAppletMicSourceBadge)
+#include "tst_tx_applet_mic_source_badge.moc"


### PR DESCRIPTION
## Summary

- PhoneCwApplet `[VAX]` button: left-click toggles `MicSource::Vax`, second click restores the previous non-VAX source (Pc or Radio).
- Right-click `[VAX]` opens Setup → Audio → TX Input.
- TxApplet mic-source badge gains a `VAX` state alongside the existing `PC mic` / `Radio mic`.
- New per-MAC + preconnect persistence key `Mic_Source_PreVax` so the previous source survives an app restart. Mirrors the existing `Mic_Source` two-key shape.
- The VAX button was wired skeletally in Phase 3-VAX and immediately marked NYI; this PR removes the overlay and binds it.

## Files touched

- `src/models/TransmitModel.{h,cpp}`: `previousNonVaxMicSource()` getter, `toggleVaxSource(bool)` slot, capture-on-set hook in `setMicSource`, `Mic_Source_PreVax` load + save.
- `src/gui/applets/PhoneCwApplet.cpp`: removes the NyiOverlay mark; adds bidirectional toggle wiring + right-click context menu + tooltip.
- `src/gui/applets/TxApplet.cpp`: extends mic-source badge from 2-way to 3-way.

No MainWindow change needed: the existing `PhoneCwApplet::openSetupRequested(category, page)` lambda at `MainWindow.cpp:4234` already routes to `dialog->selectPage(page)`, and `"TX Input"` is the registered leaf label.

## Test plan

- [x] `ctest --test-dir build --output-on-failure`: 406/407 green. The 1 failure (`tst_codec_ps_ddc_config::p1_standard_anan10e_psOn_mox`) is a pre-existing stale assertion from main commit `1d7fa56` (source returns `cntrl1=0`, test still expects `4`); unrelated to this PR.
- [x] 3 new test executables, 16 cases total:
  - `tst_transmit_model_vax_toggle` (8): defaults, capture-on-set, Vax-skips-capture, toggle on, toggle off, HL2 lock interaction, per-MAC persistence round-trip, preconnect fallback.
  - `tst_phone_applet_vax_toggle` (5): click sets Vax, second click restores prior, model change syncs button, right-click emits openSetupRequested, NYI overlay absent.
  - `tst_tx_applet_mic_source_badge` (3): Pc/Radio live, Vax live, Vax via syncFromModel.
- [ ] Manual bench on macOS + ANAN-G2: clicks 1–4 from spec §Verification.
- [ ] App restart with VAX on: button reflects model, click off restores prior source.
- [ ] HL2 (or simulated lock): toggle off lands on Pc regardless.

## Spec

- Design: [`docs/architecture/2026-05-10-vax-tx-source-toggle-design.md`](docs/architecture/2026-05-10-vax-tx-source-toggle-design.md)
- Plan: [`docs/architecture/2026-05-10-vax-tx-source-toggle-plan.md`](docs/architecture/2026-05-10-vax-tx-source-toggle-plan.md)

## Notes

- VAX is NereusSDR-native (not a Thetis port); no Thetis source-first applies for this work.
- End-of-epic code review (Opus subagent) approved with no critical or important issues; 3 nits all flagged as optional (one matches existing file-pattern, one is a cosmetic \`>\` vs \`→\` in a tooltip, one is an implicit-vs-explicit test case).

J.J. Boyd ~ KG4VCF