### PR TITLE
fix(ci,win): stage rade.dll into Windows installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -745,6 +745,20 @@ jobs:
             Write-Error "deepfilter.dll missing from third_party\deepfilter\lib\windows-x86_64\ — Windows artifact would ship broken (DFNR will crash at load)"
             exit 1
           }
+          # rade.dll: librade SHARED library produced by third_party/rade.
+          # NereusSDR.exe load-time imports it via __declspec(dllimport),
+          # so without rade.dll on the DLL search path the .exe fails to
+          # launch with "rade.dll was not found". windeployqt only resolves
+          # Qt DLLs, so this non-Qt dep must be staged by hand. v0.5.0
+          # shipped without this stanza and the Windows installer was
+          # broken; never again.
+          $radeDll = "build\third_party\rade\src\rade.dll"
+          if (Test-Path $radeDll) {
+            Copy-Item $radeDll deploy\
+          } else {
+            Write-Error "rade.dll missing from build\third_party\rade\src\ (Windows artifact would ship broken: NereusSDR.exe will fail to launch with 'rade.dll was not found')"
+            exit 1
+          }
           # Copy third-party license notices + both root license files
           # (LICENSE and LICENSE-DUAL-LICENSING) into the portable deploy
           # tree so both the ZIP and the NSIS installer pick them up.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -939,6 +939,19 @@ target_include_directories(NereusSDRObjs PUBLIC
     ${CMAKE_BINARY_DIR}/third_party/rade/build_opus-prefix/src/build_opus
 )
 
+# rade is a SHARED library on Windows (rade.dll). NereusSDR.exe load-time
+# imports it via __declspec(dllimport), so without rade.dll on the DLL
+# search path the .exe fails to launch with "rade.dll was not found".
+# CMake places rade.dll in third_party/rade/src/ but the .exe lives at
+# $<TARGET_FILE_DIR:NereusSDR>, so copy it next to the .exe at build time.
+# Mirrors the ENABLE_DFNR / deepfilter.dll pattern below.
+if(WIN32)
+    add_custom_command(TARGET NereusSDR POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE:rade>" "$<TARGET_FILE_DIR:NereusSDR>"
+        COMMENT "Copying rade.dll to build directory")
+endif()
+
 # --------------------------------------------------------------------------
 # r8brain-free-src high-quality polyphase resampler (Phase 3R Task I2)
 # License: MIT (see third_party/r8brain/LICENSE.txt)


### PR DESCRIPTION
## Summary

v0.5.0 shipped a Windows installer (and portable ZIP) that does not contain `rade.dll`. `NereusSDR.exe` load-time imports it (the API is declared `__declspec(dllimport)` when consuming librade per [`third_party/rade/src/rade_api.h`](third_party/rade/src/rade_api.h)), so the .exe fails to launch on a clean install with `rade.dll was not found`.

Confirmed by downloading `NereusSDR-0.5.0-Windows-x64-portable.zip` and listing contents: every Qt DLL, plus `libfftw3-3.dll`, `libfftw3f-3.dll`, `deepfilter.dll`, `dxcompiler.dll`, `dxil.dll`, `vc_redist.x64.exe` are present. `rade.dll` is not.

## Root cause

The `build-windows` job in `release.yml` stages every non-Qt runtime DLL by hand (windeployqt only resolves Qt DLLs). The deploy step had explicit blocks for `libfftw3-3.dll`, `libfftw3f-3.dll`, and `deepfilter.dll`, but no equivalent for `rade.dll` (which lives at `build\third_party\rade\src\rade.dll` after the build, confirmed in build log: `[188/496] Linking CXX shared library third_party\rade\src\rade.dll`).

Windows ctest runs zero tests in the release workflow (`--no-tests=ignore` swallows it), so the missing DLL never surfaced before publish.

## Fix

Two parts:

1. **`.github/workflows/release.yml`** (the actual ship-fix): add a `Test-Path` / `Copy-Item` / `Write-Error` stanza for `rade.dll` in the `build-windows` "Deploy Qt" step, mirroring the existing `deepfilter.dll` block. The next Windows release artifact will contain `rade.dll`.

2. **`CMakeLists.txt`** (defense-in-depth): add an `add_custom_command(TARGET NereusSDR POST_BUILD ...)` gated on `WIN32` that copies `$<TARGET_FILE:rade>` next to the .exe at build time. Without this, local Windows dev builds run from `build\` and any future Windows ctest invocation that loads `NereusSDR.exe` also break, and the gap would not be caught earlier than release time again.

Linux and macOS unchanged: linuxdeploy already pulls `librade.so.0.1` into the AppImage via the `LD_LIBRARY_PATH` route landed in 73b749c9, and macdeployqt copies `librade.0.1.dylib` into the `.app` bundle's `Frameworks/` directory.

## Test plan

- [ ] Trigger `release.yml` against this branch with `workflow_dispatch` (or wait for a release tag) and confirm the Windows portable ZIP contains `rade.dll` next to `NereusSDR.exe`
- [ ] Install `NereusSDR-X.Y.Z-Windows-x64-setup.exe` on a clean Windows machine, launch the .exe, switch to RADE-U mode, and confirm the app launches and RADE works
- [ ] Linux AppImage + macOS DMG still build and pass tests (no behavioural change expected; gated on `if(WIN32)`)

## Follow-ups (not in this PR)

- Windows ctest in `release.yml` currently runs zero tests, swallowed by `--no-tests=ignore`. Worth a separate look so the next missing-DLL gap fails at CI time, not at user-install time.
- v0.5.1 patch release after merge so existing Windows users get a working installer.

J.J. Boyd ~ KG4VCF