### PR TITLE
fix(build,ci): require Qt6::WebSockets so FreeDV/TCI cannot silently disappear

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
           target: desktop
           arch: linux_gcc_64
           # Qt 6.8+ folds qtsvg into qtbase; not listable as a module.
-          modules: 'qtmultimedia qtshadertools'
+          modules: 'qtmultimedia qtshadertools qtwebsockets'
           cache: true
 
       # ------------------------------------------------------------------
@@ -347,7 +347,7 @@ jobs:
           host: windows
           target: desktop
           arch: win64_mingw
-          modules: 'qtmultimedia qtshadertools'
+          modules: 'qtmultimedia qtshadertools qtwebsockets'
           tools: 'tools_mingw1310'
           cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,8 @@ jobs:
         if: matrix.use_aqt == false
         run: |
           sudo apt-get install -y qt6-base-dev qt6-multimedia-dev \
-            qt6-base-private-dev qt6-shadertools-dev qt6-svg-dev
+            qt6-base-private-dev qt6-shadertools-dev qt6-svg-dev \
+            qt6-websockets-dev
 
       - name: Install Qt 6.8 via aqtinstall (x86_64)
         if: matrix.use_aqt == true
@@ -140,7 +141,7 @@ jobs:
           pip3 install aqtinstall
           # Qt 6.8+ folds qtsvg/qttools/qttranslations into qtbase; not listable as -m modules.
           aqt install-qt linux desktop 6.8.3 linux_gcc_64 \
-            -m qtmultimedia qtshadertools \
+            -m qtmultimedia qtshadertools qtwebsockets \
             --outputdir ${{ github.workspace }}/Qt
           echo "Qt6_DIR=${{ github.workspace }}/Qt/6.8.3/gcc_64/lib/cmake/Qt6" >> $GITHUB_ENV
           echo "CMAKE_PREFIX_PATH=${{ github.workspace }}/Qt/6.8.3/gcc_64" >> $GITHUB_ENV
@@ -348,7 +349,7 @@ jobs:
           host: 'mac'
           target: 'desktop'
           arch: 'clang_64'
-          modules: 'qtmultimedia qtshadertools'
+          modules: 'qtmultimedia qtshadertools qtwebsockets'
           cache: true
 
       - name: Build FFTW from source for x86_64 (both precisions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,17 @@ find_package(Qt6 REQUIRED COMPONENTS
     Network
     Multimedia
     Svg
+    WebSockets
 )
+
+# WebSockets is REQUIRED (not optional) because both the TCI server and the
+# FreeDV Reporter / PSK Reporter spot ingest depend on it. v0.5.0 shipped a
+# macOS x86_64 build with `qtwebsockets` missing from the install-qt-action
+# modules list; CMake's QUIET find_package silently left HAVE_WEBSOCKETS
+# undefined and the resulting binary disabled both features at runtime with
+# only a warning in the log. Mirroring the v0.1.1 NEREUS_GPU_SPECTRUM lesson
+# (see release.yml Configure step): if a feature is mandatory, the build
+# system has to refuse to configure without it.
 
 # Optional Qt components
 find_package(Qt6 QUIET COMPONENTS SerialPort)
@@ -51,13 +61,6 @@ if(Qt6SerialPort_FOUND)
     message(STATUS "Qt6::SerialPort found — serial PTT/CW support enabled")
 else()
     message(STATUS "Qt6::SerialPort not found — serial PTT/CW support disabled")
-endif()
-
-find_package(Qt6 QUIET COMPONENTS WebSockets)
-if(Qt6WebSockets_FOUND)
-    message(STATUS "Qt6::WebSockets found — TCI server enabled")
-else()
-    message(STATUS "Qt6::WebSockets not found — TCI server disabled")
 endif()
 
 # --------------------------------------------------------------------------
@@ -868,10 +871,13 @@ if(Qt6SerialPort_FOUND)
     target_compile_definitions(NereusSDRObjs PUBLIC HAVE_SERIALPORT)
 endif()
 
-if(Qt6WebSockets_FOUND)
-    target_link_libraries(NereusSDRObjs PUBLIC Qt6::WebSockets)
-    target_compile_definitions(NereusSDRObjs PUBLIC HAVE_WEBSOCKETS)
-endif()
+# Qt6::WebSockets is REQUIRED above; the link and HAVE_WEBSOCKETS define
+# are unconditional. The #ifdef HAVE_WEBSOCKETS guards in TciServer,
+# FreeDVReporterClient, MainWindow, and SpotHubDialog are now redundant
+# but left in place to keep this PR surgical; cleanup tracked as a
+# follow-up.
+target_link_libraries(NereusSDRObjs PUBLIC Qt6::WebSockets)
+target_compile_definitions(NereusSDRObjs PUBLIC HAVE_WEBSOCKETS)
 
 if(FFTW3_FOUND)
     target_include_directories(NereusSDRObjs PUBLIC ${FFTW3_INCLUDE_DIRS})


### PR DESCRIPTION
## Summary

- Promotes `Qt6::WebSockets` from a `QUIET` optional `find_package` to the main `REQUIRED` block in `CMakeLists.txt`. Configure now hard-fails when `qtwebsockets` isn't installed, instead of silently leaving `HAVE_WEBSOCKETS` undefined and shipping a binary with no FreeDV Reporter / PSK Reporter / TCI server.
- Adds `qtwebsockets` (or `qt6-websockets-dev`) to the five CI/release Qt install manifests that were missing it: `ci.yml` Linux + Windows, `release.yml` Linux aarch64 native apt, `release.yml` Linux x86_64 aqtinstall, `release.yml` macOS x86_64 aqtinstall.
- Closes the regression that shipped in v0.5.0's macOS x86_64 DMG (caught via support bundle on 2026-05-14, with the runtime warning `FreeDVReporterClient: built without Qt6::WebSockets; live connections are disabled.`).

Same shape as the v0.1.1 `NEREUS_GPU_SPECTRUM` regression (see the long-standing comment in `release.yml`'s Configure step): an implicit, optional gate quietly dropped a core feature without failing the build. Treating WebSockets as mandatory aligns the CMake gate with the dep lists already documented in `CLAUDE.md` (`qt6-websockets` on Arch, `qt6-websockets-dev` on Ubuntu).

The `#ifdef HAVE_WEBSOCKETS` guards in `TciServer`, `FreeDVReporterClient`, `MainWindow`, and `SpotHubDialog` are now dead code but left in place to keep this PR surgical. A follow-up PR can strip them.

## Test plan

- [x] Local configure on macOS arm64 picks `Qt6WebSockets` from Homebrew; `compile_commands.json` shows `-DHAVE_WEBSOCKETS` on every TU that needs it.
- [x] 5 WebSocket-dependent ctest targets pass locally: `tst_tci_server_lifecycle`, `tst_tci_server_ping`, `tst_freedv_reporter_socketio`, `tst_freedv_reporter_dialog`, `tst_psk_reporter_protocol`.
- [x] Runtime log (3s smoke launch) no longer emits `built without Qt6::WebSockets`; `TciServer: IQ tap connected to RadioModel::rawIqData` confirms TCI is alive.
- [ ] CI matrix passes on all 8 rows (5 of them previously could have passed without `qtwebsockets`; now they cannot).
- [ ] After merge + next release tag, sanity-check at least one of the previously broken artifact rows (macOS x86_64 DMG is the most direct repro): install the .app, launch with `nereus.spots=true`, confirm FreeDV Reporter connects to `qso.freedv.org` and the warning is absent from the log.

J.J. Boyd ~ KG4VCF