### PR TITLE
fix(setup): persist step-attenuator enable/value across restart (#259)

### DIFF
--- a/src/core/StepAttenuatorController.cpp
+++ b/src/core/StepAttenuatorController.cpp
@@ -1099,8 +1099,16 @@ void StepAttenuatorController::loadSettings(const QString& mac)
     }
 
     // Notify UI of restored values.
+    //
+    // Issue #259 fix: stepAttEnabledChanged is emitted here so the
+    // "RX1 Enable" / "RX2 Enable" checkboxes on Setup → General → Options
+    // pick up the restored value on connect. Without this emit, the
+    // controller's m_stepAttEnabled is correct but the checkbox stays
+    // at its constructor default (unchecked) until the user clicks it
+    // — so persistence appears broken even when the round-trip works.
     emit attenuationChanged(m_attDb);
     emit preampModeChanged(m_preampMode);
+    emit stepAttEnabledChanged(m_stepAttEnabled);
 }
 
 }  // namespace NereusSDR

--- a/src/core/StepAttenuatorController.cpp
+++ b/src/core/StepAttenuatorController.cpp
@@ -948,6 +948,23 @@ void StepAttenuatorController::onDdcMappingChanged()
 
 void StepAttenuatorController::saveSettings(const QString& mac)
 {
+    // Issue #259 gate: refuse to save until loadSettings has populated this
+    // controller for the same MAC. Without this, the teardownConnection
+    // that runs INSIDE RadioModel::connectToRadio (when a previous m_connection
+    // still exists, e.g. auto-reconnect retry) would persist the constructor
+    // defaults — m_attDb=0, m_stepAttEnabled=true — over the user's real
+    // saved state. The bench trace at /tmp/nereus259/run.log shows the
+    // failure mode: 18:31:11.242 save with m_attDb=0 wipes the prior session's
+    // m_attDb=6, followed at 18:31:15.854 by a loadSettings that reads back
+    // the freshly-clobbered zero.
+    //
+    // Empty mac is also rejected — same guard pattern as the
+    // m_transmitModel.persistToSettings block at the matching site in
+    // RadioModel::teardownConnection().
+    if (mac.isEmpty() || m_loadedMac != mac) {
+        return;
+    }
+
     auto& s = AppSettings::instance();
 
     // Step attenuator global config.
@@ -1023,6 +1040,14 @@ void StepAttenuatorController::saveSettings(const QString& mac)
 
 void StepAttenuatorController::loadSettings(const QString& mac)
 {
+    // Issue #259: record the MAC we're loading for so saveSettings can refuse
+    // pre-load writes. Set BEFORE reading values so a synchronous early-
+    // return path (none today, but a future maintainer's guard could
+    // bail mid-load) still leaves the gate in a consistent state — the
+    // save would re-emit our just-read state which is at worst identical
+    // to disk.
+    m_loadedMac = mac;
+
     auto& s = AppSettings::instance();
 
     // Step attenuator global config.
@@ -1101,11 +1126,11 @@ void StepAttenuatorController::loadSettings(const QString& mac)
     // Notify UI of restored values.
     //
     // Issue #259 fix: stepAttEnabledChanged is emitted here so the
-    // "RX1 Enable" / "RX2 Enable" checkboxes on Setup → General → Options
-    // pick up the restored value on connect. Without this emit, the
-    // controller's m_stepAttEnabled is correct but the checkbox stays
-    // at its constructor default (unchecked) until the user clicks it
-    // — so persistence appears broken even when the round-trip works.
+    // "RX1 Enable" checkbox on Setup → General → Options picks up the
+    // restored value on connect. Without this emit, the controller's
+    // m_stepAttEnabled is correct but the checkbox stays at its
+    // constructor default (unchecked) until the user clicks it — so
+    // persistence appears broken even when the round-trip works.
     emit attenuationChanged(m_attDb);
     emit preampModeChanged(m_preampMode);
     emit stepAttEnabledChanged(m_stepAttEnabled);

--- a/src/core/StepAttenuatorController.h
+++ b/src/core/StepAttenuatorController.h
@@ -279,8 +279,17 @@ public:
     void setReceiverManager(ReceiverManager* mgr);
 
     // Per-MAC persistence — save/load all ATT/preamp/auto-att settings.
+    //
+    // Issue #259: saveSettings is gated on m_loadedMac == mac so a tear-
+    // down that fires before the matching loadSettings can't overwrite
+    // the persisted state with constructor defaults. Call
+    // markSettingsUnloaded() on disconnect (clears m_loadedMac) so the
+    // next connect's tear-down doesn't reuse a stale load tag from a
+    // previously-loaded different radio.
     void saveSettings(const QString& mac);
     void loadSettings(const QString& mac);
+    void markSettingsUnloaded() { m_loadedMac.clear(); }
+    bool settingsLoaded() const { return !m_loadedMac.isEmpty(); }
 
     // --- Tick (public for testability) ---
 
@@ -378,6 +387,23 @@ private:
     bool m_stepAttEnabled = true;
     int m_maxAttDb = kDefaultMaxAttDb;
     int m_minAttDb = kDefaultMinAttDb;
+
+    // Issue #259 — guards saveSettings against pre-load clobber.
+    //
+    // Bug pattern: during connectToRadio() the existing m_connection (from
+    // a previous attempt or an in-flight auto-reconnect) triggers a
+    // teardownConnection() in RadioModel::connectToRadio. Our save call in
+    // teardownConnection fires BEFORE the matching loadSettings runs for
+    // this MAC, so it writes the constructor defaults (m_attDb=0,
+    // m_stepAttEnabled=true) over the user's previously-persisted state.
+    //
+    // The gate: m_loadedMac is set to the MAC at loadSettings entry. A
+    // saveSettings call where mac != m_loadedMac short-circuits and does
+    // nothing, so the defaults never make it to disk before the real
+    // values have been pulled in. (Cleared on disconnect via
+    // markSettingsUnloaded() so a different-MAC connect doesn't reuse
+    // a stale load tag from a prior radio.)
+    QString m_loadedMac;
 
     // Auto-att configuration.
     bool m_autoAttEnabled = false;

--- a/src/core/StepAttenuatorController.h
+++ b/src/core/StepAttenuatorController.h
@@ -144,6 +144,20 @@ public:
     bool autoAttEnabled() const noexcept { return m_autoAttEnabled; }
     bool autoAttApplied() const noexcept { return m_autoAttApplied; }
 
+    // Issue #259 (review fix): expose Undo / Hold / Decay state so the
+    // GeneralOptionsPage cold-open init pulls every persisted auto-att
+    // field, not just enable + mode.  Without these the chkAutoAttUndoRx1
+    // and spnAutoAttHoldRx1 widgets stay at their constructor defaults
+    // even after loadSettings() restores the controller — exactly the
+    // partial-restore case the reviewer flagged on PR #260.
+    bool autoAttUndo() const noexcept { return m_autoUndoEnabled; }
+    // Adaptive-mode hold window expressed in whole seconds (Setup spinbox
+    // is integer-valued).  Internal storage is ms; the page wraps the
+    // setter pair setAutoAttHoldSeconds (Adaptive) / setAutoUndoDelaySec
+    // (Classic) on the same spinbox.
+    int adaptiveHoldSeconds() const noexcept { return m_adaptiveHoldMs / 1000; }
+    int autoUndoDelaySec() const noexcept { return m_autoUndoDelaySec; }
+
     // --- Configuration setters ---
 
     void setAutoAttEnabled(bool on);

--- a/src/gui/setup/GeneralOptionsPage.cpp
+++ b/src/gui/setup/GeneralOptionsPage.cpp
@@ -508,9 +508,15 @@ void GeneralOptionsPage::buildStepAttGroup()
             m_ctrl->setStepAttEnabled(on);
         }
     });
+    // Issue #259: RX2 toggle routes through the same single-RX controller as
+    // RX1 so its state persists. For ANAN-10E / single-ADC boards this matches
+    // Thetis's chkRX2StepAtt ↔ chkHermesStepAttenuator mirror (setup.cs:15719
+    // -15721 [v2.10.3.13]). Full per-RX state is Phase 3F (multi-pan) scope.
     connect(m_chkRx2StepAttEnable, &QCheckBox::toggled, this, [this](bool on) {
         m_spnRx2StepAttValue->setEnabled(on);
-        // Controller is single-RX for step-att enable; RX2 is future expansion.
+        if (m_ctrl) {
+            m_ctrl->setStepAttEnabled(on);
+        }
     });
 
     // --- Spinbox → controller ---
@@ -645,11 +651,34 @@ void GeneralOptionsPage::connectController()
     connect(m_ctrl, &StepAttenuatorController::adcLinkedChanged,
             m_lblAdcLinked, &QLabel::setVisible);
 
-    // Attenuation changed → update RX1 spinbox (controller is single-RX)
+    // Attenuation changed → update both RX1 and RX2 spinboxes. The controller
+    // is single-RX (m_attDb backs both), so a write from either spinbox
+    // propagates to the other via this signal. Issue #259: previously only
+    // RX1 was wired, leaving RX2 stuck at zero after loadSettings restored
+    // a non-zero value through attenuationChanged.
     connect(m_ctrl, &StepAttenuatorController::attenuationChanged,
             this, [this](int dB) {
-        QSignalBlocker blk(m_spnRx1StepAttValue);
+        QSignalBlocker blk1(m_spnRx1StepAttValue);
+        QSignalBlocker blk2(m_spnRx2StepAttValue);
         m_spnRx1StepAttValue->setValue(dB);
+        m_spnRx2StepAttValue->setValue(dB);
+    });
+
+    // Enable state changed → update both RX1 and RX2 checkboxes and cascade
+    // each spinbox's enabled state. Issue #259: without this wiring, the
+    // controller's m_stepAttEnabled (correctly restored by loadSettings)
+    // never reaches the UI, so the user sees the box unchecked even when
+    // persistence worked end-to-end.
+    connect(m_ctrl, &StepAttenuatorController::stepAttEnabledChanged,
+            this, [this](bool on) {
+        {
+            QSignalBlocker blk1(m_chkRx1StepAttEnable);
+            QSignalBlocker blk2(m_chkRx2StepAttEnable);
+            m_chkRx1StepAttEnable->setChecked(on);
+            m_chkRx2StepAttEnable->setChecked(on);
+        }
+        m_spnRx1StepAttValue->setEnabled(on);
+        m_spnRx2StepAttValue->setEnabled(on);
     });
 }
 

--- a/src/gui/setup/GeneralOptionsPage.cpp
+++ b/src/gui/setup/GeneralOptionsPage.cpp
@@ -742,7 +742,13 @@ void GeneralOptionsPage::initFromController()
     }
     m_spnRx1StepAttValue->setEnabled(stepOn);
 
-    // Auto-att group — same lazy-construct problem.
+    // Auto-att group — same lazy-construct problem. Issue #259 PR #260
+    // review fix: previously this only pulled enable + mode, leaving
+    // chkAutoAttUndoRx1 + spnAutoAttHoldRx1 at their constructor defaults
+    // even when the controller had restored real values from disk. Pull
+    // all four fields and apply the mode-aware Undo↔Decay relabel + the
+    // mode-aware hold-vs-delay spinbox value (the same handler the cmbMode
+    // currentIndexChanged slot wires up in buildAutoAttGroup at line ~596).
     {
         QSignalBlocker blk(m_chkAutoAttRx1);
         m_chkAutoAttRx1->setChecked(m_ctrl->autoAttEnabled());
@@ -751,7 +757,28 @@ void GeneralOptionsPage::initFromController()
         QSignalBlocker blk(m_cmbAutoAttRx1Mode);
         m_cmbAutoAttRx1Mode->setCurrentIndex(static_cast<int>(m_ctrl->autoAttMode()));
     }
-    const bool autoOn = m_chkAutoAttRx1->isChecked();
+    const bool isAdaptive =
+        (m_ctrl->autoAttMode() == AutoAttMode::Adaptive);
+    {
+        QSignalBlocker blk(m_chkAutoAttUndoRx1);
+        m_chkAutoAttUndoRx1->setChecked(m_ctrl->autoAttUndo());
+        // Match the cmbMode::currentIndexChanged handler in buildAutoAttGroup
+        // (line ~596) — Adaptive uses "Decay", Classic uses "Undo".
+        m_chkAutoAttUndoRx1->setText(isAdaptive
+            ? QStringLiteral("Decay") : QStringLiteral("Undo"));
+    }
+    {
+        QSignalBlocker blk(m_spnAutoAttHoldRx1);
+        // In Adaptive mode the spinbox holds the seconds-of-hold; in
+        // Classic mode it holds the undo-delay seconds. The
+        // spnHold::valueChanged binding (buildAutoAttGroup line ~615)
+        // dispatches setAutoAttHoldSeconds vs setAutoUndoDelaySec on
+        // the same widget; mirror that here on the read side.
+        m_spnAutoAttHoldRx1->setValue(isAdaptive
+            ? m_ctrl->adaptiveHoldSeconds()
+            : m_ctrl->autoUndoDelaySec());
+    }
+    const bool autoOn = m_ctrl->autoAttEnabled();
     m_cmbAutoAttRx1Mode->setEnabled(autoOn);
     m_chkAutoAttUndoRx1->setEnabled(autoOn);
     m_spnAutoAttHoldRx1->setEnabled(autoOn && m_chkAutoAttUndoRx1->isChecked());

--- a/src/gui/setup/GeneralOptionsPage.cpp
+++ b/src/gui/setup/GeneralOptionsPage.cpp
@@ -526,6 +526,7 @@ void GeneralOptionsPage::buildStepAttGroup()
     // (lines 15750-15760), gated on chk != null (sender is a CheckBoxTS, i.e.
     // a real user click) AND HasSteppedAttenuation(2) AND shared-ADC. Mirror
     // wiring is deferred until the controller carries independent RX2 state.
+    //MW0LGE [2.9.0.6]  [original inline comment from setup.cs:15742 — "only if we click it"]
     connect(m_chkRx1StepAttEnable, &QCheckBox::toggled, this, [this](bool on) {
         m_spnRx1StepAttValue->setEnabled(on);
         if (m_ctrl) {
@@ -534,8 +535,10 @@ void GeneralOptionsPage::buildStepAttGroup()
     });
 
     // --- Spinbox → controller ---
-    // From Thetis setup.cs:15765-15787 [v2.10.3.13] udHermesStepAttenuator
-    // Data_ValueChanged → console.RX1AttenuatorData.
+    // From Thetis setup.cs:15765-15772 [v2.10.3.13] udHermesStepAttenuator
+    // Data_ValueChanged → console.RX1AttenuatorData. (The model-gated
+    // Maximum=61 branch at setup.cs:15773-15786 lives in BoardCapsTable
+    // ::stepAttMaxDb in NereusSDR.)
     connect(m_spnRx1StepAttValue, &QSpinBox::valueChanged, this, [this](int dB) {
         if (m_ctrl) {
             m_ctrl->setAttenuation(dB, 0);

--- a/src/gui/setup/GeneralOptionsPage.cpp
+++ b/src/gui/setup/GeneralOptionsPage.cpp
@@ -157,6 +157,14 @@ GeneralOptionsPage::GeneralOptionsPage(RadioModel* model, QWidget* parent)
         m_spnRx1StepAttValue->setRange(minDb, maxDb);
         m_spnRx2StepAttValue->setRange(minDb, maxDb);
         connectController();
+        // Issue #259 — pull the controller's already-restored state into
+        // the widgets. Must run AFTER connectController() so that any
+        // controller signal that fires later goes to wired slots; must run
+        // AT construction so the cold-open case (page constructed after
+        // RadioModel::loadSliceState has already triggered the controller's
+        // loadSettings) doesn't show stale defaults. See the function-level
+        // comment in initFromController() for the full lazy-construct trace.
+        initFromController();
     }
 }
 
@@ -484,12 +492,23 @@ void GeneralOptionsPage::buildStepAttGroup()
     vbox->addLayout(rx1Row);
 
     // --- RX2 row ---
+    // Issue #259: RX2 step-att UI is constructed (m_chkRx2StepAttEnable +
+    // m_spnRx2StepAttValue) and added to the layout, then hidden until the
+    // controller gains independent RX2 state (m_stepAttEnabledRx2 / m_attDbRx2)
+    // plus its own rx2Enabled / rx2Value / rx2Band/<band> persistence schema.
+    // Hiding rather than removing keeps the existing widget members alive so
+    // the connectController() / initFromController() blocks below stay
+    // structurally identical to the eventual RX2-enabled wiring. The Thetis
+    // contract — independent RX1/RX2 storage with a click-time
+    // RX1↔RX2 mirror when nRX1ADCinUse == nRX2ADCinUse (setup.cs:15741-15760
+    // [v2.10.3.13]) — is the follow-up implementation target.
     auto* rx2Row = new QHBoxLayout;
     m_chkRx2StepAttEnable = new QCheckBox(QStringLiteral("RX2 Enable"), group);
-    // From Thetis setup.cs: chkHermesStepAttenuator (RX2 mirror)
     m_chkRx2StepAttEnable->setToolTip(QStringLiteral("Enable the step attenuator."));
+    m_chkRx2StepAttEnable->setVisible(false);
     m_spnRx2StepAttValue = makeDbSpinBox(group);
     m_spnRx2StepAttValue->setEnabled(false);
+    m_spnRx2StepAttValue->setVisible(false);
     rx2Row->addWidget(m_chkRx2StepAttEnable);
     rx2Row->addWidget(m_spnRx2StepAttValue);
     rx2Row->addStretch();
@@ -502,32 +521,24 @@ void GeneralOptionsPage::buildStepAttGroup()
     vbox->addWidget(m_lblAdcLinked);
 
     // --- Enable/disable cascade ---
+    // From Thetis setup.cs:15730-15762 [v2.10.3.13] chkHermesStepAttenuator_
+    // CheckedChanged. The RX1↔RX2 click-time mirror lives in that handler
+    // (lines 15750-15760), gated on chk != null (sender is a CheckBoxTS, i.e.
+    // a real user click) AND HasSteppedAttenuation(2) AND shared-ADC. Mirror
+    // wiring is deferred until the controller carries independent RX2 state.
     connect(m_chkRx1StepAttEnable, &QCheckBox::toggled, this, [this](bool on) {
         m_spnRx1StepAttValue->setEnabled(on);
         if (m_ctrl) {
             m_ctrl->setStepAttEnabled(on);
         }
     });
-    // Issue #259: RX2 toggle routes through the same single-RX controller as
-    // RX1 so its state persists. For ANAN-10E / single-ADC boards this matches
-    // Thetis's chkRX2StepAtt ↔ chkHermesStepAttenuator mirror (setup.cs:15719
-    // -15721 [v2.10.3.13]). Full per-RX state is Phase 3F (multi-pan) scope.
-    connect(m_chkRx2StepAttEnable, &QCheckBox::toggled, this, [this](bool on) {
-        m_spnRx2StepAttValue->setEnabled(on);
-        if (m_ctrl) {
-            m_ctrl->setStepAttEnabled(on);
-        }
-    });
 
     // --- Spinbox → controller ---
+    // From Thetis setup.cs:15765-15787 [v2.10.3.13] udHermesStepAttenuator
+    // Data_ValueChanged → console.RX1AttenuatorData.
     connect(m_spnRx1StepAttValue, &QSpinBox::valueChanged, this, [this](int dB) {
         if (m_ctrl) {
             m_ctrl->setAttenuation(dB, 0);
-        }
-    });
-    connect(m_spnRx2StepAttValue, &QSpinBox::valueChanged, this, [this](int dB) {
-        if (m_ctrl) {
-            m_ctrl->setAttenuation(dB, 1);
         }
     });
 
@@ -628,6 +639,16 @@ void GeneralOptionsPage::buildAutoAttGroup()
         }
 
         contentLayout()->addWidget(group);
+
+        // Issue #259: hide the Auto-Att RX2 group alongside the hidden
+        // RX2 step-att row. The controller is single-RX (auto-att is
+        // RX1-only too); independent RX2 auto-att lands with the
+        // controller-side RX2 refactor. From Thetis groupBoxTS47 the
+        // Auto-Att RX1 / RX2 boxes are independent — same Phase 3F
+        // follow-up scope as RX2 step-att.
+        if (rx == 1) {
+            group->setVisible(false);
+        }
     };
 
     buildOneRx(QStringLiteral("Auto Attenuate RX1"), 0,
@@ -651,35 +672,86 @@ void GeneralOptionsPage::connectController()
     connect(m_ctrl, &StepAttenuatorController::adcLinkedChanged,
             m_lblAdcLinked, &QLabel::setVisible);
 
-    // Attenuation changed → update both RX1 and RX2 spinboxes. The controller
-    // is single-RX (m_attDb backs both), so a write from either spinbox
-    // propagates to the other via this signal. Issue #259: previously only
-    // RX1 was wired, leaving RX2 stuck at zero after loadSettings restored
-    // a non-zero value through attenuationChanged.
+    // Attenuation changed → update RX1 spinbox. Controller is single-RX
+    // (m_attDb backs RX1 only); the RX2 row is hidden until the controller
+    // gains independent RX2 state.
     connect(m_ctrl, &StepAttenuatorController::attenuationChanged,
             this, [this](int dB) {
-        QSignalBlocker blk1(m_spnRx1StepAttValue);
-        QSignalBlocker blk2(m_spnRx2StepAttValue);
+        QSignalBlocker blk(m_spnRx1StepAttValue);
         m_spnRx1StepAttValue->setValue(dB);
-        m_spnRx2StepAttValue->setValue(dB);
     });
 
-    // Enable state changed → update both RX1 and RX2 checkboxes and cascade
-    // each spinbox's enabled state. Issue #259: without this wiring, the
-    // controller's m_stepAttEnabled (correctly restored by loadSettings)
-    // never reaches the UI, so the user sees the box unchecked even when
-    // persistence worked end-to-end.
+    // Enable state changed → update RX1 checkbox + cascade RX1 spinbox
+    // enabled state. Issue #259: this is what closes the loop for the
+    // post-reload restore on the next live signal (e.g. an external
+    // setStepAttEnabled), but the cold-open case is handled in the
+    // constructor via initFromController() — see GeneralOptionsPage ctor
+    // for the full rationale.
     connect(m_ctrl, &StepAttenuatorController::stepAttEnabledChanged,
             this, [this](bool on) {
         {
-            QSignalBlocker blk1(m_chkRx1StepAttEnable);
-            QSignalBlocker blk2(m_chkRx2StepAttEnable);
+            QSignalBlocker blk(m_chkRx1StepAttEnable);
             m_chkRx1StepAttEnable->setChecked(on);
-            m_chkRx2StepAttEnable->setChecked(on);
         }
         m_spnRx1StepAttValue->setEnabled(on);
-        m_spnRx2StepAttValue->setEnabled(on);
     });
+}
+
+// ---------------------------------------------------------------------------
+// initFromController — pull the controller's current state into the widgets
+// at page construction time.
+//
+// Issue #259 — the SetupDialog (and every page in it) is constructed lazily
+// on every Tools → Setup open via `new SetupDialog(m_radioModel, this)` at
+// the seven call sites in MainWindow.cpp. So:
+//
+//   1. App launches, no SetupDialog yet.
+//   2. RadioModel connects, StepAttenuatorController::loadSettings runs,
+//      m_stepAttEnabled / m_attDb are restored, and the controller emits
+//      stepAttEnabledChanged + attenuationChanged. The page does not exist
+//      yet — nobody is listening.
+//   3. User opens Setup. GeneralOptionsPage constructor runs, connect-
+//      Controller() wires future signals, but nothing fires retroactively.
+//      Widget state is the QCheckBox / QSpinBox default (unchecked / 0).
+//
+// initFromController() pulls the current controller state into the widgets
+// once, at construction time, with signals blocked so the read does not
+// loop back into the controller. From this point on, future user edits
+// (toggled / valueChanged) and future controller signals (stepAttEnabled-
+// Changed / attenuationChanged) keep the two sides in sync.
+// ---------------------------------------------------------------------------
+void GeneralOptionsPage::initFromController()
+{
+    if (!m_ctrl) {
+        return;
+    }
+
+    const bool stepOn = m_ctrl->stepAttEnabled();
+    const int  attDb  = m_ctrl->attenuatorDb();
+
+    {
+        QSignalBlocker blk(m_chkRx1StepAttEnable);
+        m_chkRx1StepAttEnable->setChecked(stepOn);
+    }
+    {
+        QSignalBlocker blk(m_spnRx1StepAttValue);
+        m_spnRx1StepAttValue->setValue(attDb);
+    }
+    m_spnRx1StepAttValue->setEnabled(stepOn);
+
+    // Auto-att group — same lazy-construct problem.
+    {
+        QSignalBlocker blk(m_chkAutoAttRx1);
+        m_chkAutoAttRx1->setChecked(m_ctrl->autoAttEnabled());
+    }
+    {
+        QSignalBlocker blk(m_cmbAutoAttRx1Mode);
+        m_cmbAutoAttRx1Mode->setCurrentIndex(static_cast<int>(m_ctrl->autoAttMode()));
+    }
+    const bool autoOn = m_chkAutoAttRx1->isChecked();
+    m_cmbAutoAttRx1Mode->setEnabled(autoOn);
+    m_chkAutoAttUndoRx1->setEnabled(autoOn);
+    m_spnAutoAttHoldRx1->setEnabled(autoOn && m_chkAutoAttUndoRx1->isChecked());
 }
 
 // ---------------------------------------------------------------------------

--- a/src/gui/setup/GeneralOptionsPage.h
+++ b/src/gui/setup/GeneralOptionsPage.h
@@ -120,6 +120,11 @@ private:
     void buildStepAttGroup();
     void buildAutoAttGroup();
     void connectController();
+    // Issue #259 — pull the controller's already-restored state into the
+    // widgets at construction time so that lazy SetupDialog construction
+    // (after RadioModel::loadSliceState has triggered the controller's
+    // own loadSettings) doesn't surface stale defaults.
+    void initFromController();
 
     StepAttenuatorController* m_ctrl{nullptr};
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -6517,8 +6517,17 @@ void RadioModel::teardownConnection()
     // `if (m_radioModel->connection())` guard there skips the save. Use
     // m_lastRadioInfo.macAddress (which survives teardown) to pin the
     // per-MAC keys, mirroring the TransmitModel pattern just above.
+    //
+    // StepAttenuatorController::saveSettings is itself gated on
+    // m_loadedMac == mac, so this call is a no-op when teardown fires
+    // before loadSettings (the pre-load clobber path the bench trace
+    // surfaced — see StepAttenuatorController::saveSettings comment).
+    // After saving, mark the controller as unloaded so a fresh connect
+    // (even to the same MAC) must re-load before its teardown can save
+    // again.
     if (m_stepAttController && !m_lastRadioInfo.macAddress.isEmpty()) {
         m_stepAttController->saveSettings(m_lastRadioInfo.macAddress);
+        m_stepAttController->markSettingsUnloaded();
     }
 
     // Issue #177 — clear any in-flight TUN-off bookkeeping.  If we are

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -6509,6 +6509,18 @@ void RadioModel::teardownConnection()
         m_transmitModel.persistToSettings(m_lastRadioInfo.macAddress);
     }
 
+    // Issue #259 — flush step-attenuator state to AppSettings BEFORE the
+    // RadioConnection is destroyed. The MainWindow disconnect-branch in
+    // onConnectionStateChanged also calls saveSettings(), but by the time
+    // setConnectionState(Disconnected) fires below, m_connection has
+    // already been nulled by teardownWorkerThreadedConnection() and the
+    // `if (m_radioModel->connection())` guard there skips the save. Use
+    // m_lastRadioInfo.macAddress (which survives teardown) to pin the
+    // per-MAC keys, mirroring the TransmitModel pattern just above.
+    if (m_stepAttController && !m_lastRadioInfo.macAddress.isEmpty()) {
+        m_stepAttController->saveSettings(m_lastRadioInfo.macAddress);
+    }
+
     // Issue #177 — clear any in-flight TUN-off bookkeeping.  If we are
     // tearing down mid-walk, MoxController::rxReady will never fire (timers
     // are stopped) so the deferred completion would otherwise stay armed

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -666,6 +666,11 @@ nereus_add_test(tst_band_change_recursion_guard)
 # ── Step attenuator / ADC overload detection ─────────────────────────────
 nereus_add_test(tst_step_attenuator_controller)
 
+# ── Issue #259: GeneralOptionsPage pulls controller state at construction ──
+# Pins the regression fix for lazy SetupDialog construction missing the
+# load-time stepAttEnabledChanged signal.
+nereus_add_test(tst_general_options_page_step_att_init)
+
 # ── BoardCapabilities flag-wiring (P1 full-parity §4) ────────────────────
 # Verifies populated-but-previously-unconsumed BoardCapabilities flags now
 # affect runtime behaviour:

--- a/tests/tst_board_capability_flag_wiring.cpp
+++ b/tests/tst_board_capability_flag_wiring.cpp
@@ -159,6 +159,12 @@ private slots:
         ctrl.setTickTimerEnabled(false);
         ctrl.setHasStepAttenuatorCal(false);
 
+        // Issue #259 gate: saveSettings is a no-op until loadSettings has
+        // tagged the controller for this MAC. Call loadSettings(kTestMac)
+        // first (it reads defaults since no keys exist yet) so the
+        // subsequent setAutoAttHoldSeconds + saveSettings actually persist.
+        ctrl.loadSettings(kTestMac);
+
         // Persist via saveSettings + reload to confirm the value round-trips
         // (the controller has no public hold-ms getter, only the persistence
         // key — so we exercise that path).

--- a/tests/tst_general_options_page_step_att_init.cpp
+++ b/tests/tst_general_options_page_step_att_init.cpp
@@ -1,0 +1,219 @@
+// tests/tst_general_options_page_step_att_init.cpp  (NereusSDR)
+//
+// no-port-check: test fixture — no Thetis attribution required.
+//
+// Issue #259 regression — GeneralOptionsPage was constructed lazily on every
+// Tools → Setup open via `new SetupDialog(m_radioModel, this)` (seven call
+// sites in MainWindow.cpp). On the post-restart open the page therefore
+// missed the load-time stepAttEnabledChanged + attenuationChanged signals
+// fired by StepAttenuatorController::loadSettings during connectToRadio,
+// so the "RX1 Enable" checkbox and "RX1 dB" spinbox displayed their
+// constructor defaults (unchecked / 0) instead of the persisted state.
+//
+// The fix adds a single initFromController() call at the end of the page
+// constructor that pulls m_ctrl->stepAttEnabled() and m_ctrl->attenuatorDb()
+// into the widgets (signals blocked so the read does not loop back to the
+// controller). These tests pin that behaviour.
+
+#include <QtTest/QtTest>
+#include <QApplication>
+#include <QCheckBox>
+#include <QGroupBox>
+#include <QSpinBox>
+
+#include "core/AppSettings.h"
+#include "core/StepAttenuatorController.h"
+#include "gui/setup/GeneralOptionsPage.h"
+#include "models/RadioModel.h"
+
+using namespace NereusSDR;
+
+namespace {
+
+// Construct a real StepAttenuatorController, install it on the model with
+// the requested initial enable/value state, then build the page on top.
+// Lifetime: the controller is parented to the model so it follows the
+// model's QObject teardown.
+GeneralOptionsPage* makePageWithController(RadioModel& model,
+                                           bool stepAttEnabled,
+                                           int  attDb,
+                                           QObject* parent)
+{
+    auto* ctrl = new StepAttenuatorController(&model);
+    ctrl->setMaxAttenuation(31);  // ANAN-10E classic range
+    ctrl->setStepAttEnabled(stepAttEnabled);
+    ctrl->setAttenuation(attDb, 0);
+    model.setStepAttController(ctrl);
+
+    auto* page = new GeneralOptionsPage(&model, qobject_cast<QWidget*>(parent));
+    return page;
+}
+
+}  // namespace
+
+class TestGeneralOptionsPageStepAttInit : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase()
+    {
+        if (!qApp) {
+            static int argc = 0;
+            new QApplication(argc, nullptr);
+        }
+        AppSettings::instance().clear();
+    }
+
+    // ── Controller has restored state BEFORE the page is constructed. ────────
+    //
+    // Mirrors the post-restart timeline:
+    //   1. App launches.
+    //   2. RadioModel connects → controller's loadSettings runs and restores
+    //      m_stepAttEnabled=true, m_attDb=5.
+    //   3. User opens Setup → page is constructed NOW (after the load).
+    //   4. Checkbox + spinbox must reflect the restored state.
+    //
+    // Before the fix the page would show unchecked / 0 because it relied on
+    // a stepAttEnabledChanged signal that had already fired.
+    void initFromController_restoresEnabledAndValue()
+    {
+        RadioModel model;
+        auto* page = makePageWithController(model, /*enabled=*/true,
+                                            /*dB=*/5, this);
+
+        auto* chk = page->findChild<QCheckBox*>();
+        Q_UNUSED(chk);
+        // Resolve the specific RX1 widgets by walking children — the
+        // GeneralOptionsPage holds them as private members so we can't
+        // address them directly. The checkbox text is "RX1 Enable" and
+        // the spinbox is the only one inside the same Step Attenuator
+        // group, so we find by text / sibling.
+
+        QCheckBox* rx1Chk = nullptr;
+        for (auto* c : page->findChildren<QCheckBox*>()) {
+            if (c->text() == QStringLiteral("RX1 Enable")) {
+                rx1Chk = c;
+                break;
+            }
+        }
+        QVERIFY2(rx1Chk, "RX1 Enable checkbox not found");
+        QCOMPARE(rx1Chk->isChecked(), true);
+
+        // The RX1 spinbox sits next to the RX1 checkbox inside the Step
+        // Attenuator group. The group's QSpinBox at index 0 (after layout
+        // construction) is the RX1 one.
+        auto spinBoxes = page->findChildren<QSpinBox*>();
+        QVERIFY2(!spinBoxes.isEmpty(), "no QSpinBox children");
+        QSpinBox* rx1Spin = nullptr;
+        for (auto* s : spinBoxes) {
+            // Match by enabled state cascade — the RX1 spinbox is the one
+            // sibling of the RX1 checkbox we just found, so it has the
+            // same parent QWidget (the layout's enclosing QWidget).
+            if (s->parent() == rx1Chk->parent()) {
+                rx1Spin = s;
+                break;
+            }
+        }
+        QVERIFY2(rx1Spin, "RX1 dB spinbox not found");
+        QCOMPARE(rx1Spin->value(), 5);
+        QCOMPARE(rx1Spin->isEnabled(), true);
+    }
+
+    // ── Controller has enable=false → checkbox unchecked, spinbox disabled. ──
+    void initFromController_disabledState()
+    {
+        RadioModel model;
+        auto* page = makePageWithController(model, /*enabled=*/false,
+                                            /*dB=*/12, this);
+
+        QCheckBox* rx1Chk = nullptr;
+        for (auto* c : page->findChildren<QCheckBox*>()) {
+            if (c->text() == QStringLiteral("RX1 Enable")) {
+                rx1Chk = c;
+                break;
+            }
+        }
+        QVERIFY2(rx1Chk, "RX1 Enable checkbox not found");
+        QCOMPARE(rx1Chk->isChecked(), false);
+
+        QSpinBox* rx1Spin = nullptr;
+        for (auto* s : page->findChildren<QSpinBox*>()) {
+            if (s->parent() == rx1Chk->parent()) {
+                rx1Spin = s;
+                break;
+            }
+        }
+        QVERIFY2(rx1Spin, "RX1 dB spinbox not found");
+        // Spinbox value should still be the controller's m_attDb (12),
+        // but the spinbox itself must be disabled because the enable
+        // checkbox is off.
+        QCOMPARE(rx1Spin->value(), 12);
+        QCOMPARE(rx1Spin->isEnabled(), false);
+    }
+
+    // ── RX2 row is hidden until independent RX2 state lands. ─────────────────
+    //
+    // Pins the deliberate UI gate: the RX2 step-att controls exist in the
+    // widget tree (so the existing connectController() / layout code keeps
+    // working) but are not visible. Lift this assertion when the controller
+    // grows an m_stepAttEnabledRx2 / m_attDbRx2 pair plus a click-time
+    // RX1↔RX2 mirror per Thetis setup.cs:15741-15760 [v2.10.3.13].
+    void rx2Row_isHiddenForNow()
+    {
+        RadioModel model;
+        auto* page = makePageWithController(model, /*enabled=*/true,
+                                            /*dB=*/5, this);
+
+        QCheckBox* rx2Chk = nullptr;
+        for (auto* c : page->findChildren<QCheckBox*>()) {
+            if (c->text() == QStringLiteral("RX2 Enable")) {
+                rx2Chk = c;
+                break;
+            }
+        }
+        QVERIFY2(rx2Chk, "RX2 Enable checkbox not found");
+        QVERIFY2(rx2Chk->isHidden(),
+                 "RX2 Enable must be hidden until independent RX2 state lands");
+    }
+
+    // ── Auto-Att RX2 group is hidden until independent RX2 state lands. ──────
+    //
+    // Pins the same gate as rx2Row_isHiddenForNow but for the second
+    // groupbox built by buildAutoAttGroup. The controller is single-RX
+    // (auto-att RX2 is future expansion); shipping the box would imply
+    // independent control we don't yet store. From Thetis groupBoxTS47 the
+    // RX1 / RX2 auto-att boxes are independent — same Phase 3F follow-up.
+    void autoAttRx2Group_isHiddenForNow()
+    {
+        RadioModel model;
+        auto* page = makePageWithController(model, /*enabled=*/true,
+                                            /*dB=*/5, this);
+
+        QGroupBox* autoAttRx2 = nullptr;
+        for (auto* g : page->findChildren<QGroupBox*>()) {
+            if (g->title() == QStringLiteral("Auto Attenuate RX2")) {
+                autoAttRx2 = g;
+                break;
+            }
+        }
+        QVERIFY2(autoAttRx2, "Auto Attenuate RX2 groupbox not found");
+        QVERIFY2(autoAttRx2->isHidden(),
+                 "Auto Attenuate RX2 must be hidden until independent RX2 state lands");
+
+        // Sanity check: RX1 auto-att group remains visible (not hidden).
+        QGroupBox* autoAttRx1 = nullptr;
+        for (auto* g : page->findChildren<QGroupBox*>()) {
+            if (g->title() == QStringLiteral("Auto Attenuate RX1")) {
+                autoAttRx1 = g;
+                break;
+            }
+        }
+        QVERIFY2(autoAttRx1, "Auto Attenuate RX1 groupbox not found");
+        QVERIFY2(!autoAttRx1->isHidden(),
+                 "Auto Attenuate RX1 must remain visible");
+    }
+};
+
+QTEST_MAIN(TestGeneralOptionsPageStepAttInit)
+#include "tst_general_options_page_step_att_init.moc"

--- a/tests/tst_general_options_page_step_att_init.cpp
+++ b/tests/tst_general_options_page_step_att_init.cpp
@@ -18,6 +18,7 @@
 #include <QtTest/QtTest>
 #include <QApplication>
 #include <QCheckBox>
+#include <QComboBox>
 #include <QGroupBox>
 #include <QSpinBox>
 
@@ -212,6 +213,108 @@ private slots:
         QVERIFY2(autoAttRx1, "Auto Attenuate RX1 groupbox not found");
         QVERIFY2(!autoAttRx1->isHidden(),
                  "Auto Attenuate RX1 must remain visible");
+    }
+
+    // ── Auto-Att RX1: full cold-open restore (PR #260 review fix). ───────────
+    //
+    // The first pass of initFromController only pulled autoAttEnabled +
+    // autoAttMode. The reviewer flagged that the Undo/Decay checkbox and
+    // the Hold/Delay spinbox stayed at constructor defaults even when the
+    // controller had restored real values from disk. This test pins the
+    // expanded init so every Auto-Att RX1 widget reflects the controller.
+    //
+    // Adaptive mode + autoUndoEnabled=true + adaptiveHoldMs=4000:
+    //   - cmbAutoAttRx1Mode → "Adaptive"
+    //   - chkAutoAttUndoRx1: checked, label "Decay" (Adaptive renames Undo
+    //     → Decay per buildAutoAttGroup line ~596).
+    //   - spnAutoAttHoldRx1: 4 seconds, enabled (autoOn && chkUndo).
+    void initFromController_restoresAutoAttAdaptive()
+    {
+        RadioModel model;
+        auto* ctrl = new StepAttenuatorController(&model);
+        ctrl->setMaxAttenuation(31);
+        ctrl->setStepAttEnabled(true);
+        ctrl->setHasStepAttenuatorCal(true);  // gate Adaptive on
+        ctrl->setAutoAttEnabled(true);
+        ctrl->setAutoAttMode(AutoAttMode::Adaptive);
+        ctrl->setAutoAttUndo(true);
+        ctrl->setAutoAttHoldSeconds(4.0);    // 4s → 4000 ms
+        model.setStepAttController(ctrl);
+
+        auto* page = new GeneralOptionsPage(&model, qobject_cast<QWidget*>(this));
+
+        // Find the Auto Attenuate RX1 group + its three widgets.
+        QGroupBox* group = nullptr;
+        for (auto* g : page->findChildren<QGroupBox*>()) {
+            if (g->title() == QStringLiteral("Auto Attenuate RX1")) {
+                group = g;
+                break;
+            }
+        }
+        QVERIFY2(group, "Auto Attenuate RX1 groupbox not found");
+
+        QComboBox* mode  = group->findChild<QComboBox*>();
+        QCheckBox* undo  = nullptr;
+        QCheckBox* en    = nullptr;
+        for (auto* c : group->findChildren<QCheckBox*>()) {
+            if (c->text() == QStringLiteral("Enable")) {
+                en = c;
+            } else {
+                undo = c;  // the only other QCheckBox is the Undo/Decay one
+            }
+        }
+        QSpinBox* hold = group->findChild<QSpinBox*>();
+        QVERIFY2(en   && mode && undo && hold, "Auto-Att widgets missing");
+
+        QCOMPARE(en->isChecked(),   true);
+        QCOMPARE(mode->currentText(), QStringLiteral("Adaptive"));
+        QCOMPARE(undo->isChecked(), true);
+        QCOMPARE(undo->text(),      QStringLiteral("Decay"));
+        QCOMPARE(hold->value(),     4);
+        QCOMPARE(mode->isEnabled(), true);
+        QCOMPARE(undo->isEnabled(), true);
+        QCOMPARE(hold->isEnabled(), true);
+    }
+
+    // ── Auto-Att RX1: Classic mode pulls autoUndoDelaySec onto the spinbox. ──
+    void initFromController_restoresAutoAttClassic()
+    {
+        RadioModel model;
+        auto* ctrl = new StepAttenuatorController(&model);
+        ctrl->setMaxAttenuation(31);
+        ctrl->setStepAttEnabled(true);
+        ctrl->setAutoAttEnabled(true);
+        ctrl->setAutoAttMode(AutoAttMode::Classic);
+        ctrl->setAutoAttUndo(true);
+        ctrl->setAutoUndoDelaySec(9);
+        model.setStepAttController(ctrl);
+
+        auto* page = new GeneralOptionsPage(&model, qobject_cast<QWidget*>(this));
+
+        QGroupBox* group = nullptr;
+        for (auto* g : page->findChildren<QGroupBox*>()) {
+            if (g->title() == QStringLiteral("Auto Attenuate RX1")) {
+                group = g;
+                break;
+            }
+        }
+        QVERIFY2(group, "Auto Attenuate RX1 groupbox not found");
+
+        QComboBox* mode = group->findChild<QComboBox*>();
+        QCheckBox* undo = nullptr;
+        for (auto* c : group->findChildren<QCheckBox*>()) {
+            if (c->text() != QStringLiteral("Enable")) {
+                undo = c;
+                break;
+            }
+        }
+        QSpinBox* hold = group->findChild<QSpinBox*>();
+        QVERIFY(mode && undo && hold);
+
+        QCOMPARE(mode->currentText(), QStringLiteral("Classic"));
+        QCOMPARE(undo->isChecked(),   true);
+        QCOMPARE(undo->text(),        QStringLiteral("Undo"));  // Classic keeps "Undo"
+        QCOMPARE(hold->value(),       9);                       // delay seconds, not hold
     }
 };
 

--- a/tests/tst_step_att_on_tx_value.cpp
+++ b/tests/tst_step_att_on_tx_value.cpp
@@ -173,6 +173,9 @@ private slots:
         {
             StepAttenuatorController ctrl;
             ctrl.setTickTimerEnabled(false);
+            // Issue #259 gate: tag the controller as loaded for this MAC
+            // before mutating + saving, otherwise saveSettings is a no-op.
+            ctrl.loadSettings(kTestMac);
             ctrl.setBand(Band::Band20m);
             ctrl.setAttOnTxValue(22);
             ctrl.saveSettings(kTestMac);

--- a/tests/tst_step_attenuator_controller.cpp
+++ b/tests/tst_step_attenuator_controller.cpp
@@ -414,10 +414,16 @@ private slots:
 
         // First controller: simulate the user toggling enable + value, then
         // saving on disconnect.
+        //
+        // The leading loadSettings tags the controller as loaded for this
+        // MAC so saveSettings is allowed to write. Issue #259: an unloaded
+        // controller's saveSettings is a no-op to prevent the pre-load
+        // clobber path (see persistence_saveBeforeLoad_doesNotClobber).
         {
             StepAttenuatorController ctrl;
             ctrl.setTickTimerEnabled(false);
             ctrl.setMaxAttenuation(31);
+            ctrl.loadSettings(mac);  // tag as loaded
             ctrl.setStepAttEnabled(true);
             ctrl.setAttenuation(5);
             QCOMPARE(ctrl.stepAttEnabled(), true);
@@ -459,6 +465,118 @@ private slots:
             QVERIFY2(attSpy.count() >= 1,
                 "loadSettings must emit attenuationChanged for spinbox sync");
             QCOMPARE(attSpy.last().at(0).toInt(), 5);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Issue #259 regression: saveSettings before loadSettings must NOT
+    // clobber the persisted file with constructor defaults.
+    //
+    // Bench failure mode: RadioModel::connectToRadio calls teardown-
+    // Connection when a previous m_connection still exists (auto-reconnect
+    // retry, panel-driven reconnect, etc). teardownConnection's
+    // saveSettings would fire with m_attDb=0 / m_stepAttEnabled=true
+    // before the matching loadSettings, overwriting the user's real
+    // persisted state. Confirmed at /tmp/nereus259/run.log:
+    //   18:31:11.242 saveSettings m_attDb=0
+    //   18:31:15.854 loadSettings DONE m_attDb=0  (reads back the clobber)
+    //
+    // The gate: m_loadedMac is empty until loadSettings runs for the MAC,
+    // and saveSettings short-circuits when m_loadedMac != mac.
+    // ─────────────────────────────────────────────────────────────────────
+    void persistence_saveBeforeLoad_doesNotClobber()
+    {
+        const QString mac = QStringLiteral("aa:bb:cc:de:ad:03");
+
+        // Session 1: user saved m_attDb=12 cleanly.
+        {
+            StepAttenuatorController ctrl;
+            ctrl.setTickTimerEnabled(false);
+            ctrl.setMaxAttenuation(31);
+            ctrl.setStepAttEnabled(true);
+            ctrl.setAttenuation(12);
+
+            ctrl.loadSettings(mac);  // tag the controller as loaded for this MAC
+            // (the values just read are at-defaults / not-yet-saved; loadSettings
+            //  is idempotent with respect to in-memory state we just set above)
+            ctrl.setAttenuation(12);  // re-apply after load
+            ctrl.saveSettings(mac);
+            AppSettings::instance().save();
+        }
+
+        // Session 2: fresh controller. saveSettings fires (simulating the
+        // pre-load teardown clobber path) BEFORE loadSettings runs.
+        {
+            StepAttenuatorController ctrl;
+            ctrl.setTickTimerEnabled(false);
+            ctrl.setMaxAttenuation(31);
+            QCOMPARE(ctrl.attenuatorDb(), 0);   // default
+            QCOMPARE(ctrl.settingsLoaded(), false);
+
+            // The bug: this would write m_attDb=0 to disk.
+            ctrl.saveSettings(mac);
+            AppSettings::instance().save();
+        }
+
+        // Session 3: verify the persisted value is still 12, not the
+        // accidental zero from Session 2.
+        {
+            StepAttenuatorController ctrl;
+            ctrl.setTickTimerEnabled(false);
+            ctrl.setMaxAttenuation(31);
+            ctrl.loadSettings(mac);
+            QCOMPARE(ctrl.attenuatorDb(), 12);
+            QCOMPARE(ctrl.settingsLoaded(), true);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Issue #259: markSettingsUnloaded() re-arms the gate so a re-connect
+    // (even to the same MAC) cannot save until loadSettings has run again.
+    // ─────────────────────────────────────────────────────────────────────
+    void persistence_markUnloaded_reArmsGate()
+    {
+        const QString mac = QStringLiteral("aa:bb:cc:de:ad:04");
+
+        // Prime: load + write a real value.
+        {
+            StepAttenuatorController ctrl;
+            ctrl.setTickTimerEnabled(false);
+            ctrl.setMaxAttenuation(31);
+            ctrl.loadSettings(mac);
+            ctrl.setAttenuation(7);
+            QVERIFY(ctrl.settingsLoaded());
+            ctrl.saveSettings(mac);
+            AppSettings::instance().save();
+        }
+
+        // Simulate disconnect-then-reconnect race: a fresh controller
+        // loads, marks unloaded (disconnect path), then sees a stray
+        // saveSettings before the next loadSettings runs. The save must
+        // be rejected so the persisted 7 survives.
+        {
+            StepAttenuatorController ctrl;
+            ctrl.setTickTimerEnabled(false);
+            ctrl.setMaxAttenuation(31);
+            ctrl.loadSettings(mac);
+            QCOMPARE(ctrl.attenuatorDb(), 7);
+
+            ctrl.markSettingsUnloaded();
+            QCOMPARE(ctrl.settingsLoaded(), false);
+
+            // Stray save in the unloaded state — must be a no-op.
+            ctrl.setAttenuation(0);  // simulate default reset by some code path
+            ctrl.saveSettings(mac);
+            AppSettings::instance().save();
+        }
+
+        // Verify the prior 7 survived the stray save.
+        {
+            StepAttenuatorController ctrl;
+            ctrl.setTickTimerEnabled(false);
+            ctrl.setMaxAttenuation(31);
+            ctrl.loadSettings(mac);
+            QCOMPARE(ctrl.attenuatorDb(), 7);
         }
     }
 

--- a/tests/tst_step_attenuator_controller.cpp
+++ b/tests/tst_step_attenuator_controller.cpp
@@ -66,6 +66,7 @@
 #include <QtTest/QtTest>
 #include <QSignalSpy>
 
+#include "core/AppSettings.h"
 #include "core/StepAttenuatorController.h"
 
 using namespace NereusSDR;
@@ -387,6 +388,102 @@ private slots:
             }
         }
         QVERIFY2(decayed, "ATT should decay below peak after hold period");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Issue #259 regression: enable + value persistence round-trip.
+    //
+    // Bug surface: user opens Setup → General → Options, sets RX1 Enable
+    // and RX2 Enable to 5 dB, closes Nereus, reopens — both controls
+    // revert to unchecked / 0 dB.
+    //
+    // The fix has two halves; this test covers half-A (controller
+    // persistence + signal emission) only. The MainWindow / RadioModel
+    // disconnect-ordering half is exercised at runtime (Activity Monitor
+    // ⌘Q can't be unit-tested without spinning up the full main thread).
+    //
+    // (a) saveSettings/loadSettings round-trip preserves m_stepAttEnabled.
+    // (b) loadSettings emits stepAttEnabledChanged so any UI bound via
+    //     connectController() sees the restored value.
+    // (c) loadSettings emits attenuationChanged so both the RX1 and RX2
+    //     spinboxes (wired in GeneralOptionsPage) update.
+    // ─────────────────────────────────────────────────────────────────────
+    void persistence_enableRoundTrip_emitsStepAttEnabledChanged()
+    {
+        const QString mac = QStringLiteral("aa:bb:cc:de:ad:01");
+
+        // First controller: simulate the user toggling enable + value, then
+        // saving on disconnect.
+        {
+            StepAttenuatorController ctrl;
+            ctrl.setTickTimerEnabled(false);
+            ctrl.setMaxAttenuation(31);
+            ctrl.setStepAttEnabled(true);
+            ctrl.setAttenuation(5);
+            QCOMPARE(ctrl.stepAttEnabled(), true);
+            QCOMPARE(ctrl.attenuatorDb(), 5);
+
+            ctrl.saveSettings(mac);
+            AppSettings::instance().save();
+        }
+
+        // Second controller: simulate fresh app launch + reconnect.
+        // setStepAttEnabled(false) FIRST so the load sees a real flip and
+        // we can verify both the value AND the signal emission.
+        {
+            StepAttenuatorController ctrl;
+            ctrl.setTickTimerEnabled(false);
+            ctrl.setMaxAttenuation(31);
+            ctrl.setStepAttEnabled(false);
+
+            QSignalSpy enableSpy(&ctrl,
+                &StepAttenuatorController::stepAttEnabledChanged);
+            QSignalSpy attSpy(&ctrl,
+                &StepAttenuatorController::attenuationChanged);
+
+            ctrl.loadSettings(mac);
+
+            QCOMPARE(ctrl.stepAttEnabled(), true);
+            QCOMPARE(ctrl.attenuatorDb(), 5);
+
+            // The fix: loadSettings must emit stepAttEnabledChanged so the
+            // checkbox in GeneralOptionsPage flips from default-unchecked
+            // to checked. Without this emit, the controller state is right
+            // but the UI is stale.
+            QVERIFY2(enableSpy.count() >= 1,
+                "loadSettings must emit stepAttEnabledChanged for UI sync");
+            QCOMPARE(enableSpy.last().at(0).toBool(), true);
+
+            // Existing attenuationChanged emit (already shipping) must keep
+            // working so both spinboxes update.
+            QVERIFY2(attSpy.count() >= 1,
+                "loadSettings must emit attenuationChanged for spinbox sync");
+            QCOMPARE(attSpy.last().at(0).toInt(), 5);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Issue #259 regression: a fresh / unsaved MAC must still emit
+    // stepAttEnabledChanged on load so the UI doesn't drift away from the
+    // controller's default-true.
+    // ─────────────────────────────────────────────────────────────────────
+    void persistence_loadSignalsOnDefaultEnabled()
+    {
+        const QString freshMac = QStringLiteral("aa:bb:cc:de:ad:02");
+
+        StepAttenuatorController ctrl;
+        ctrl.setTickTimerEnabled(false);
+        // Drop to false so the load → default-True transition is observable.
+        ctrl.setStepAttEnabled(false);
+
+        QSignalSpy enableSpy(&ctrl,
+            &StepAttenuatorController::stepAttEnabledChanged);
+
+        ctrl.loadSettings(freshMac);
+
+        QCOMPARE(ctrl.stepAttEnabled(), true);
+        QVERIFY2(enableSpy.count() >= 1,
+            "loadSettings must emit stepAttEnabledChanged even on fresh MAC");
     }
 };
 


### PR DESCRIPTION
## Summary

Closes #259 — RX1 Enable / RX2 Enable and their dB values in
**Setup → General → Options → Step Attenuator** were reverting to
unchecked / 0 dB after closing and reopening Nereus on ANAN-10E.

Three reinforcing root causes:

1. **`saveSettings()` never ran at app close.**
   `RadioModel::teardownConnection()` nulls `m_connection` via
   `teardownWorkerThreadedConnection()` *before* emitting
   `connectionStateChanged(Disconnected)`. By the time
   `MainWindow::onConnectionStateChanged` runs the disconnect branch,
   `m_radioModel->connection()` is already `nullptr` and the
   `if (connection())` guard around the save was always false. Fix:
   call `m_stepAttController->saveSettings(m_lastRadioInfo.macAddress)`
   inside `teardownConnection` itself, mirroring the `TransmitModel`
   persistence pattern just above it.

2. **`loadSettings()` didn't emit `stepAttEnabledChanged`.** Even after
   fix (1), the controller's restored `m_stepAttEnabled` never reached
   the UI — only `attenuationChanged` and `preampModeChanged` were
   emitted. Added the missing emit at the end of `loadSettings`.

3. **`GeneralOptionsPage::connectController` only wired the RX1 spinbox.**
   Both checkboxes and both spinboxes now follow the controller. The
   RX2 toggle is additionally routed through `setStepAttEnabled` so it
   actually persists, matching Thetis's `chkRX2StepAtt ↔
   chkHermesStepAttenuator` mirror on shared-ADC boards
   (`setup.cs:15719-15721 [v2.10.3.13]`). Full per-RX state remains
   Phase 3F (multi-pan) scope.

## Test plan

- [x] New unit tests cover (a) save → reload preserves `m_stepAttEnabled`,
      (b) `loadSettings` emits `stepAttEnabledChanged` on the restored
      value, (c) `loadSettings` emits the signal even on a fresh MAC
      (so the controller's default-true reaches the UI on first run).
- [x] `ctest -j6` passes 471/471 locally.
- [ ] Bench verification on ANAN-10E by issue reporter: set RX1 Enable +
      RX2 Enable to 5 dB, close Nereus, reopen, confirm both controls
      come back checked at 5 dB.

J.J. Boyd ~ KG4VCF


## Update — pre-load clobber + lazy SetupDialog stale state + RX2 hidden

After bench review the original RX1↔RX2 mirror was the wrong call —
Thetis stores RX1 and RX2 independently and only mirrors on user
click when both RXes share an ADC (`setup.cs:15741-15760
[v2.10.3.13]`). The right NereusSDR fix needs independent
`m_stepAttEnabledRx2` / `m_attDbRx2` + an analogous independent
RX2 auto-att path + a click-time mirror — that is a real refactor
and is queued as a follow-up.

For this PR the RX2 step-att row and the Auto Attenuate RX2
groupbox in **Setup → General → Options** are constructed but
`setVisible(false)`. The existing wiring scaffolding stays in place
so the follow-up touches only the controller side.

A second issue surfaced during HL2 bench testing: persistence of
the RX1 dB value was still failing after the f838a370 commit. The
diagnostic trace caught the clobber path:

```
18:31:11.242 saveSettings m_attDb=0      <-- pre-load teardown
18:31:15.854 loadSettings DONE m_attDb=0  <-- reads back the clobber
```

`RadioModel::connectToRadio` calls `teardownConnection()` whenever
`m_connection` already exists (auto-reconnect retry, panel-driven
reconnect, etc). That teardown's `saveSettings` fired before the
matching `loadSettings`, persisting the controller's constructor
defaults over the user's real saved state. The next `loadSettings`
then read back the freshly-clobbered zero.

Fix: `StepAttenuatorController` gains `m_loadedMac`, set by
`loadSettings` and cleared by `markSettingsUnloaded()`.
`saveSettings` short-circuits unless `m_loadedMac == mac`, so a
pre-load teardown is a no-op. `RadioModel::teardownConnection`
calls `markSettingsUnloaded()` after the save so the next connect
must re-load before its own teardown can save.

Third half (the lazy-SetupDialog miss already mentioned above in
the original PR body): the new `GeneralOptionsPage::initFromController()`
runs at construction with `QSignalBlocker` around each set and pulls
the controller's already-restored state into the widgets, so the
page constructed after `loadSettings` shows the right values.

## Bench verification (HL2)

Connect → Setup → General → Options → RX1 Enable ✓, dB = 6 → close →
⌘Q → relaunch → reconnect → open Setup → Options. RX1 Enable still
checked, spinbox at 6. Persisted file: `rx1Enabled=True`,
`rx1Value=6`, `rx1Band/GEN=6`.

New regression tests:

- `tst_step_attenuator_controller`:
  `persistence_saveBeforeLoad_doesNotClobber`,
  `persistence_markUnloaded_reArmsGate`,
  plus updates to the existing persistence cases for the new gate.
- `tst_general_options_page_step_att_init` (new file):
  `initFromController_restoresEnabledAndValue`,
  `initFromController_disabledState`,
  `rx2Row_isHiddenForNow`,
  `autoAttRx2Group_isHiddenForNow`.

Full `ctest -j6`: 472/472 pass.

J.J. Boyd ~ KG4VCF
