### PR TITLE
fix(spots): seed panadapter visibility mask at startup

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -718,7 +718,23 @@ MainWindow::MainWindow(QWidget* parent)
     // network I/O fires. Each client guards against double-start so
     // re-invocation is harmless (e.g. if a future code path also calls
     // this after a profile switch).
+    //
+    // 2026-05-18 bench fix: seed the SpectrumWidget per-source visibility
+    // mask BEFORE restoring any auto-start state.  Without this, the
+    // panadapter overlay mask (m_spotSourceVisible) is empty at startup
+    // and the renderer's missing-key fallback (true == visible) leaks
+    // every source's spots regardless of the user's "Show on panadapter"
+    // checkbox state.  Bench operator hit it with FreeDV: FreeDvAutoStart
+    // + Display checkbox unchecked = spots still painting at app start
+    // until SpotHub was opened manually.  Six of seven sources share the
+    // same symmetry break (PSK Reporter is send-only); fixing it here
+    // closes the gap for all of them in one place.  The matching seed
+    // inside openSpotHub() is now a defensive guard kept for the case
+    // where the spectrum widget races construction; see lines below.
     QTimer::singleShot(0, this, [this] {
+        if (m_spectrumWidget) {
+            m_spectrumWidget->loadSpotDisplaySettings();
+        }
         if (m_radioModel) {
             m_radioModel->restoreSpotClientAutoStartState();
         }
@@ -5461,10 +5477,16 @@ void MainWindow::openSpotHub()
                         m_spectrumWidget->loadSpotDisplaySettings();
                     }
                 });
-        // First-time seed: pick up any settings that were persisted
-        // before the dialog was ever opened. Without this, the spectrum
-        // overlay would only reflect the AppSettings defaults until the
-        // operator first opened the dialog and changed a knob.
+        // Defensive re-seed.  The primary seed runs at MainWindow startup
+        // (see the QTimer::singleShot(0, ...) lambda earlier in this file
+        // that pairs loadSpotDisplaySettings + restoreSpotClientAutoStartState),
+        // which guarantees the panadapter mask is populated before any
+        // auto-started spot client emits its first spot.  This call is kept
+        // as a belt-and-suspenders idempotent re-seed for the (rare) case
+        // where the spectrum widget was not yet available at startup but
+        // is now -- loadSpotDisplaySettings re-reads AppSettings and the
+        // setter is no-op when the value is unchanged, so the cost is
+        // bounded and the behaviour is correct either way.
         if (m_spectrumWidget) {
             m_spectrumWidget->loadSpotDisplaySettings();
         }


### PR DESCRIPTION
## Summary

- `SpectrumWidget::loadSpotDisplaySettings` was only called from inside `openSpotHub()`'s lazy-construction block, never at app launch. Any spot client whose `AutoConnect`/`AutoStart` key was True began emitting spots before the user opened SpotHub, and the renderer's `m_spotSourceVisible` mask fell back to its missing-key default (`true == visible`), leaking every source's spots regardless of the Display tab checkbox state.
- Reproduced with FreeDV: `FreeDvAutoStart=True` plus the Display "FreeDV" checkbox unchecked left FreeDV spots painting on the panadapter from the moment the qso.freedv.org WebSocket fired, until SpotHub was opened (and on some workflows toggled) to re-seed the mask through the existing `settingsChanged` path.
- Six of seven sources share the symmetry break: DxCluster, RBN, WSJT-X, SpotCollector, POTA, FreeDV. PSK Reporter is send-only so it never ingests spots and is unaffected.

## Fix

Call `loadSpotDisplaySettings()` inside the existing `QTimer::singleShot(0, ...)` startup lambda in `MainWindow::MainWindow`, ordered BEFORE `restoreSpotClientAutoStartState()` so the mask is populated for every source before any auto-started client emits its first spot. The matching seed inside `openSpotHub()` is retained as an idempotent defensive guard (the setter is a no-op when the value is unchanged).

One-file change, +26 / -4, all comment-heavy. The existing `tst_spothub_display_knobs` coverage of `loadSpotDisplaySettings` is unchanged and still passes; only the call site moved.

## Test plan

- [x] `cmake --build build --target tst_spothub_display_knobs` builds clean
- [x] `ctest -R spothub_display` passes (1/1)
- [x] App launches cleanly, startup log confirms both `FreeDVReporter: starting connection` and `DxClusterClient: connecting` fire after the mask seed
- [ ] Bench: cold-start with `FreeDvAutoStart=True` and `SpotSourceVisible/FreeDV=False`; confirm no FreeDV spots paint at app start
- [ ] Bench A/B: temporarily uncheck DX Cluster on Display tab; cold-start; confirm DxCluster spots also stay off the panadapter

J.J. Boyd ~ KG4VCF