### PR TITLE
fix(spots): dedup by lifetime instead of fixed 60s window (#263)

### DIFF
--- a/src/models/SpotModel.cpp
+++ b/src/models/SpotModel.cpp
@@ -7,6 +7,21 @@
 // (see https://github.com/ten9876/AetherSDR/blob/main/LICENSE).
 //
 // Modification history (NereusSDR):
+//   2026-05-17  J.J. Boyd / KG4VCF  Issue #263 fix.  dedupIndexFor
+//                                    no longer uses a fixed 60 s window
+//                                    (which expired long before the
+//                                    typical 1800 s lifetime, leaving
+//                                    duplicates on the panadapter
+//                                    overlay).  Instead, reuse the
+//                                    existing index for as long as the
+//                                    prior spot is still alive
+//                                    (addedMs + lifetimeSeconds*1000 >
+//                                    nowMs).  Added expireOlderThan()
+//                                    sweeper + 30 s QTimer in the ctor
+//                                    so aged spots actually leave m_spots
+//                                    (previously addedMs + lifetimeSeconds
+//                                    were stored but never enforced).
+//                                    AI tooling: Anthropic Claude Code.
 //   2026-05-11  J.J. Boyd / KG4VCF  Phase 3J-2 Task D1. Initial port.
 //                                    AetherSDR's "AetherSDR" namespace
 //                                    becomes "NereusSDR". applySpotStatus
@@ -31,14 +46,42 @@
 
 namespace NereusSDR {
 
+namespace {
+// Issue #263: 30 s sweeper cadence.  Cheap (the spot map is bounded at a
+// few hundred entries) and catches WSJT-X 120 s lifetime spots well
+// before they get a chance to duplicate.
+constexpr int kExpireTimerIntervalMs = 30 * 1000;
+}  // namespace
+
+SpotModel::SpotModel(QObject* parent)
+    : QObject(parent)
+{
+    m_expireTimer.setInterval(kExpireTimerIntervalMs);
+    m_expireTimer.setTimerType(Qt::CoarseTimer);
+    QObject::connect(&m_expireTimer, &QTimer::timeout, this, [this]() {
+        expireOlderThan(QDateTime::currentMSecsSinceEpoch());
+    });
+    m_expireTimer.start();
+}
+
 // From AetherSDR src/models/SpotModel.cpp:6-52 [@0cd4559]
 void SpotModel::applySpotStatus(int index, const QMap<QString, QString>& kvs)
 {
     bool isNew = !m_spots.contains(index);
     auto& spot = m_spots[index];
     spot.index = index;
-    if (isNew)
-        spot.addedMs = QDateTime::currentMSecsSinceEpoch();
+    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+    if (isNew) {
+        spot.addedMs = nowMs;
+    }
+    // Issue #263 review follow-up (2026-05-18): refresh lastSeenMs on
+    // every applySpotStatus call so the expiration sweep (and the
+    // dedup-window check inside dedupIndexForAtTime) treat this as a
+    // fresh observation.  Without this, a steadily-active station
+    // would expire `lifetimeSeconds` after its FIRST observation
+    // rather than after its LAST, causing label flicker on the
+    // panadapter / Spot List row bounce.
+    spot.lastSeenMs = nowMs;
 
     for (auto it = kvs.constBegin(); it != kvs.constEnd(); ++it) {
         const QString& key = it.key();
@@ -83,14 +126,26 @@ void SpotModel::applySpotStatus(int index, const QMap<QString, QString>& kvs)
 // From AetherSDR src/models/SpotModel.cpp:54-58 [@0cd4559]
 void SpotModel::removeSpot(int index)
 {
-    if (m_spots.remove(index))
+    if (m_spots.remove(index)) {
+        // Issue #263: drop the dedup cache slot too so the next emit
+        // of the same callsign mints a fresh index rather than
+        // returning a dangling one that no longer exists in m_spots.
+        for (auto it = m_dedupCache.begin(); it != m_dedupCache.end(); ) {
+            if (it.value() == index) {
+                it = m_dedupCache.erase(it);
+            } else {
+                ++it;
+            }
+        }
         emit spotRemoved(index);
+    }
 }
 
 // From AetherSDR src/models/SpotModel.cpp:60-64 [@0cd4559]
 void SpotModel::clear()
 {
     m_spots.clear();
+    m_dedupCache.clear();  // Issue #263: cache must shed with the map.
     emit spotsCleared();
 }
 
@@ -100,12 +155,17 @@ void SpotModel::refresh()
     emit spotsRefreshed();
 }
 
-// Phase 3J-1 closeout follow-up (2026-05-12): cross-source spot dedup.
-// See SpotModel.h for design + rationale.  Implemented here (not header-
-// inline) so the cache prune logic doesn't bloat every translation unit.
-int SpotModel::dedupIndexFor(const QString& callsign,
-                             double freqMhz,
-                             qint64 windowMs)
+// Phase 3J-1 closeout follow-up (2026-05-12) + issue #263 (2026-05-17):
+// cross-source spot dedup.  See SpotModel.h for design + rationale.
+int SpotModel::dedupIndexFor(const QString& callsign, double freqMhz)
+{
+    return dedupIndexForAtTime(callsign, freqMhz,
+                               QDateTime::currentMSecsSinceEpoch());
+}
+
+int SpotModel::dedupIndexForAtTime(const QString& callsign,
+                                   double freqMhz,
+                                   qint64 nowMs)
 {
     // Bucket by 1 kHz so 14.205 / 14.2055 / 14.206 collapse to one spot.
     const long bucketKHz =
@@ -114,46 +174,74 @@ int SpotModel::dedupIndexFor(const QString& callsign,
                          + QLatin1Char('|')
                          + QString::number(bucketKHz);
 
-    const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
-
     auto it = m_dedupCache.find(key);
     if (it != m_dedupCache.end()) {
-        const int existingIdx = it.value().first;
-        const qint64 lastMs   = it.value().second;
-        if (nowMs - lastMs <= windowMs) {
-            // Within the dedup window -- reuse the existing index so
-            // applySpotStatus emits spotUpdated instead of spotAdded.
-            // Refresh last-seen so a steadily-active station doesn't
-            // expire mid-stream.
-            it.value().second = nowMs;
-            return existingIdx;
-        }
-        // Window expired -- treat as fresh.  Mint a new index but
-        // overwrite the cache slot so memory doesn't grow without
-        // bound for ham contests that have ten thousand stations.
-        const int newIdx = ++m_nextDedupIndex;
-        it.value() = {newIdx, nowMs};
-        return newIdx;
-    }
-
-    // Brand-new (callsign, freqBucket).  Mint, cache, return.
-    const int newIdx = ++m_nextDedupIndex;
-    m_dedupCache.insert(key, {newIdx, nowMs});
-
-    // Periodic prune: every 100th allocation, drop entries older than
-    // 4x window.  Cheap amortized; keeps the cache table bounded.
-    if ((m_nextDedupIndex % 100) == 0) {
-        const qint64 pruneCutoff = nowMs - (4 * windowMs);
-        auto pit = m_dedupCache.begin();
-        while (pit != m_dedupCache.end()) {
-            if (pit.value().second < pruneCutoff) {
-                pit = m_dedupCache.erase(pit);
-            } else {
-                ++pit;
+        const int existingIdx = it.value();
+        auto sit = m_spots.find(existingIdx);
+        if (sit != m_spots.end()) {
+            // Reuse the index for as long as the prior spot is still
+            // alive.  lifetimeSeconds * 1000 may overflow qint64 for
+            // pathologically huge values, but the field is clamped by
+            // applySpotStatus's toInt() to INT_MAX = ~68 years, so the
+            // multiplication is safe in any realistic case.
+            //
+            // Issue #263 review follow-up (2026-05-18): compare against
+            // lastSeenMs (refreshed on every observation) rather than
+            // addedMs (set once on first insert) so a steadily-active
+            // station stays alive indefinitely.  Refresh lastSeenMs
+            // here too — applySpotStatus will set it again on the next
+            // line, but doing it here makes dedup-only call sites
+            // (TCI clients, future callers) symmetric.
+            const qint64 ttlMs =
+                static_cast<qint64>(sit.value().lifetimeSeconds) * 1000;
+            if (nowMs - sit.value().lastSeenMs < ttlMs) {
+                sit.value().lastSeenMs = nowMs;
+                return existingIdx;
             }
+            // Prior spot has expired but the sweeper hasn't run yet.
+            // Evict here so the panadapter overlay loses the stale
+            // label before the re-emit lands.
+            m_spots.erase(sit);
+            emit spotRemoved(existingIdx);
+        }
+        // Either the spot is gone or it just expired.  Mint and rebind.
+    }
+
+    const int newIdx = ++m_nextDedupIndex;
+    m_dedupCache.insert(key, newIdx);
+    return newIdx;
+}
+
+void SpotModel::expireOlderThan(qint64 nowMs)
+{
+    QVector<int> expired;
+    for (auto it = m_spots.constBegin(); it != m_spots.constEnd(); ++it) {
+        const auto& s = it.value();
+        if (s.lifetimeSeconds <= 0) { continue; }
+        const qint64 ttlMs = static_cast<qint64>(s.lifetimeSeconds) * 1000;
+        // Issue #263 review follow-up (2026-05-18): expire based on
+        // lastSeenMs, not addedMs.  See dedupIndexForAtTime for rationale.
+        if (nowMs - s.lastSeenMs >= ttlMs) {
+            expired.append(it.key());
         }
     }
-    return newIdx;
+    if (expired.isEmpty()) { return; }
+
+    // Build the cache keys to drop in lockstep with the spot evictions
+    // so an immediate re-emit of the same callsign mints a fresh index
+    // rather than returning a dangling one.
+    QHash<int, QString> idxToKey;
+    for (auto it = m_dedupCache.constBegin(); it != m_dedupCache.constEnd(); ++it) {
+        idxToKey.insert(it.value(), it.key());
+    }
+    for (int idx : expired) {
+        m_spots.remove(idx);
+        auto kit = idxToKey.constFind(idx);
+        if (kit != idxToKey.constEnd()) {
+            m_dedupCache.remove(kit.value());
+        }
+        emit spotRemoved(idx);
+    }
 }
 
 } // namespace NereusSDR

--- a/src/models/SpotModel.h
+++ b/src/models/SpotModel.h
@@ -42,7 +42,7 @@
 #include <QHash>
 #include <QString>
 #include <QDateTime>
-#include <utility>
+#include <QTimer>
 
 namespace NereusSDR {
 
@@ -61,14 +61,23 @@ struct SpotData {
     QDateTime timestamp;
     int lifetimeSeconds{1800};  // default 30 min
     int priority{0};
-    qint64 addedMs{0};         // local wall-clock when added
+    qint64 addedMs{0};         // local wall-clock when first added (immutable)
+    // Issue #263 review follow-up (2026-05-18): local wall-clock of the
+    // most recent observation.  Refreshed by applySpotStatus on every
+    // update AND by dedupIndexForAtTime when it reuses an existing
+    // index, so a station re-emitted regularly inside its lifetime
+    // does NOT expire mid-stream (which would flicker the label /
+    // bounce the Spot List row).  Expiration checks against
+    // lastSeenMs, not addedMs.
+    qint64 lastSeenMs{0};
 };
 
 // From AetherSDR src/models/SpotModel.h:27-49 [@0cd4559]
 class SpotModel : public QObject {
     Q_OBJECT
 public:
-    explicit SpotModel(QObject* parent = nullptr) : QObject(parent) {}
+    explicit SpotModel(QObject* parent = nullptr);
+    ~SpotModel() override = default;
 
     const QMap<int, SpotData>& spots() const { return m_spots; }
 
@@ -86,23 +95,41 @@ public:
     // EVERY spot, EVERY re-emit, from EVERY source.  Result: same
     // callsign appears 5-10 times on the spot list within seconds.
     //
-    // dedupIndexFor(callsign, freqMhz, windowMs) returns:
-    //   - the existing index for (callsign, freqBucket) when within
-    //     windowMs of the previous emit -> caller passes it to
+    // Issue #263 (2026-05-17): the original 60 s fixed window expired
+    // long before the typical 1800 s spot lifetime, so a re-emit of
+    // CT3MD on the same kHz at +90 s minted a fresh index, and (because
+    // there was no expiration sweeper either) the prior entry stayed in
+    // m_spots.  Result: the panadapter overlay stacked N copies of the
+    // same callsign.  Fix: dedupIndexFor now reuses the existing index
+    // for as long as the previous spot is still alive (addedMs +
+    // lifetimeSeconds * 1000 > nowMs).  expireOlderThan() (driven by an
+    // internal QTimer) sweeps aged spots so the index can be recycled.
+    //
+    // dedupIndexFor(callsign, freqMhz) returns:
+    //   - the existing index for (callsign, freqBucket) when the prior
+    //     spot's lifetime hasn't elapsed -> caller passes it to
     //     applySpotStatus, which then emits spotUpdated (not spotAdded);
-    //   - a freshly-minted monotonic index otherwise.
+    //   - a freshly-minted monotonic index otherwise (and evicts the
+    //     stale entry so the panadapter overlay loses it).
     //
     // freqBucket is the freqMhz rounded to the nearest 1 kHz so split-
     // operating spots (e.g. DX 14.205 vs 14.206) merge to one entry.
-    // Default windowMs of 60 s catches the typical "RBN sends every
-    // CQ" rate without losing the user's ability to see the same
-    // station spotted again hours later as a fresh entry.
     //
     // Caller is RadioModel's on*SpotReceived family of handlers.
     // SpotModel itself remains TCI-keyed: TCI clients drive their own
     // index allocation and don't go through dedup.
-    int dedupIndexFor(const QString& callsign, double freqMhz,
-                      qint64 windowMs = 60000);
+    int dedupIndexFor(const QString& callsign, double freqMhz);
+
+    // Clock-injectable test seam for dedup.  Production calls
+    // dedupIndexFor() which delegates to this with the wall clock.
+    int dedupIndexForAtTime(const QString& callsign, double freqMhz,
+                            qint64 nowMs);
+
+    // Issue #263: periodic sweeper.  Removes every spot whose
+    // addedMs + lifetimeSeconds * 1000 < nowMs and emits spotRemoved
+    // for each.  Production wires this to a 30 s QTimer in the ctor;
+    // the parameter overload is the test seam.
+    void expireOlderThan(qint64 nowMs);
 
 signals:
     void spotAdded(const SpotData& spot);
@@ -115,11 +142,13 @@ signals:
 private:
     QMap<int, SpotData> m_spots;
 
-    // Phase 3J-1 closeout follow-up (2026-05-12): dedup state.
-    // Key:   "<UPPER_CALLSIGN>|<freqBucketKHz>"
-    // Value: <last spot index, last-seen ms epoch>
-    QHash<QString, std::pair<int, qint64>> m_dedupCache;
+    // Phase 3J-1 closeout follow-up (2026-05-12) + issue #263 (2026-05-17).
+    // Maps "<UPPER_CALLSIGN>|<freqBucketKHz>" to the live SpotData index.
+    // An entry is valid only as long as m_spots still contains that
+    // index; expireOlderThan() and removeSpot() prune both maps together.
+    QHash<QString, int> m_dedupCache;
     int m_nextDedupIndex{0};
+    QTimer m_expireTimer;
 };
 
 } // namespace NereusSDR

--- a/tests/tst_spot_model.cpp
+++ b/tests/tst_spot_model.cpp
@@ -49,6 +49,24 @@ private slots:
     void decodes0x7FAsSpace();
     void removeSpotEmitsSignal();
     void clearEmitsSignal();
+
+    // Issue #263 regression: duplicate spots on the panadapter / SpotHub.
+    // The pre-fix dedupIndexFor used a fixed 60 s window that expired
+    // long before the 1800 s default spot lifetime, so a re-emitted RBN
+    // / cluster spot at the same callsign+freq minted a fresh index and
+    // the panadapter overlay stacked N copies of the same callsign.
+    void dedupReusesIndexWhileSpotIsAlive();
+    void dedupMintsFreshIndexAfterSpotExpires();
+    void expirationRemovesAgedSpots();
+
+    // Issue #263 review follow-up (2026-05-18): a steadily-active
+    // station re-emitted regularly inside its lifetime must NOT
+    // expire mid-stream.  Pre-fix code measured expiration against
+    // addedMs (immutable after first insert), so a station emitted
+    // every minute for 30 minutes still got evicted at minute 30,
+    // causing the panadapter label to flicker and the Spot List row
+    // to bounce.  Verifies the lastSeenMs refresh on dedup-reuse.
+    void dedupReuseRefreshesLifetime();
 };
 
 void TestSpotModel::initialState()
@@ -157,6 +175,151 @@ void TestSpotModel::clearEmitsSignal()
     QSignalSpy spy(&model, &SpotModel::spotsCleared);
     model.clear();
     QCOMPARE(spy.count(), 1);
+    QCOMPARE(model.spots().size(), 0);
+}
+
+// Issue #263 regression test #1.  Re-emit of the same callsign+freq
+// inside the spot's lifetime must collapse to the same index so the
+// panadapter overlay never stacks duplicate labels.  Pre-fix used a
+// fixed 60 s window and would mint a fresh index for re-emits after
+// the window even though the prior entry was still alive (and still
+// painted on the overlay).
+void TestSpotModel::dedupReusesIndexWhileSpotIsAlive()
+{
+    SpotModel model;
+
+    // First emission: mint a fresh index, set a long lifetime.
+    const int idx1 = model.dedupIndexFor("CT3MD", 14.222);
+    QMap<QString, QString> kvs;
+    kvs["callsign"] = "CT3MD";
+    kvs["rx_freq"]  = "14.222";
+    kvs["tx_freq"]  = "14.222";
+    kvs["lifetime_seconds"] = "1800";  // 30 min, cluster default
+    model.applySpotStatus(idx1, kvs);
+
+    // Same callsign + freq re-emit AFTER the old 60 s window would have
+    // expired.  Because the spot is still alive (lifetime=1800 s), the
+    // dedup must reuse idx1, not mint a new one.
+    QSignalSpy addedSpy(&model, &SpotModel::spotAdded);
+    QSignalSpy updatedSpy(&model, &SpotModel::spotUpdated);
+
+    const int idx2 = model.dedupIndexForAtTime(
+        "CT3MD", 14.222,
+        QDateTime::currentMSecsSinceEpoch() + 90 * 1000);  // +90 s
+    model.applySpotStatus(idx2, kvs);
+
+    QCOMPARE(idx2, idx1);
+    QCOMPARE(addedSpy.count(), 0);
+    QCOMPARE(updatedSpy.count(), 1);
+    QCOMPARE(model.spots().size(), 1);
+}
+
+// Issue #263 regression test #2.  Once the previous spot's lifetime
+// has fully elapsed, a re-emit should be treated as fresh (mint a new
+// index).  Companion to the expiration test below.
+void TestSpotModel::dedupMintsFreshIndexAfterSpotExpires()
+{
+    SpotModel model;
+    QMap<QString, QString> kvs;
+    kvs["callsign"] = "CT3MD";
+    kvs["rx_freq"]  = "14.222";
+    kvs["tx_freq"]  = "14.222";
+    kvs["lifetime_seconds"] = "120";  // WSJT-X default
+    const int idx1 = model.dedupIndexFor("CT3MD", 14.222);
+    model.applySpotStatus(idx1, kvs);
+
+    // Simulate a re-emit 5 min later.  Lifetime (120 s) has expired,
+    // so the prior spot should be evicted and a fresh index minted.
+    QSignalSpy removedSpy(&model, &SpotModel::spotRemoved);
+    const int idx2 = model.dedupIndexForAtTime(
+        "CT3MD", 14.222,
+        QDateTime::currentMSecsSinceEpoch() + 5 * 60 * 1000);
+
+    QVERIFY(idx2 != idx1);
+    QCOMPARE(removedSpy.count(), 1);
+    QCOMPARE(removedSpy.takeFirst().at(0).toInt(), idx1);
+}
+
+// Issue #263 regression test #3.  expireOlderThan() is the periodic
+// sweeper that walks m_spots and removes entries past their
+// addedMs + lifetimeSeconds horizon.  Without this, spots accumulate
+// forever even when dedup is honored, because there's nothing to
+// shrink the canonical map.
+void TestSpotModel::expirationRemovesAgedSpots()
+{
+    SpotModel model;
+    auto putSpot = [&model](int idx, const QString& call, double freq, int lifetimeSec) {
+        QMap<QString, QString> kvs;
+        kvs["callsign"] = call;
+        kvs["rx_freq"]  = QString::number(freq, 'f', 4);
+        kvs["tx_freq"]  = QString::number(freq, 'f', 4);
+        kvs["lifetime_seconds"] = QString::number(lifetimeSec);
+        model.applySpotStatus(idx, kvs);
+    };
+    putSpot(1, "K1AA", 14.222, 120);
+    putSpot(2, "K2BB", 14.225, 1800);
+    putSpot(3, "K3CC", 14.230, 1800);
+    QCOMPARE(model.spots().size(), 3);
+
+    QSignalSpy removedSpy(&model, &SpotModel::spotRemoved);
+    // Advance the clock 5 minutes.  Only K1AA (120 s lifetime) should
+    // expire.  K2BB and K3CC stay (1800 s lifetime).
+    model.expireOlderThan(
+        QDateTime::currentMSecsSinceEpoch() + 5 * 60 * 1000);
+
+    QCOMPARE(removedSpy.count(), 1);
+    QCOMPARE(removedSpy.takeFirst().at(0).toInt(), 1);
+    QCOMPARE(model.spots().size(), 2);
+    QVERIFY(!model.spots().contains(1));
+    QVERIFY(model.spots().contains(2));
+    QVERIFY(model.spots().contains(3));
+}
+
+// Issue #263 review follow-up (2026-05-18).  Pre-fix, expireOlderThan
+// + dedupIndexForAtTime both compared against addedMs (set once at
+// first insert).  A station heard every minute for 30 minutes would
+// expire at minute 30 even though it was just heard 60 s ago, then
+// re-mint with a fresh index — label flicker, Spot List row bounce.
+// Verifies that re-emit via dedupIndexForAtTime refreshes the spot's
+// lastSeenMs so the lifetime window slides forward.
+void TestSpotModel::dedupReuseRefreshesLifetime()
+{
+    SpotModel model;
+    QMap<QString, QString> kvs;
+    kvs["callsign"] = "K1AA";
+    kvs["rx_freq"]  = "14.250";
+    kvs["tx_freq"]  = "14.250";
+    kvs["lifetime_seconds"] = "120";
+
+    // First observation.  applySpotStatus stamps addedMs / lastSeenMs
+    // with the real wall clock — capture it for the simulated-time
+    // assertions below.
+    const int idx1 = model.dedupIndexFor("K1AA", 14.250);
+    model.applySpotStatus(idx1, kvs);
+    const qint64 baseline = model.spots()[idx1].lastSeenMs;
+
+    // Re-emit at +100 s.  Within the 120 s lifetime, dedup must reuse
+    // idx1 AND advance lastSeenMs so the spot doesn't age out of the
+    // sweeper window.
+    const int idx2 = model.dedupIndexForAtTime(
+        "K1AA", 14.250, baseline + 100 * 1000);
+    QCOMPARE(idx2, idx1);
+    QCOMPARE(model.spots()[idx1].lastSeenMs, baseline + 100 * 1000);
+
+    // Sweep at +215 s: 115 s since last seen — still inside the 120 s
+    // window, the spot must stay.  Pre-fix this would have used
+    // addedMs and expired the spot at baseline+120 s.
+    model.expireOlderThan(baseline + 215 * 1000);
+    QCOMPARE(model.spots().size(), 1);
+    QVERIFY(model.spots().contains(idx1));
+
+    // Sweep at +225 s: 125 s since last seen — past the 120 s window,
+    // the spot legitimately expires.  Confirms the lastSeenMs path
+    // still enforces the timeout when re-emits actually stop.
+    QSignalSpy removedSpy(&model, &SpotModel::spotRemoved);
+    model.expireOlderThan(baseline + 225 * 1000);
+    QCOMPARE(removedSpy.count(), 1);
+    QCOMPARE(removedSpy.takeFirst().at(0).toInt(), idx1);
     QCOMPARE(model.spots().size(), 0);
 }
 


### PR DESCRIPTION
## Summary
- `SpotModel::dedupIndexFor` now reuses the existing index for as long as the prior spot is still alive (`addedMs + lifetimeSeconds * 1000 > nowMs`), instead of the prior fixed 60 s window
- Added `expireOlderThan()` sweeper driven by a 30 s `QTimer` in the ctor so aged spots actually leave `m_spots` (the lifetime field was previously stored but never enforced)
- `removeSpot()` and `clear()` now also drop the dedup cache slot so the next emit mints a fresh index rather than returning a dangling one
- Review follow-up (2026-05-18): added `SpotData::lastSeenMs`, refreshed on every observation. Expiration compares against `lastSeenMs` instead of `addedMs` so a steadily-active station (RBN re-spotting every minute) does not expire mid-stream and bounce the Spot List row

## Why
The 3J-1 closeout dedup used a 60 s window that expired long before the typical 1800 s spot lifetime, so a re-emit of the same callsign at the same kHz from RBN/cluster/PSK Reporter past +60 s minted a fresh index. Because there was no expiration sweeper either, the prior entry stayed in `m_spots` and the panadapter overlay stacked N copies of the same callsign. Operator observed CT3MD x3, TC19TC x3, 8P6PE x3 on 20 m. Reported as #263.

## Test plan
- [x] `tst_spot_model::dedupReusesIndexWhileSpotIsAlive`: same callsign+freq at +90 s under 1800 s lifetime reuses index, emits `spotUpdated`
- [x] `tst_spot_model::dedupMintsFreshIndexAfterSpotExpires`: same callsign+freq at +5 min under 120 s lifetime evicts prior plus mints fresh
- [x] `tst_spot_model::expirationRemovesAgedSpots`: `expireOlderThan` drops only aged spots
- [x] `tst_spot_model::dedupReuseRefreshesLifetime`: re-emit at +100 s under 120 s lifetime survives a +215 s sweep and only expires at +225 s
- [x] All 11 existing spot tests pass (`tst_spot_model`, `tst_spot_table_model`, `tst_spot_overlay_render`, `tst_spothub_*` x3, `tst_radio_model_spot_wiring`, `tst_mainwindow_tools_spot_hub`, `tst_spot_settings_round_trip`, `tst_spot_auto_start`, `tst_spot_collector_parser`)
- [ ] Bench verify on live RBN/cluster: leave SpotHub open for >2 min on a busy band, confirm panadapter overlay shows one label per (callsign, freqBucket)

J.J. Boyd ~ KG4VCF