### PR TITLE
fix(60m): allow US 60m TX at standard USB dial frequencies (#271)

### DIFF
--- a/src/core/safety/BandPlanGuard.cpp
+++ b/src/core/safety/BandPlanGuard.cpp
@@ -157,8 +157,13 @@ constexpr std::array<ChannelEntry, 11> kUkChannels60m{{
     { 5'405'000,  3'000 },   // console.cs:2654 — Channel(5.4050,   3000)
 }};
 
-// US: 5 channels @ 2.8 kHz each (console.cs:2657-2661 [v2.10.3.13]).
-constexpr std::array<ChannelEntry, 5> kUsChannels60m{{
+// US: 5 channel center frequencies (console.cs:2657-2661 [v2.10.3.13]).
+// Used by Thetis only for VFO snap / band-stack display, NOT for TX gating
+// (IsOKToTX in clsBandStackManager.cs:1063-1083 [v2.10.3.13] permits TX
+// anywhere in the broad B60M 5.1-5.5 MHz range — see kUsBandRanges below).
+// Retained here for cite-trail integrity; not consulted by isValidTxFreq.
+// See channels60mFor: US falls through to the broad range case.
+[[maybe_unused]] constexpr std::array<ChannelEntry, 5> kUsChannels60m{{
     { 5'332'000, 2'800 },   // console.cs:2657 — Channel(5.3320, 2800)
     { 5'348'000, 2'800 },   // console.cs:2658 — Channel(5.3480, 2800)
     { 5'358'500, 2'800 },   // console.cs:2659 — Channel(5.3585, 2800)
@@ -295,8 +300,17 @@ static ChannelSpan channels60mFor(Region region) noexcept
         return { kUkChannels60m.data(), kUkChannels60m.size() };
     case Region::Japan:
         return { kJapanChannels60m.data(), kJapanChannels60m.size() };
-    case Region::UnitedStates:
-        return { kUsChannels60m.data(), kUsChannels60m.size() };
+    // US is intentionally NOT channelized for TX gating. Thetis allows TX
+    // anywhere in the broad B60M 5.1-5.5 MHz range with the USB/CWL/CWU/DIGU
+    // mode restriction (IsOKToTX at clsBandStackManager.cs:1063-1083
+    // [v2.10.3.13] + US mode switch at console.cs:29416-29432 [v2.10.3.13]).
+    // The FCC dial convention (47 CFR 97.303(h)) places USB suppressed-carrier
+    // at channel_center - 1.5 kHz, which sits OUTSIDE a 2.8 kHz wide channel
+    // window centred on Thetis's channel-center constants — channelizing the
+    // gate at those centers rejected the very dial frequencies operators use
+    // (issue #271, ANAN-10E on macOS, 2026-05-18). US returns {nullptr, 0}
+    // so the broad-range branch in isValidTxFreq governs.
+    //
     // TODO(3M follow-up): Add per-region 60m channel arms for regions with
     // discrete channelization (Italy, Slovakia, etc. — see Thetis source).
     // Regions with NO channelization MUST NOT fall through to US channels —
@@ -387,40 +401,49 @@ bool BandPlanGuard::isValidTxFreq(Region region, std::int64_t freqHz,
         return true;
     }
 
-    // NereusSDR safety enhancement: gates US 60m TX on the 5 discrete channel
-    // centers (±BW/2). This is more restrictive than Thetis's IsOKToTX
-    // (clsBandStackManager.cs:1063-1083 [v2.10.3.13]), which allows TX
-    // anywhere in the broad B60M range. Thetis uses the channels_60m table
-    // (console.cs:2643-2669 [v2.10.3.13]) only for VFO snap and band-stack
-    // display, NOT for TX gating. The channelized gate is intentional here per
-    // FCC Part 97.303(h), which permits US 60m operation on these 5 channels
-    // only.
-    //
-    // US 60m mode restriction (USB/CWL/CWU/DIGU only) per console.cs:29423.
+    // Channelized 60m gating (UK, Japan): per-channel allocations are the
+    // authoritative TX window. NereusSDR-native safety net for the strict
+    // per-channel allocations defined by those regulators. Thetis itself
+    // permits TX anywhere in the broad B60M range; we retain channelization
+    // for UK / Japan because the regulator-defined allocation IS the channel
+    // set, not a wider band.
     const ChannelSpan ch60m = channels60mFor(region);
     for (std::size_t i = 0; i < ch60m.size; ++i) {
         if (isInChannel(freqHz, ch60m.data[i])) {
-            if (region == Region::UnitedStates && !isUs60mModeAllowed(mode)) {
-                return false;
-            }
             return true;
         }
     }
 
-    // All other bands: check per-region band edges.
-    // Skip B60M rows only when the region has discrete channels — for those
-    // regions, channelization was the authoritative check above and the broad
-    // B60M range entry is a placeholder. For regions with NO channelization
-    // (e.g. Australia's wide 5.0-7.0 MHz allocation), the B60M range row
-    // is the authoritative source and must NOT be skipped.
+    // Per-region band edges.
+    //
+    // US 60m mode restriction — console.cs:29416-29432 [v2.10.3.13]:
+    //   _tx_band == Band.B60M && current_region == FRSRegion.US && !extended
+    //   → switch on CurrentDSPMode: allow USB / CWL / CWU / DIGU, reject all
+    //     others.
+    // Applied inline below when the matched range is Band60m for US. Thetis
+    // gates US 60m TX on the broad 5.1-5.5 MHz range (IsOKToTX at
+    // clsBandStackManager.cs:1063-1083 [v2.10.3.13]); channel centers in
+    // kUsChannels60m are dial-convention markers for band-stack snap, NOT TX
+    // gates. FCC 47 CFR 97.303(h) places the USB suppressed-carrier dial at
+    // channel_center - 1.5 kHz, which is OUTSIDE a 2.8 kHz wide window
+    // centred on Thetis's channel-center constants — channelizing the gate
+    // there rejected the standard USB dial frequency (issue #271).
+    //
+    // Skip B60M rows ONLY when channelization was authoritative above
+    // (ch60m.size > 0 — UK, Japan). For regions without channelization
+    // (US, Australia, etc.) the B60M range row IS the authoritative source.
     const RangeSpan ranges = bandRangesFor(region);
     for (std::size_t i = 0; i < ranges.size; ++i) {
         if (ranges.data[i].band == Band::Band60m && ch60m.size > 0) {
-            // B60M range placeholder — channelization was the authoritative
-            // check above. Skip to avoid false positives on the broad edge.
             continue;
         }
         if (isInBandRange(freqHz, ranges.data[i])) {
+            if (region == Region::UnitedStates &&
+                ranges.data[i].band == Band::Band60m &&
+                !isUs60mModeAllowed(mode))
+            {
+                return false;
+            }
             return true;
         }
     }

--- a/tests/tst_band_plan_guard.cpp
+++ b/tests/tst_band_plan_guard.cpp
@@ -12,7 +12,11 @@ class TestBandPlanGuard : public QObject
     Q_OBJECT
 private slots:
     void us60m_validChannelCenter_returnsTrue();
-    void us60m_offChannel_returnsFalse();
+    void us60m_betweenChannels_returnsTrue();
+    void us60m_usbDialChannel1_returnsTrue();
+    void us60m_usbDialChannel5_returnsTrue();
+    void us60m_belowBandEdge_returnsFalse();
+    void us60m_aboveBandEdge_returnsFalse();
     void us60m_LSBmode_returnsFalse();
     void us60m_permittedModes_returnTrue();
     void uk60m_channel1_3kHz_returnsTrue();
@@ -33,21 +37,62 @@ private slots:
 
 void TestBandPlanGuard::us60m_validChannelCenter_returnsTrue()
 {
-    // US 60m channel 1: 5.3320 MHz, 2.8 kHz BW, USB only
-    // From Thetis console.cs:2657 [v2.10.3.13]
+    // US 60m channel 1 CW dial: 5.3320 MHz (channel center, FCC 47 CFR
+    // 97.303(h) CW operating frequency).
     BandPlanGuard guard;
     auto result = guard.isValidTxFreq(
         Region::UnitedStates, 5'332'000, DSPMode::USB, /*extended=*/false);
     QVERIFY(result);
 }
 
-void TestBandPlanGuard::us60m_offChannel_returnsFalse()
+void TestBandPlanGuard::us60m_betweenChannels_returnsTrue()
 {
-    // 5.340 MHz is between US 60m channels 1 and 2 — not a valid channel center
+    // Regression for issue #271: a USB dial between channel centers must still
+    // pass once the dial sits inside the broad B60M 5.1-5.5 MHz range.
+    // Thetis IsOKToTX (clsBandStackManager.cs:1063-1083 [v2.10.3.13]) accepts
+    // the entire range, gated only by the US-specific USB/CWL/CWU/DIGU mode
+    // restriction.
     BandPlanGuard guard;
     auto result = guard.isValidTxFreq(
         Region::UnitedStates, 5'340'000, DSPMode::USB, /*extended=*/false);
-    QVERIFY(!result);
+    QVERIFY(result);
+}
+
+void TestBandPlanGuard::us60m_usbDialChannel1_returnsTrue()
+{
+    // Regression for issue #271 (funsutton, ANAN-10E, macOS, 2026-05-18).
+    // FCC 47 CFR 97.303(h) puts the US 60m channel 1 USB suppressed-carrier
+    // dial at 5330.5 kHz (= channel center 5332.0 - 1.5 kHz). The previous
+    // channelized gate rejected this dial because 5330.5 < 5330.6 (the lower
+    // edge of channel_center ± 1.4 kHz). Must now pass.
+    BandPlanGuard guard;
+    QVERIFY(guard.isValidTxFreq(
+        Region::UnitedStates, 5'330'500, DSPMode::USB, /*extended=*/false));
+}
+
+void TestBandPlanGuard::us60m_usbDialChannel5_returnsTrue()
+{
+    // FCC 47 CFR 97.303(h) channel 5 USB dial: 5403.5 kHz (channel center
+    // 5405.0 - 1.5 kHz). Same regression path as channel 1.
+    BandPlanGuard guard;
+    QVERIFY(guard.isValidTxFreq(
+        Region::UnitedStates, 5'403'500, DSPMode::USB, /*extended=*/false));
+}
+
+void TestBandPlanGuard::us60m_belowBandEdge_returnsFalse()
+{
+    // 5.099 MHz is below the US B60M lower edge of 5.1 MHz (kUsBandRanges).
+    BandPlanGuard guard;
+    QVERIFY(!guard.isValidTxFreq(
+        Region::UnitedStates, 5'099'000, DSPMode::USB, /*extended=*/false));
+}
+
+void TestBandPlanGuard::us60m_aboveBandEdge_returnsFalse()
+{
+    // 5.501 MHz is above the US B60M upper edge of 5.5 MHz (kUsBandRanges).
+    BandPlanGuard guard;
+    QVERIFY(!guard.isValidTxFreq(
+        Region::UnitedStates, 5'501'000, DSPMode::USB, /*extended=*/false));
 }
 
 void TestBandPlanGuard::us60m_LSBmode_returnsFalse()


### PR DESCRIPTION
## Summary

- Drops the channelized US 60m TX gate that rejected the standard FCC USB suppressed-carrier dial (`channel_center - 1.5 kHz`).
- Aligns `BandPlanGuard::isValidTxFreq` with Thetis behavior: broad 5.1-5.5 MHz B60M range plus the USB/CWL/CWU/DIGU mode restriction.
- Adds four regression tests pinning the FCC dial frequencies (Channels 1 + 5) and the broad-range boundary.

## Root cause

`BandPlanGuard.cpp` channelized US 60m TX at `channel_center +/- 1.4 kHz` using the FCC channel-center constants `5332.0 / 5348.0 / 5358.5 / 5373.0 / 5405.0` kHz and 2.8 kHz BW. But FCC 47 CFR 97.303(h) puts the USB dial 1.5 kHz BELOW the channel center, so Channel 1's USB dial of 5330.5 kHz sat 100 Hz below the gate's lower edge of 5330.6 kHz. Any user who tuned via the band-stack to the standard USB dial frequency hit "Frequency outside TX-allowed range".

Thetis itself never channelizes US 60m TX. `IsOKToTX` (`clsBandStackManager.cs:1063-1083 [v2.10.3.13]`) accepts the entire 5.1-5.5 MHz range; `console.cs:29416-29432` separately enforces USB / CWL / CWU / DIGU only. The NereusSDR channelization was a 3M-0-era safety enhancement that turned out broken because it conflated channel-center constants with dial-frequency conventions.

## Change

`src/core/safety/BandPlanGuard.cpp` -- US returns `{nullptr, 0}` from `channels60mFor`, so the broad-range branch governs. US 60m mode restriction is applied inline when the matched range is `Band60m`. UK and Japan keep channelization (the per-channel allocation IS the regulator-defined window in those regions).

`kUsChannels60m` is retained for cite-trail integrity but no longer consulted; tagged `[[maybe_unused]]` to silence the warning.

## Test plan

- [x] `tst_band_plan_guard` -- 24/24 PASS
- [x] `tst_band_plan_guard_mox_rejection` -- 25/25 PASS
- [x] `tst_band_plan_guard_mode_allow_list` -- 28/28 PASS
- [x] New regression cases:
  - `us60m_usbDialChannel1_returnsTrue` -- 5330.5 kHz (Channel 1 USB dial per FCC 47 CFR 97.303(h))
  - `us60m_usbDialChannel5_returnsTrue` -- 5403.5 kHz (Channel 5 USB dial)
  - `us60m_betweenChannels_returnsTrue` -- 5340 kHz (was rejected, now allowed under broad-range)
  - `us60m_belowBandEdge_returnsFalse` -- 5099 kHz (outside 5.1-5.5 MHz range)
  - `us60m_aboveBandEdge_returnsFalse` -- 5501 kHz (outside upper edge)
- [x] `verify-thetis-headers.py` -- 343/343 files PASS
- [x] `verify-inline-tag-preservation.py` -- OK, no missing tags
- [ ] Bench: ANAN-10E on macOS, tune to 5330.5 kHz USB, confirm PTT enables (reporter to validate)

Closes #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)