### PR TITLE
fix(p1,tx): connect log spam + TX teardown moveToThread (#258)

### DIFF
--- a/src/core/P1RadioConnection.cpp
+++ b/src/core/P1RadioConnection.cpp
@@ -2090,7 +2090,18 @@ void P1RadioConnection::onReadyRead()
 {
     if (!m_socket) { return; }
 
-    const ConnectionState cs = state();
+    // Note: not `const` — we update this local snapshot below when the
+    // Connecting -> Connected promotion fires on the first 1032-byte
+    // datagram, so the "ep6 stream established" log line emits exactly
+    // once per readyRead batch instead of once per datagram in the batch.
+    // Without the update, when UDP delivers a burst of ep6 frames in a
+    // single readyRead (common on first-connect because the radio is
+    // already streaming when metis-start lands), every iteration of the
+    // drain loop below sees `cs == Connecting`, calls setState(Connected)
+    // (idempotent), and re-emits the log line.  Issue #258 — observed
+    // 181 spurious "Connected, ep6 stream established" lines in <10 ms
+    // on first connect, misread as a "reconnect storm" in the bug report.
+    ConnectionState cs = state();
     // Only process ep6 data when Connected or Connecting (reconnect attempt).
     if (cs != ConnectionState::Connected && cs != ConnectionState::Connecting) {
         // Drain the socket anyway to avoid buffering.
@@ -2144,6 +2155,9 @@ void P1RadioConnection::onReadyRead()
                 if (m_reconnectTimer) { m_reconnectTimer->stop(); }
                 if (!m_watchdogTimer->isActive()) { m_watchdogTimer->start(); }
                 setState(ConnectionState::Connected);
+                // Sync the local snapshot so subsequent iterations of the
+                // drain loop don't re-enter this branch.  Issue #258.
+                cs = ConnectionState::Connected;
                 if (wasReconnecting) {
                     if (!m_reconnectedLogged) {
                         qCDebug(lcConnection) << "P1: Reconnected, ep6 stream restored";

--- a/src/core/TxWorkerThread.cpp
+++ b/src/core/TxWorkerThread.cpp
@@ -376,6 +376,34 @@ void TxWorkerThread::run()
         dispatchOneBlock();
     }
 
+    // Issue #258 — move m_txChannel back to this worker's creator thread
+    // (i.e. RadioModel's thread = main) BEFORE run() exits.
+    //
+    // Qt6's QObject::moveToThread requires the call to be made from the
+    // object's CURRENT thread.  If RadioModel::teardownConnection (or
+    // setActiveRxCountLive) tries to do this from the main thread AFTER
+    // stopPump returns, m_txChannel's affinity is still THIS (now-finished)
+    // worker — Qt emits "Current thread (%p) is not the object's thread"
+    // and silently aborts the move.  m_txWorker.reset() then destroys
+    // this QThread while m_txChannel still holds thread affinity pointing
+    // at it; the dangling thread-data is then walked during m_txChannel's
+    // own destruction, which on Windows surfaces as a 0xc0000409
+    // security-check failure in ucrtbase.dll (field-observed in #258).
+    //
+    // Doing the move HERE — from this worker thread, which IS m_txChannel's
+    // current affinity — satisfies Qt's precondition and lets stopPump's
+    // QThread::wait() return with m_txChannel already safely back on main.
+    // The corresponding moveToThread calls in RadioModel.cpp are preserved
+    // as defensive no-ops (Qt early-returns when target == current).
+    //
+    // `this->thread()` is the QObject affinity of the TxWorkerThread
+    // *object* (not the OS thread executing run()), which by construction
+    // is the thread that constructed this TxWorkerThread — RadioModel's
+    // thread = main.
+    if (m_txChannel) {
+        m_txChannel->moveToThread(this->thread());
+    }
+
     qCInfo(lcTxWorker) << "run: worker thread loop exited";
 }
 

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -6563,6 +6563,14 @@ void RadioModel::teardownConnection()
         // semaphore release that breaks the worker out of waitForBlock).
         m_txWorker->stopPump();
         if (m_txChannel) {
+            // Issue #258: TxWorkerThread::run() moves m_txChannel back to
+            // this thread before returning, so by the time stopPump's
+            // QThread::wait() unblocks, m_txChannel is already here.  This
+            // call is therefore a defensive no-op (Qt early-returns when
+            // the target thread equals the object's current thread).  Keep
+            // it so the invariant is explicit at the teardown site and a
+            // future refactor that breaks the run()-side move still leaves
+            // teardown safe rather than introducing a hard crash.
             m_txChannel->moveToThread(this->thread());
         }
         m_txWorker.reset();
@@ -8425,6 +8433,10 @@ qint64 RadioModel::setActiveRxCountLive(int newCount)
     if (m_txWorker) {
         m_txWorker->stopPump();
         if (m_txChannel) {
+            // Issue #258: TxWorkerThread::run() moves m_txChannel back to
+            // this thread before returning, so this call is a defensive
+            // no-op (Qt early-returns when target == current).  See
+            // teardownConnection for the full rationale.
             m_txChannel->moveToThread(this->thread());
         }
     }

--- a/tests/fakes/P1FakeRadio.cpp
+++ b/tests/fakes/P1FakeRadio.cpp
@@ -1,5 +1,13 @@
 // tests/fakes/P1FakeRadio.cpp
 //
+// no-port-check: NereusSDR-original test fake.  The `networkproto1.c`
+// filename references below are wire-format spec citations (byte
+// layouts the fake emits and consumes), not ported logic; the
+// implementation here is independently written against the OpenHPSDR
+// Protocol 1 wire format.  See HOW-TO-PORT.md §Inline cite versioning
+// for the difference between port-attribution-bearing cites and
+// documentation-only filename references in tests.
+//
 // Protocol 1 fake radio for loopback integration tests.
 // Implements just enough of the P1 wire protocol to exercise
 // P1RadioConnection's socket path.

--- a/tests/fakes/P1FakeRadio.cpp
+++ b/tests/fakes/P1FakeRadio.cpp
@@ -45,7 +45,9 @@ void P1FakeRadio::start()
     m_streamTimer = new QTimer(this);
     m_streamTimer->setInterval(10);
     connect(m_streamTimer, &QTimer::timeout, this, &P1FakeRadio::onAutoStreamTick);
-    m_streamTimer->start();
+    if (m_autoStreamEnabled) {
+        m_streamTimer->start();
+    }
 }
 
 void P1FakeRadio::stop()
@@ -82,6 +84,17 @@ void P1FakeRadio::resume()
     m_silent = false;
     // m_clientAddress/m_clientPort will be repopulated when the reconnect
     // attempt sends a fresh metis-start.
+}
+
+void P1FakeRadio::setAutoStreamEnabled(bool enabled)
+{
+    m_autoStreamEnabled = enabled;
+    if (!m_streamTimer) { return; }  // start() not called yet
+    if (enabled) {
+        if (!m_streamTimer->isActive()) { m_streamTimer->start(); }
+    } else {
+        if (m_streamTimer->isActive()) { m_streamTimer->stop(); }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/fakes/P1FakeRadio.h
+++ b/tests/fakes/P1FakeRadio.h
@@ -40,6 +40,15 @@ public:
     // Resume handling packets and restart auto-streaming.
     void resume();
 
+    // Disable (or re-enable) the 10 ms auto-stream timer so a test has full
+    // control over when ep6 frames arrive at the receiver.  Must be called
+    // BEFORE start() to suppress the timer entirely; called after start() it
+    // stops the timer in place.  Tests that need to burst-inject N ep6
+    // frames into a single readyRead batch (e.g. the issue #258 first-
+    // connect log-spam regression) call this before start(), then drive
+    // frames manually with sendEp6Frames(N).  Default is enabled.
+    void setAutoStreamEnabled(bool enabled);
+
     int  ep2FramesReceived() const { return m_ep2Count; }
     bool isRunning()         const { return m_running; }
 
@@ -65,6 +74,7 @@ private:
     quint16      m_clientPort{0};
     bool         m_running{false};
     bool         m_silent{false};
+    bool         m_autoStreamEnabled{true};
     int          m_ep2Count{0};
     quint32      m_ep6Seq{0};
     int          m_firmwareVersion{72};  // arbitrary default; any value is now valid

--- a/tests/tst_p1_loopback_connection.cpp
+++ b/tests/tst_p1_loopback_connection.cpp
@@ -10,6 +10,7 @@
 
 #include <QtTest/QtTest>
 #include <QSignalSpy>
+#include <atomic>
 #include "core/P1RadioConnection.h"
 #include "core/RadioConnection.h"
 #include "core/RadioDiscovery.h"
@@ -18,6 +19,26 @@
 
 using namespace NereusSDR;
 using NereusSDR::Test::P1FakeRadio;
+
+namespace {
+// Issue #258 regression — message handler that counts "ep6 stream established"
+// log lines emitted during the test.  Installed once per test method (init())
+// and uninstalled (cleanup()) so the count is fresh between cases.
+static std::atomic<int> g_ep6EstablishedLogCount{0};
+static QtMessageHandler g_previousMsgHandler = nullptr;
+
+static void countEp6EstablishedLogs(QtMsgType type,
+                                    const QMessageLogContext& ctx,
+                                    const QString& msg)
+{
+    if (msg.contains(QStringLiteral("Connected, ep6 stream established"))) {
+        g_ep6EstablishedLogCount.fetch_add(1);
+    }
+    if (g_previousMsgHandler) {
+        g_previousMsgHandler(type, ctx, msg);
+    }
+}
+} // namespace
 
 class TestP1LoopbackConnection : public QObject {
     Q_OBJECT
@@ -115,6 +136,66 @@ private slots:
         // the fake's readyRead slot one event-loop turn after disconnect().
         QTRY_VERIFY_WITH_TIMEOUT(!fake.isRunning(), 1000);
 
+        fake.stop();
+    }
+
+    // Issue #258 regression — when a burst of N 1032-byte ep6 datagrams
+    // lands in a single readyRead batch while state is still Connecting,
+    // the "P1: Connected, ep6 stream established" log line must fire
+    // EXACTLY ONCE, not once per datagram.  Field repro: first connect
+    // emitted 181 spurious lines in <10 ms because cs was a const local
+    // snapshot read outside the drain loop.
+    void firstConnectLogFiresExactlyOncePerBatch() {
+        P1FakeRadio fake;
+        // Disable the 10 ms auto-stream timer so we have exclusive control
+        // over when ep6 frames arrive.  Otherwise the first auto-stream
+        // tick would promote state to Connected before our burst lands,
+        // masking the bug (state==Connected -> log branch not taken).
+        fake.setAutoStreamEnabled(false);
+        fake.start();
+
+        // Install the counting message handler AFTER fake.start() so the
+        // fake's own diagnostics aren't counted (they don't match the
+        // substring, but belt-and-braces).
+        g_ep6EstablishedLogCount.store(0);
+        g_previousMsgHandler = qInstallMessageHandler(countEp6EstablishedLogs);
+
+        P1RadioConnection conn;
+        conn.init();
+
+        RadioInfo info;
+        info.address         = fake.localAddress();
+        info.port            = fake.localPort();
+        info.boardType       = HPSDRHW::HermesLite;
+        info.protocol        = ProtocolVersion::Protocol1;
+        info.macAddress      = QStringLiteral("aa:bb:cc:11:22:33");
+        info.firmwareVersion = 72;
+        info.name            = QStringLiteral("FakeHL2");
+        conn.connectToRadio(info);
+
+        // Wait for the fake to receive metis-start (m_running flips true)
+        // — that means conn is now in Connecting waiting for first ep6.
+        QTRY_VERIFY_WITH_TIMEOUT(fake.isRunning(), 3000);
+        QCOMPARE(conn.state(), ConnectionState::Connecting);
+
+        // Burst-send 100 ep6 frames in a tight loop.  All 100 land in
+        // the OS UDP receive queue before conn's event loop ticks; when
+        // onReadyRead fires it drains all 100 in one while-loop pass.
+        fake.sendEp6Frames(100);
+
+        // Pump the event loop until the conn transitions to Connected
+        // (i.e. at least the first of the 100 frames has been drained
+        // through onReadyRead).
+        QTRY_COMPARE_WITH_TIMEOUT(conn.state(), ConnectionState::Connected, 3000);
+
+        // Bug A: pre-fix this was 100 (once per datagram in the batch).
+        // Post-fix: 1.
+        QCOMPARE(g_ep6EstablishedLogCount.load(), 1);
+
+        qInstallMessageHandler(g_previousMsgHandler);
+        g_previousMsgHandler = nullptr;
+
+        conn.disconnect();
         fake.stop();
     }
 

--- a/tests/tst_tx_worker_thread.cpp
+++ b/tests/tst_tx_worker_thread.cpp
@@ -689,6 +689,83 @@ private slots:
 
         QCOMPARE(ch.antiVoxDetectorTau(), 0.020);
     }
+
+    // ── 15. Issue #258 — stopPump moves m_txChannel back to caller thread ──
+    //
+    // Regression for the field crash where switching audio devices on
+    // Windows triggered a 0xc0000409 stack-buffer-overflow in
+    // ucrtbase.dll during disconnect.  Root cause: RadioModel::
+    // teardownConnection called m_txChannel->moveToThread(this->thread())
+    // from the main thread AFTER stopPump() had already joined the
+    // worker.  Qt6's moveToThread requires the call to be made from the
+    // object's CURRENT thread; with m_txChannel still affined to the
+    // (finished) worker, the move silently aborted with a warning and
+    // left m_txChannel with dangling thread-affinity once the worker
+    // QThread was reset().  The fix moves m_txChannel back from inside
+    // TxWorkerThread::run() before it exits.
+    //
+    // This test asserts BOTH halves of the invariant:
+    //   (a) After stopPump() returns, m_txChannel->thread() == the
+    //       creator thread (here: the test thread).
+    //   (b) No "Current thread (%p) is not the object's thread" warning
+    //       was emitted at any point during the teardown.
+    void stopPump_movesTxChannelToCallerThread_noWarning()
+    {
+        // ── Install a Qt message handler that counts moveToThread warnings.
+        static std::atomic<int> warningCount{0};
+        warningCount.store(0);
+        QtMessageHandler prev = qInstallMessageHandler(
+            [](QtMsgType type, const QMessageLogContext&, const QString& msg) {
+                Q_UNUSED(type);
+                if (msg.contains(QStringLiteral(
+                        "Current thread")) &&
+                    msg.contains(QStringLiteral(
+                        "is not the object's thread"))) {
+                    warningCount.fetch_add(1);
+                }
+            });
+
+        AudioEngine engine;
+        TxChannel ch(kChannelId, kBufSize, kBufSize);
+        MockConnection conn;
+        ch.setConnection(&conn);
+
+        TxMicSource src;
+        src.start();
+
+        TxWorkerThread w;
+        w.setTxChannel(&ch);
+        w.setAudioEngine(&engine);
+        w.setMicSource(&src);
+
+        // Mimic the production handoff: move TxChannel into the worker.
+        // This MUST be done from main (TxChannel's current thread).
+        QThread* const callerThread = QThread::currentThread();
+        ch.moveToThread(&w);
+        QCOMPARE(ch.thread(), static_cast<QThread*>(&w));
+
+        w.startPump();
+        QTRY_COMPARE_WITH_TIMEOUT(w.isRunning(), true, 500);
+
+        // Spin briefly so run() definitely enters its waitForBlock loop.
+        QTest::qWait(50);
+
+        // Tear down — this is the call sequence RadioModel uses.
+        w.stopPump();
+        QCOMPARE(w.isRunning(), false);
+
+        // (a) After stopPump returns, TxChannel must be back on the
+        //     caller thread.  Pre-fix: it stayed on the (finished) worker.
+        QCOMPARE(ch.thread(), callerThread);
+
+        // (b) No moveToThread cross-thread warning fired anywhere along
+        //     the way (neither inside run() nor at the now-defensive
+        //     call sites in RadioModel — though those aren't exercised
+        //     here; the run()-side move is enough to clear the warning).
+        QCOMPARE(warningCount.load(), 0);
+
+        qInstallMessageHandler(prev);
+    }
 };
 
 QTEST_MAIN(TestTxWorkerThread)


### PR DESCRIPTION
## Summary

Two surgical fixes for the disconnect-time `0xc0000409` stack-buffer-overflow W4ORS hit on Windows 11 / Hermes Lite 2 in #258.  Investigation of the attached app log + Windows event log fault data turned up two real bugs in the disconnect path; the audio-backend-switch the report blames is a red herring (his audio config stayed unchanged across both connect cycles in the log).

- **P1 connect log spam.** `P1RadioConnection::onReadyRead` captured `cs` as a `const` snapshot outside the per-datagram drain loop.  When the radio is already streaming as metis-start lands, the OS UDP buffer holds N ep6 frames at the moment `readyRead` first fires; every iteration of the loop sees `cs == Connecting`, idempotently calls `setState(Connected)`, and re-emits `"P1: Connected, ep6 stream established"`.  Field repro: 181 spurious lines in <10 ms on first connect, which W4ORS reasonably misread as a "reconnect storm" -- but the state machine itself is correct.  Introduced by [78282d76](../commit/78282d76) / #239.
- **TX teardown `moveToThread`.** `RadioModel::teardownConnection` (and `setActiveRxCountLive`) called `m_txChannel->moveToThread(this->thread())` from the main thread AFTER `m_txWorker->stopPump()` already joined the worker.  Qt6 requires the call from the object's CURRENT thread; with m_txChannel still affined to the (just-finished) worker QThread, Qt emits the exact warning seen in W4ORS's log ("Current thread (...) is not the object's thread (...)") and silently aborts the move.  `m_txWorker.reset()` then destroys the QThread while m_txChannel's thread-data still points at it; the dangling internals get walked during m_txChannel's own destruction and surface on Windows as `0xc0000409` in `ucrtbase.dll`.  Has been firing on every disconnect since [52f27bc4](../commit/52f27bc4) (Phase 3M-1c TX pump v3, 2026-05-02) -- usually didn't crash because the destruction order kept things just-in-bounds, but the reporter's specific timing tipped it over.

## Fix

- **Bug A:** drop `const` on `cs`; sync the local snapshot to `Connected` after `setState()` so subsequent iterations of the drain loop skip the branch.
- **Bug B:** move m_txChannel back to the worker's creator thread INSIDE `TxWorkerThread::run()` just before the loop-exit log, on the worker thread itself (which IS m_txChannel's current affinity), so Qt's precondition is satisfied and the move actually succeeds.  The matching call sites in `RadioModel.cpp` are kept as defensive no-ops (Qt early-returns when target == current) with comments pointing at the new run()-side move -- locks in the invariant at the teardown site against a future refactor that breaks the run()-side move.

## Test plan

- [x] `ctest -R tst_p1_loopback_connection` (6 / 6 passing) -- new `firstConnectLogFiresExactlyOncePerBatch` bursts 100 ep6 frames into a single `readyRead` via a new `P1FakeRadio::setAutoStreamEnabled(false)` knob and asserts via `QtMessageHandler` that the "ep6 stream established" log fires exactly once.  Verified to fail at 100 / 1 with the fix reverted.
- [x] `ctest -R tst_tx_worker_thread` (18 / 18 passing) -- new `stopPump_movesTxChannelToCallerThread_noWarning` mirrors the production handoff and asserts BOTH halves of the invariant: `m_txChannel->thread() == main` after stopPump AND zero `"Current thread is not the object's thread"` warnings during teardown.  Verified to fail (ch.thread() returns `TxWorkerThread` instead of main) with the fix reverted.
- [x] `ctest -R tst_cross_thread_teardown` -- still passing, no regression.
- [x] Main app build (`NereusSDR.app` on macOS) still clean.
- [ ] Manual bench on HL2 (W4ORS) or ANAN-G2: connect, disconnect, repeat ×3.  Confirm log shows exactly one `"ep6 stream established"` line per connect and no `QObject::moveToThread` warnings on disconnect.

## Confidence

Bug B is highly suspect for the actual `0xc0000409` crash but the report's four `.dmp` files are all `PAGEDU64` kernel-mode bugcheck dumps from the audio-stack cascade that followed the NereusSDR crash, not the `NereusSDR.exe` usermode crash dump -- so the causal link is inference from app log + Windows event log fault data, not a confirmed stack walk.  If the next build still crashes on the same flow, the WER usermode dump at `%LOCALAPPDATA%\CrashDumps\NereusSDR.exe.*.dmp` would have the actual stack.

Reported by @Chris-W4ORS in #258.

J.J. Boyd ~ KG4VCF