### PR TITLE
fix(setup): clear Qt warnings + add timing instrumentation (#272)

### DIFF
--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -78,8 +78,21 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QShowEvent>
+#include <QElapsedTimer>
+#include <QLoggingCategory>
 
 namespace NereusSDR {
+
+// Timing instrumentation added in response to #272, where a ~3-second build
+// + ~40-second click-time freeze stalled the audio engine long enough for
+// the HL2 ep6 watchdog (2011 ms) to fire and the unclean audio teardown to
+// cascade into a CLOCK_WATCHDOG_TIMEOUT BSOD on a legacy Realtek driver.
+// Per-section + per-page-switch deltas let the next repro identify which
+// page or interaction is blocking the UI thread, without needing a profiler.
+//
+// Disabled by default. Enable with:
+//   QT_LOGGING_RULES="nereus.setup.timing.debug=true"
+Q_LOGGING_CATEGORY(lcSetupTiming, "nereus.setup.timing")
 
 // ── Construction ──────────────────────────────────────────────────────────────
 
@@ -123,15 +136,31 @@ SetupDialog::SetupDialog(RadioModel* model, QWidget* parent)
     layout->addWidget(splitter, 1);
 
     // ── Build the tree and pages ──────────────────────────────────────────────
+    // #272 instrumentation: track total buildTree() cost. Per-category
+    // deltas are emitted from inside buildTree() via a local tick helper.
+    QElapsedTimer buildTimer;
+    buildTimer.start();
     buildTree();
+    qCDebug(lcSetupTiming)
+        << "buildTree() total elapsed (ms):" << buildTimer.elapsed()
+        << "pages:" << m_stack->count();
 
-    // Connect tree selection → stack page
+    // Connect tree selection → stack page.
+    // #272 instrumentation: time the page-switch path. The QStackedWidget
+    // setCurrentIndex() will fire showEvent() on the destination page, which
+    // is where any deferred / click-time work would surface.
     connect(m_tree, &QTreeWidget::currentItemChanged,
             this, [this](QTreeWidgetItem* current, QTreeWidgetItem* /*previous*/) {
                 if (current == nullptr) { return; }
                 const int index = current->data(0, Qt::UserRole).toInt();
                 if (index >= 0) {
+                    QElapsedTimer switchTimer;
+                    switchTimer.start();
                     m_stack->setCurrentIndex(index);
+                    qCDebug(lcSetupTiming)
+                        << "page switch ->" << current->text(0)
+                        << "(stack index" << index << ") elapsed (ms):"
+                        << switchTimer.elapsed();
                 }
             });
 
@@ -203,6 +232,18 @@ void SetupDialog::setTciServer(NereusSDR::TciServer* server)
 
 void SetupDialog::buildTree()
 {
+    // #272 instrumentation: per-category construction-time tick. Each call
+    // logs the elapsed time since the previous tick, so a slow category's
+    // delta will stand out in the log. Resets the timer on each call.
+    QElapsedTimer sectionTimer;
+    sectionTimer.start();
+    auto tick = [&sectionTimer](const char* label) {
+        const qint64 ms = sectionTimer.elapsed();
+        qCDebug(lcSetupTiming) << "buildTree section" << label
+                               << "elapsed (ms):" << ms;
+        sectionTimer.restart();
+    };
+
     // ── Helper: create a category (top-level, non-selectable) ─────────────────
     auto addCategory = [this](const QString& label) -> QTreeWidgetItem* {
         auto* item = new QTreeWidgetItem(m_tree, QStringList{label});
@@ -248,6 +289,8 @@ void SetupDialog::buildTree()
         return item;
     };
 
+    tick("helpers");
+
     // ── General ──────────────────────────────────────────────────────────────
     QTreeWidgetItem* general = addCategory("General");
     add(general, "Startup & Preferences", new StartupPrefsPage(m_model));
@@ -277,6 +320,8 @@ void SetupDialog::buildTree()
                 this,    &SetupDialog::cpuMeterRateChanged);
         add(general, "Options", genOpts);
     }
+
+    tick("General");
 
     // ── Hardware ─────────────────────────────────────────────────────────────
     QTreeWidgetItem* hardware = addCategory("Hardware");
@@ -310,6 +355,8 @@ void SetupDialog::buildTree()
     // dialog was already open) with a live capability subscription.
     // From Thetis comboRadioModel_SelectedIndexChanged (setup.cs:19812-20310
     // [v2.10.3.13+501e3f51]) — per-SKU PA tab visibility.
+    tick("Hardware");
+
     m_paCategoryItem  = addCategory("PA");
     m_paGainPage      = new PaGainByBandPage(m_model);
     m_paWattMeterPage = new PaWattMeterPage(m_model);
@@ -329,6 +376,8 @@ void SetupDialog::buildTree()
     // PA Values readout was promoted to its own dedicated page.
     connect(m_paWattMeterPage, &PaWattMeterPage::resetPaValuesRequested,
             m_paValuesPage,    &PaValuesPage::resetPaValues);
+
+    tick("PA");
 
     // ── Audio ─────────────────────────────────────────────────────────────────
     QTreeWidgetItem* audio = addCategory("Audio");
@@ -351,6 +400,8 @@ void SetupDialog::buildTree()
             m_model,
             m_model ? m_model->micProfileManager() : nullptr,
             m_model ? &m_model->transmitModel() : nullptr));
+
+    tick("Audio");
 
     // ── DSP ───────────────────────────────────────────────────────────────────
     QTreeWidgetItem* dsp = addCategory("DSP");
@@ -385,6 +436,8 @@ void SetupDialog::buildTree()
     // Mirrors Thetis tpDSPOptions tab (design Section 4A).
     add(dsp, "Options",  new DspOptionsPage(m_model));
 
+    tick("DSP");
+
     // ── Display ───────────────────────────────────────────────────────────────
     QTreeWidgetItem* display = addCategory("Display");
 
@@ -418,6 +471,8 @@ void SetupDialog::buildTree()
     add(display, "RX2 Display",        new Rx2DisplayPage(m_model));
     add(display, "TX Display",         new TxDisplayPage(m_model));
 
+    tick("Display");
+
     // ── Transmit ──────────────────────────────────────────────────────────────
     QTreeWidgetItem* transmit = addCategory("Transmit");
     add(transmit, "Power",              new PowerPage(m_model));
@@ -447,6 +502,8 @@ void SetupDialog::buildTree()
     // the Thetis tpDSPVOX tab IA.
     add(transmit, "DEXP/VOX",           new DexpVoxPage(m_model));
 
+    tick("Transmit");
+
     // ── Appearance ────────────────────────────────────────────────────────────
     QTreeWidgetItem* appearance = addCategory("Appearance");
     add(appearance, "Colors & Theme",       new ColorsThemePage(m_model));
@@ -454,6 +511,8 @@ void SetupDialog::buildTree()
     add(appearance, "Gradients",            new GradientsPage(m_model));
     add(appearance, "Skins",               new SkinsPage(m_model));
     add(appearance, "Collapsible Display",  new CollapsibleDisplayPage(m_model));
+
+    tick("Appearance");
 
     // ── CAT & Network ─────────────────────────────────────────────────────────
     QTreeWidgetItem* cat = addCategory("CAT & Network");
@@ -481,14 +540,20 @@ void SetupDialog::buildTree()
     add(cat, "TCP/IP CAT",   new CatTcpIpPage);
     add(cat, "MIDI Control", new CatMidiControlPage);
 
+    tick("CAT & Network");
+
     // ── Keyboard ──────────────────────────────────────────────────────────────
     QTreeWidgetItem* keyboard = addCategory("Keyboard");
     add(keyboard, "Shortcuts", new KeyboardShortcutsPage);
+
+    tick("Keyboard");
 
     // ── Test ──────────────────────────────────────────────────────────────────
     // Phase 3M-1c H.1: top-level Test category for the Two-Tone IMD page.
     QTreeWidgetItem* test = addCategory("Test");
     add(test, "Two-Tone IMD", new TestTwoTonePage(m_model));
+
+    tick("Test");
 
     // ── Diagnostics ───────────────────────────────────────────────────────────
     QTreeWidgetItem* diagnostics = addCategory("Diagnostics");
@@ -501,7 +566,10 @@ void SetupDialog::buildTree()
     add(diagnostics, "Hardware Tests",     new DiagHardwareTestsPage);
     add(diagnostics, "Logging & Performance", new DiagLoggingPage);
 
+    tick("Diagnostics");
+
     m_tree->expandAll();
+    tick("expandAll");
 }
 
 // ── Phase 8 of #167: PA category visibility wiring ─────────────────────────────

--- a/src/gui/diagnostics/DiagnosticsPhaseHPages.cpp
+++ b/src/gui/diagnostics/DiagnosticsPhaseHPages.cpp
@@ -45,8 +45,13 @@ ConnectionQualityPage::ConnectionQualityPage(RadioModel* model, QWidget* parent)
 
 void ConnectionQualityPage::buildUI()
 {
+    // addSection() already installs a QVBoxLayout on `group` (and on
+    // `histGroup` below). Creating a second `new QVBoxLayout(group)` here
+    // triggers the QLayout "already has a layout" runtime warning — #272
+    // captured 7 of these in the W4ORS May 16 log, all from this file.
+    // Reuse the layout addSection() already installed instead.
     auto* group = addSection(QStringLiteral("Live Counters"));
-    auto* form = new QVBoxLayout(group);
+    auto* form = qobject_cast<QVBoxLayout*>(group->layout());
 
     auto addRow = [&](const QString& label, QLabel*& out) {
         auto* row = new QHBoxLayout();
@@ -64,7 +69,7 @@ void ConnectionQualityPage::buildUI()
     addRow(QStringLiteral("EP6 sequence gaps:"),   m_seqGapLabel);
 
     auto* histGroup = addSection(QStringLiteral("60 s History"));
-    auto* histLayout = new QVBoxLayout(histGroup);
+    auto* histLayout = qobject_cast<QVBoxLayout*>(histGroup->layout());
     m_historyPlaceholder = new QLabel(
         QStringLiteral("60 s history graph — wired in follow-up phase."));
     m_historyPlaceholder->setStyleSheet(QStringLiteral("color: #888;"));
@@ -103,8 +108,10 @@ SettingsValidationPage::SettingsValidationPage(RadioModel* model, QWidget* paren
 
 void SettingsValidationPage::buildUI()
 {
+    // Reuse the layout addSection() installs (see ConnectionQualityPage::buildUI
+    // for context — #272).
     auto* group = addSection(QStringLiteral("Validation Issues"));
-    auto* layout = new QVBoxLayout(group);
+    auto* layout = qobject_cast<QVBoxLayout*>(group->layout());
 
     m_issueList = new QListWidget;
     m_issueList->setStyleSheet(
@@ -190,8 +197,10 @@ ExportImportConfigPage::ExportImportConfigPage(RadioModel* model, QWidget* paren
 
 void ExportImportConfigPage::buildUI()
 {
+    // Reuse the layout addSection() installs (see ConnectionQualityPage::buildUI
+    // for context — #272). Same pattern applies to allGroup + radioGroup below.
     auto* fileGroup = addSection(QStringLiteral("Settings File"));
-    auto* fileLayout = new QVBoxLayout(fileGroup);
+    auto* fileLayout = qobject_cast<QVBoxLayout*>(fileGroup->layout());
     m_settingsPathLabel = new QLabel(
         QStringLiteral("Path: %1").arg(AppSettings::instance().filePath()));
     m_settingsPathLabel->setStyleSheet(QStringLiteral("color: #c8d8e8;"));
@@ -199,7 +208,7 @@ void ExportImportConfigPage::buildUI()
     fileLayout->addWidget(m_settingsPathLabel);
 
     auto* allGroup = addSection(QStringLiteral("Full Configuration (XML)"));
-    auto* allLayout = new QVBoxLayout(allGroup);
+    auto* allLayout = qobject_cast<QVBoxLayout*>(allGroup->layout());
     auto* btnRow = new QHBoxLayout;
     m_exportAllBtn = new QPushButton(QStringLiteral("Export All Settings…"));
     m_importAllBtn = new QPushButton(QStringLiteral("Import All Settings…"));
@@ -209,7 +218,7 @@ void ExportImportConfigPage::buildUI()
     allLayout->addLayout(btnRow);
 
     auto* radioGroup = addSection(QStringLiteral("Per-Radio Configuration"));
-    auto* radioLayout = new QVBoxLayout(radioGroup);
+    auto* radioLayout = qobject_cast<QVBoxLayout*>(radioGroup->layout());
     m_radioSummaryLabel = new QLabel(
         QStringLiteral("Per-radio export will copy only the hardware/<mac>/* "
                        "subtree for the connected radio."));
@@ -290,8 +299,10 @@ LogsPage::LogsPage(QWidget* parent)
 
 void LogsPage::buildUI()
 {
+    // Reuse the layout addSection() installs (see ConnectionQualityPage::buildUI
+    // for context — #272).
     auto* group = addSection(QStringLiteral("Recent Log"));
-    auto* layout = new QVBoxLayout(group);
+    auto* layout = qobject_cast<QVBoxLayout*>(group->layout());
     m_logView = new QPlainTextEdit;
     m_logView->setReadOnly(true);
     m_logView->setStyleSheet(QStringLiteral(

--- a/src/gui/setup/DeviceCard.cpp
+++ b/src/gui/setup/DeviceCard.cpp
@@ -326,7 +326,11 @@ void DeviceCard::buildLayout()
         outer->addLayout(pillRow);
     }
 
-    setLayout(outer);
+    // `outer` was already installed as this widget's layout by the
+    // `new QVBoxLayout(this)` parent-ctor at the top of this function; a
+    // second `setLayout(outer)` triggers the QGroupBox "already has a layout"
+    // runtime warning (×7 on Settings open — fired 3 times from AudioDevicesPage
+    // and 4 times from AudioVaxPage's VaxChannelCards before #272).
 
     // ── Wire all controls to the commit slot ────────────────────────────
     // Use event-filter on QComboBox / QCheckBox inside the card so wheel

--- a/src/gui/setup/hardware/Hl2OptionsTab.cpp
+++ b/src/gui/setup/hardware/Hl2OptionsTab.cpp
@@ -380,6 +380,15 @@ void Hl2OptionsTab::buildI2cControl(QWidget* parent)
     connect(m_btnWrite, &QPushButton::clicked,
             this, &Hl2OptionsTab::onI2cWriteClicked);
 
+    // Belt-and-braces Write gate: m_btnWrite only enables when BOTH
+    // chkI2cEnable and chkI2cWriteEnable are checked. Wired exactly once
+    // here in the build path — previously this was wired inside
+    // onI2cEnableToggled with Qt::UniqueConnection + lambda, which is the
+    // shape Qt warns about ("unique connections require a pointer to member
+    // function") because lambdas can't be deduped. #272.
+    connect(m_chkI2cWriteEnable, &QCheckBox::toggled,
+            this, &Hl2OptionsTab::syncI2cWriteButtonEnabled);
+
     // Push read responses into the byte labels as they arrive.
     if (m_ioBoard) {
         connect(m_ioBoard, &IoBoardHl2::i2cReadResponseReceived, this,
@@ -483,20 +492,18 @@ void Hl2OptionsTab::onI2cEnableToggled(bool on)
     if (m_udI2cWriteData)  { m_udI2cWriteData->setEnabled(on); }
     if (m_chkI2cWriteEnable) { m_chkI2cWriteEnable->setEnabled(on); }
     if (m_btnRead)         { m_btnRead->setEnabled(on); }
-    // Write button needs both gates.
-    if (m_btnWrite) {
-        m_btnWrite->setEnabled(on && m_chkI2cWriteEnable
-                               && m_chkI2cWriteEnable->isChecked());
-    }
-    if (m_chkI2cWriteEnable) {
-        connect(m_chkI2cWriteEnable, &QCheckBox::toggled, m_btnWrite,
-                [this](bool we) {
-                    if (m_btnWrite) {
-                        m_btnWrite->setEnabled(
-                            m_chkI2cEnable && m_chkI2cEnable->isChecked() && we);
-                    }
-                }, Qt::UniqueConnection);
-    }
+    // Write button is gated by both checkboxes — route through the helper
+    // so the build-time chkI2cWriteEnable toggle wire and this enable
+    // toggle both end up at the same place.
+    syncI2cWriteButtonEnabled();
+}
+
+void Hl2OptionsTab::syncI2cWriteButtonEnabled()
+{
+    if (!m_btnWrite) { return; }
+    const bool i2cOn = m_chkI2cEnable && m_chkI2cEnable->isChecked();
+    const bool writeOn = m_chkI2cWriteEnable && m_chkI2cWriteEnable->isChecked();
+    m_btnWrite->setEnabled(i2cOn && writeOn);
 }
 
 void Hl2OptionsTab::onI2cReadClicked()

--- a/src/gui/setup/hardware/Hl2OptionsTab.h
+++ b/src/gui/setup/hardware/Hl2OptionsTab.h
@@ -139,6 +139,14 @@ private slots:
     void onOutputPinClicked(int idx);
     void onIoBoardOcByteChanged(quint8 ocByte, int bandIdx, bool mox);
 
+    // Recomputes m_btnWrite's enabled state from the two gating checkboxes
+    // (chkI2cEnable + chkI2cWriteEnable). Wired once in buildI2cControl, and
+    // also called directly from onI2cEnableToggled. Replaces an earlier
+    // lambda-based connect with Qt::UniqueConnection that fired the Qt
+    // "unique connections require a pointer to member function" warning on
+    // every Settings dialog open (lambdas can't be deduped) — #272.
+    void syncI2cWriteButtonEnabled();
+
 private:
     void buildHermesLiteOptions(QWidget* parent);
     void buildI2cControl(QWidget* parent);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2088,6 +2088,14 @@ target_compile_definitions(tst_pa_setup_per_sku_visibility PRIVATE NEREUS_BUILD_
 nereus_add_test(tst_setup_dialog_pa_reset_wiring)
 target_compile_definitions(tst_setup_dialog_pa_reset_wiring PRIVATE NEREUS_BUILD_TESTS)
 
+# ── #272 regression: zero Qt programming-error warnings during SetupDialog ──
+# construction. Pre-fix the W4ORS May 16 log captured 7× "QLayout: Attempting
+# to add QLayout" warnings (DeviceCard double setLayout) and 1× "unique
+# connections require a pointer to member function" warning
+# (Hl2OptionsTab lambda + Qt::UniqueConnection). Both fixed; this test
+# pins them at zero.
+nereus_add_test(tst_setup_dialog_qt_warnings)
+
 # ── Phase 3M-0 Task 14: MainWindow status-bar TX Inhibit + PA Status badge ───
 # Tests the label-state logic for the two safety indicator widgets added to
 # the MainWindow status bar:

--- a/tests/tst_setup_dialog_qt_warnings.cpp
+++ b/tests/tst_setup_dialog_qt_warnings.cpp
@@ -1,0 +1,145 @@
+// tests/tst_setup_dialog_qt_warnings.cpp  (NereusSDR)
+//
+// Regression test for #272 — the May 16 W4ORS BSOD report flagged two Qt
+// runtime warnings firing during SetupDialog construction:
+//
+//   QObject::connect(QCheckBox, QPushButton): unique connections require a
+//     pointer to member function of a QObject subclass
+//   QLayout: Attempting to add QLayout "" to QGroupBox "", which already
+//     has a layout                                                     [×7]
+//
+// Both are real Qt programming errors (one was a lambda passed with
+// Qt::UniqueConnection in Hl2OptionsTab::onI2cEnableToggled, where the slot
+// could not be deduped; the other was a redundant setLayout() call in
+// DeviceCard::buildLayout after the QVBoxLayout(this) parent-ctor already
+// installed the layout). They were not the BSOD root cause, but they did
+// pollute the log Chris attached to the issue and they survive any
+// SetupDialog-construction-time freeze investigation, so closing them out
+// makes future repro logs easier to read.
+//
+// no-port-check: this is a NereusSDR-original UI test fixture; the cited
+// Thetis files are referenced in the production source comments and not
+// here.
+//
+// Strategy: install a QtMessageHandler before SetupDialog construction;
+// pattern-match each emitted message against the two known warnings;
+// assert zero matches.
+
+#include <QtTest/QtTest>
+#include <QApplication>
+
+#include <atomic>
+
+#include "core/AppSettings.h"
+#include "gui/SetupDialog.h"
+#include "models/RadioModel.h"
+
+using namespace NereusSDR;
+
+namespace {
+std::atomic<int>* g_layoutDoubleAdd = nullptr;
+std::atomic<int>* g_uniqueLambdaConnect = nullptr;
+
+void counterHandler(QtMsgType type, const QMessageLogContext&, const QString& msg)
+{
+    Q_UNUSED(type);
+    // QGroupBox double-setLayout — "QLayout: Attempting to add QLayout"
+    if (g_layoutDoubleAdd &&
+        msg.contains(QStringLiteral("Attempting to add QLayout"))) {
+        g_layoutDoubleAdd->fetch_add(1);
+    }
+    // Lambda + Qt::UniqueConnection — "unique connections require a
+    // pointer to member function"
+    if (g_uniqueLambdaConnect &&
+        msg.contains(QStringLiteral("unique connections require"))) {
+        g_uniqueLambdaConnect->fetch_add(1);
+    }
+}
+} // namespace
+
+class TstSetupDialogQtWarnings : public QObject {
+    Q_OBJECT
+
+private slots:
+    void initTestCase()
+    {
+        if (!qApp) {
+            static int argc = 0;
+            new QApplication(argc, nullptr);
+        }
+        AppSettings::instance().clear();
+    }
+
+    void cleanup()
+    {
+        AppSettings::instance().clear();
+    }
+
+    void setupDialog_construction_emits_no_layout_double_add_warnings();
+    void setupDialog_construction_emits_no_unique_lambda_connect_warnings();
+};
+
+// ---------------------------------------------------------------------------
+// Test 1: zero "Attempting to add QLayout" warnings.
+//
+// Pre-fix: 7 fired (3 from AudioDevicesPage's DeviceCards + 4 from
+// AudioVaxPage's VaxChannelCard DeviceCards). Post-fix: 0.
+// ---------------------------------------------------------------------------
+void TstSetupDialogQtWarnings::
+    setupDialog_construction_emits_no_layout_double_add_warnings()
+{
+    std::atomic<int> layoutCount{0};
+    g_layoutDoubleAdd = &layoutCount;
+    g_uniqueLambdaConnect = nullptr;
+    QtMessageHandler prev = qInstallMessageHandler(counterHandler);
+
+    {
+        RadioModel model;
+        SetupDialog dialog(&model);
+        Q_UNUSED(dialog);
+    }
+
+    qInstallMessageHandler(prev);
+    g_layoutDoubleAdd = nullptr;
+
+    QCOMPARE(layoutCount.load(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: zero "unique connections require" warnings.
+//
+// Pre-fix: 1 fired from Hl2OptionsTab::onI2cEnableToggled wiring its
+// m_chkI2cWriteEnable → m_btnWrite gating lambda with Qt::UniqueConnection
+// each time the slot ran. Post-fix: the wiring moves to buildI2cControl
+// (called once) and the slot becomes a real PMF on the tab.
+//
+// Note: HardwarePage only constructs the Hl2OptionsTab when the connected
+// radio reports HL2 capabilities. In this test no radio is connected, so
+// the tab may not be built at all — in which case the warning naturally
+// never fires regardless of the fix. The QCOMPARE to zero still holds:
+// the assertion is "no warning fires during SetupDialog construction",
+// and that's true both when the tab is skipped and when it's built with
+// the fixed wiring.
+// ---------------------------------------------------------------------------
+void TstSetupDialogQtWarnings::
+    setupDialog_construction_emits_no_unique_lambda_connect_warnings()
+{
+    std::atomic<int> uniqueLambdaCount{0};
+    g_layoutDoubleAdd = nullptr;
+    g_uniqueLambdaConnect = &uniqueLambdaCount;
+    QtMessageHandler prev = qInstallMessageHandler(counterHandler);
+
+    {
+        RadioModel model;
+        SetupDialog dialog(&model);
+        Q_UNUSED(dialog);
+    }
+
+    qInstallMessageHandler(prev);
+    g_uniqueLambdaConnect = nullptr;
+
+    QCOMPARE(uniqueLambdaCount.load(), 0);
+}
+
+QTEST_MAIN(TstSetupDialogQtWarnings)
+#include "tst_setup_dialog_qt_warnings.moc"


### PR DESCRIPTION
## Summary

Closes the two Qt programming-error warnings flagged in W4ORS's #272 BSOD log (`QLayout: Attempting to add QLayout` x7 and `QObject::connect ... unique connections require a pointer to member function`), and adds opt-in `QElapsedTimer` instrumentation around `SetupDialog::buildTree()` plus the tree-click page-switch path so the next #272 freeze repro identifies the slow page.

Neither warning was the BSOD root cause. The cascade is a ~40s UI freeze stalling the audio engine long enough for the HL2 ep6 watchdog (2011 ms) to fire, then the unclean audio teardown tipping a legacy 2010 Realtek driver into `CLOCK_WATCHDOG_TIMEOUT`. Same fault class as #258 / fixed in #261, different code path. The real freeze (eager 47-page `SetupDialog` construction plus click-time work on the DSP pages) needs a proper plan and lazy-page-construction refactor, tracked as follow-up to #272. This PR just clears the log noise so the next bench repro is readable.

## What changed

1. **7 layout warnings** traced via lldb to `DiagnosticsPhaseHPages.cpp`: 7 callsites do `new QVBoxLayout(group)` on a `QGroupBox` that `SetupPage::addSection()` already installed a `QVBoxLayout` on. Reuse the existing layout via `qobject_cast<QVBoxLayout*>(group->layout())` in `ConnectionQualityPage`, `SettingsValidationPage`, `ExportImportConfigPage` (3 sections), and `LogsPage`.
2. **Unique-connection warning** in `Hl2OptionsTab::onI2cEnableToggled`: wired `m_chkI2cWriteEnable` to `m_btnWrite` gating with `Qt::UniqueConnection` plus a lambda each time the slot ran. Qt can't dedupe lambdas, so the warning fired and the connection accumulated. Moved the wire into `buildI2cControl` (called once) and extracted the gating into a private slot `syncI2cWriteButtonEnabled()`.
3. **Dead `setLayout(outer)` in `DeviceCard::buildLayout`** removed (the `new QVBoxLayout(this)` parent-ctor already installed the layout; the explicit re-install was a no-op).
4. **`SetupDialog` timing instrumentation** added under a new `nereus.setup.timing` logging category (disabled by default). Per-category section deltas and total `buildTree()` elapsed log at construction time. Page-switch handler logs the destination page label plus elapsed ms. Enable with `QT_LOGGING_RULES="nereus.setup.timing.debug=true"`.

## Test plan

- [x] `ctest -R tst_setup_dialog_qt_warnings` (new test) passing. Pre-fix: 7 layout warnings (plus 1 unique-lambda warning when HL2 is connected). Post-fix: 0 of each.
- [x] `ctest -R "setup|hl2|device_card|diagnostics"`: 33/33 passing.
- [x] Full app build clean on macOS Apple Silicon (1 pre-existing unused-lambda-capture warning in `AppearanceSetupPages.cpp`, unrelated).
- [ ] Manual bench (W4ORS or any HL2 bench): connect, open Settings, click through Diagnostics + Hardware + DSP. Confirm Qt log is free of `QLayout: Attempting to add QLayout` and `unique connections require` lines. Optional: set `QT_LOGGING_RULES="nereus.setup.timing.debug=true"` and capture the timing breakdown for the freeze.

## Follow-up

- Real freeze fix (lazy `SetupDialog` page construction or off-main-thread audio enumeration) needs its own plan. The instrumentation in this PR is the starting point for that investigation.

Reported by @Chris-W4ORS in #272.