### PR TITLE
fix(tci): guard m_audioTapSources against dangling RxChannel pointers

### DIFF
--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -487,7 +487,7 @@ void TciServer::hookAudioAndIqTaps()
                             Qt::DirectConnection);
                     // Phase 26 review finding #4: track so stop() can
                     // explicitly disconnect before tearing down TciServer state.
-                    m_audioTapSources.insert(rxCh);
+                    m_audioTapSources.append(rxCh);
                     qCInfo(lcTci) << "TciServer: RX audio tap connected to RxChannel 0";
                 }
             };
@@ -656,8 +656,16 @@ void TciServer::stop()
         QObject::disconnect(m_model, nullptr, this, nullptr);
         m_iqTapConnected = false;  // P2.3: reset so start() can reconnect
     }
-    for (RxChannel* rxCh : std::as_const(m_audioTapSources)) {
-        QObject::disconnect(rxCh, nullptr, this, nullptr);
+    // 2026-05-17 crash fix: m_audioTapSources is now QSet<QPointer<RxChannel>>
+    // (see TciServer.h).  Skip entries whose underlying RxChannel was
+    // already destroyed (typical after a disconnect-from-radio that ran
+    // m_wdspEngine->shutdown()).  Qt::~QObject already auto-disconnected
+    // those signals when the channel died, so the missed iteration is a
+    // no-op rather than missed cleanup.
+    for (const QPointer<RxChannel>& rxCh : std::as_const(m_audioTapSources)) {
+        if (rxCh) {
+            QObject::disconnect(rxCh.data(), nullptr, this, nullptr);
+        }
     }
     m_audioTapSources.clear();  // P2.3: reset so hookAudioAndIqTaps() re-arms
 

--- a/src/core/TciServer.h
+++ b/src/core/TciServer.h
@@ -35,6 +35,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QSet>
+#include <QVector>
 #include <array>
 #include <memory>
 
@@ -366,10 +367,19 @@ private:
     // could race with destruction if the signal fires after m_clients is
     // cleared but before the TciServer stack frame is gone.
     //
-    // QSet of raw pointers — we do NOT own these; they are owned by WdspEngine.
-    // stop() iterates and calls QObject::disconnect(rxCh, nullptr, this, nullptr).
-    // The set is cleared last so the disconnect calls are always valid.
-    QSet<RxChannel*> m_audioTapSources;
+    // 2026-05-17 crash fix: was QSet<RxChannel*> — raw pointers.  WdspEngine
+    // destroys RxChannels on disconnect-from-radio, but nothing pruned this
+    // set, leaving dangling raw pointers.  On the next stop() (typically at
+    // app exit) the disconnect loop dereferenced freed memory and SIGSEGV'd.
+    // QPointer is Qt's guarded pointer: it auto-nulls when the underlying
+    // QObject is destroyed (zero-overhead hook into QObject::~QObject), so
+    // the stop() loop can skip dead entries safely.  We still do NOT own
+    // these channels — WdspEngine remains the owner.
+    //
+    // QVector rather than QSet because QPointer has no built-in qHash; the
+    // set is always 0 or 1 entry in practice (single RX channel until 3F),
+    // so the linear-scan dedupe in hookAudioAndIqTaps is free.
+    QVector<QPointer<RxChannel>> m_audioTapSources;
 
     // Phase 3J-1 review P2.3: guard flag for the IQ tap connection.
     // hookAudioAndIqTaps() sets this to true after connecting


### PR DESCRIPTION
## Summary
- `TciServer::m_audioTapSources` changes from `QSet<RxChannel*>` to `QVector<QPointer<RxChannel>>`
- `TciServer::stop()` iterates and skips null QPointer entries (channels destroyed earlier still get cleaned via Qt's own `QObject::~QObject` auto-disconnect)

## Why
`TciServer::stop()` crashed with SIGSEGV during `~MainWindow` teardown after the user had previously disconnected from a radio. `WdspEngine::shutdown()` destroys all `RxChannel`s on disconnect; nothing pruned `m_audioTapSources`, leaving dangling raw pointers. The stop() loop then dereferenced freed memory in `QObject::disconnect`.

Crash signature (from operator JJ/KG4VCF's `~/Library/Logs/DiagnosticReports/`):
```
EXC_BAD_ACCESS at 0x730223862fa63d61
QObject::disconnect at TciServer.cpp:660
TciServer::stop() at TciServer.cpp:660
TciServer::~TciServer() at TciServer.cpp:545
QObjectPrivate::deleteChildren()
QWidget::~QWidget()
main+4208 [main.cpp:275]
```

`QPointer` is Qt's guarded pointer: it auto-nulls when the underlying `QObject` is destroyed (zero-overhead hook into `QObject::~QObject`). Using it in `m_audioTapSources` means the stop() loop is safe even when channels died before the server.

## Why QVector instead of QSet
`QPointer<T>` has no built-in `qHash`, and the set is always 0 or 1 entry in practice (single RX channel until Phase 3F multi-pan), so the linear-scan dedupe in `hookAudioAndIqTaps` is free.

## Test plan
- [x] All 19 TCI tests pass (lifecycle, ping, dispatch, init burst, binary frames, sensor formats, vfo coalescer, audio + IQ roundtrip, log window)
- [x] Build clean
- [ ] Bench: launch on HL2, disconnect, quit — should exit without crash (no longer triggers the dangling-pointer SIGSEGV)

No dedicated unit test added — constructing a real `RxChannel` requires full WDSP init. The QPointer change is correct by construction (well-established Qt idiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)