### PR TITLE
fix(macos): add audio-input entitlement so mic prompt fires

### DIFF
--- a/packaging/macos/app-entitlements.plist
+++ b/packaging/macos/app-entitlements.plist
@@ -10,5 +10,23 @@
          in lock-step is brittle for Qt apps. -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+
+    <!-- Hardened runtime gates microphone access at the kernel
+         entitlement check, *before* TCC ever shows the consent dialog.
+         Without this key, [AVCaptureDevice requestAccessForMediaType:
+         AVMediaTypeAudio] returns NO immediately and silently. No
+         prompt, no error, no entry in System Settings -> Privacy &
+         Security -> Microphone. Required for SSB voice TX, live mic
+         level monitoring, and the launch-time TCC-engagement call
+         in src/core/MacMicPermission.mm.
+         NSMicrophoneUsageDescription is injected into Info.plist by
+         CMakeLists.txt POST_BUILD; that string is necessary but not
+         sufficient under hardened runtime. The kernel entitlement
+         is the third required gate. v0.4.0 shipped without this key,
+         producing a silent-failure mic on Apple Silicon distribution
+         builds; fix verified by re-signing the v0.4.0 bundle with
+         this exact entitlement on a tester's iMac. -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- v0.4.0's release bundle is signed with hardened runtime but missing `com.apple.security.device.audio-input`. macOS blocks the mic request at the kernel entitlement check before TCC sees it, so no permission dialog ever appears on Intel or Apple Silicon distribution installs.
- One-key addition to `packaging/macos/app-entitlements.plist`. Long inline comment explains the three-gate model (Info.plist string + runtime API call + kernel entitlement) so the next person doesn't add only one or two and ship it broken again.
- Verified out-of-band: re-signed the live v0.4.0 bundle with this exact entitlements blob on a tester's Apple Silicon iMac; mic dialog fires at launch as expected.

## Files touched

- `packaging/macos/app-entitlements.plist`: adds `com.apple.security.device.audio-input` with explanatory comment.

## Test plan

- [ ] CI: `release.yml` `Codesign app` step succeeds on both `arm64` and `x86_64` matrix rows.
- [ ] CI: `Notarize .pkg` step succeeds (audio-input is on Apple's notarization-allowed entitlement list).
- [ ] Manual: install the resulting v0.4.1 DMG on an Apple Silicon Mac with no prior mic grant for NereusSDR (or run `tccutil reset Microphone com.boydsoftprez.NereusSDR` first), launch, confirm "NereusSDR would like to access the microphone" dialog appears within 1-2s of launch.
- [ ] Manual: confirm NereusSDR is listed in System Settings -> Privacy & Security -> Microphone after granting.
- [ ] Manual: open Phone applet, hit MOX, confirm mic input registers on level meter.

## Notes

- Three-gate model for any TCC-protected resource on macOS under hardened runtime:
  1. `NSMicrophoneUsageDescription` in Info.plist (CMakeLists.txt POST_BUILD)
  2. `requestAccessForMediaType:AVMediaTypeAudio` API call (src/core/MacMicPermission.mm:24)
  3. `com.apple.security.device.audio-input` entitlement (this PR)

  All three are necessary, none alone is sufficient. v0.4.0 wired 1 and 2 but not 3, producing silent kernel-level denial.

- Suggested release-note line for v0.4.1: "If you're upgrading from v0.4.0 and the mic dialog doesn't appear at launch, open Terminal and run \`tccutil reset Microphone com.boydsoftprez.NereusSDR\`, then relaunch NereusSDR."

J.J. Boyd ~ KG4VCF