### PR TITLE
fix(ci,codeql): unify CodeQL with ci.yml on Qt 6.8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,16 +24,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install system dependencies
+        # System libs only. Qt itself comes from install-qt-action below
+        # so CodeQL matches ci.yml + release.yml (Qt 6.8.*). Apt qt6-*
+        # on ubuntu-24.04 ships Qt 6.4.2, which is too old for
+        # QRhiWidget and used to force -DNEREUS_GPU_SPECTRUM=OFF here;
+        # aligning Qt versions across all three workflows removes that
+        # workaround and stops CodeQL drifting from CI behavior.
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             cmake ninja-build pkg-config g++ \
-            qt6-base-dev qt6-base-private-dev qt6-multimedia-dev \
-            qt6-shadertools-dev qt6-svg-dev qt6-websockets-dev \
             libgl1-mesa-dev libfftw3-dev \
             libasound2-dev libjack-jackd2-dev \
             libpipewire-0.3-dev
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.8.*'
+          host: linux
+          target: desktop
+          arch: linux_gcc_64
+          # Qt 6.8+ folds qtsvg into qtbase; not listable as a module.
+          modules: 'qtmultimedia qtshadertools qtwebsockets'
+          cache: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -42,13 +57,8 @@ jobs:
 
       - name: Build
         run: |
-          # CodeQL runs on Ubuntu with apt-managed Qt 6.4.2, which is
-          # older than QRhiWidget's 6.7+ requirement. GPU spectrum is
-          # explicitly disabled here so CMake's FATAL_ERROR path does
-          # not trip. Same reasoning as Linux ci.yml Configure step.
           cmake -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DNEREUS_GPU_SPECTRUM=OFF
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo
           cmake --build build -j$(nproc)
 
       - name: Perform CodeQL Analysis

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -315,6 +315,7 @@ warren@wpratt.com
 #  include "applets/ClientChainApplet.h"
 #  include "core/TciServer.h"
 #  include "setup/TciLogWindow.h"  // Phase 3J-1 closeout Item 2 (2026-05-12)
+#  include <QWebSocket>
 #endif
 #include "SpectrumOverlayPanel.h"
 #include "SetupDialog.h"

--- a/src/gui/applets/TciApplet.cpp
+++ b/src/gui/applets/TciApplet.cpp
@@ -39,6 +39,7 @@
 #include <QSlider>
 #include <QTimer>
 #include <QVBoxLayout>
+#include <QWebSocket>
 
 #include <cmath>
 

--- a/src/gui/setup/CatNetworkSetupPages.cpp
+++ b/src/gui/setup/CatNetworkSetupPages.cpp
@@ -11,6 +11,7 @@
 #include <QNetworkInterface>
 #ifdef HAVE_WEBSOCKETS
 #include "core/TciServer.h"
+#include <QWebSocket>
 #endif
 
 #include <QVBoxLayout>


### PR DESCRIPTION
## Summary

CodeQL was the only workflow still on apt `qt6-*` (Qt 6.4.2 on ubuntu-24.04); `ci.yml` and `release.yml` both build against Qt 6.8.*. The mismatch surfaced right after #252 — with QtWebSockets newly available to apt, CodeQL compiled `CatNetworkSetupPages.cpp` and tripped on a `connect(..., &TciServer::clientConnected, this, [this](QWebSocket*){...})` lambda. Qt 6.4.2's `QMetaTypeId<QWebSocket*>` instantiation requires the complete type; Qt 6.8 pulls `<QWebSocket>` in transitively via newer qtbase headers, so `ci.yml` + `release.yml` never saw it. Last failed run: [25898280102](https://github.com/boydsoftprez/NereusSDR/actions/runs/25898280102).

Two changes:

1. **`.github/workflows/codeql.yml`** — replace the apt `qt6-*` install with `jurplel/install-qt-action@v4` (Qt 6.8.*, modules `qtmultimedia qtshadertools qtwebsockets`), matching `ci.yml`. Drops the `-DNEREUS_GPU_SPECTRUM=OFF` workaround (Qt 6.8 has QRhiWidget) and rewrites the stale comment that pointed at the old apt-Qt limitation.

2. **`#include <QWebSocket>` in 3 .cpp files** that use `QWebSocket*` in `&QObject::connect` lambda / slot signatures: `CatNetworkSetupPages.cpp`, `MainWindow.cpp`, `TciApplet.cpp`. Belt-and-braces: the source is now correct C++ regardless of which Qt headers happen to pull `<QWebSocket>` in transitively, so future Qt-version drift or include-order shuffles can't regress this. CodeQL stopped at the first failure (file 469/506) but the other two files share the same pattern and would have followed.

After this PR all three workflows (`ci.yml`, `codeql.yml`, `release.yml` Linux x86_64) build against Qt 6.8.x, which is what "stop fighting with the different paths" means in practice for the Linux x86_64 path.

## Test plan

- [ ] CodeQL workflow goes green on this branch.
- [ ] CI workflow stays green on this branch (transitive include not relied on, but the explicit include shouldn't regress anything).
- [ ] No follow-up apt module gymnastics next time we add a Qt component.

J.J. Boyd ~ KG4VCF