### PR TITLE
fix(persistence): atomic settings writes + .bak rotation + corrupt-file preservation (#241)

### DIFF
--- a/src/core/AppSettings.cpp
+++ b/src/core/AppSettings.cpp
@@ -62,10 +62,12 @@
 
 #include "AppSettings.h"
 
+#include <QDateTime>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QRegularExpression>
+#include <QSaveFile>
 #include <QSet>
 #include <QStandardPaths>
 #include <QXmlStreamReader>
@@ -336,22 +338,61 @@ static QString sanitizeXmlForLoad(const QString& text)
     return out;
 }
 
-void AppSettings::load()
-{
-    QFile file(m_filePath);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qDebug() << "No settings file found at" << m_filePath << "— using defaults";
-        return;
-    }
+// Corruption-aware load helpers (issue #241).
+//
+// readFileForParse: returns the raw XML text only when the file looks
+//                   intact enough to attempt a parse. Returns nullopt for
+//                   "file is missing", "file is unreadable", "file is
+//                   empty", and "file starts with NUL bytes" (the canonical
+//                   shape produced by an NTFS journal rollback over an
+//                   in-flight write — see issue #241).
+//
+// parseSettingsXml: parses sanitized XML into the supplied QMaps and
+//                   returns true only when the parser reaches the end
+//                   without raising hasError(). On a clean failure both
+//                   maps are left empty so the caller can fall through to
+//                   the .bak path without inheriting half-loaded keys.
+namespace {
 
-    // Read the entire file as UTF-8 text and run it through the recovery
-    // sanitizer before parsing. Pre-2026-04-30 builds wrote element names
-    // with literal '+' (and other non-NameChars from Thetis profile names),
-    // which causes QXmlStreamReader to bail mid-file. The sanitizer escapes
-    // those chars structurally; well-formed files pass through unchanged.
-    const QString rawXml      = QString::fromUtf8(file.readAll());
-    const QString sanitizedXml = sanitizeXmlForLoad(rawXml);
+enum class ReadResult {
+    Ok,             // file was readable + non-empty + did not start with NULs
+    Missing,        // file does not exist (first-run path — no corruption)
+    Unreadable,     // file exists but open() failed (treat as corrupt)
+    EmptyOrZeroed,  // file is zero bytes or starts with NUL (treat as corrupt)
+};
+
+ReadResult readFileForParse(const QString& path, QString& outXml)
+{
+    QFileInfo info(path);
+    if (!info.exists()) {
+        return ReadResult::Missing;
+    }
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return ReadResult::Unreadable;
+    }
+    const QByteArray bytes = file.readAll();
     file.close();
+    if (bytes.isEmpty()) {
+        return ReadResult::EmptyOrZeroed;
+    }
+    // NTFS journal rollback over an in-flight write zeroes whole sectors at
+    // the head of the file (issue #241 — 28 × 4 KB = 114,688 leading NULs
+    // observed). A leading NUL byte is never valid for our XML output.
+    if (bytes.at(0) == '\0') {
+        return ReadResult::EmptyOrZeroed;
+    }
+    outXml = QString::fromUtf8(bytes);
+    return ReadResult::Ok;
+}
+
+bool parseSettingsXml(const QString& sanitizedXml,
+                      QMap<QString, QString>& outSettings,
+                      QMap<QString, QString>& outStationSettings,
+                      QString& outStationName)
+{
+    outSettings.clear();
+    outStationSettings.clear();
 
     QXmlStreamReader xml(sanitizedXml);
     QString currentStation;
@@ -361,24 +402,22 @@ void AppSettings::load()
         xml.readNext();
         if (xml.isStartElement()) {
             const QString tag = xml.name().toString();
-            if (tag == "NereusSDR") {
+            if (tag == QStringLiteral("NereusSDR")) {
                 continue;
             }
-            // Check if this is a station section
             if (!inStation && xml.attributes().hasAttribute(QStringLiteral("type"))
                 && xml.attributes().value(QStringLiteral("type")) == QStringLiteral("station")) {
                 inStation = true;
                 currentStation = tag;
-                m_stationName = tag;
+                outStationName = tag;
                 continue;
             }
-            // Read element text as value; decode key back to internal format
             const QString value = xml.readElementText();
             const QString key   = decodeXmlKey(tag);
             if (inStation) {
-                m_stationSettings.insert(key, value);
+                outStationSettings.insert(key, value);
             } else {
-                m_settings.insert(key, value);
+                outSettings.insert(key, value);
             }
         } else if (xml.isEndElement() && inStation) {
             if (xml.name().toString() == currentStation) {
@@ -388,15 +427,24 @@ void AppSettings::load()
     }
 
     if (xml.hasError()) {
-        qWarning() << "XML parse error in settings:" << xml.errorString();
+        // Wipe the partially-populated maps — half-loaded settings are
+        // worse than starting from .bak or defaults (silent data loss is
+        // exactly what issue #241 was filed against).
+        outSettings.clear();
+        outStationSettings.clear();
+        return false;
     }
+    return true;
+}
 
+void logLoadedSummary(const QMap<QString, QString>& settings,
+                      int stationSettingsCount)
+{
     int radiosCount = 0;
     QStringList radioMacs;
-    for (auto it = m_settings.constBegin(); it != m_settings.constEnd(); ++it) {
+    for (auto it = settings.constBegin(); it != settings.constEnd(); ++it) {
         if (it.key().startsWith(QStringLiteral("radios/"))) {
             radiosCount++;
-            // Capture distinct MAC keys for the diagnostic
             const QString rest = it.key().mid(QStringLiteral("radios/").size());
             const int slash = rest.indexOf(QLatin1Char('/'));
             if (slash > 0) {
@@ -407,10 +455,110 @@ void AppSettings::load()
             }
         }
     }
-    qDebug() << "Loaded" << m_settings.size() << "settings,"
-             << m_stationSettings.size() << "station settings;"
+    qDebug() << "Loaded" << settings.size() << "settings,"
+             << stationSettingsCount << "station settings;"
              << radiosCount << "saved-radio keys across"
              << radioMacs.size() << "MAC(s)";
+}
+
+} // namespace
+
+void AppSettings::load()
+{
+    // Reset diagnostic state at the top of every load() so wasCorruptedOnLoad()
+    // / preservedCorruptFilePath() / recoveredFromBackup() always reflect THIS
+    // load attempt rather than a previous instance's history.
+    m_wasCorruptedOnLoad       = false;
+    m_preservedCorruptFilePath.clear();
+    m_recoveredFromBackup      = false;
+
+    const QString bakPath = m_filePath + QStringLiteral(".bak");
+
+    // Try the main settings file first.
+    QString rawXml;
+    const ReadResult mainRead = readFileForParse(m_filePath, rawXml);
+
+    if (mainRead == ReadResult::Ok) {
+        const QString sanitized = sanitizeXmlForLoad(rawXml);
+        if (parseSettingsXml(sanitized, m_settings, m_stationSettings, m_stationName)) {
+            logLoadedSummary(m_settings, m_stationSettings.size());
+            return;
+        }
+        qWarning() << "XML parse error in settings:" << m_filePath
+                   << "— treating as corrupt (issue #241 recovery path)";
+    } else if (mainRead == ReadResult::EmptyOrZeroed) {
+        qWarning() << "Settings file" << m_filePath
+                   << "is empty or starts with NUL bytes (NTFS journal rollback shape)"
+                   << "— treating as corrupt (issue #241 recovery path)";
+    } else if (mainRead == ReadResult::Unreadable) {
+        qWarning() << "Settings file" << m_filePath
+                   << "exists but could not be opened — treating as corrupt";
+    } else {
+        // ReadResult::Missing — first-run path. No corruption, no .bak attempt.
+        qDebug() << "No settings file found at" << m_filePath << "— using defaults";
+        return;
+    }
+
+    // ── Corruption path ──────────────────────────────────────────────────
+    //
+    // Preserve the corrupt file BEFORE doing anything else so the user
+    // (or a developer) can attempt manual recovery. The next save() would
+    // otherwise overwrite the only remaining copy with factory defaults
+    // (the exact failure mode reported in issue #241).
+    const QString stamp = QDateTime::currentDateTime().toString(
+                              QStringLiteral("yyyyMMdd-HHmmss"));
+    const QString corruptPath = m_filePath + QStringLiteral(".corrupt-") + stamp;
+    if (QFile::rename(m_filePath, corruptPath)) {
+        m_wasCorruptedOnLoad      = true;
+        m_preservedCorruptFilePath = corruptPath;
+        qWarning() << "Corrupt settings file preserved as" << corruptPath;
+    } else {
+        // Rename failed (cross-volume, permissions, etc.). Fall back to a
+        // copy + remove; if even that fails just leave the corrupt file
+        // alone — defaults will still write through QSaveFile and won't
+        // touch it until the next save() runs.
+        if (QFile::copy(m_filePath, corruptPath)) {
+            QFile::remove(m_filePath);
+            m_wasCorruptedOnLoad       = true;
+            m_preservedCorruptFilePath = corruptPath;
+            qWarning() << "Corrupt settings file copied (rename failed) to" << corruptPath;
+        } else {
+            qWarning() << "Could not preserve corrupt settings file at" << corruptPath
+                       << "— attempting backup recovery anyway";
+        }
+    }
+
+    // Try the .bak fallback. If it exists and parses cleanly we restore
+    // the previous good state; otherwise we leave m_settings empty and
+    // proceed with defaults.
+    if (QFileInfo::exists(bakPath)) {
+        QString bakXml;
+        const ReadResult bakRead = readFileForParse(bakPath, bakXml);
+        if (bakRead == ReadResult::Ok) {
+            const QString sanitized = sanitizeXmlForLoad(bakXml);
+            if (parseSettingsXml(sanitized, m_settings, m_stationSettings, m_stationName)) {
+                m_recoveredFromBackup = true;
+                qWarning() << "Recovered settings from backup file" << bakPath;
+                logLoadedSummary(m_settings, m_stationSettings.size());
+                return;
+            }
+            qWarning() << "Backup settings file" << bakPath
+                       << "is also corrupt — falling back to defaults";
+        } else if (bakRead != ReadResult::Missing) {
+            qWarning() << "Backup settings file" << bakPath
+                       << "exists but is unreadable / empty / NUL-prefixed"
+                       << "— falling back to defaults";
+        }
+    } else {
+        qWarning() << "No backup settings file at" << bakPath
+                   << "— falling back to defaults";
+    }
+
+    // Defaults path — leave both maps empty so first save() writes a fresh
+    // factory-default file. The corrupt file (if rename succeeded) and the
+    // .bak (if any) are untouched on disk for forensic inspection.
+    m_settings.clear();
+    m_stationSettings.clear();
 }
 
 void AppSettings::save()
@@ -418,36 +566,92 @@ void AppSettings::save()
     // Ensure directory exists
     QDir().mkpath(QFileInfo(m_filePath).absolutePath());
 
-    QFile file(m_filePath);
+    // ── .bak rotation (issue #241) ──────────────────────────────────────
+    //
+    // Before overwriting the live settings file we copy the current good
+    // version to "<filePath>.bak" via a .bak.tmp staging step that we
+    // atomically rename into place. This guarantees that if a crash takes
+    // down the system mid-save, the next launch finds either:
+    //   (a) the previous good main file (atomic write below has not yet
+    //       run), OR
+    //   (b) the new main file plus a .bak holding the previous good state.
+    //
+    // We never enter a state where main is corrupt AND .bak is missing —
+    // that's the exact failure mode reported in issue #241 (NTFS journal
+    // rollback over a non-atomic write left the user with no recovery
+    // path at all).
+    if (QFileInfo::exists(m_filePath)) {
+        const QString bakPath    = m_filePath + QStringLiteral(".bak");
+        const QString bakTmpPath = m_filePath + QStringLiteral(".bak.tmp");
+        QFile::remove(bakTmpPath);  // tolerate stale .bak.tmp from a prior crash
+        if (QFile::copy(m_filePath, bakTmpPath)) {
+            // QFile::rename refuses to clobber an existing destination, so
+            // remove the previous .bak first. The window between remove()
+            // and rename() is tolerable here: even if a crash hits between
+            // the two, the main file is still intact (we have not touched
+            // it yet) and .bak.tmp will be cleaned up on the next save.
+            QFile::remove(bakPath);
+            if (!QFile::rename(bakTmpPath, bakPath)) {
+                qWarning() << "Could not rotate settings backup to" << bakPath
+                           << "— previous .bak (if any) lost; main save proceeding";
+                QFile::remove(bakTmpPath);
+            }
+        } else {
+            qWarning() << "Could not stage settings backup at" << bakTmpPath
+                       << "— main save proceeding without rotating .bak";
+        }
+    }
+
+    // ── Atomic write of the main file (issue #241) ──────────────────────
+    //
+    // QSaveFile writes to a hidden temp file alongside the destination,
+    // calls fsync() on commit(), then performs an atomic rename over the
+    // destination. On NTFS that rename uses MoveFileEx with
+    // MOVEFILE_REPLACE_EXISTING which is journaled at the metadata level
+    // — the destination is either entirely the previous version or
+    // entirely the new version, never a partial overlay. This makes the
+    // "leading 28 × 4 KB sectors zeroed" failure mode from issue #241
+    // structurally impossible.
+    QSaveFile file(m_filePath);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qWarning() << "Could not save settings to" << m_filePath;
+        qWarning() << "Could not save settings to" << m_filePath
+                   << ":" << file.errorString();
         return;
     }
 
-    QXmlStreamWriter xml(&file);
-    xml.setAutoFormatting(true);
-    xml.writeStartDocument();
-    xml.writeStartElement("NereusSDR");
+    {
+        QXmlStreamWriter xml(&file);
+        xml.setAutoFormatting(true);
+        xml.writeStartDocument();
+        xml.writeStartElement(QStringLiteral("NereusSDR"));
 
-    // Write top-level settings (encode keys so XML element names are valid)
-    for (auto it = m_settings.constBegin(); it != m_settings.constEnd(); ++it) {
-        xml.writeTextElement(encodeXmlKey(it.key()), it.value());
-    }
-
-    // Write station settings
-    if (!m_stationSettings.isEmpty()) {
-        xml.writeStartElement(m_stationName);
-        xml.writeAttribute("type", "station");
-        for (auto it = m_stationSettings.constBegin(); it != m_stationSettings.constEnd(); ++it) {
+        // Write top-level settings (encode keys so XML element names are valid)
+        for (auto it = m_settings.constBegin(); it != m_settings.constEnd(); ++it) {
             xml.writeTextElement(encodeXmlKey(it.key()), it.value());
         }
-        xml.writeEndElement();
+
+        // Write station settings
+        if (!m_stationSettings.isEmpty()) {
+            xml.writeStartElement(m_stationName);
+            xml.writeAttribute(QStringLiteral("type"), QStringLiteral("station"));
+            for (auto it = m_stationSettings.constBegin(); it != m_stationSettings.constEnd(); ++it) {
+                xml.writeTextElement(encodeXmlKey(it.key()), it.value());
+            }
+            xml.writeEndElement();
+        }
+
+        xml.writeEndElement(); // NereusSDR
+        xml.writeEndDocument();
     }
 
-    xml.writeEndElement(); // NereusSDR
-    xml.writeEndDocument();
+    if (!file.commit()) {
+        qWarning() << "Could not commit settings to" << m_filePath
+                   << ":" << file.errorString();
+        return;
+    }
 
-    file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+    QFile::setPermissions(m_filePath,
+                          QFileDevice::ReadOwner | QFileDevice::WriteOwner);
 }
 
 QVariant AppSettings::value(const QString& key, const QVariant& defaultValue) const

--- a/src/core/AppSettings.h
+++ b/src/core/AppSettings.h
@@ -145,6 +145,33 @@ public:
     QString filePath() const { return m_filePath; }
 
     // ------------------------------------------------------------------
+    // Crash-safety + corruption recovery (issue #241).
+    //
+    // load() may detect a corrupt settings file (leading zero bytes from
+    // an NTFS journal rollback, a mid-stream XML parse failure, or any
+    // other condition that prevents a clean parse). When that happens:
+    //
+    //   1. The corrupt file is renamed in place to
+    //      "<filePath>.corrupt-YYYYMMDD-HHMMSS" so the user can attempt
+    //      manual recovery (or hand it to a developer).
+    //   2. If a "<filePath>.bak" sidecar exists from the previous good
+    //      save() it is parsed; on a clean parse those values become the
+    //      live settings and the next save() rewrites .bak as the
+    //      one-deep history again.
+    //   3. If .bak is missing or also corrupt the in-memory state is
+    //      empty (defaults will be written on the next save()).
+    //
+    // wasCorruptedOnLoad() returns true once load() has hit case (1).
+    // preservedCorruptFilePath() returns the renamed path for use in a
+    // post-startup UI notification. recoveredFromBackup() reports
+    // whether case (2) succeeded.  All three are query-only and reset
+    // on the next load().
+    // ------------------------------------------------------------------
+    bool    wasCorruptedOnLoad() const     { return m_wasCorruptedOnLoad; }
+    QString preservedCorruptFilePath() const { return m_preservedCorruptFilePath; }
+    bool    recoveredFromBackup() const    { return m_recoveredFromBackup; }
+
+    // ------------------------------------------------------------------
     // Profile support (Issue #100) — multiple concurrent NereusSDR
     // instances against different radios. A profile name scopes the
     // settings file (and the log dir, in main.cpp) to a per-profile
@@ -354,6 +381,12 @@ private:
     QMap<QString, QString> m_settings;
     QMap<QString, QString> m_stationSettings;
     QString m_stationName{"NereusSDR"};
+
+    // Issue #241 — corruption-recovery diagnostics (cleared at the top of
+    // every load()).
+    bool    m_wasCorruptedOnLoad{false};
+    QString m_preservedCorruptFilePath;
+    bool    m_recoveredFromBackup{false};
 };
 
 } // namespace NereusSDR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2045,6 +2045,13 @@ nereus_add_test(tst_connection_panel_state_pills)
 # NereusSDR-original; no Thetis attribution needed.
 nereus_add_test(tst_app_settings_migration)
 
+# ── Issue #241: settings file crash-safety + corruption recovery ─────────────
+# 8 tests covering atomic save (QSaveFile), .bak rotation, leading-NUL
+# corruption recovery, mid-stream XML parse-error recovery, no-.bak fallback
+# to defaults, missing-file = first-run (not corruption), diagnostics-reset
+# between load() calls, and no QSaveFile temp residue.
+nereus_add_test(tst_app_settings_corruption)
+
 # ── Task 5.1: SettingsSchemaVersion + v0.3.0 migration ────────────────────────
 # 5 tests: retired keys removed on v<3 → v3 migration, idempotency, fresh-install
 # (no version key), no-op when already at v3, version-zero path.

--- a/tests/tst_app_settings_corruption.cpp
+++ b/tests/tst_app_settings_corruption.cpp
@@ -1,0 +1,345 @@
+// Issue #241 — settings persistence crash-safety + corruption recovery.
+//
+// Verifies the four invariants added in the issue #241 fix:
+//
+//   1. save() rotates the previous good main file to "<file>.bak" via a
+//      .bak.tmp staging step before overwriting main.
+//   2. save() writes the new main file atomically (via QSaveFile) so the
+//      destination is never observed as a partial overlay — the failure
+//      mode reported in #241 (NTFS journal rollback zeroing the leading
+//      28 × 4 KB sectors of the file) cannot recur on a clean shutdown
+//      path.
+//   3. load() detects a corrupt main file (leading-NUL bytes from a
+//      journal rollback OR an XML parse failure) and:
+//        a) renames it to "<file>.corrupt-YYYYMMDD-HHMMSS",
+//        b) restores from "<file>.bak" if a clean parse succeeds,
+//        c) otherwise falls through to defaults (m_settings empty).
+//   4. After successful recovery from .bak the diagnostic accessors
+//      (wasCorruptedOnLoad / preservedCorruptFilePath / recoveredFromBackup)
+//      reflect what happened so a future MainWindow notification can show
+//      the user the preserved-file path.
+//
+// Uses QTemporaryDir + AppSettings(filePath) — no singleton, no real
+// user-config writes.  TestSandboxInit.cpp guards the singleton path even
+// if a stray AppSettings::instance() call slips into a future test.
+
+#include <QtTest/QtTest>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QDir>
+
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+namespace {
+
+// Writes raw bytes to a path, creating the parent directory if needed.
+// Returns true on success. Used to seed corrupt files for the recovery
+// scenarios.
+bool writeRawBytes(const QString& path, const QByteArray& bytes)
+{
+    QDir().mkpath(QFileInfo(path).absolutePath());
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        return false;
+    }
+    const qint64 n = f.write(bytes);
+    f.close();
+    return n == bytes.size();
+}
+
+// Returns true iff path exists and starts with NUL byte(s) — the canonical
+// shape produced by an NTFS journal rollback.
+bool startsWithNul(const QString& path)
+{
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly)) return false;
+    const QByteArray head = f.read(1);
+    return head.size() == 1 && head.at(0) == '\0';
+}
+
+} // namespace
+
+class TstAppSettingsCorruption : public QObject {
+    Q_OBJECT
+
+private slots:
+    // ─────────────────────────────────────────────────────────────────────
+    // .bak rotation: a second save() copies the prior main file to .bak
+    // ─────────────────────────────────────────────────────────────────────
+    void bakIsRotatedOnSecondSave()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("NereusSDR.settings"));
+
+        // First save — only main file should exist (no prior good state to rotate).
+        {
+            AppSettings s(path);
+            s.setValue(QStringLiteral("Marker"), QStringLiteral("v1"));
+            s.save();
+        }
+        QVERIFY(QFileInfo::exists(path));
+        QVERIFY2(!QFileInfo::exists(path + QStringLiteral(".bak")),
+                 ".bak should not exist after the first save() (no prior good state to rotate)");
+
+        // Second save — main becomes v2 and .bak should hold v1.
+        {
+            AppSettings s(path);
+            s.load();
+            QCOMPARE(s.value(QStringLiteral("Marker")).toString(), QStringLiteral("v1"));
+            s.setValue(QStringLiteral("Marker"), QStringLiteral("v2"));
+            s.save();
+        }
+        QVERIFY2(QFileInfo::exists(path + QStringLiteral(".bak")),
+                 "Second save() should produce a .bak holding the previous good state");
+
+        // Verify .bak content is v1 by loading it directly.
+        AppSettings bak(path + QStringLiteral(".bak"));
+        bak.load();
+        QCOMPARE(bak.value(QStringLiteral("Marker")).toString(), QStringLiteral("v1"));
+
+        // And main is v2.
+        AppSettings main(path);
+        main.load();
+        QCOMPARE(main.value(QStringLiteral("Marker")).toString(), QStringLiteral("v2"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // .bak.tmp staging: no .bak.tmp residue after a normal save()
+    // ─────────────────────────────────────────────────────────────────────
+    void bakTmpIsCleanedUp()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("NereusSDR.settings"));
+
+        AppSettings s(path);
+        s.setValue(QStringLiteral("Marker"), QStringLiteral("v1"));
+        s.save();
+        s.setValue(QStringLiteral("Marker"), QStringLiteral("v2"));
+        s.save();
+
+        QVERIFY2(!QFileInfo::exists(path + QStringLiteral(".bak.tmp")),
+                 ".bak.tmp should not be present after a clean save() — it must be renamed to .bak");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Issue #241 main scenario: NTFS-style leading-NUL corruption.
+    // Main is preserved as .corrupt-* and settings restored from .bak.
+    // ─────────────────────────────────────────────────────────────────────
+    void leadingNulCorruptionIsRecoveredFromBak()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("NereusSDR.settings"));
+
+        // Save three times. .bak is rotated to "main-before-this-save" on
+        // each save() that finds an existing main file, so:
+        //   after save#1: main=v1, no .bak yet
+        //   after save#2: main=v2, .bak=v1
+        //   after save#3: main=v3, .bak=v2
+        // Corrupting main here loses v3 (main was the only place it lived);
+        // .bak still holds v2, which is the best possible recovery point.
+        {
+            AppSettings s(path);
+            s.setValue(QStringLiteral("UserPref"), QStringLiteral("v1"));
+            s.save();
+            s.setValue(QStringLiteral("UserPref"), QStringLiteral("v2"));
+            s.save();
+            s.setValue(QStringLiteral("UserPref"), QStringLiteral("v3"));
+            s.save();
+        }
+        QVERIFY(QFileInfo::exists(path + QStringLiteral(".bak")));
+
+        // Simulate an NTFS journal rollback over an in-flight write: the
+        // first 114,688 bytes (28 × 4 KB) of the main file are zeroed, but
+        // the file itself is not deleted. (Issue #241 reported exactly this
+        // shape — the actual user file was 608,457 bytes with 114,688
+        // leading NULs; we use a smaller buffer here for test speed.)
+        QByteArray corrupted(8192, '\0');
+        corrupted.append("|0.0|0.0|trailing-garbage|");
+        QVERIFY(writeRawBytes(path, corrupted));
+        QVERIFY(startsWithNul(path));
+
+        // Load — should detect corruption, preserve as .corrupt-*, restore
+        // from .bak with the previous good values intact.
+        AppSettings recovered(path);
+        recovered.load();
+
+        QVERIFY2(recovered.wasCorruptedOnLoad(),
+                 "load() must flag the leading-NUL file as corrupt");
+        QVERIFY2(recovered.recoveredFromBackup(),
+                 "load() must restore from .bak when main is corrupt and .bak is good");
+
+        const QString preserved = recovered.preservedCorruptFilePath();
+        QVERIFY2(!preserved.isEmpty(), "preservedCorruptFilePath() must report the rename target");
+        QVERIFY2(preserved.contains(QStringLiteral(".corrupt-")),
+                 "Preserved file must use .corrupt-YYYYMMDD-HHMMSS suffix");
+        QVERIFY2(QFileInfo::exists(preserved),
+                 "Preserved corrupt file must remain on disk for forensic inspection");
+        QVERIFY2(!QFileInfo::exists(path) || QFileInfo(path).size() == 0,
+                 "Original main path should be moved (or empty) after corrupt-preserve rename");
+
+        // Recovered settings come from .bak, which holds the previous-to-last
+        // good save (v2). The most recent save (v3) was in main and is lost
+        // along with the corruption — that data only ever existed in one
+        // place. .bak is one save behind by design (standard rotation
+        // pattern; symmetric to atomic-rename limitations).
+        QCOMPARE(recovered.value(QStringLiteral("UserPref")).toString(),
+                 QStringLiteral("v2"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Mid-stream XML parse failure: also routes through the .bak path.
+    // ─────────────────────────────────────────────────────────────────────
+    void midStreamXmlErrorIsRecoveredFromBak()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("NereusSDR.settings"));
+
+        // Save three times so .bak holds a populated previous-good state.
+        // (See bakIsRotatedOnSecondSave / leadingNulCorruptionIsRecoveredFromBak
+        // for the rotation timing — .bak is one save behind main.)
+        {
+            AppSettings s(path);
+            s.setValue(QStringLiteral("Marker"), QStringLiteral("first"));
+            s.save();
+            s.setValue(QStringLiteral("Marker"), QStringLiteral("second"));
+            s.save();
+            s.setValue(QStringLiteral("Marker"), QStringLiteral("third"));
+            s.save();
+        }
+
+        // Truncate the main file mid-element so QXmlStreamReader trips
+        // hasError(). The NUL-prefix check won't catch this — it's the
+        // parse-error path, not the journal-rollback path.
+        const QByteArray broken =
+            QByteArrayLiteral("<?xml version=\"1.0\"?><NereusSDR><Marker>halfwa");
+        QVERIFY(writeRawBytes(path, broken));
+
+        AppSettings recovered(path);
+        recovered.load();
+
+        QVERIFY(recovered.wasCorruptedOnLoad());
+        QVERIFY(recovered.recoveredFromBackup());
+        // .bak holds "second" (one save behind the corrupted "third" main).
+        QCOMPARE(recovered.value(QStringLiteral("Marker")).toString(),
+                 QStringLiteral("second"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // No .bak available + corrupt main → defaults, but corrupt file
+    // is still preserved so the user has a forensic copy.
+    // ─────────────────────────────────────────────────────────────────────
+    void corruptMainWithNoBakFallsThroughToDefaults()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("NereusSDR.settings"));
+
+        // Seed a corrupt main file directly — no prior save(), so no .bak.
+        QByteArray corrupted(4096, '\0');
+        QVERIFY(writeRawBytes(path, corrupted));
+        QVERIFY(!QFileInfo::exists(path + QStringLiteral(".bak")));
+
+        AppSettings recovered(path);
+        recovered.load();
+
+        QVERIFY(recovered.wasCorruptedOnLoad());
+        QVERIFY2(!recovered.recoveredFromBackup(),
+                 "recoveredFromBackup() must be false when no .bak exists");
+        QVERIFY2(!recovered.preservedCorruptFilePath().isEmpty(),
+                 "Corrupt file should still be preserved even without a .bak to recover from");
+        QVERIFY(QFileInfo::exists(recovered.preservedCorruptFilePath()));
+
+        // No settings carried over — but the next save() will write a fresh
+        // file via QSaveFile and won't touch the preserved corrupt copy.
+        QVERIFY2(recovered.allKeys().isEmpty(),
+                 "load() with corrupt main + no .bak must leave the in-memory store empty");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // First-run path is NOT a corruption event (no diagnostics tripped).
+    // ─────────────────────────────────────────────────────────────────────
+    void missingFileIsNotTreatedAsCorruption()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("NereusSDR.settings"));
+
+        AppSettings fresh(path);
+        fresh.load();  // file does not exist
+
+        QVERIFY2(!fresh.wasCorruptedOnLoad(),
+                 "Missing settings file is the first-run path, not a corruption event");
+        QVERIFY(fresh.preservedCorruptFilePath().isEmpty());
+        QVERIFY(!fresh.recoveredFromBackup());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Diagnostics reset between load() calls so they reflect THIS attempt.
+    // ─────────────────────────────────────────────────────────────────────
+    void diagnosticsResetBetweenLoads()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("NereusSDR.settings"));
+
+        // Build a good .bak then corrupt main.
+        {
+            AppSettings s(path);
+            s.setValue(QStringLiteral("Marker"), QStringLiteral("good"));
+            s.save();
+            s.setValue(QStringLiteral("Marker"), QStringLiteral("good2"));
+            s.save();
+        }
+        QVERIFY(writeRawBytes(path, QByteArray(2048, '\0')));
+
+        AppSettings inst(path);
+        inst.load();
+        QVERIFY(inst.wasCorruptedOnLoad());
+        QVERIFY(inst.recoveredFromBackup());
+
+        // Now save the recovered state (rewrites a clean main + rotates .bak)
+        // and load again. This second load must NOT report the previous
+        // corruption — the file is healthy now.
+        inst.save();
+        inst.load();
+        QVERIFY2(!inst.wasCorruptedOnLoad(),
+                 "wasCorruptedOnLoad() must reset between load() calls");
+        QVERIFY(inst.preservedCorruptFilePath().isEmpty());
+        QVERIFY(!inst.recoveredFromBackup());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // QSaveFile semantics: a .tmp side-file from QSaveFile must not leak
+    // into the directory after a successful save (regression guard for
+    // the atomic-write switchover).
+    // ─────────────────────────────────────────────────────────────────────
+    void noQSaveFileTmpResidueAfterSuccessfulSave()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("NereusSDR.settings"));
+
+        AppSettings s(path);
+        s.setValue(QStringLiteral("Marker"), QStringLiteral("once"));
+        s.save();
+
+        // QSaveFile picks a hidden temp name like "NereusSDR.settings.XXXXXX"
+        // alongside the destination. After commit() these must all be gone.
+        QDir d(QFileInfo(path).absolutePath());
+        const QStringList residue = d.entryList(
+            { QStringLiteral("NereusSDR.settings.??????") }, QDir::Files);
+        QVERIFY2(residue.isEmpty(),
+                 qPrintable(QStringLiteral("QSaveFile residue left behind: ")
+                            + residue.join(QLatin1Char(','))));
+    }
+};
+
+QTEST_APPLESS_MAIN(TstAppSettingsCorruption)
+#include "tst_app_settings_corruption.moc"


### PR DESCRIPTION
## Summary

- Closes #241 — settings file vulnerable to NTFS journal-rollback corruption with no recovery path.
- Switches `AppSettings::save()` from plain `QFile` to **`QSaveFile`** (write-temp + fsync + atomic rename). The leading-NUL-sectors shape reported in #241 becomes structurally impossible.
- Adds **`.bak` rotation** on every save (one-deep history via `<file>.bak.tmp` staging + atomic rename).
- `load()` now detects two corruption shapes (leading-NUL bytes, mid-stream XML parse error) and **preserves the corrupt file as `<file>.corrupt-YYYYMMDD-HHMMSS`** before doing anything else.
- After preservation, `load()` **auto-recovers from `<file>.bak`** when it parses cleanly. The next save rewrites both files.
- Three new query-only accessors (`wasCorruptedOnLoad()` / `preservedCorruptFilePath()` / `recoveredFromBackup()`) feed a future MainWindow UI notification.
- 8 new test cases in `tst_app_settings_corruption.cpp`. Full ctest run: 447/448 green (the only failure, `tst_app_settings_profile`, is pre-existing on main).

This is the structural fix the reporter requested — all four mitigations in their issue write-up are implemented. The only deferred follow-up is a startup UI notification ("Previous settings could not be loaded; preserved as ..."); the accessors are in place, MainWindow can pick them up in a separate small change.

## Test plan

- [x] `ctest -R tst_app_settings_corruption` passes (8/8)
- [x] Full `ctest` run: 447/448 (pre-existing unrelated failure on main)
- [x] Pre-commit verifier chain (Thetis headers, freedv headers, port classifier, inline cites, compliance inventory) all green
- [ ] Manual bench: connect ANAN-G2, configure a non-default value, kill -9 the app mid-save, verify next launch reads back the previous good state from `.bak` and logs the `.corrupt-*` path
- [ ] Windows manual bench: install via NSIS, configure, force a BSOD or hold the power button, verify recovery on relaunch
- [ ] Inspect `~/Library/Preferences/NereusSDR/` (macOS) or `%LOCALAPPDATA%\NereusSDR\` (Windows) after a normal session and confirm the directory contains main + `.bak` (no `.bak.tmp` residue, no QSaveFile temp residue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)