### PR TITLE
fix(antenna): Mk II BPF rx-only relay split + clear stale rxOnly on ANT pick (#257)

### DIFF
--- a/src/core/P2RadioConnection.cpp
+++ b/src/core/P2RadioConnection.cpp
@@ -1837,6 +1837,18 @@ CodecContext P2RadioConnection::buildCodecContext() const
     ctx.rxOnlyAnt = m_alex.rxOnlyAnt;
     ctx.rxOut     = m_alex.rxOut;
 
+    // Mk II BPF board flag — drives the rx-only relay encoding split in
+    // P2CodecOrionMkII::buildAlex0(). True for ORIONMKII / ANAN-7000D /
+    // ANAN-8000D / ANAN_G2 / ANAN_G2_1K / ANVELINAPRO3 per
+    // HardwareProfile.cpp:137-172 (which mirrors Thetis
+    // clsHardwareSpecific.cs:85-184 SetMKIIBPF(1) callsites).
+    //
+    // Source: Thetis ChannelMaster/netInterface.c:461-477 [v2.10.3.13 @501e3f51]
+    // (the `if (mkiibpf)` branch in SetAntBits — without this, RX-only
+    // selections fire the wrong relay on Mk II BPF boards and the antenna
+    // never actually reaches the receiver). Issue #257.
+    ctx.mkiiBpf = m_hardwareProfile.mkiiBpf;
+
     // Alex HPF / LPF bits (recomputed by setReceiverFrequency on freq change)
     ctx.alexHpfBits = static_cast<quint8>(m_alex.hpfBits);
     ctx.alexLpfBits = static_cast<quint8>(m_alex.lpfBits);

--- a/src/core/codec/CodecContext.h
+++ b/src/core/codec/CodecContext.h
@@ -299,6 +299,21 @@ struct CodecContext {
     // Source: Thetis networkproto1.c:455 [v2.10.3.13 @501e3f5]
     bool    rxOut{false};
 
+    // Mk II BPF board flag — true for ORIONMKII / ANAN-7000D / ANAN-8000D /
+    // ANAN_G2 / ANAN_G2_1K / ANVELINAPRO3 (anything routed through the Mk II
+    // band-pass-filter board). Drives the rx-only relay encoding split in
+    // P2CodecOrionMkII::buildAlex0().
+    //
+    // Source: Thetis ChannelMaster/netInterface.c:461-477 [v2.10.3.13 @501e3f51]
+    // (the `if (mkiibpf)` branch in SetAntBits). When set, the wire layer
+    // routes RX-only selections to `_10_dB_Atten` (bit 14, "RX MASTER IN SEL"
+    // RL22) instead of `_Rx_1_Out` (bit 11, RL17 RX BYPASS OUT) for every
+    // RX-only path except EXT2 (rx_only_ant==1) and transmit.
+    //
+    // Populated by P2RadioConnection::buildCodecContext() from
+    // m_hardwareProfile.mkiiBpf (HardwareProfile.cpp:137-172).
+    bool    mkiiBpf{false};
+
     // Duplex / diversity (bank 0 C4 bits 2 + 7).
     bool    duplex{true};
     bool    diversity{false};

--- a/src/core/codec/P2CodecOrionMkII.cpp
+++ b/src/core/codec/P2CodecOrionMkII.cpp
@@ -331,8 +331,60 @@ quint32 P2CodecOrionMkII::buildAlex0(const CodecContext& ctx) const
         } else if (rxOnlyBits == 0x03) {
             reg |= (1u <<  8);  // _XVTR_Rx_In [network.h:279 @501e3f5]
         }
-        if (ctx.rxOut) {
-            reg |= (1u << 11);  // _Rx_1_Out [network.h:282 @501e3f5]
+
+        // RX bypass / RX MASTER IN SEL relay encoding — issue #257.
+        //
+        // From Thetis ChannelMaster/netInterface.c:461-477 [v2.10.3.13 @501e3f51]:
+        //   if (mkiibpf)
+        //   {
+        //       if (rx_only_ant == 1 || tx) // set rx bypass only if Ext2 enabled
+        //       {
+        //           prbpfilter->_Rx_1_Out = (rx_out & 0x01) != 0; // RX BYPASS OUT RL17
+        //           prbpfilter->_10_dB_Atten = 0; // RX MASTER IN SEL RL22
+        //       }
+        //       else
+        //       {
+        //           prbpfilter->_Rx_1_Out = 0; // RX BYPASS OUT RL17
+        //           prbpfilter->_10_dB_Atten = rx_out & 0x1; // RX MASTER IN SEL RL22
+        //       }
+        //   }
+        //   else
+        //   {
+        //       prbpfilter->_Rx_1_Out = (rx_out & 0x01) != 0; // RX BYPASS OUT RL17
+        //   }
+        //
+        // Non-Mk II boards (HERMES / ANAN10/100/200D / REDPITAYA) keep the
+        // legacy single-relay encoding: bit 11 (_Rx_1_Out, RL17) carries
+        // rx_out unconditionally.
+        //
+        // Mk II BPF boards (ORIONMKII / ANAN-7000D / ANAN-8000D / ANAN_G2 /
+        // ANAN_G2_1K / ANVELINAPRO3) split it:
+        //   - EXT2 (rx_only_ant==1) OR transmitting → bit 11 (_Rx_1_Out, RL17)
+        //   - Everything else (EXT1 / BYPS / XVTR while receiving) →
+        //       bit 14 (_10_dB_Atten, the "RX MASTER IN SEL" RL22 line on
+        //       Mk II BPF — same wire bit, different physical relay).
+        //
+        // ctx.mox carries the MOX (transmit) bit; matches Thetis SetAntBits()
+        // `tx` parameter (Alex.cs:401 `NetworkIO.SetAntBits(rx_only_ant,
+        // trx_ant, tx_ant, rx_out, tx);`).
+        //
+        // Bit-14 reference: network.h:285 `_10_dB_Atten : 1, // bit 14
+        // (RX MASTER IN SEL RL22)`.
+        if (ctx.mkiiBpf) {
+            const bool ext2OrTx = (rxOnlyBits == 0x01) || ctx.mox;
+            if (ext2OrTx) {
+                if (ctx.rxOut) {
+                    reg |= (1u << 11);  // _Rx_1_Out RL17 — EXT2 or TX path
+                }
+            } else {
+                if (ctx.rxOut) {
+                    reg |= (1u << 14);  // _10_dB_Atten / RX MASTER IN SEL RL22
+                }
+            }
+        } else {
+            if (ctx.rxOut) {
+                reg |= (1u << 11);  // _Rx_1_Out [network.h:282 @501e3f5]
+            }
         }
     }
 

--- a/src/gui/applets/RxApplet.cpp
+++ b/src/gui/applets/RxApplet.cpp
@@ -303,11 +303,19 @@ void RxApplet::buildUi()
                 if (m_model && m_pan) {
                     // ANT1/2/3 → setRxAnt. RX-only labels → setRxOnlyAnt (position in sku).
                     // "RX out on TX" is the bypass toggle — not routed via setRxAnt.
+                    //
+                    // Issue #257: picking ANT1/2/3 also clears any pending
+                    // rx-only mux (rxOnlyAnt → 0) so the RX bypass relay
+                    // releases and the main TX/RX input is restored. Mirrors
+                    // Thetis ProcessAlexAntCheckBox (setup.cs:13643-13705
+                    // [v2.10.3.13 @501e3f51]) where unchecking every RX-only
+                    // checkbox sends `setRxOnlyAnt(band, 0)`.
                     if (text.startsWith(QStringLiteral("ANT"))) {
                         int antNum = 1;
                         if (text == QStringLiteral("ANT2")) { antNum = 2; }
                         else if (text == QStringLiteral("ANT3")) { antNum = 3; }
                         m_model->alexControllerMutable().setRxAnt(m_pan->band(), antNum);
+                        m_model->alexControllerMutable().setRxOnlyAnt(m_pan->band(), 0);  // issue #257
                     } else if (m_popupSku && text != QStringLiteral("RX out on TX")) {
                         // RX-only label: find its position in sku.rxOnlyLabels (1-indexed)
                         const auto& lbls = m_popupSku->rxOnlyLabels;

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -522,8 +522,13 @@ RadioModel::RadioModel(QObject* parent)
         applyAlexAntennaForBand(b);
         // T13 — keep the slice's cached ANT labels in sync so UI
         // surfaces reading slice->rxAntenna() see the current-band value.
+        //
+        // Issue #257: pass the SkuUiProfile so the RX-only label slot
+        // (EXT1 / BYPS / XVTR depending on SKU) wins over the ANT* default
+        // when rxOnlyAnt(band) != 0.
         if (m_activeSlice) {
-            m_activeSlice->refreshAntennasFromAlex(m_alexController, b);
+            const SkuUiProfile sku = skuUiProfileFor(m_hardwareProfile.model);
+            m_activeSlice->refreshAntennasFromAlex(m_alexController, b, &sku);
         }
     });
     // Also persist the two blockTxAnt* safety toggles; they can change
@@ -5343,8 +5348,12 @@ void RadioModel::wireSliceSignals()
             // on the previous band's label (caught during PR #N
             // bench testing — KG4VCF 2026-04-22). Mirrors the T9
             // path at line 476-478.
+            //
+            // Issue #257: pass the SkuUiProfile so the new band's RX-only
+            // selection (if any) gets the right SKU-specific label.
             if (m_activeSlice) {
-                m_activeSlice->refreshAntennasFromAlex(m_alexController, newBand);
+                const SkuUiProfile sku = skuUiProfileFor(m_hardwareProfile.model);
+                m_activeSlice->refreshAntennasFromAlex(m_alexController, newBand, &sku);
             }
         }
         scheduleSettingsSave();
@@ -6124,11 +6133,20 @@ void RadioModel::wireSliceSignals()
         // Fixes SpectrumOverlayPanel antenna combo silently no-op'ing for
         // non-ANT selections (B3 fix-up).
         // Source: same routing as RxApplet popup handler (RxApplet.cpp:279-293).
+        //
+        // Issue #257: the antenna popup is a single mutually-exclusive
+        // selection, so picking ANT1/2/3 must also clear the rx-only mux
+        // (rxOnlyAnt → 0). Without this the RX-bypass relay stays engaged
+        // from a prior EXT1/BYPS/XVTR pick and the radio never returns to
+        // the main RX input. Mirrors Thetis ProcessAlexAntCheckBox
+        // (setup.cs:13643-13705 [v2.10.3.13 @501e3f51]) where unchecking
+        // every RX-only checkbox sends `setRxOnlyAnt(band, 0)`.
         if (ant.startsWith(QStringLiteral("ANT"))) {
             int antNum = 1;
             if (ant == QLatin1String("ANT2")) { antNum = 2; }
             else if (ant == QLatin1String("ANT3")) { antNum = 3; }
             m_alexController.setRxAnt(m_lastBand, antNum);
+            m_alexController.setRxOnlyAnt(m_lastBand, 0);  // issue #257 — release bypass mux
         } else if (ant != QStringLiteral("RX out on TX")) {
             // RX-only label: find 1-based position in SkuUiProfile::rxOnlyLabels.
             const SkuUiProfile sku = skuUiProfileFor(m_hardwareProfile.model);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -87,6 +87,7 @@
 #include "core/RadioDiscovery.h"
 #include "core/RadioConnection.h"
 #include "core/HardwareProfile.h"
+#include "core/SkuUiProfile.h"  // issue #257 — setLastBandForTest passes the SKU into refreshAntennasFromAlex
 #include "core/safety/SwrProtectionController.h"
 #include "core/safety/TxInhibitMonitor.h"
 #include "core/safety/BandPlanGuard.h"
@@ -654,8 +655,14 @@ public:
             // Mirror the production T10 path so tests catch regressions
             // in the slice-label refresh (see RadioModel.cpp frequencyChanged
             // handler for the canonical version).
+            //
+            // Issue #257: production now passes the SkuUiProfile so the
+            // RX-only label slot wins over the ANT* default. Mirror that
+            // here so band-cross tests exercise the same path.
             if (m_activeSlice) {
-                m_activeSlice->refreshAntennasFromAlex(m_alexController, b);
+                const NereusSDR::SkuUiProfile sku =
+                    NereusSDR::skuUiProfileFor(m_hardwareProfile.model);
+                m_activeSlice->refreshAntennasFromAlex(m_alexController, b, &sku);
             }
         }
     }

--- a/src/models/SliceModel.cpp
+++ b/src/models/SliceModel.cpp
@@ -118,6 +118,7 @@
 #include "core/RadeChannel.h"
 #include "core/WdspEngine.h"
 #include "core/accessories/AlexController.h"
+#include "core/SkuUiProfile.h"  // issue #257 — rxOnlyLabels lookup in refreshAntennasFromAlex
 #include "models/RadioModel.h"
 
 #include <QFile>
@@ -518,10 +519,22 @@ void SliceModel::setTxAntenna(const QString& ant)
 // is idempotent — AlexController::setRxAnt/setTxAnt returns early (without
 // emitting antennaChanged) when the stored value equals the new value
 // (AlexController.cpp:95,107), so no signal loop occurs.
-void SliceModel::refreshAntennasFromAlex(const AlexController& alex, Band band)
+//
+// Issue #257: when AlexController::rxOnlyAnt(band) != 0 the radio is
+// actually routing through the rx-only mux (EXT1 / EXT2 / BYPS / XVTR
+// depending on SKU). The cached m_rxAntenna label must reflect that or
+// the user sees "ANT1" while the radio is on EXT1 — and the next pick of
+// "ANT1" in the popup gets no-op'd by setRxAntenna's equality guard,
+// trapping the user on the bypass path. With the SkuUiProfile in hand
+// we resolve rxOnlyAnt (1..3) to the per-SKU label trio (BYPS/EXT1/XVTR
+// for ANAN-7000D, EXT2/EXT1/XVTR for ANAN-100D, etc).
+void SliceModel::refreshAntennasFromAlex(const AlexController& alex,
+                                         Band band,
+                                         const SkuUiProfile* sku)
 {
-    const int rx = alex.rxAnt(band);   // 1..3
-    const int tx = alex.txAnt(band);
+    const int rxOnly = alex.rxOnlyAnt(band);  // 0=none, 1/2/3 indexed
+    const int rx     = alex.rxAnt(band);      // 1..3
+    const int tx     = alex.txAnt(band);      // 1..3
     auto name = [](int n) {
         switch (n) {
             case 2:  return QStringLiteral("ANT2");
@@ -529,12 +542,26 @@ void SliceModel::refreshAntennasFromAlex(const AlexController& alex, Band band)
             default: return QStringLiteral("ANT1");
         }
     };
+
+    // Issue #257: prefer the SKU-specific RX-only label when the bypass mux
+    // is engaged. Fall back to the ANT* label when sku is null, when the
+    // mux is disengaged (rxOnly == 0), or when the indexed slot in the SKU
+    // is empty (defensive — should never happen because rxOnlyLabels is
+    // always-3 in SkuUiProfile.h).
+    QString rxLabel;
+    if (sku && rxOnly >= 1 && rxOnly <= 3) {
+        const QString& slot = sku->rxOnlyLabels[static_cast<size_t>(rxOnly - 1)];
+        rxLabel = slot.isEmpty() ? name(rx) : slot;
+    } else {
+        rxLabel = name(rx);
+    }
+
     // Use the public setters so rxAntennaChanged / txAntennaChanged
     // signals fire — VFO Flag and RxApplet listen. The loop back to
     // AlexController via T12's handler is idempotent: AlexController's
     // setRxAnt/setTxAnt returns early on equal value, so no signal is
     // emitted.
-    setRxAntenna(name(rx));
+    setRxAntenna(rxLabel);
     setTxAntenna(name(tx));
 }
 

--- a/src/models/SliceModel.h
+++ b/src/models/SliceModel.h
@@ -136,6 +136,9 @@ namespace NereusSDR {
 // Forward declaration — full type used only in refreshAntennasFromAlex()
 // which takes a const-ref. The full header is included in SliceModel.cpp.
 class AlexController;
+struct SkuUiProfile;  // issue #257 — passed to refreshAntennasFromAlex so the
+                      // RX-only label slot (rxOnly != 0) wins over the main
+                      // ANT* label on Mk II BPF / EXT* path reads.
 
 // Stage 1 stub ladder — Stage 2 replaces with Thetis tune_step_list
 // (console.cs tune_step_list has 11 entries; Stage 1 uses this 6-entry
@@ -694,8 +697,16 @@ public slots:
     // grid in Setup. Relies on AlexController::setRxAnt/setTxAnt being
     // idempotent (no signal on equal value) to avoid a feedback loop
     // with the T12 slice→AlexController write path.
+    //
+    // Issue #257: when the per-band AlexController state has rxOnlyAnt != 0
+    // (user picked EXT1 / EXT2 / BYPS / XVTR), the indicator must show the
+    // SKU-specific RX-only label instead of "ANT1/2/3" (which would lie
+    // about the actual radio routing). The optional SkuUiProfile parameter
+    // carries the per-SKU label trio; nullptr keeps the prior ANT-only
+    // behavior for callers that have no SKU context.
     void refreshAntennasFromAlex(const NereusSDR::AlexController& alex,
-                                 NereusSDR::Band band);
+                                 NereusSDR::Band band,
+                                 const NereusSDR::SkuUiProfile* sku = nullptr);
 
 signals:
     void frequencyChanged(double freq);

--- a/tests/tst_antenna_routing_model.cpp
+++ b/tests/tst_antenna_routing_model.cpp
@@ -328,6 +328,77 @@ private slots:
         delete mock;
     }
 
+    // ── Issue #257 regression coverage ────────────────────────────────────────
+
+    // Issue #257 (Bug 2a): picking ANT* after an EXT* / BYPS / XVTR pick must
+    // also clear rxOnlyAnt so the RX-bypass mux releases and the main TX/RX
+    // input is restored. Without the fix, m_rxOnlyAnt stays non-zero and the
+    // wire keeps engaging the bypass mux even though the UI shows "ANT1".
+    //
+    // Mirrors the user-reported flow on w3ub's ANAN-7000DLE Mk II.
+    void issue257_picking_ANT_releases_rxOnly_mux() {
+        RadioModel model;
+        model.setBoardForTest(HPSDRHW::OrionMKII);  // ANAN-7000D family — SKU labels BYPS/EXT1/XVTR
+        model.setCapsForTest(/*hasAlex=*/true);
+        model.addSlice();
+        SliceModel* slice = model.sliceAt(0);
+        QVERIFY(slice);
+
+        auto* mock = new MockConnection();
+        model.injectConnectionForTest(mock);
+        model.wireSliceSignalsForTest();
+
+        // Stage 1: user picks "EXT1" → rxOnlyAnt should land at 2.
+        // (BYPS=1, EXT1=2, XVTR=3 in the SkuUiProfile for ANAN-7000D.)
+        slice->setRxAntenna(QStringLiteral("EXT1"));
+        QCOMPARE(model.alexController().rxOnlyAnt(model.lastBand()), 2);
+
+        // Stage 2: user picks "ANT1" → handler must clear rxOnlyAnt to 0.
+        // This is the regression check: pre-fix, setRxOnlyAnt(0) was never
+        // called and the mux stayed engaged.
+        slice->setRxAntenna(QStringLiteral("ANT1"));
+        QCOMPARE(model.alexController().rxOnlyAnt(model.lastBand()), 0);
+        QCOMPARE(model.alexController().rxAnt(model.lastBand()),     1);
+
+        model.injectConnectionForTest(nullptr);
+        delete mock;
+    }
+
+    // Issue #257 (Bug 2b): the slice's cached m_rxAntenna label must reflect
+    // the SKU-specific RX-only label (BYPS/EXT1/XVTR for ANAN-7000D) when
+    // rxOnlyAnt != 0. Pre-fix, refreshAntennasFromAlex always returned
+    // "ANT1/2/3" from alex.rxAnt(band), so the indicator showed "ANT1" while
+    // the radio was actually routing through EXT1 — the user saw the wrong
+    // label AND couldn't restore ANT1 because setRxAntenna's equality guard
+    // no-op'd the next ANT1 pick.
+    void issue257_refresh_shows_rxOnly_label_on_mkii_sku() {
+        RadioModel model;
+        model.setBoardForTest(HPSDRHW::OrionMKII);  // ANAN-7000D family
+        model.setCapsForTest(/*hasAlex=*/true);
+        model.addSlice();
+        SliceModel* slice = model.sliceAt(0);
+        QVERIFY(slice);
+
+        auto* mock = new MockConnection();
+        model.injectConnectionForTest(mock);
+        model.wireSliceSignalsForTest();
+
+        // Seed rxOnlyAnt=2 (EXT1 slot on ANAN-7000D) via the controller.
+        // The antennaChanged signal triggers RadioModel's connect lambda,
+        // which calls applyAlexAntennaForBand + refreshAntennasFromAlex.
+        model.alexControllerMutable().setRxOnlyAnt(model.lastBand(), 2);
+
+        // Slice's cached rxAntenna should now show the SKU label, NOT "ANT1".
+        QCOMPARE(slice->rxAntenna(), QStringLiteral("EXT1"));
+
+        // Clearing rxOnlyAnt back to 0 should drop the label back to "ANT1".
+        model.alexControllerMutable().setRxOnlyAnt(model.lastBand(), 0);
+        QCOMPARE(slice->rxAntenna(), QStringLiteral("ANT1"));
+
+        model.injectConnectionForTest(nullptr);
+        delete mock;
+    }
+
     // !caps.hasAlex → all fields zeroed + tx=false (full zero-out check).
     // Complements hasAlex_false_writes_zero_routing with rxOnlyAnt/rxOut fields.
     // From Thetis Alex.cs:312-316 [@501e3f5].

--- a/tests/tst_p2_codec_orionmkii.cpp
+++ b/tests/tst_p2_codec_orionmkii.cpp
@@ -300,6 +300,88 @@ private slots:
         }
     }
 
+    // Issue #257 — Mk II BPF encoding split.
+    //
+    // Thetis ChannelMaster/netInterface.c:461-477 [v2.10.3.13 @501e3f51]
+    // SetAntBits():
+    //   if (mkiibpf)
+    //   {
+    //       if (rx_only_ant == 1 || tx)   // EXT2 path or TX
+    //       {
+    //           prbpfilter->_Rx_1_Out = (rx_out & 0x01) != 0;  // bit 11 RL17
+    //           prbpfilter->_10_dB_Atten = 0;                  // bit 14 RL22
+    //       }
+    //       else                          // EXT1 / BYPS / XVTR while RX
+    //       {
+    //           prbpfilter->_Rx_1_Out = 0;
+    //           prbpfilter->_10_dB_Atten = rx_out & 0x1;       // bit 14 RL22
+    //       }
+    //   }
+    //   else
+    //   {
+    //       prbpfilter->_Rx_1_Out = (rx_out & 0x01) != 0;      // bit 11 RL17
+    //   }
+    //
+    // Mask isolates bits 11 + 14 (the two relay bits split by the conditional)
+    // so the test ignores HPF/LPF/ANT/RX-only-mux contamination.
+    void alex0_mkiibpf_relay_split_byteLock() {
+        struct Case {
+            const char* name;
+            bool        mkiiBpf;
+            int         rxOnly;
+            bool        rxOut;
+            bool        mox;
+            quint32     expectedBits11_14;  // bits 11 + 14 only
+        };
+        const std::array<Case, 12> cases = {{
+            // Non-Mk II boards — bit 11 carries rx_out unconditionally;
+            // bit 14 always clear.
+            {"non-mkii  ANT1     rxOut=0 rx", false, 0, false, false, 0u},
+            {"non-mkii  EXT1     rxOut=1 rx", false, 2, true,  false, (1u << 11)},
+            {"non-mkii  EXT1     rxOut=1 tx", false, 2, true,  true,  (1u << 11)},
+            {"non-mkii  XVTR     rxOut=1 rx", false, 3, true,  false, (1u << 11)},
+
+            // Mk II boards — split:
+            //   rxOnly==1 (EXT2) OR mox=1  →  bit 11 set, bit 14 clear
+            //   else (EXT1 / XVTR / no-mux on RX)  →  bit 14 set, bit 11 clear
+            {"mkii      ANT1     rxOut=0 rx", true,  0, false, false, 0u},
+            {"mkii      EXT2     rxOut=1 rx", true,  1, true,  false, (1u << 11)},
+            {"mkii      EXT1     rxOut=1 rx", true,  2, true,  false, (1u << 14)},  // the bug fix
+            {"mkii      XVTR     rxOut=1 rx", true,  3, true,  false, (1u << 14)},
+            {"mkii      EXT2     rxOut=1 tx", true,  1, true,  true,  (1u << 11)},
+            {"mkii      EXT1     rxOut=1 tx", true,  2, true,  true,  (1u << 11)},
+            {"mkii      XVTR     rxOut=1 tx", true,  3, true,  true,  (1u << 11)},
+            {"mkii      no-mux   rxOut=1 rx", true,  0, true,  false, (1u << 14)},
+        }};
+
+        constexpr quint32 kMask11_14 = (1u << 11) | (1u << 14);
+
+        for (const auto& tc : cases) {
+            P2CodecOrionMkII codec;
+            CodecContext ctx;
+            ctx.p2AlexRxAnt = 1;   // ANT1 — doesn't affect bits 11/14
+            ctx.p2AlexTxAnt = 1;
+            ctx.rxOnlyAnt   = tc.rxOnly;
+            ctx.rxOut       = tc.rxOut;
+            ctx.mox         = tc.mox;
+            ctx.mkiiBpf     = tc.mkiiBpf;
+
+            quint8 buf[1444] = {};
+            codec.composeCmdHighPriority(ctx, buf);
+
+            const quint32 alex0 =
+                (quint32(buf[1432]) << 24) | (quint32(buf[1433]) << 16) |
+                (quint32(buf[1434]) <<  8) |  quint32(buf[1435]);
+
+            const quint32 masked = alex0 & kMask11_14;
+            if (masked != tc.expectedBits11_14) {
+                qWarning("alex0_mkiibpf_relay_split: case '%s' failed: got 0x%08x expected 0x%08x",
+                         tc.name, masked, tc.expectedBits11_14);
+            }
+            QCOMPARE(masked, tc.expectedBits11_14);
+        }
+    }
+
     // Thetis parity: Alex0/Alex1 antenna bits per netInterface.c:479-485
     //   _ANT_1 → bit 24; _ANT_2 → bit 25; _ANT_3 → bit 26
     // [v2.10.3.13 @501e3f5]


### PR DESCRIPTION
## Summary

* Port the missed Thetis `if (mkiibpf)` branch of `SetAntBits` into `P2CodecOrionMkII::buildAlex0`. Mk II BPF boards (ORIONMKII / ANAN-7000D / ANAN-8000D / ANAN_G2 / ANAN_G2_1K / ANVELINAPRO3) now route RX-only EXT1 / BYPS / XVTR through bit 14 (`_10_dB_Atten`, RL22 RX MASTER IN SEL) instead of bit 11 (`_Rx_1_Out`, RL17 RX BYPASS OUT). EXT2 and TX still use bit 11 per Thetis netInterface.c:461-477 [v2.10.3.13 @501e3f51].
* When the user picks "ANT1/2/3" from the antenna popup, also call `setRxOnlyAnt(band, 0)` so the bypass mux releases. Mirrors Thetis `ProcessAlexAntCheckBox` (setup.cs:13643-13705 [v2.10.3.13 @501e3f51]).
* Teach `SliceModel::refreshAntennasFromAlex` to consult `SkuUiProfile::rxOnlyLabels` so the cached `rxAntenna` reflects the per-SKU RX-only label (BYPS/EXT1/XVTR for ANAN-7000D, EXT2/EXT1/XVTR for ANAN-100D, etc) when the mux is engaged.

Closes #257.

## Test plan

- [x] `ctest -R "alex|antenna|codec_orionmkii|codec_saturn|p2_codec|sku_ui_profile"` — 20/20 green (includes new tests)
- [x] Full `ctest` suite — 471/471 green
- [x] New `alex0_mkiibpf_relay_split_byteLock` 12-case truth table in `tst_p2_codec_orionmkii.cpp` (covers non-Mk II × Mk II × rxOnly × rxOut × mox)
- [x] New `issue257_picking_ANT_releases_rxOnly_mux` and `issue257_refresh_shows_rxOnly_label_on_mkii_sku` in `tst_antenna_routing_model.cpp`
- [ ] **Bench (w3ub)**: ANAN-7000DLE Mk II — pick EXT1, confirm signal levels reflect a real EXT1 connection (not a disconnected input); then pick ANT1, confirm radio returns to main input
- [ ] **Bench (any Alex board)**: pick EXT1 → pick ANT1; verify indicator label tracks the actual antenna at each step
- [ ] Confirm v0.5.1 persistence (per-MAC `hardware/<mac>/alex/antenna/<band>/rxonly`) still survives a reconnect cycle after the fix

J.J. Boyd ~ KG4VCF