### PR TITLE
Fix VOX "juggle to prime" bench symptom on radio connect

### DIFF
--- a/src/core/MoxController.cpp
+++ b/src/core/MoxController.cpp
@@ -1046,6 +1046,28 @@ void MoxController::setAntiVoxRun(bool run)
     emit antiVoxRunRequested(run);
 }
 
+// ---------------------------------------------------------------------------
+// primeWdspState — bench fix 2026-05-14 ("VOX needs juggling to prime").
+//
+// Resets the three NaN sentinels that guard the *Requested signals and
+// re-runs the recompute helpers so the late-wired TxChannel receives the
+// current values.  See the header comment block for the full motivation.
+//
+// Anti-VOX tau and anti-VOX run are NOT covered here because their TM ->
+// MoxController connects are deferred to wireConnectionSignals
+// (RadioModel.cpp:5025/5051) and the explicit re-push there
+// (RadioModel.cpp:5043/5070) already lands after TxWorkerThread is wired.
+// ---------------------------------------------------------------------------
+void MoxController::primeWdspState()
+{
+    m_lastVoxThresholdEmitted = std::numeric_limits<double>::quiet_NaN();
+    m_lastVoxHangTimeEmitted  = std::numeric_limits<double>::quiet_NaN();
+    m_lastAntiVoxGainEmitted  = std::numeric_limits<double>::quiet_NaN();
+    recomputeVoxThreshold();
+    recomputeVoxHangTime();
+    recomputeAntiVoxGain();
+}
+
 // ===========================================================================
 // H.4 — PTT-source dispatch slots (MIC / CAT / VOX / SPACE / X2)
 //

--- a/src/core/MoxController.h
+++ b/src/core/MoxController.h
@@ -507,6 +507,40 @@ public slots:
     //   MoxController::antiVoxRunRequested → TxWorkerThread::setAntiVoxRun
     void setAntiVoxRun(bool run);
 
+    // ── Bench fix 2026-05-14: WDSP re-prime after late-wired TxChannel ───────
+    //
+    // primeWdspState: re-emit the three NaN-sentinel-guarded signals
+    //   voxThresholdRequested, voxHangTimeRequested, antiVoxGainRequested
+    // using the current MoxController member state, by resetting the
+    // m_lastXxxEmitted sentinels and re-running the recompute() helpers.
+    //
+    // Motivation (reported bench symptom 2026-05-14, "VOX needs juggling to
+    // prime"): TransmitModel::loadFromSettings (RadioModel.cpp:2631) is called
+    // EARLY in connectToRadio, before the MoxController -> TxChannel connects
+    // at RadioModel.cpp:3604/3612/3620 are established by the WDSP-init
+    // lambda.  During that load the TM -> MoxController connections (wired in
+    // RadioModel ctor at lines 770/812) fire setVoxThreshold / setVoxHangTime
+    // / setAntiVoxGain, each consuming its NaN sentinel via the first-call
+    // emit -- but those emits land in a void receiver because TxChannel
+    // doesn't exist yet.  After TxChannel is wired the sentinels are already
+    // consumed, so a same-value call short-circuits.  Result: WDSP retains
+    // its construction-time defaults until the user moves a slider, which
+    // generates a different value that passes the equality guard.
+    //
+    // The asymmetric design choice for antiVoxTau (RadioModel.cpp:5025) and
+    // antiVoxRun (RadioModel.cpp:5051) -- defer the TM -> Mox connect until
+    // after TxWorkerThread is constructed and add an explicit re-push --
+    // avoids the race entirely.  primeWdspState() retrofits the equivalent
+    // semantic for the three older paths without restructuring their connect
+    // ordering.
+    //
+    // Called from RadioModel::pushTxProcessingChain (the WDSP-init lambda at
+    // RadioModel.cpp:3747) after the MoxController -> TxChannel connects are
+    // established.  Safe to call multiple times -- each call resets the
+    // sentinels and re-emits, which is the desired behaviour on
+    // disconnect/reconnect (a fresh TxChannel needs to be re-primed).
+    void primeWdspState();
+
     // ── H.4: PTT-source dispatch slots ───────────────────────────────────────
     //
     // Each slot routes an external PTT event through the MoxController state

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3804,6 +3804,29 @@ void RadioModel::connectToRadio(const RadioInfo& info)
                 m_txChannel->setDexpLowCut(m_transmitModel.dexpLowCutHz());
                 m_txChannel->setDexpHighCut(m_transmitModel.dexpHighCutHz());
                 m_txChannel->setDexpRunSideChannelFilter(m_transmitModel.dexpSideChannelFilterEnabled());
+
+                // ── Bench fix 2026-05-14: re-prime MoxController WDSP signals ──
+                //
+                // loadFromSettings (line 2631) ran BEFORE the MoxController ->
+                // TxChannel connects above (lines 3604/3612/3620), so the
+                // first-call NaN-sentinel emit of voxThresholdRequested /
+                // voxHangTimeRequested / antiVoxGainRequested landed in a
+                // void receiver and the sentinels are now consumed.  Reset
+                // them and re-run the recompute helpers so the load-time
+                // values reach the freshly-wired TxChannel.
+                //
+                // Reported bench symptom: "VOX needs juggling to prime" --
+                // sliders show correct visual position on launch (model
+                // restored from per-MAC AppSettings) but WDSP retains its
+                // construction-time defaults until the user moves a slider.
+                //
+                // antiVoxTau and antiVoxRun are not covered here -- their
+                // TM -> Mox connects are deferred to wireConnectionSignals
+                // (lines 5025/5051) where an explicit re-push already
+                // happens after TxWorkerThread is wired.
+                if (m_moxController) {
+                    m_moxController->primeWdspState();
+                }
             };
 
             // 1. txEqEnabledChanged → setTxEqRunning.

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -3804,29 +3804,6 @@ void RadioModel::connectToRadio(const RadioInfo& info)
                 m_txChannel->setDexpLowCut(m_transmitModel.dexpLowCutHz());
                 m_txChannel->setDexpHighCut(m_transmitModel.dexpHighCutHz());
                 m_txChannel->setDexpRunSideChannelFilter(m_transmitModel.dexpSideChannelFilterEnabled());
-
-                // ── Bench fix 2026-05-14: re-prime MoxController WDSP signals ──
-                //
-                // loadFromSettings (line 2631) ran BEFORE the MoxController ->
-                // TxChannel connects above (lines 3604/3612/3620), so the
-                // first-call NaN-sentinel emit of voxThresholdRequested /
-                // voxHangTimeRequested / antiVoxGainRequested landed in a
-                // void receiver and the sentinels are now consumed.  Reset
-                // them and re-run the recompute helpers so the load-time
-                // values reach the freshly-wired TxChannel.
-                //
-                // Reported bench symptom: "VOX needs juggling to prime" --
-                // sliders show correct visual position on launch (model
-                // restored from per-MAC AppSettings) but WDSP retains its
-                // construction-time defaults until the user moves a slider.
-                //
-                // antiVoxTau and antiVoxRun are not covered here -- their
-                // TM -> Mox connects are deferred to wireConnectionSignals
-                // (lines 5025/5051) where an explicit re-push already
-                // happens after TxWorkerThread is wired.
-                if (m_moxController) {
-                    m_moxController->primeWdspState();
-                }
             };
 
             // 1. txEqEnabledChanged → setTxEqRunning.
@@ -4141,6 +4118,40 @@ void RadioModel::connectToRadio(const RadioInfo& info)
             // calls land on TxWorkerThread via the queued connections above.
             // See line 1879-1881 for the design pattern this mirrors.
             pushTxProcessingChain();
+
+            // ── Bench fix 2026-05-14: re-prime MoxController WDSP signals ──
+            //
+            // loadFromSettings (line 2631) ran BEFORE the MoxController ->
+            // TxChannel connects above (lines 3604/3612/3620), so the
+            // first-call NaN-sentinel emit of voxThresholdRequested /
+            // voxHangTimeRequested / antiVoxGainRequested landed in a void
+            // receiver and the sentinels are now consumed.  Reset them and
+            // re-run the recompute helpers so the load-time values reach
+            // the freshly-wired TxChannel.
+            //
+            // Reported bench symptom: "VOX needs juggling to prime" --
+            // sliders show correct visual position on launch (model restored
+            // from per-MAC AppSettings) but WDSP retains its construction-
+            // time defaults until the user moves a slider.
+            //
+            // Thread-affinity note (PR #253 review): this call lives at the
+            // initial-sync site (main thread, before m_txChannel->moveToThread
+            // below), NOT inside pushTxProcessingChain.  pushTxProcessingChain
+            // is reused by the activeProfileChanged connect at line ~4111
+            // whose receiver is m_txChannel; after moveToThread that lambda
+            // body executes on the TX worker thread, and a MoxController
+            // mutation from there would race the main-thread TM -> Mox
+            // setters.  Profile changes don't need the re-prime anyway: the
+            // TM -> Mox -> TxChannel signal chain handles per-property
+            // updates through recompute()'s computed-value guard.
+            //
+            // antiVoxTau and antiVoxRun are not covered here -- their TM ->
+            // Mox connects are deferred to wireConnectionSignals (lines
+            // 5025/5051) where an explicit re-push already happens after
+            // TxWorkerThread is wired.
+            if (m_moxController) {
+                m_moxController->primeWdspState();
+            }
 
             // ── 3M-1c TX pump architecture redesign: TxWorkerThread setup ──────
             //

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2274,6 +2274,14 @@ nereus_add_test(tst_mox_controller_vox_threshold)
 # Source: Thetis setup.cs:18896-18900 + 18986-18990 [v2.10.3.13].
 nereus_add_test(tst_mox_controller_anti_vox)
 
+# ── Bench fix 2026-05-14: MoxController::primeWdspState() ─────────────────
+# Verifies that primeWdspState() re-emits voxThresholdRequested,
+# voxHangTimeRequested, and antiVoxGainRequested after the NaN-sentinel
+# "first-call emit" was consumed by loadFromSettings into a void receiver
+# (TxChannel not yet wired).  Regression for the "VOX needs juggling to
+# prime" bench symptom.
+nereus_add_test(tst_mox_controller_prime_wdsp_state)
+
 # ── Phase 3M-1b Task H.4: MoxController PTT-source dispatch ──────────────────
 # Verifies:
 #   Accepted slots (5): onMicPttFromRadio, onCatPtt, onVoxActive, onSpacePtt,

--- a/tests/tst_mox_controller_prime_wdsp_state.cpp
+++ b/tests/tst_mox_controller_prime_wdsp_state.cpp
@@ -1,0 +1,220 @@
+// =================================================================
+// tests/tst_mox_controller_prime_wdsp_state.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original test. No Thetis logic is ported in this test
+// file. The test exercises:
+//   - MoxController::primeWdspState()
+//
+// Regression for the "VOX needs juggling to prime" bench symptom
+// reported 2026-05-14: TxApplet's VOX threshold/hold sliders show
+// the correct visual position on app launch (model values restored
+// from per-MAC AppSettings via TransmitModel::loadFromSettings), but
+// WDSP retains its construction-time defaults until the user moves
+// a slider.  Moving the slider then "primes" VOX, after which it
+// works correctly.
+//
+// Root cause: loadFromSettings (RadioModel.cpp:2631) runs early in
+// the connect sequence, calling MoxController::setVoxThreshold /
+// setVoxHangTime / setAntiVoxGain.  Each setter's NaN-sentinel
+// "first-call emit" fires voxThresholdRequested / voxHangTimeRequested
+// / antiVoxGainRequested -- but the receiver-side connects
+// (MoxController -> TxChannel at RadioModel.cpp:3604/3612/3620) are
+// only established LATER in the WDSP-init lambda.  The emits land
+// in a void receiver; the NaN sentinels are consumed.  The next
+// setter call with the same value short-circuits at the sentinel
+// guard, so WDSP never gets re-primed.
+//
+// Fix: primeWdspState() resets the three NaN sentinels and re-runs
+// the three recompute() helpers.  Called from pushTxProcessingChain
+// (RadioModel.cpp:3747 lambda) after the MoxController -> TxChannel
+// connects are established.
+//
+// Tests verify that primeWdspState() emits the three signals with
+// the current (load-time) values, even when the prior emit consumed
+// the NaN sentinel into a void receiver.
+// =================================================================
+
+// no-port-check: NereusSDR-original test file -- no upstream Thetis port.
+
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+
+#include <cmath>
+
+#include "core/MoxController.h"
+
+using namespace NereusSDR;
+
+class TestMoxControllerPrimeWdspState : public QObject {
+    Q_OBJECT
+
+private slots:
+
+    // ════════════════════════════════════════════════════════════════════════
+    // §1 -- primeWdspState() re-emits voxThresholdRequested after first-call
+    //
+    // Simulates the bench scenario: setVoxThreshold consumes the NaN sentinel
+    // during loadFromSettings (when no TxChannel listener is wired), then
+    // primeWdspState() runs after TxChannel is wired and must re-emit.
+    // ════════════════════════════════════════════════════════════════════════
+
+    void primeWdspState_reEmitsVoxThreshold()
+    {
+        MoxController ctrl;
+        // Simulate loadFromSettings: setter fires NaN-sentinel first emit
+        // (which in the bench scenario lands in a void TxChannel receiver).
+        ctrl.setVoxThreshold(-25);
+
+        // Attach spy AFTER the sentinel-consuming first emit.
+        QSignalSpy spy(&ctrl, &MoxController::voxThresholdRequested);
+
+        // Simulate post-wiring prime: TxChannel listener is now connected.
+        ctrl.primeWdspState();
+
+        QCOMPARE(spy.count(), 1);
+        // Computed threshold = pow(10, -25/20) * micBoost*scalar
+        //                    = pow(10, -1.25) * 1.0 (default boost=true, scalar=1.0)
+        //                    ~= 0.05623
+        const double expected = std::pow(10.0, -25.0 / 20.0);
+        QVERIFY(qFuzzyCompare(spy.at(0).at(0).toDouble(), expected));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // §2 -- primeWdspState() re-emits voxHangTimeRequested after first-call
+    //
+    // Same pattern: setVoxHangTime consumes NaN sentinel, primeWdspState()
+    // must force a re-emit so the late-wired TxChannel receives the load
+    // value (ms -> seconds conversion preserved).
+    // ════════════════════════════════════════════════════════════════════════
+
+    void primeWdspState_reEmitsVoxHangTime()
+    {
+        MoxController ctrl;
+        ctrl.setVoxHangTime(800);  // NaN sentinel consumed by first emit
+
+        QSignalSpy spy(&ctrl, &MoxController::voxHangTimeRequested);
+
+        ctrl.primeWdspState();
+
+        QCOMPARE(spy.count(), 1);
+        // ms -> seconds conversion: 800 / 1000.0 = 0.8
+        QVERIFY(qFuzzyCompare(spy.at(0).at(0).toDouble(), 0.8));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // §3 -- primeWdspState() re-emits antiVoxGainRequested after first-call
+    //
+    // Same pattern for the third NaN-sentinel signal (dB -> linear via /20.0).
+    // ════════════════════════════════════════════════════════════════════════
+
+    void primeWdspState_reEmitsAntiVoxGain()
+    {
+        MoxController ctrl;
+        ctrl.setAntiVoxGain(-20);  // NaN sentinel consumed; gain = pow(10,-1) = 0.1
+
+        QSignalSpy spy(&ctrl, &MoxController::antiVoxGainRequested);
+
+        ctrl.primeWdspState();
+
+        QCOMPARE(spy.count(), 1);
+        // pow(10, -20/20) = pow(10, -1) = 0.1
+        QVERIFY(qFuzzyCompare(spy.at(0).at(0).toDouble(), 0.1));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // §4 -- primeWdspState() fires all three signals in one call
+    //
+    // Integration: a single primeWdspState() call after loadFromSettings has
+    // touched all three setters must re-emit all three signals.  This is the
+    // production call site shape inside pushTxProcessingChain.
+    // ════════════════════════════════════════════════════════════════════════
+
+    void primeWdspState_emitsAllThreeSignalsOnce()
+    {
+        MoxController ctrl;
+        ctrl.setVoxThreshold(-30);   // consumes vox threshold NaN sentinel
+        ctrl.setVoxHangTime(1500);   // consumes vox hang time NaN sentinel
+        ctrl.setAntiVoxGain(6);      // consumes anti-vox gain NaN sentinel
+
+        QSignalSpy spyThr(&ctrl, &MoxController::voxThresholdRequested);
+        QSignalSpy spyHng(&ctrl, &MoxController::voxHangTimeRequested);
+        QSignalSpy spyAvg(&ctrl, &MoxController::antiVoxGainRequested);
+
+        ctrl.primeWdspState();
+
+        QCOMPARE(spyThr.count(), 1);
+        QCOMPARE(spyHng.count(), 1);
+        QCOMPARE(spyAvg.count(), 1);
+
+        // Cross-check the computed doubles match the same recompute formulas:
+        const double expThr = std::pow(10.0, -30.0 / 20.0);   // ~0.03162
+        const double expHng = 1500.0 / 1000.0;                // 1.5 s
+        const double expAvg = std::pow(10.0,   6.0 / 20.0);   // ~1.9953
+        QVERIFY(qFuzzyCompare(spyThr.at(0).at(0).toDouble(), expThr));
+        QVERIFY(qFuzzyCompare(spyHng.at(0).at(0).toDouble(), expHng));
+        QVERIFY(qFuzzyCompare(spyAvg.at(0).at(0).toDouble(), expAvg));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // §5 -- primeWdspState() at default state still emits
+    //
+    // Edge case: if the user's persisted VOX values happen to match the
+    // MoxController member defaults (vox threshold = -40, vox hang = 500 ms,
+    // anti-vox gain = 0), the bench symptom still manifests because the
+    // first emit during loadFromSettings is consumed before TxChannel is
+    // wired.  primeWdspState() must re-emit even when nothing was "changed"
+    // from the construction-time default.
+    // ════════════════════════════════════════════════════════════════════════
+
+    void primeWdspState_emitsEvenAtDefaultState()
+    {
+        MoxController ctrl;
+        // Touch each setter with the default value to consume the NaN
+        // sentinels (mirrors loadFromSettings reading the defaults from
+        // disk and calling the setters).
+        ctrl.setVoxThreshold(-40);
+        ctrl.setVoxHangTime(500);
+        ctrl.setAntiVoxGain(0);
+
+        QSignalSpy spyThr(&ctrl, &MoxController::voxThresholdRequested);
+        QSignalSpy spyHng(&ctrl, &MoxController::voxHangTimeRequested);
+        QSignalSpy spyAvg(&ctrl, &MoxController::antiVoxGainRequested);
+
+        ctrl.primeWdspState();
+
+        QCOMPARE(spyThr.count(), 1);
+        QCOMPARE(spyHng.count(), 1);
+        QCOMPARE(spyAvg.count(), 1);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // §6 -- primeWdspState() repeated calls each re-emit
+    //
+    // Subsequent connects (disconnect / reconnect to the same radio) need
+    // to re-prime a freshly-constructed TxChannel.  primeWdspState() must
+    // not "remember" that it already primed once.
+    // ════════════════════════════════════════════════════════════════════════
+
+    void primeWdspState_repeatedCallsEachReEmit()
+    {
+        MoxController ctrl;
+        ctrl.setVoxThreshold(-25);
+        ctrl.setVoxHangTime(800);
+        ctrl.setAntiVoxGain(-20);
+
+        QSignalSpy spyThr(&ctrl, &MoxController::voxThresholdRequested);
+        QSignalSpy spyHng(&ctrl, &MoxController::voxHangTimeRequested);
+        QSignalSpy spyAvg(&ctrl, &MoxController::antiVoxGainRequested);
+
+        ctrl.primeWdspState();  // first prime
+        ctrl.primeWdspState();  // second prime (simulates reconnect)
+
+        QCOMPARE(spyThr.count(), 2);
+        QCOMPARE(spyHng.count(), 2);
+        QCOMPARE(spyAvg.count(), 2);
+    }
+};
+
+QTEST_MAIN(TestMoxControllerPrimeWdspState)
+#include "tst_mox_controller_prime_wdsp_state.moc"


### PR DESCRIPTION
## Summary

- Adds `MoxController::primeWdspState()` to re-emit `voxThresholdRequested` / `voxHangTimeRequested` / `antiVoxGainRequested` after the late-wired TxChannel is connected, fixing the "VOX needs juggling to prime" bench symptom reported 2026-05-14.
- Calls it from the `pushTxProcessingChain` lambda alongside the existing DEXP initial-sync block, so the load-time VOX values reach WDSP on every fresh connect (and on profile change).
- Adds `tst_mox_controller_prime_wdsp_state` (6 cases) covering the three signals individually, all-three-in-one, default-value-matches-persisted, and the reconnect re-prime case.

## Root cause

`TransmitModel::loadFromSettings` runs at [RadioModel.cpp:2631](src/models/RadioModel.cpp) — early in the connect sequence, before the `MoxController` → `TxChannel` signal connects at [RadioModel.cpp:3604/3612/3620](src/models/RadioModel.cpp). The existing `TransmitModel` → `MoxController` connects (wired in `RadioModel` ctor, lines 770/812) fire `setVoxThreshold` / `setVoxHangTime` / `setAntiVoxGain` during the load. Each setter's NaN-sentinel "first-call emit" fires `voxThresholdRequested` etc. — but those emits land in a void receiver because `TxChannel` does not exist yet. After `TxChannel` is wired, the sentinels are already consumed, so a same-value setter call short-circuits at the `qFuzzyCompare` guard inside `recompute*()`. WDSP retains its construction-time defaults until the user moves a slider, which generates a *different* value that passes the guard.

The asymmetric design for `antiVoxTau` ([RadioModel.cpp:5025](src/models/RadioModel.cpp)) and `antiVoxRun` ([RadioModel.cpp:5051](src/models/RadioModel.cpp)) — defer the TM→Mox connect until *after* `TxWorkerThread` is wired plus an explicit re-push at lines 5043/5070 — already avoids this race for those two paths. `primeWdspState` retrofits the equivalent semantic for the three older paths without restructuring their connect ordering.

## Test plan

- [x] `ctest -R "tst_mox_controller|tst_transmit_model_vox|tst_audio_tx_input_mic_boost"` → 13/13 pass on macOS arm64.
- [x] `ctest -R "tst_radio_model_drive_path|tst_radio_model_dexp_routing|tst_radio_model_eq_lev_alc_wiring|tst_radio_model_3m1b_ownership|tst_radio_model_push_tx_mode_and_bandpass"` → 5/5 pass.
- [x] Main `NereusSDR.app` builds and signs clean.
- [ ] Bench: connect to ANAN-G2 (or HL2) with non-default persisted VOX threshold/hold values, enable VOX, confirm gating trips at the persisted threshold *without* moving the slider first.

J.J. Boyd ~ KG4VCF