### PR TITLE
fix(ci,codeql): add qt6-websockets-dev to CodeQL apt install

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install -y \
             cmake ninja-build pkg-config g++ \
             qt6-base-dev qt6-base-private-dev qt6-multimedia-dev \
-            qt6-shadertools-dev qt6-svg-dev \
+            qt6-shadertools-dev qt6-svg-dev qt6-websockets-dev \
             libgl1-mesa-dev libfftw3-dev \
             libasound2-dev libjack-jackd2-dev \
             libpipewire-0.3-dev


### PR DESCRIPTION
## Summary

Follow-up to #251 (Qt6::WebSockets promoted to `REQUIRED`). The CodeQL workflow has its own apt-install step that wasn't in my original CI audit, so the new REQUIRED gate fired on `main` right after the merge:

```
Found package configuration file:
  /usr/lib/x86_64-linux-gnu/cmake/Qt6/Qt6Config.cmake
but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT FOUND.
Reason given by package:
  Failed to find required Qt component "WebSockets".
```

One-line fix: same shape as `release.yml`'s Linux aarch64 native row. Adds `qt6-websockets-dev` to the apt package list in `.github/workflows/codeql.yml`.

This is exactly what the REQUIRED gate is supposed to do (surface missing manifests instead of shipping a silently broken binary), so I'm treating the post-merge CodeQL failure as the gate working correctly + a workflow audit miss on my part.

## Test plan

- [ ] CodeQL workflow goes green on this branch.
- [ ] Confirm no other workflow installs Qt6 without `qtwebsockets` / `qt6-websockets-dev` (audit redone here; the `.github/docker/Dockerfile` is also incomplete but is not exercised by any current workflow, so I'm leaving that as a separate latent issue rather than bundling it here).

J.J. Boyd ~ KG4VCF