### PR TITLE
Applet visibility menu (☰ + Containers) with 4O3A capability gating

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -763,6 +763,7 @@ set(GUI_SOURCES
     src/gui/applets/AppletWidget.cpp
     src/gui/applets/NyiOverlay.cpp
     src/gui/applets/AppletPanelWidget.cpp
+    src/gui/applets/AppletVisibilityController.cpp
     src/gui/applets/RxApplet.cpp
     src/gui/applets/TxApplet.cpp
     src/gui/applets/TxEqDialog.cpp

--- a/docs/architecture/2026-05-10-applet-visibility-menu-design.md
+++ b/docs/architecture/2026-05-10-applet-visibility-menu-design.md
@@ -24,8 +24,8 @@ Both menus stay in sync, share persistence, and only list applets that are actua
 | 2 | Applet inclusion | Only currently-wired applets (5: Rx, Tx, PhoneCw, Vax, PureSignal). Ghosts excluded until their phase ships. |
 | 3 | Architecture | New `AppletVisibilityController` class — single source of truth shared by both menus and the panel. Fits existing controller pattern (Alex/Mox/Clarity/Antenna). |
 | 4 | Order preservation | Hide/show via `QWidget::setVisible()` on the wrapper (not `removeApplet`/`addApplet`). Order stays stable across toggles. Requires new `AppletPanelWidget::setAppletVisible(applet, bool)` method. |
-| 5 | Banner button gesture | Visible `☰` icon button (5th button, after gear). Discoverable. Right-click context menu rejected as too hidden. |
-| 6 | Banner button scope | Only on Container #0 (the applet panel). Other containers don't host applets, so no `☰` button. |
+| 5 | Banner button gesture | Visible `☰` icon button. Discoverable. Right-click context menu rejected as too hidden. |
+| 6 | Banner button location | A new ~22 px header row added to `AppletPanelWidget` itself (the panel has no banner today; not wrapped in `ContainerWidget`). Floating meter containers and other `ContainerWidget` instances don't get the button. |
 | 7 | Persistence keys | `AppletRxVisible`, `AppletTxVisible`, `AppletPhoneCwVisible`, `AppletVaxVisible`, `AppletPureSignalVisible`. Stored as `True`/`False` strings per AppSettings convention. |
 | 8 | Persistence scope | Global (not per-MAC). UI preference — survives radio swaps. |
 | 9 | First-run defaults (shipped 5) | All 5 visible. Matches current behavior — no surprise for existing users. |
@@ -57,18 +57,18 @@ Section-header rendering: prefer `QMenu::addSection("Applets")` (Qt 5.1+; styles
 
 Each of the 5 new entries is a checkable `QAction`. Toggling flips the check immediately and shows/hides the corresponding applet in the right-side panel. Display labels match the applet's `appletTitle()` virtual.
 
-### 3.2 Banner button — Container #0
+### 3.2 Banner button — AppletPanelWidget
 
-Today's banner has 4 icon buttons (`ContainerWidget.cpp:117-166`): axis-lock, pin-on-top, float/dock, settings (gear).
+**Important context.** The right-side AppletPanelWidget is *not* wrapped in a `ContainerWidget`. The `ContainerWidget` class (with its 4-button banner: axis-lock / pin / float / settings) is used for floating meter containers and overlay-docked containers — it is not the host of the applet panel. The applet panel sits directly in the main `QSplitter` with no banner header today.
 
-Add a 5th, immediately right of the gear:
+Therefore: this design adds a **new thin header row** to `AppletPanelWidget` itself, above the existing MeterWidget header area. ~22 px tall, dark background matching the per-applet title bars (`Style::titleBarStyle()`), containing only the `☰` button right-aligned.
 
-- Icon: `☰` (hamburger). Same 16×16 button cell as the others.
-- Tooltip: `"Show or hide applets in this container."`
+- Icon: `☰` (hamburger). 22×22 button.
+- Tooltip: `"Show or hide applets."`
 - Click: opens a `QMenu` aligned to the button's bottom-right corner.
 - Menu contents: same 5 checkable items as the top-menu Applets section.
 
-The button is **only created on the AppletPanel-bearing container** (Container #0). Other containers (floating meter windows, future panadapter containers) do not host applets and do not get the button. Implementation detail: `ContainerWidget::setHostedAppletPanel(...)` (or equivalent) becomes the trigger that adds the button.
+Floating meter containers and other `ContainerWidget` instances do not get the button (they don't host applets).
 
 ### 3.3 Behavior — both menus
 
@@ -156,9 +156,9 @@ In the menu builder (the existing block around `MainWindow.cpp:2764`):
 - For each `id` in `m_appletVis->registeredIds()`, add a checkable QAction whose `toggled(bool)` slot calls `m_appletVis->setVisible(id, checked)`.
 - Store these QActions in `QHash<QString, QAction*> m_appletMenuActions` for later checkmark sync.
 
-In a new `ContainerWidget` extension (or a small `BannerAppletMenuButton` helper):
-- Build the same QAction list, parented to the `☰` button's `QMenu`.
-- Same `toggled` connection to `m_appletVis->setVisible(...)`.
+In `AppletPanelWidget`:
+- Add a `setBannerMenu(QMenu* menu)` API (or constructor-time `setBannerMenu` call from `MainWindow`) that installs the menu on the new ☰ button.
+- Build the same 5 checkable actions parented to that menu, wired to `m_appletVis->setVisible(...)` via `toggled`.
 
 In the controller's signal handler (a slot on `MainWindow`):
 - Look up `applet = m_appletsById[id]`.

--- a/docs/architecture/2026-05-10-applet-visibility-menu-design.md
+++ b/docs/architecture/2026-05-10-applet-visibility-menu-design.md
@@ -1,0 +1,295 @@
+# Applet Visibility Menu — Design
+
+> **Status:** Drafted 2026-05-10. Awaiting user review before implementation plan.
+> **Branch:** TBD (likely off `main` after current epics merge)
+> **Predecessor:** None (UX restoration of feature commented-out in `25597df`, 2026-05-02)
+> **Successor:** Implementation plan via `superpowers:writing-plans`
+
+## 1. Goal
+
+Restore — and meaningfully extend — the ability to show or hide individual applets in the right-side `AppletPanelWidget`. The original feature lived under the top-bar **Containers** menu as a `addContainerToggle()` lambda (`src/gui/MainWindow.cpp:2773-2796`) and was disabled in commit `25597df` per `docs/superpowers/plans/2026-05-01-ui-polish-right-panel.md §Task 6` because the seven entries it carried were all ghost applets without functional wiring.
+
+Since then, `PureSignalApplet` has shipped wired (`v0.4.0`, commit `2271f8a`), and the user wants the toggling capability back in two places:
+
+1. The original top-bar location (Containers menu).
+2. A new in-context entry point: a hamburger (`☰`) icon button on the right-side panel's banner.
+
+Both menus stay in sync, share persistence, and only list applets that are actually wired and useful today.
+
+## 2. Locked decisions (from brainstorm, 2026-05-10)
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Menu locations | Both — top menu (Containers) AND `☰` button on Container #0 banner |
+| 2 | Applet inclusion | Only currently-wired applets (5: Rx, Tx, PhoneCw, Vax, PureSignal). Ghosts excluded until their phase ships. |
+| 3 | Architecture | New `AppletVisibilityController` class — single source of truth shared by both menus and the panel. Fits existing controller pattern (Alex/Mox/Clarity/Antenna). |
+| 4 | Order preservation | Hide/show via `QWidget::setVisible()` on the wrapper (not `removeApplet`/`addApplet`). Order stays stable across toggles. Requires new `AppletPanelWidget::setAppletVisible(applet, bool)` method. |
+| 5 | Banner button gesture | Visible `☰` icon button (5th button, after gear). Discoverable. Right-click context menu rejected as too hidden. |
+| 6 | Banner button scope | Only on Container #0 (the applet panel). Other containers don't host applets, so no `☰` button. |
+| 7 | Persistence keys | `AppletRxVisible`, `AppletTxVisible`, `AppletPhoneCwVisible`, `AppletVaxVisible`, `AppletPureSignalVisible`. Stored as `True`/`False` strings per AppSettings convention. |
+| 8 | Persistence scope | Global (not per-MAC). UI preference — survives radio swaps. |
+| 9 | First-run defaults (shipped 5) | All 5 visible. Matches current behavior — no surprise for existing users. |
+| 10 | Future-applet defaults | New applets added in later phases default to **visible** when their phase ships, so existing users discover the new surface on first launch of the new version. |
+| 11 | Sync between menus | Both QActions update their `checked` state when controller emits `visibilityChanged`. `QSignalBlocker` prevents recursive toggle loops. |
+| 12 | Phase 3F multi-pan readiness | Today: single global visibility map (only Container #0 hosts applets). At 3F: extend `AppletVisibilityController` to take a containerId. Persistence key schema becomes `Applet/<containerId>/<appletId>/Visible`. Out of scope for this design; called out as a known evolution path. |
+
+## 3. UX summary
+
+### 3.1 Top menu — Containers
+
+Layout (additions in **bold**):
+
+```
+Containers
+├─ Show Container...
+├─ Edit Container ▸
+├─ Reset Default Layout
+├─ ─────────────── (existing separator, MainWindow.cpp:2764)
+├─ Applets        (NEW section header — see Qt rendering note below)
+├─ ✓ RX           (NEW)
+├─ ✓ TX           (NEW)
+├─ ✓ Phone / CW   (NEW)
+├─ ✓ VAX          (NEW)
+└─ ✓ PureSignal   (NEW)
+```
+
+Section-header rendering: prefer `QMenu::addSection("Applets")` (Qt 5.1+; styles vary across platforms but is the idiomatic choice). Fallback if the platform style ignores it: a disabled `QAction` with grey, slightly-smaller font.
+
+Each of the 5 new entries is a checkable `QAction`. Toggling flips the check immediately and shows/hides the corresponding applet in the right-side panel. Display labels match the applet's `appletTitle()` virtual.
+
+### 3.2 Banner button — Container #0
+
+Today's banner has 4 icon buttons (`ContainerWidget.cpp:117-166`): axis-lock, pin-on-top, float/dock, settings (gear).
+
+Add a 5th, immediately right of the gear:
+
+- Icon: `☰` (hamburger). Same 16×16 button cell as the others.
+- Tooltip: `"Show or hide applets in this container."`
+- Click: opens a `QMenu` aligned to the button's bottom-right corner.
+- Menu contents: same 5 checkable items as the top-menu Applets section.
+
+The button is **only created on the AppletPanel-bearing container** (Container #0). Other containers (floating meter windows, future panadapter containers) do not host applets and do not get the button. Implementation detail: `ContainerWidget::setHostedAppletPanel(...)` (or equivalent) becomes the trigger that adds the button.
+
+### 3.3 Behavior — both menus
+
+- Toggling an entry persists immediately; survives quit/restart.
+- Both menus stay synchronized: toggling via the `☰` updates the top menu's checkmark and vice versa.
+- Hiding an applet hides the entire wrapper (title bar + body). The space collapses; remaining applets shift up.
+- Showing an applet again restores it to its **original position in the stack** (RX always above TX, TX above Phone/CW, etc.) — never reshuffles.
+- No animation in v1. Instant show/hide.
+
+## 4. Architecture
+
+### 4.1 New class — `AppletVisibilityController`
+
+Files: `src/gui/applets/AppletVisibilityController.{h,cpp}`. Estimated ~80-120 lines.
+
+Owned by `MainWindow`, constructed after `m_appletPanel`.
+
+**Responsibilities:**
+- Holds the registry of applet IDs, display names, and current visibility state.
+- Reads initial state from `AppSettings` on first registration of each applet.
+- Writes to `AppSettings` on every `setVisible` call (synchronous; small data; write-through is safe).
+- Emits `visibilityChanged(QString id, bool visible)` whenever state flips.
+
+**API sketch (final signatures TBD in implementation plan):**
+
+```cpp
+class AppletVisibilityController : public QObject {
+    Q_OBJECT
+public:
+    explicit AppletVisibilityController(QObject* parent = nullptr);
+
+    // Called once per applet at startup (typically from MainWindow).
+    // defaultVisible is used only when no AppSettings key exists yet.
+    void registerApplet(const QString& id,
+                        const QString& displayName,
+                        bool defaultVisible);
+
+    // Public state accessors.
+    bool isVisible(const QString& id) const;
+    QStringList registeredIds() const;          // insertion order preserved
+    QString displayName(const QString& id) const;
+
+public slots:
+    void setVisible(const QString& id, bool visible);
+
+signals:
+    void visibilityChanged(const QString& id, bool visible);
+
+private:
+    struct Entry { QString displayName; bool visible; };
+    QMap<QString, Entry> m_entries;             // key = id
+    QStringList m_order;                        // registration order
+};
+```
+
+### 4.2 Modified — `AppletPanelWidget`
+
+Add one method:
+
+```cpp
+void setAppletVisible(AppletWidget* applet, bool visible);
+```
+
+Implementation: looks up `m_wrappers[applet]`, calls `wrapper->setVisible(visible)`. No reparent, no destroy, no churn. Order in `m_stackLayout` is unchanged.
+
+Existing `addApplet`/`removeApplet` API remains untouched for backward compatibility (other code paths may still use it).
+
+### 4.3 Modified — `MainWindow`
+
+In `buildDefaultContainerLayout()` (or equivalent): after the 5 wired applets are added to the panel, register each one with the controller:
+
+```cpp
+m_appletVis->registerApplet("Rx",         "RX",          true);
+m_appletVis->registerApplet("Tx",         "TX",          true);
+m_appletVis->registerApplet("PhoneCw",    "Phone / CW",  true);
+m_appletVis->registerApplet("Vax",        "VAX",         true);
+m_appletVis->registerApplet("PureSignal", "PureSignal",  true);
+```
+
+Maintain a side map `QHash<QString, AppletWidget*> m_appletsById` so the controller's signal can be routed to the right applet.
+
+In the menu builder (the existing block around `MainWindow.cpp:2764`):
+- After the existing `Reset Default Layout` action and separator, add a new separator.
+- Add a disabled `"Applets"` section header QAction (greyed, non-clickable label).
+- For each `id` in `m_appletVis->registeredIds()`, add a checkable QAction whose `toggled(bool)` slot calls `m_appletVis->setVisible(id, checked)`.
+- Store these QActions in `QHash<QString, QAction*> m_appletMenuActions` for later checkmark sync.
+
+In a new `ContainerWidget` extension (or a small `BannerAppletMenuButton` helper):
+- Build the same QAction list, parented to the `☰` button's `QMenu`.
+- Same `toggled` connection to `m_appletVis->setVisible(...)`.
+
+In the controller's signal handler (a slot on `MainWindow`):
+- Look up `applet = m_appletsById[id]`.
+- Call `m_appletPanel->setAppletVisible(applet, visible)`.
+- Sync both menus' QActions: `QSignalBlocker block(action); action->setChecked(visible);` for each menu's copy.
+
+### 4.4 Data flow (recap)
+
+```
+User clicks toggle  (top menu OR banner ☰ menu)
+    → QAction::toggled(bool)
+    → AppletVisibilityController::setVisible(id, bool)
+        → AppSettings::setValue("Applet<Id>Visible", "True"/"False")
+        → emit visibilityChanged(id, bool)
+            → MainWindow slot
+                → m_appletPanel->setAppletVisible(applet, bool)  [wrapper hides/shows]
+                → for each menu copy of the QAction:
+                       QSignalBlocker → action->setChecked(bool)
+```
+
+## 5. Persistence
+
+### 5.1 Keys
+
+| Applet ID | AppSettings key |
+|---|---|
+| Rx | `AppletRxVisible` |
+| Tx | `AppletTxVisible` |
+| PhoneCw | `AppletPhoneCwVisible` |
+| Vax | `AppletVaxVisible` |
+| PureSignal | `AppletPureSignalVisible` |
+
+Values: `"True"` / `"False"` strings, per `AppSettings` convention (CLAUDE.md §"Settings Persistence (AppSettings — NOT QSettings)").
+
+### 5.2 Defaults
+
+| Scenario | Behavior |
+|---|---|
+| Fresh install | All 5 keys absent → controller uses `defaultVisible=true` per registration → all 5 visible |
+| Existing user, first launch with feature | Same — keys absent, all 5 visible (matches current behavior, zero surprise) |
+| User has hidden Rx, restarts | `AppletRxVisible=False` persists, applied at startup, RX hidden until user re-enables |
+| Future phase wires e.g. CwxApplet | Registration happens with `defaultVisible=true`. Existing users see "CW Keyer" appear in their panel + menu on first launch of new version. Can hide via menu if unwanted. |
+
+### 5.3 Migration
+
+None required. The feature has never persisted state before; absence of keys is the natural first-run condition.
+
+## 6. Order preservation rationale
+
+The original `addApplet`/`removeApplet` API destroys the wrapper on remove and creates a new one on re-add. This causes:
+
+1. **Order loss.** A re-shown applet is appended at the end of the stack (`m_stackLayout->insertWidget(count - 1, wrapper)`), not restored to its original position.
+2. **Widget churn.** Wrapper, title bar, label, grip dots — all destroyed and rebuilt. Cheap, but unnecessary.
+3. **Latent reparent risk.** `AppletPanelWidget::clearHeaderWidget` carries a long comment (lines 117-128) explaining a Windows D3D11 swapchain bug triggered by reparenting `QRhiWidget` children. Applets don't currently host `QRhiWidget`, but adding `setVisible`-based hide/show eliminates the risk class entirely.
+
+`setAppletVisible(applet, bool)` solves all three by simply calling `wrapper->setVisible(bool)` — wrapper stays in the layout, applet stays parented, and Qt's layout recomputes around the hidden wrapper (which reports zero `sizeHint()` when hidden).
+
+## 7. Phase 3F multi-pan readiness
+
+When 3F lands and additional containers can host their own applet sets, the visibility model needs a containerId axis. Path of least disruption:
+
+1. `AppletVisibilityController::registerApplet` gains an optional `containerId` parameter (default = `"0"` for backward compatibility).
+2. Persistence keys evolve to `Applet/<containerId>/<appletId>/Visible` (nested keys per AppSettings).
+3. The `☰` button's menu reads only the current container's slice of the registry.
+4. The top menu shows a per-container submenu structure: `Containers > Container #0 > Applets > ...`.
+
+Out of scope for this design. Called out so the v1 schema doesn't paint into a corner. The single-container schema in §5.1 is forward-compatible: when 3F migration runs, a small one-time pass moves `AppletRxVisible` → `Applet/0/Rx/Visible`, etc.
+
+## 8. Testing
+
+### 8.1 Unit tests — `tst_applet_visibility_controller.cpp`
+
+- Register one applet with `defaultVisible=true`, no AppSettings key → `isVisible(id) == true`.
+- Register one applet with `defaultVisible=true`, AppSettings key `"False"` already present → `isVisible(id) == false` (persisted state wins).
+- Call `setVisible(id, false)` → `isVisible(id) == false`, AppSettings key now `"False"`.
+- Construct a fresh controller pointed at the same AppSettings → `isVisible(id) == false` (round-trip).
+- Spy on `visibilityChanged` signal: verify exactly one emission per `setVisible` call with correct args. Verify no emission when value doesn't change (idempotent).
+- Register two applets, check `registeredIds()` returns insertion order.
+
+### 8.2 Panel test — `tst_applet_panel_set_visible.cpp`
+
+- Build `AppletPanelWidget`, add 3 mock applets (Rx, Tx, PhoneCw equivalents).
+- Call `setAppletVisible(tx, false)` → `m_wrappers[tx]->isVisible() == false`. Wrapper still in layout (`m_stackLayout->indexOf(wrapper) >= 0`).
+- Call `setAppletVisible(tx, true)` → wrapper visible, layout index unchanged.
+- Verify `setAppletVisible(nullptr, ...)` is a no-op (no crash).
+- Verify `setAppletVisible(applet_not_in_panel, ...)` is a no-op.
+
+### 8.3 Wire-up test — `tst_mainwindow_applet_menu.cpp`
+
+- Build `MainWindow`, open Containers menu, locate the Applets section: assert 5 actions present with correct text, all checkable, all initially checked.
+- Trigger toggle on TX action programmatically → assert TX applet wrapper is hidden in panel; assert AppSettings has `AppletTxVisible="False"`.
+- Locate the `☰` banner button on Container #0; open its menu → assert same 5 actions present with TX showing unchecked (sync verified).
+- Trigger toggle on TX via the banner menu → assert TX visible again; top menu's TX action is also checked.
+- Verify `QSignalBlocker` prevents recursive emission (toggle once, controller emits once).
+
+### 8.4 Verification (manual, at bench)
+
+Not gated on this PR but documented for the change-log entry:
+
+- Launch app, confirm all 5 applets visible.
+- Toggle each via top menu, confirm panel updates.
+- Toggle each via `☰` button, confirm top menu's checkmark mirrors.
+- Quit, relaunch, confirm hidden state survives.
+- Hide all 5, confirm panel collapses to header (S-Meter) only.
+- Re-show all, confirm original order (Rx, Tx, PhoneCw, Vax, PureSignal top-to-bottom).
+
+## 9. Out of scope
+
+- Per-container visibility (deferred to Phase 3F — see §7).
+- Drag-to-reorder applets within the panel (separate feature; if asked for, would need its own design).
+- Animated show/hide transitions (could add later; not v1).
+- Visibility toggling for ghost applets that aren't wired yet (excluded by design — they don't appear in either menu until their phase ships).
+- Applet visibility as part of skin/layout import (Phase 3H concern; if a skin later persists these keys, the existing AppSettings layer handles it).
+- Right-click context menu on the banner header (rejected; visible `☰` button preferred for discoverability).
+
+## 10. Source attribution
+
+This is a NereusSDR-original feature. No Thetis equivalent (Thetis exposes container-level show/hide via setup checkboxes — `setup.cs:24443-24657 [v2.10.3.13]` — but no per-applet-toggle pattern, since Thetis applets are static UserControl members of fixed container forms).
+
+The `AppletPanelWidget` itself is an AetherSDR port (header at `AppletPanelWidget.cpp:1-24` credits Jeremy/KK7GWY); the new `setAppletVisible` method is a NereusSDR addition. Per CLAUDE.md style guide, the new method gets a comment noting it as NereusSDR-original; the existing AetherSDR header stays intact.
+
+`AppletVisibilityController` is wholly NereusSDR-original. No upstream cite needed.
+
+## 11. Implementation order (rough)
+
+To be detailed in the implementation plan via `superpowers:writing-plans`. Sketch:
+
+1. `AppletVisibilityController` class + unit tests.
+2. `AppletPanelWidget::setAppletVisible` + panel test.
+3. Wire `MainWindow`: construct controller, register 5 applets, bind controller signal to panel.
+4. Top menu: add separator, section header, 5 checkable actions, bind to controller.
+5. Banner button: add `☰` to Container #0, build menu, bind to controller. May need a small `ContainerWidget` API addition.
+6. Two-way sync: controller signal → both menus' `setChecked` with `QSignalBlocker`.
+7. Wire-up test + bench verification.

--- a/docs/superpowers/plans/2026-05-10-applet-visibility-menu.md
+++ b/docs/superpowers/plans/2026-05-10-applet-visibility-menu.md
@@ -1,0 +1,1307 @@
+# Applet Visibility Menu Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore per-applet show/hide toggling with two access points — the top-bar **Containers** menu and a new ☰ button on the right-side `AppletPanelWidget` — backed by a small `AppletVisibilityController` that owns persistence and keeps both menus in sync.
+
+**Architecture:** A new `AppletVisibilityController` is the single source of truth. Both menus call into it; it persists each change to AppSettings and emits `visibilityChanged`. `MainWindow` connects that signal to a slot that hides/shows the applet wrapper in the panel and updates the checked state on both menu copies (via `QSignalBlocker`). `AppletPanelWidget` gains two changes: a new `setAppletVisible(applet, bool)` method that toggles wrapper visibility (preserving order) and a thin top banner row that hosts the ☰ button.
+
+**Tech Stack:** C++20 / Qt6 (QObject, QMenu, QAction, QPushButton, QSignalBlocker), QtTest, AppSettings (`src/core/AppSettings.h` — never `QSettings`), CMake / Ninja.
+
+**Spec:** `docs/architecture/2026-05-10-applet-visibility-menu-design.md`
+
+**User-visible strings rule:** All tooltip / button / menu text in this plan is plain English. No source cites (`Thetis X:N`, `[v2.10.3.13]`, etc.) appear inside any QString — those go in `//` comments adjacent to the QString line, never inside the user-visible text.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `src/gui/applets/AppletVisibilityController.h` | CREATE | Public class header — registry, state accessors, `setVisible` slot, `visibilityChanged` signal |
+| `src/gui/applets/AppletVisibilityController.cpp` | CREATE | AppSettings round-trip, signal emission, default handling |
+| `src/gui/applets/AppletPanelWidget.h` | MODIFY | New public `setAppletVisible(AppletWidget*, bool)`; new `setBannerMenu(QMenu*)`; private members for the banner row + ☰ button |
+| `src/gui/applets/AppletPanelWidget.cpp` | MODIFY | Implement above; add a 22 px top banner row (hidden until `setBannerMenu` called) |
+| `src/gui/MainWindow.h` | MODIFY | Add `m_appletVis` (owned), `m_appletsById` (QHash), `m_topMenuAppletActions` + `m_bannerAppletActions` (QHash<QString,QAction*>); add `m_appletsMenu` (the QMenu used by both surfaces, or two menus if needed) |
+| `src/gui/MainWindow.cpp` | MODIFY | Construct controller after panel; register 5 applets; build top-menu Applets section; build banner menu; wire `visibilityChanged` slot |
+| `tests/tst_applet_visibility_controller.cpp` | CREATE | Unit tests: defaults, persistence round-trip, signal emission, idempotent setVisible, registration order |
+| `tests/tst_applet_panel_set_visible.cpp` | CREATE | Panel test: setAppletVisible toggles wrapper visibility while preserving layout index; null-safety |
+| `tests/tst_applet_visibility_menu_wiring.cpp` | CREATE | Wiring test: MainWindow's top-menu Applets actions + banner-menu actions both flip the controller AND mirror each other's checked state |
+| `CMakeLists.txt` | MODIFY | Add `src/gui/applets/AppletVisibilityController.cpp` to source list near existing applet sources (around line 707) |
+| `tests/CMakeLists.txt` | MODIFY | Three `nereus_add_test(...)` registrations for the new test files |
+
+---
+
+## Task 1: AppletPanelWidget gains `setAppletVisible(applet, bool)`
+
+This is the prerequisite for everything else: a way to hide/show an applet without losing its position in the stack.
+
+**Files:**
+- Modify: `src/gui/applets/AppletPanelWidget.h`
+- Modify: `src/gui/applets/AppletPanelWidget.cpp`
+- Create: `tests/tst_applet_panel_set_visible.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tst_applet_panel_set_visible.cpp`:
+
+```cpp
+// Verify AppletPanelWidget::setAppletVisible toggles wrapper visibility
+// while keeping the applet's position in the stack layout intact.
+
+#include <QApplication>
+#include <QtTest/QtTest>
+#include <QVBoxLayout>
+#include <QScrollArea>
+#include "gui/applets/AppletPanelWidget.h"
+#include "gui/applets/AppletWidget.h"
+
+using namespace NereusSDR;
+
+namespace {
+// Minimal AppletWidget concrete subclass for tests. Real applets pull in
+// half the radio model; this stub avoids that.
+class FakeApplet : public AppletWidget {
+public:
+    explicit FakeApplet(const QString& title) : m_title(title) {}
+    QString appletTitle() const override { return m_title; }
+private:
+    QString m_title;
+};
+} // anon
+
+class TstAppletPanelSetVisible : public QObject {
+    Q_OBJECT
+private slots:
+    void hides_wrapper_without_changing_layout_index();
+    void shows_wrapper_again_at_same_index();
+    void null_applet_is_noop();
+    void unknown_applet_is_noop();
+};
+
+// Helper: get the wrapper QWidget for an applet by walking the scroll area's
+// inner stack layout and finding the wrapper whose child is the applet.
+static QWidget* wrapperFor(AppletPanelWidget& panel, AppletWidget* applet)
+{
+    auto* scroll = panel.findChild<QScrollArea*>();
+    if (!scroll) { return nullptr; }
+    auto* stackWidget = scroll->widget();
+    if (!stackWidget) { return nullptr; }
+    auto* layout = qobject_cast<QVBoxLayout*>(stackWidget->layout());
+    if (!layout) { return nullptr; }
+    for (int i = 0; i < layout->count(); ++i) {
+        auto* w = layout->itemAt(i)->widget();
+        if (w && w->isAncestorOf(applet)) { return w; }
+    }
+    return nullptr;
+}
+
+static int indexOf(AppletPanelWidget& panel, QWidget* wrapper)
+{
+    auto* scroll = panel.findChild<QScrollArea*>();
+    auto* stackWidget = scroll->widget();
+    auto* layout = qobject_cast<QVBoxLayout*>(stackWidget->layout());
+    return layout->indexOf(wrapper);
+}
+
+void TstAppletPanelSetVisible::hides_wrapper_without_changing_layout_index()
+{
+    AppletPanelWidget panel;
+    auto* a = new FakeApplet(QStringLiteral("A"));
+    auto* b = new FakeApplet(QStringLiteral("B"));
+    panel.addApplet(a);
+    panel.addApplet(b);
+
+    QWidget* wrapperB = wrapperFor(panel, b);
+    QVERIFY(wrapperB);
+    int idxBefore = indexOf(panel, wrapperB);
+
+    panel.setAppletVisible(b, false);
+
+    QVERIFY(!wrapperB->isVisible());
+    QCOMPARE(indexOf(panel, wrapperB), idxBefore);
+}
+
+void TstAppletPanelSetVisible::shows_wrapper_again_at_same_index()
+{
+    AppletPanelWidget panel;
+    panel.show();  // needed so isVisible() returns true after setVisible(true)
+    auto* a = new FakeApplet(QStringLiteral("A"));
+    auto* b = new FakeApplet(QStringLiteral("B"));
+    panel.addApplet(a);
+    panel.addApplet(b);
+
+    QWidget* wrapperB = wrapperFor(panel, b);
+    int idxBefore = indexOf(panel, wrapperB);
+
+    panel.setAppletVisible(b, false);
+    panel.setAppletVisible(b, true);
+
+    QVERIFY(wrapperB->isVisible());
+    QCOMPARE(indexOf(panel, wrapperB), idxBefore);
+}
+
+void TstAppletPanelSetVisible::null_applet_is_noop()
+{
+    AppletPanelWidget panel;
+    panel.setAppletVisible(nullptr, false);  // must not crash
+    panel.setAppletVisible(nullptr, true);
+}
+
+void TstAppletPanelSetVisible::unknown_applet_is_noop()
+{
+    AppletPanelWidget panel;
+    auto* orphan = new FakeApplet(QStringLiteral("Orphan"));
+    panel.setAppletVisible(orphan, false);  // not added; must not crash
+    delete orphan;
+}
+
+QTEST_MAIN(TstAppletPanelSetVisible)
+#include "tst_applet_panel_set_visible.moc"
+```
+
+- [ ] **Step 2: Register the test in CMake**
+
+Edit `tests/CMakeLists.txt`. Find the existing `nereus_add_test(tst_applet_panel_gutter)` line (around line ~80; grep for it). Add immediately after:
+
+```cmake
+# -- AppletPanelWidget setAppletVisible: order-preserving show/hide --
+nereus_add_test(tst_applet_panel_set_visible)
+```
+
+- [ ] **Step 3: Build and run the test to verify it fails**
+
+```bash
+cmake --build build -j --target tst_applet_panel_set_visible
+ctest --test-dir build -R tst_applet_panel_set_visible -V
+```
+
+Expected: build fails with `error: 'class NereusSDR::AppletPanelWidget' has no member named 'setAppletVisible'` (or similar).
+
+- [ ] **Step 4: Add `setAppletVisible` to `AppletPanelWidget.h`**
+
+Open `src/gui/applets/AppletPanelWidget.h`. Find the existing `void removeApplet(AppletWidget* applet);` declaration. Add immediately after it:
+
+```cpp
+    // Toggle visibility of an already-added applet without removing it
+    // from the layout. Preserves stack position when re-shown. No-op for
+    // null or unknown applets. NereusSDR-original (no Thetis equivalent).
+    void setAppletVisible(AppletWidget* applet, bool visible);
+```
+
+- [ ] **Step 5: Implement `setAppletVisible` in `AppletPanelWidget.cpp`**
+
+Open `src/gui/applets/AppletPanelWidget.cpp`. Find the existing `removeApplet` implementation (lines 163-178). Add immediately after the closing brace:
+
+```cpp
+void AppletPanelWidget::setAppletVisible(AppletWidget* applet, bool visible)
+{
+    if (!applet) { return; }
+    QWidget* wrapper = m_wrappers.value(applet, nullptr);
+    if (!wrapper) { return; }  // applet not in this panel
+    wrapper->setVisible(visible);
+}
+```
+
+- [ ] **Step 6: Build and run the test to verify it passes**
+
+```bash
+cmake --build build -j --target tst_applet_panel_set_visible
+ctest --test-dir build -R tst_applet_panel_set_visible -V
+```
+
+Expected: PASS, all 4 cases green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gui/applets/AppletPanelWidget.h \
+        src/gui/applets/AppletPanelWidget.cpp \
+        tests/tst_applet_panel_set_visible.cpp \
+        tests/CMakeLists.txt
+git commit -m "$(cat <<'EOF'
+feat(applet-panel): setAppletVisible preserves stack order
+
+Adds an order-preserving alternative to addApplet/removeApplet for
+the upcoming applet visibility menu. setVisible() on the wrapper
+keeps it in the layout (zero sizeHint when hidden) so re-shows
+restore to the original position.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: AppletVisibilityController class
+
+The bookkeeper. Owns the visibility map, AppSettings round-trip, and change signal.
+
+**Files:**
+- Create: `src/gui/applets/AppletVisibilityController.h`
+- Create: `src/gui/applets/AppletVisibilityController.cpp`
+- Create: `tests/tst_applet_visibility_controller.cpp`
+- Modify: `CMakeLists.txt`
+- Modify: `tests/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tst_applet_visibility_controller.cpp`:
+
+```cpp
+// Verify AppletVisibilityController state, persistence, and signal emission.
+// no-port-check: NereusSDR-original — no Thetis source.
+
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include "gui/applets/AppletVisibilityController.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstAppletVisibilityController : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase()    { AppSettings::instance().clear(); }
+    void cleanup()         { AppSettings::instance().clear(); }
+
+    void default_visible_when_no_settings_key();
+    void default_hidden_when_no_settings_key();
+    void persisted_value_overrides_default();
+    void setVisible_persists_and_emits();
+    void setVisible_idempotent_no_emit_on_same_value();
+    void registeredIds_returns_insertion_order();
+    void displayName_round_trip();
+};
+
+void TstAppletVisibilityController::default_visible_when_no_settings_key()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Rx"), QStringLiteral("RX"), true);
+    QVERIFY(c.isVisible(QStringLiteral("Rx")));
+}
+
+void TstAppletVisibilityController::default_hidden_when_no_settings_key()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Cwx"), QStringLiteral("CW Keyer"), false);
+    QVERIFY(!c.isVisible(QStringLiteral("Cwx")));
+}
+
+void TstAppletVisibilityController::persisted_value_overrides_default()
+{
+    AppSettings::instance().setValue(QStringLiteral("AppletRxVisible"),
+                                     QStringLiteral("False"));
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Rx"), QStringLiteral("RX"), true);
+    QVERIFY(!c.isVisible(QStringLiteral("Rx")));  // persisted False wins
+}
+
+void TstAppletVisibilityController::setVisible_persists_and_emits()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Tx"), QStringLiteral("TX"), true);
+    QSignalSpy spy(&c, &AppletVisibilityController::visibilityChanged);
+
+    c.setVisible(QStringLiteral("Tx"), false);
+
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.first().at(0).toString(), QStringLiteral("Tx"));
+    QCOMPARE(spy.first().at(1).toBool(), false);
+    QCOMPARE(AppSettings::instance().value(QStringLiteral("AppletTxVisible"))
+             .toString(), QStringLiteral("False"));
+
+    // Round-trip: a fresh controller picks up the persisted False.
+    AppletVisibilityController c2;
+    c2.registerApplet(QStringLiteral("Tx"), QStringLiteral("TX"), true);
+    QVERIFY(!c2.isVisible(QStringLiteral("Tx")));
+}
+
+void TstAppletVisibilityController::setVisible_idempotent_no_emit_on_same_value()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Vax"), QStringLiteral("VAX"), true);
+    QSignalSpy spy(&c, &AppletVisibilityController::visibilityChanged);
+
+    c.setVisible(QStringLiteral("Vax"), true);   // already true → no emit
+    QCOMPARE(spy.count(), 0);
+
+    c.setVisible(QStringLiteral("Vax"), false);  // change → emit
+    QCOMPARE(spy.count(), 1);
+
+    c.setVisible(QStringLiteral("Vax"), false);  // unchanged → no emit
+    QCOMPARE(spy.count(), 1);
+}
+
+void TstAppletVisibilityController::registeredIds_returns_insertion_order()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Rx"),         QStringLiteral("RX"),          true);
+    c.registerApplet(QStringLiteral("Tx"),         QStringLiteral("TX"),          true);
+    c.registerApplet(QStringLiteral("PhoneCw"),    QStringLiteral("Phone / CW"),  true);
+    c.registerApplet(QStringLiteral("Vax"),        QStringLiteral("VAX"),         true);
+    c.registerApplet(QStringLiteral("PureSignal"), QStringLiteral("PureSignal"),  true);
+
+    QStringList expected{
+        QStringLiteral("Rx"), QStringLiteral("Tx"), QStringLiteral("PhoneCw"),
+        QStringLiteral("Vax"), QStringLiteral("PureSignal")
+    };
+    QCOMPARE(c.registeredIds(), expected);
+}
+
+void TstAppletVisibilityController::displayName_round_trip()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("PhoneCw"), QStringLiteral("Phone / CW"), true);
+    QCOMPARE(c.displayName(QStringLiteral("PhoneCw")),
+             QStringLiteral("Phone / CW"));
+    QCOMPARE(c.displayName(QStringLiteral("Unknown")), QString{});
+}
+
+QTEST_MAIN(TstAppletVisibilityController)
+#include "tst_applet_visibility_controller.moc"
+```
+
+- [ ] **Step 2: Register the test in CMake**
+
+In `tests/CMakeLists.txt`, add near the other applet tests:
+
+```cmake
+# -- AppletVisibilityController: state, persistence, signal emission --
+nereus_add_test(tst_applet_visibility_controller)
+```
+
+- [ ] **Step 3: Build and run — verify failure**
+
+```bash
+cmake --build build -j --target tst_applet_visibility_controller
+```
+
+Expected: build fails with "AppletVisibilityController.h: No such file or directory".
+
+- [ ] **Step 4: Create `AppletVisibilityController.h`**
+
+Create `src/gui/applets/AppletVisibilityController.h`:
+
+```cpp
+#pragma once
+
+// =================================================================
+// src/gui/applets/AppletVisibilityController.h  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original. No Thetis equivalent — Thetis exposes
+// container-level show/hide via setup checkboxes, not per-applet
+// toggles. AetherSDR has no equivalent.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-05-10 — Created in C++20/Qt6 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via
+//                 Anthropic Claude Code. Backs the Containers >
+//                 Applets menu and the right-side panel ☰ menu.
+// =================================================================
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QHash>
+
+namespace NereusSDR {
+
+class AppletVisibilityController : public QObject {
+    Q_OBJECT
+public:
+    explicit AppletVisibilityController(QObject* parent = nullptr);
+
+    // Register an applet's id, display name, and default visibility.
+    // If an AppSettings key for this id already exists, the persisted
+    // value wins over defaultVisible. Idempotent on the same id; later
+    // calls overwrite the display name but preserve current state.
+    void registerApplet(const QString& id,
+                        const QString& displayName,
+                        bool defaultVisible);
+
+    bool isVisible(const QString& id) const;
+    QStringList registeredIds() const;       // insertion order preserved
+    QString displayName(const QString& id) const;
+
+public slots:
+    void setVisible(const QString& id, bool visible);
+
+signals:
+    // Emitted only when the value actually changes.
+    void visibilityChanged(const QString& id, bool visible);
+
+private:
+    static QString settingsKey(const QString& id);  // "AppletRxVisible" etc.
+
+    struct Entry {
+        QString displayName;
+        bool visible{true};
+    };
+    QHash<QString, Entry> m_entries;   // id -> entry
+    QStringList m_order;               // registration order
+};
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 5: Create `AppletVisibilityController.cpp`**
+
+Create `src/gui/applets/AppletVisibilityController.cpp`:
+
+```cpp
+// =================================================================
+// src/gui/applets/AppletVisibilityController.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original. See header for attribution.
+//
+// =================================================================
+
+#include "AppletVisibilityController.h"
+#include "core/AppSettings.h"
+
+namespace NereusSDR {
+
+AppletVisibilityController::AppletVisibilityController(QObject* parent)
+    : QObject(parent)
+{
+}
+
+QString AppletVisibilityController::settingsKey(const QString& id)
+{
+    return QStringLiteral("Applet") + id + QStringLiteral("Visible");
+}
+
+void AppletVisibilityController::registerApplet(const QString& id,
+                                                 const QString& displayName,
+                                                 bool defaultVisible)
+{
+    if (id.isEmpty()) { return; }
+
+    if (!m_entries.contains(id)) {
+        m_order.append(id);
+    }
+
+    Entry& e = m_entries[id];
+    e.displayName = displayName;
+
+    // Pick up persisted value if present, else use defaultVisible.
+    const QString stored = AppSettings::instance()
+        .value(settingsKey(id), QString{}).toString();
+    if (stored == QStringLiteral("True")) {
+        e.visible = true;
+    } else if (stored == QStringLiteral("False")) {
+        e.visible = false;
+    } else {
+        e.visible = defaultVisible;
+    }
+}
+
+bool AppletVisibilityController::isVisible(const QString& id) const
+{
+    auto it = m_entries.find(id);
+    return it != m_entries.end() ? it->visible : false;
+}
+
+QStringList AppletVisibilityController::registeredIds() const
+{
+    return m_order;
+}
+
+QString AppletVisibilityController::displayName(const QString& id) const
+{
+    auto it = m_entries.find(id);
+    return it != m_entries.end() ? it->displayName : QString{};
+}
+
+void AppletVisibilityController::setVisible(const QString& id, bool visible)
+{
+    auto it = m_entries.find(id);
+    if (it == m_entries.end()) { return; }
+    if (it->visible == visible) { return; }   // idempotent no-op
+
+    it->visible = visible;
+    AppSettings::instance().setValue(
+        settingsKey(id),
+        visible ? QStringLiteral("True") : QStringLiteral("False"));
+    emit visibilityChanged(id, visible);
+}
+
+} // namespace NereusSDR
+```
+
+- [ ] **Step 6: Add the new source file to the main build**
+
+Edit the top-level `CMakeLists.txt`. Find the line `src/gui/applets/AppletPanelWidget.cpp` (around line 707). Add immediately after:
+
+```cmake
+    src/gui/applets/AppletVisibilityController.cpp
+```
+
+- [ ] **Step 7: Build and run the test — verify pass**
+
+```bash
+cmake --build build -j --target tst_applet_visibility_controller
+ctest --test-dir build -R tst_applet_visibility_controller -V
+```
+
+Expected: PASS, all 7 cases green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/gui/applets/AppletVisibilityController.h \
+        src/gui/applets/AppletVisibilityController.cpp \
+        tests/tst_applet_visibility_controller.cpp \
+        CMakeLists.txt \
+        tests/CMakeLists.txt
+git commit -m "$(cat <<'EOF'
+feat(applets): AppletVisibilityController + AppSettings round-trip
+
+Bookkeeper class that owns per-applet visibility state, persists
+each change to AppSettings (key format AppletXxxVisible), and emits
+visibilityChanged on actual changes. Backs the upcoming Containers
+> Applets menu and the right-side panel hamburger menu.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: AppletPanelWidget gains a top banner row + ☰ button
+
+The right-side applet panel has no banner today. Add a thin (22 px) row at the top with one button on the right. The button is hidden until `setBannerMenu(QMenu*)` installs a menu on it (defensive — keeps the panel usable from any test that doesn't exercise the menu).
+
+**Files:**
+- Modify: `src/gui/applets/AppletPanelWidget.h`
+- Modify: `src/gui/applets/AppletPanelWidget.cpp`
+
+This task has no new test file — it's UI scaffolding that will be exercised by Task 7's wiring test. We do verify the button appears once a menu is set, via a quick check appended to the existing `tst_applet_panel_gutter.cpp` (or a small standalone file if you prefer). For brevity here, we extend the existing gutter test.
+
+- [ ] **Step 1: Add a check to existing gutter test**
+
+In `tests/tst_applet_panel_gutter.cpp`, add a new private slot declaration and implementation:
+
+```cpp
+// In the class:
+    void bannerButtonHiddenUntilMenuSet();
+    void bannerButtonShownAndOpensMenuOnceSet();
+
+// Implementations (append at end of file, before QTEST_MAIN):
+#include <QMenu>
+#include <QPushButton>
+
+void TstAppletPanelGutter::bannerButtonHiddenUntilMenuSet()
+{
+    AppletPanelWidget panel;
+    auto* btn = panel.findChild<QPushButton*>(
+        QStringLiteral("appletPanelBannerButton"));
+    QVERIFY(btn != nullptr);     // exists in widget tree
+    QVERIFY(!btn->isVisible());  // hidden by default
+}
+
+void TstAppletPanelGutter::bannerButtonShownAndOpensMenuOnceSet()
+{
+    AppletPanelWidget panel;
+    panel.show();
+    auto* menu = new QMenu(&panel);
+    menu->addAction(QStringLiteral("dummy"));
+    panel.setBannerMenu(menu);
+
+    auto* btn = panel.findChild<QPushButton*>(
+        QStringLiteral("appletPanelBannerButton"));
+    QVERIFY(btn != nullptr);
+    QVERIFY(btn->isVisible());
+    QCOMPARE(btn->menu(), menu);
+}
+```
+
+- [ ] **Step 2: Build and run — verify failure**
+
+```bash
+cmake --build build -j --target tst_applet_panel_gutter
+ctest --test-dir build -R tst_applet_panel_gutter -V
+```
+
+Expected: FAIL with "no member named setBannerMenu" or similar.
+
+- [ ] **Step 3: Add banner row + button to `AppletPanelWidget.h`**
+
+Open `src/gui/applets/AppletPanelWidget.h`. Find the `private:` section near the bottom. Add:
+
+```cpp
+public:
+    // Install a menu on the panel's top-right ☰ button. Until this is
+    // called, the button is hidden. Pass nullptr to remove the menu and
+    // re-hide the button.
+    void setBannerMenu(QMenu* menu);
+
+private:
+    // ... existing private members ...
+    QWidget*     m_bannerRow{nullptr};      // 22 px top header row
+    QPushButton* m_bannerMenuButton{nullptr};  // ☰ button (right-aligned)
+```
+
+Also add forward declarations at the top of the file (after existing forward decls):
+
+```cpp
+class QPushButton;
+class QMenu;
+```
+
+- [ ] **Step 4: Implement banner row in `AppletPanelWidget.cpp`**
+
+Open `src/gui/applets/AppletPanelWidget.cpp`. Add to the `#include` block:
+
+```cpp
+#include <QPushButton>
+#include <QMenu>
+```
+
+In the constructor (`AppletPanelWidget::AppletPanelWidget`), find the line `m_rootLayout->addLayout(m_headerLayout);` (around line 56). Insert BEFORE that line:
+
+```cpp
+    // Banner row at the very top — hosts the ☰ menu button (hidden
+    // until setBannerMenu installs a menu).
+    m_bannerRow = new QWidget(this);
+    m_bannerRow->setFixedHeight(22);
+    m_bannerRow->setStyleSheet(Style::titleBarStyle());
+    auto* bannerLayout = new QHBoxLayout(m_bannerRow);
+    bannerLayout->setContentsMargins(2, 0, 4, 0);
+    bannerLayout->setSpacing(4);
+    bannerLayout->addStretch();
+
+    m_bannerMenuButton = new QPushButton(QStringLiteral("☰"), m_bannerRow);
+    m_bannerMenuButton->setObjectName(QStringLiteral("appletPanelBannerButton"));
+    m_bannerMenuButton->setFixedSize(22, 18);
+    // User-visible tooltip — plain English, no source cites.
+    m_bannerMenuButton->setToolTip(QStringLiteral("Show or hide applets"));
+    m_bannerMenuButton->setStyleSheet(QStringLiteral(
+        "QPushButton {"
+        "  background: transparent; color: %1;"
+        "  border: none; font-size: 12px;"
+        "}"
+        "QPushButton:hover { color: %2; }"
+    ).arg(Style::kTitleText, Style::kAccent));
+    m_bannerMenuButton->hide();   // hidden until setBannerMenu called
+    bannerLayout->addWidget(m_bannerMenuButton);
+
+    m_rootLayout->addWidget(m_bannerRow);
+```
+
+Then add the `setBannerMenu` implementation near `addApplet` / `removeApplet`:
+
+```cpp
+void AppletPanelWidget::setBannerMenu(QMenu* menu)
+{
+    if (!m_bannerMenuButton) { return; }
+    m_bannerMenuButton->setMenu(menu);
+    m_bannerMenuButton->setVisible(menu != nullptr);
+}
+```
+
+(If `Style::kAccent` does not exist, substitute the project's accent colour constant; grep `Style::k` in `src/gui/StyleConstants.h` for the available list. `Style::kTitleText` is verified present at `AppletPanelWidget.cpp:218`.)
+
+- [ ] **Step 5: Build and run the gutter test — verify pass**
+
+```bash
+cmake --build build -j --target tst_applet_panel_gutter
+ctest --test-dir build -R tst_applet_panel_gutter -V
+```
+
+Expected: PASS, including the two new banner cases plus the original gutter case.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gui/applets/AppletPanelWidget.h \
+        src/gui/applets/AppletPanelWidget.cpp \
+        tests/tst_applet_panel_gutter.cpp
+git commit -m "$(cat <<'EOF'
+feat(applet-panel): top banner row with hamburger menu button
+
+22 px header row above the existing MeterWidget header. Hosts a
+single right-aligned ☰ button, hidden until setBannerMenu installs
+a menu. Backs the in-context applet show/hide menu wired in a
+follow-up commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: MainWindow constructs the controller and registers the 5 wired applets
+
+Wire the controller into MainWindow's startup flow. This task only registers applets and connects the controller's signal to the panel — the menus come in Tasks 5 and 6.
+
+**Files:**
+- Modify: `src/gui/MainWindow.h`
+- Modify: `src/gui/MainWindow.cpp`
+
+- [ ] **Step 1: Add member declarations to `MainWindow.h`**
+
+Open `src/gui/MainWindow.h`. Add forward declarations near other forward decls:
+
+```cpp
+class AppletVisibilityController;
+class AppletWidget;
+```
+
+In the `private:` section, add:
+
+```cpp
+    AppletVisibilityController* m_appletVis{nullptr};
+    QHash<QString, AppletWidget*> m_appletsById;
+```
+
+Add the include in `MainWindow.cpp` (don't include in header — forward declare suffices):
+
+```cpp
+#include "gui/applets/AppletVisibilityController.h"
+```
+
+- [ ] **Step 2: Construct controller and register applets**
+
+Open `src/gui/MainWindow.cpp`. Find line 1993 (the `panel->addApplet(m_pureSignalApplet);` call — the last applet add). Insert AFTER that line, before the next blank line / `}`:
+
+```cpp
+    // ── Applet visibility controller (Containers > Applets + ☰ menus) ──
+    // NereusSDR-original. Backs the show/hide menu surfaces. Registration
+    // order matches the order the applets were added above; toggle
+    // defaults are all true (existing layout preserved on first launch).
+    m_appletVis = new AppletVisibilityController(this);
+
+    m_appletsById[QStringLiteral("Rx")]         = m_rxApplet;
+    m_appletsById[QStringLiteral("Tx")]         = txApplet;       // local
+    m_appletsById[QStringLiteral("PhoneCw")]    = m_phoneCwApplet;
+    m_appletsById[QStringLiteral("Vax")]        = m_vaxApplet;
+    m_appletsById[QStringLiteral("PureSignal")] = m_pureSignalApplet;
+
+    // Display names match each applet's appletTitle() — keep in sync if
+    // an applet's title changes.
+    m_appletVis->registerApplet(QStringLiteral("Rx"),
+                                QStringLiteral("RX"),         true);
+    m_appletVis->registerApplet(QStringLiteral("Tx"),
+                                QStringLiteral("TX"),         true);
+    m_appletVis->registerApplet(QStringLiteral("PhoneCw"),
+                                QStringLiteral("Phone / CW"), true);
+    m_appletVis->registerApplet(QStringLiteral("Vax"),
+                                QStringLiteral("VAX"),        true);
+    m_appletVis->registerApplet(QStringLiteral("PureSignal"),
+                                QStringLiteral("PureSignal"), true);
+
+    // Apply initial visibility state from the controller (in case
+    // AppSettings already had values from a prior session).
+    for (const QString& id : m_appletVis->registeredIds()) {
+        if (auto* a = m_appletsById.value(id, nullptr)) {
+            panel->setAppletVisible(a, m_appletVis->isVisible(id));
+        }
+    }
+
+    // Pump future visibility changes from the controller into the panel.
+    connect(m_appletVis, &AppletVisibilityController::visibilityChanged,
+            this, [this](const QString& id, bool visible) {
+        if (auto* a = m_appletsById.value(id, nullptr)) {
+            if (m_appletPanel) {
+                m_appletPanel->setAppletVisible(a, visible);
+            }
+        }
+    });
+```
+
+(Note: `txApplet` is the local name at line 1859; `m_txApplet` is the cached pointer. Use whichever is in scope at the insertion point. Both refer to the same widget. Prefer `m_txApplet` if it's already set — verify by reading lines 1859-1861.)
+
+- [ ] **Step 3: Build the app — verify it still compiles and runs**
+
+```bash
+cmake --build build -j
+./build/NereusSDR &
+sleep 3
+pkill -f NereusSDR
+```
+
+Expected: clean build, app launches, all 5 applets visible (no functional change yet — the controller exists but no menus consume it).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/gui/MainWindow.h src/gui/MainWindow.cpp
+git commit -m "$(cat <<'EOF'
+feat(main-window): register 5 wired applets with visibility controller
+
+Constructs AppletVisibilityController after the panel is built,
+registers Rx / Tx / PhoneCw / Vax / PureSignal with their display
+names, applies any persisted visibility state at startup, and
+pumps later changes from the controller into the panel.
+
+No menu surfaces yet — those come in the next two commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Top-menu Applets section under Containers
+
+Restore the Containers > Applets section that was disabled in `25597df`, now driven by the controller.
+
+**Files:**
+- Modify: `src/gui/MainWindow.h` (add `m_topMenuAppletActions` map)
+- Modify: `src/gui/MainWindow.cpp`
+
+- [ ] **Step 1: Add action map declaration**
+
+In `src/gui/MainWindow.h`, near the `m_appletsById` line added in Task 4, add:
+
+```cpp
+    QHash<QString, QAction*> m_topMenuAppletActions;
+```
+
+Add the include for QAction at top of MainWindow.h if not already present. (It almost certainly is — MainWindow has many menus.)
+
+- [ ] **Step 2: Replace the dead toggle block in `MainWindow.cpp`**
+
+Open `src/gui/MainWindow.cpp`. Find the dead block at lines 2766-2796 (the commented-out `addContainerToggle` lambda and the 7 ghost-applet entries). Replace the entire block with:
+
+```cpp
+    // ── Containers > Applets section ─────────────────────────────────────
+    // Show/hide toggles for each currently-wired applet. Backed by
+    // m_appletVis (AppletVisibilityController). Two-way sync with the
+    // ☰ menu on AppletPanelWidget happens via the controller's
+    // visibilityChanged signal.
+    //
+    // Predecessor: dead lambda at MainWindow.cpp 2766-2796 was disabled
+    // in 25597df because its 7 entries were all ghost applets. The new
+    // section ships only currently-wired applets. Add new entries here
+    // as additional applets ship (default visible per design §5.2).
+    if (m_appletVis) {
+        // Section header. addSection is the idiomatic Qt API; falls back
+        // gracefully on platforms where it renders as a plain label.
+        containersMenu->addSection(QStringLiteral("Applets"));
+
+        for (const QString& id : m_appletVis->registeredIds()) {
+            QAction* act = containersMenu->addAction(
+                m_appletVis->displayName(id));
+            act->setCheckable(true);
+            act->setChecked(m_appletVis->isVisible(id));
+            // User-visible tooltip — plain English, no source cites.
+            act->setToolTip(QStringLiteral("Show or hide the %1 applet")
+                            .arg(m_appletVis->displayName(id)));
+
+            connect(act, &QAction::toggled, this, [this, id](bool checked) {
+                if (m_appletVis) { m_appletVis->setVisible(id, checked); }
+            });
+            m_topMenuAppletActions.insert(id, act);
+        }
+
+        // Sync checkmark when the controller's state changes (e.g. via
+        // the banner ☰ menu). QSignalBlocker prevents recursive toggle.
+        connect(m_appletVis, &AppletVisibilityController::visibilityChanged,
+                this, [this](const QString& id, bool visible) {
+            if (auto* act = m_topMenuAppletActions.value(id, nullptr)) {
+                QSignalBlocker block(act);
+                act->setChecked(visible);
+            }
+        });
+    }
+```
+
+(Note: the existing separator at line 2764 — `containersMenu->addSeparator();` — stays in place. It precedes our new `addSection` call.)
+
+- [ ] **Step 3: Build and smoke-test**
+
+```bash
+cmake --build build -j
+./build/NereusSDR &
+sleep 3
+```
+
+Manually verify (or have an agent screenshot): open Containers menu — see "Applets" section header followed by 5 checkable items, all checked. Toggle TX — TX applet hides. Re-toggle — TX returns to its original spot.
+
+```bash
+pkill -f NereusSDR
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/gui/MainWindow.h src/gui/MainWindow.cpp
+git commit -m "$(cat <<'EOF'
+feat(menu): restore Containers > Applets show/hide section
+
+Replaces the dead commented-out addContainerToggle block from
+25597df with a controller-driven Applets section. Ships with
+the 5 currently-wired applets (Rx / Tx / PhoneCw / Vax /
+PureSignal); future applets register and appear automatically
+as their phases ship.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Banner ☰ menu on AppletPanelWidget
+
+Build the same 5 toggles as a separate `QMenu`, install it on the panel's ☰ button, and wire two-way sync.
+
+**Files:**
+- Modify: `src/gui/MainWindow.h` (add `m_bannerAppletActions` + `m_bannerAppletsMenu`)
+- Modify: `src/gui/MainWindow.cpp`
+
+- [ ] **Step 1: Add member declarations**
+
+In `src/gui/MainWindow.h`, add:
+
+```cpp
+    QMenu* m_bannerAppletsMenu{nullptr};
+    QHash<QString, QAction*> m_bannerAppletActions;
+```
+
+Add `class QMenu;` forward decl if not already present.
+
+- [ ] **Step 2: Build the banner menu in `MainWindow.cpp`**
+
+Open `src/gui/MainWindow.cpp`. Find the controller-construction block from Task 4. Insert AFTER the `connect(m_appletVis, ...visibilityChanged ...)` lambda from Task 4 (the panel-pump connection), so the banner setup runs before the menu-bar build later in the file:
+
+```cpp
+    // ── Banner ☰ menu on AppletPanelWidget ──────────────────────────────
+    if (m_appletVis && m_appletPanel) {
+        m_bannerAppletsMenu = new QMenu(this);
+
+        for (const QString& id : m_appletVis->registeredIds()) {
+            QAction* act = m_bannerAppletsMenu->addAction(
+                m_appletVis->displayName(id));
+            act->setCheckable(true);
+            act->setChecked(m_appletVis->isVisible(id));
+            // User-visible tooltip — plain English.
+            act->setToolTip(QStringLiteral("Show or hide the %1 applet")
+                            .arg(m_appletVis->displayName(id)));
+
+            connect(act, &QAction::toggled, this, [this, id](bool checked) {
+                if (m_appletVis) { m_appletVis->setVisible(id, checked); }
+            });
+            m_bannerAppletActions.insert(id, act);
+        }
+
+        // Sync banner checkmarks when state changes elsewhere (top menu).
+        connect(m_appletVis, &AppletVisibilityController::visibilityChanged,
+                this, [this](const QString& id, bool visible) {
+            if (auto* act = m_bannerAppletActions.value(id, nullptr)) {
+                QSignalBlocker block(act);
+                act->setChecked(visible);
+            }
+        });
+
+        m_appletPanel->setBannerMenu(m_bannerAppletsMenu);
+    }
+```
+
+- [ ] **Step 3: Build and smoke-test**
+
+```bash
+cmake --build build -j
+./build/NereusSDR &
+sleep 3
+```
+
+Manually verify (or screenshot): the right-side panel now has a ☰ button at the top-right of a thin dark bar above the meter widget. Click it — same 5 toggles appear, all checked. Toggle TX via the ☰ menu — TX hides AND the Containers > Applets > TX checkmark also clears.
+
+```bash
+pkill -f NereusSDR
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/gui/MainWindow.h src/gui/MainWindow.cpp
+git commit -m "$(cat <<'EOF'
+feat(applet-panel): hamburger menu on banner mirrors Containers menu
+
+Builds a second QMenu of the same 5 applet toggles, installs it
+on AppletPanelWidget's ☰ button, and wires it to the same
+controller as the top-menu section. QSignalBlocker on each side
+prevents toggle echo loops.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: End-to-end wiring test
+
+A focused integration test that proves both menu surfaces share state via the controller.
+
+**Files:**
+- Create: `tests/tst_applet_visibility_menu_wiring.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+This test does NOT spin up a full MainWindow (too heavy and fragile in CI). Instead it constructs a controller directly, builds the same two QMenu structures the production code builds, and verifies they stay in sync via the controller's signal. This is a faithful proxy for the production wiring without the rest of the app.
+
+- [ ] **Step 1: Create the test**
+
+Create `tests/tst_applet_visibility_menu_wiring.cpp`:
+
+```cpp
+// Verify the two QMenu structures (top menu + banner menu) wired in
+// MainWindow stay in sync via AppletVisibilityController. This test
+// builds the menu structures the same way MainWindow does, without
+// instantiating MainWindow itself.
+// no-port-check: NereusSDR-original — no Thetis source.
+
+#include <QtTest/QtTest>
+#include <QApplication>
+#include <QMenu>
+#include <QAction>
+#include <QHash>
+#include "gui/applets/AppletVisibilityController.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstAppletVisibilityMenuWiring : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase() { AppSettings::instance().clear(); }
+    void cleanup()      { AppSettings::instance().clear(); }
+
+    void both_menus_have_5_actions_initially_checked();
+    void toggling_top_menu_action_updates_banner_menu();
+    void toggling_banner_action_updates_top_menu();
+    void no_recursive_emit_loop();
+};
+
+namespace {
+struct Wired {
+    AppletVisibilityController* ctl;
+    QMenu* topMenu;
+    QMenu* bannerMenu;
+    QHash<QString, QAction*> topActions;
+    QHash<QString, QAction*> bannerActions;
+};
+
+// Mirror of the MainWindow setup, in test scope.
+Wired buildMenus(QObject* parent)
+{
+    Wired w;
+    w.ctl = new AppletVisibilityController(parent);
+    w.ctl->registerApplet(QStringLiteral("Rx"),
+                          QStringLiteral("RX"), true);
+    w.ctl->registerApplet(QStringLiteral("Tx"),
+                          QStringLiteral("TX"), true);
+    w.ctl->registerApplet(QStringLiteral("PhoneCw"),
+                          QStringLiteral("Phone / CW"), true);
+    w.ctl->registerApplet(QStringLiteral("Vax"),
+                          QStringLiteral("VAX"), true);
+    w.ctl->registerApplet(QStringLiteral("PureSignal"),
+                          QStringLiteral("PureSignal"), true);
+
+    w.topMenu = new QMenu(qobject_cast<QWidget*>(parent));
+    w.bannerMenu = new QMenu(qobject_cast<QWidget*>(parent));
+
+    auto wireMenu = [&w](QMenu* menu, QHash<QString, QAction*>& sink) {
+        for (const QString& id : w.ctl->registeredIds()) {
+            QAction* act = menu->addAction(w.ctl->displayName(id));
+            act->setCheckable(true);
+            act->setChecked(w.ctl->isVisible(id));
+            QObject::connect(act, &QAction::toggled,
+                             [w, id](bool checked) {
+                w.ctl->setVisible(id, checked);
+            });
+            sink.insert(id, act);
+        }
+    };
+    wireMenu(w.topMenu,    w.topActions);
+    wireMenu(w.bannerMenu, w.bannerActions);
+
+    auto syncMenu = [&w](QHash<QString, QAction*>& sink) {
+        QObject::connect(w.ctl, &AppletVisibilityController::visibilityChanged,
+                         [sink](const QString& id, bool v) {
+            if (auto* act = sink.value(id, nullptr)) {
+                QSignalBlocker block(act);
+                act->setChecked(v);
+            }
+        });
+    };
+    syncMenu(w.topActions);
+    syncMenu(w.bannerActions);
+
+    return w;
+}
+} // anon
+
+void TstAppletVisibilityMenuWiring::both_menus_have_5_actions_initially_checked()
+{
+    QObject parent;
+    Wired w = buildMenus(&parent);
+    QCOMPARE(w.topMenu->actions().size(),    5);
+    QCOMPARE(w.bannerMenu->actions().size(), 5);
+    for (QAction* a : w.topMenu->actions())    { QVERIFY(a->isChecked()); }
+    for (QAction* a : w.bannerMenu->actions()) { QVERIFY(a->isChecked()); }
+}
+
+void TstAppletVisibilityMenuWiring::toggling_top_menu_action_updates_banner_menu()
+{
+    QObject parent;
+    Wired w = buildMenus(&parent);
+    QAction* topTx = w.topActions.value(QStringLiteral("Tx"));
+    QAction* banTx = w.bannerActions.value(QStringLiteral("Tx"));
+
+    topTx->toggle();   // checked -> unchecked
+    QVERIFY(!topTx->isChecked());
+    QVERIFY(!banTx->isChecked());     // mirrored
+    QVERIFY(!w.ctl->isVisible(QStringLiteral("Tx")));
+}
+
+void TstAppletVisibilityMenuWiring::toggling_banner_action_updates_top_menu()
+{
+    QObject parent;
+    Wired w = buildMenus(&parent);
+    QAction* topPs = w.topActions.value(QStringLiteral("PureSignal"));
+    QAction* banPs = w.bannerActions.value(QStringLiteral("PureSignal"));
+
+    banPs->toggle();
+    QVERIFY(!banPs->isChecked());
+    QVERIFY(!topPs->isChecked());
+    QVERIFY(!w.ctl->isVisible(QStringLiteral("PureSignal")));
+}
+
+void TstAppletVisibilityMenuWiring::no_recursive_emit_loop()
+{
+    QObject parent;
+    Wired w = buildMenus(&parent);
+    QSignalSpy spy(w.ctl, &AppletVisibilityController::visibilityChanged);
+
+    w.topActions.value(QStringLiteral("Vax"))->toggle();
+    QCOMPARE(spy.count(), 1);     // exactly one emission, no echo loop
+
+    w.bannerActions.value(QStringLiteral("Vax"))->toggle();
+    QCOMPARE(spy.count(), 2);
+}
+
+QTEST_MAIN(TstAppletVisibilityMenuWiring)
+#include "tst_applet_visibility_menu_wiring.moc"
+```
+
+- [ ] **Step 2: Register the test in CMake**
+
+In `tests/CMakeLists.txt`, near the other applet tests:
+
+```cmake
+# -- Two-way sync between top-menu and banner-menu applet toggles --
+nereus_add_test(tst_applet_visibility_menu_wiring)
+```
+
+- [ ] **Step 3: Build and run — verify pass**
+
+```bash
+cmake --build build -j --target tst_applet_visibility_menu_wiring
+ctest --test-dir build -R tst_applet_visibility_menu_wiring -V
+```
+
+Expected: PASS, all 4 cases green.
+
+- [ ] **Step 4: Run the full applet test family one more time**
+
+```bash
+ctest --test-dir build -R "applet" -V
+```
+
+Expected: every test matching `applet` is green (the new ones from this plan plus the existing `tst_applet_panel_gutter`, `tst_applet_ps_wiring`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/tst_applet_visibility_menu_wiring.cpp tests/CMakeLists.txt
+git commit -m "$(cat <<'EOF'
+test(applets): two-way menu sync for visibility controller
+
+Faithful proxy of the MainWindow wiring: top menu and banner
+menu both bind to the same controller, toggling either updates
+the other's checked state, and no recursive emit loops occur.
+Tests the wiring shape without instantiating MainWindow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Bench-verify and tidy
+
+Manual verification at the bench, plus a final pass to make sure nothing was missed.
+
+- [ ] **Step 1: Build and launch the app**
+
+```bash
+cmake --build build -j
+./build/NereusSDR &
+```
+
+- [ ] **Step 2: Walk the manual verification matrix from spec §8.4**
+
+Verify each item:
+
+1. App launches — all 5 applets visible (RX, TX, Phone/CW, VAX, PureSignal top-to-bottom).
+2. Containers > Applets section present, all 5 items checked.
+3. ☰ button visible top-right of the panel; click opens menu with same 5 items, all checked.
+4. Toggle TX from top menu → TX hides in panel; ☰ menu's TX is now unchecked.
+5. Toggle TX back from ☰ menu → TX returns to its original spot (not bottom); top-menu TX is now checked.
+6. Hide all 5 → panel collapses to header (banner row + meter widget) only.
+7. Re-show all → original order: RX, TX, Phone/CW, VAX, PureSignal.
+8. Quit, relaunch → hidden states from before the quit are restored.
+9. Open `~/.config/NereusSDR/NereusSDR.settings`, verify `AppletXxxVisible` keys are present and match.
+
+- [ ] **Step 3: Kill the app**
+
+```bash
+pkill -f NereusSDR
+```
+
+- [ ] **Step 4: Run the full test suite once**
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests green. Investigate any unrelated failures (might be pre-existing flakes — check `git diff` to confirm none of this plan's edits touched the failing area).
+
+- [ ] **Step 5: Final commit if any tidy was needed**
+
+If verification surfaced any small fix (e.g. a missing tooltip, a stylesheet typo), fix and commit:
+
+```bash
+git add <fixed files>
+git commit -m "fix(applet-vis): <one-line description>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+If no tidy needed, skip this step.
+
+---
+
+## Done
+
+The feature is complete when:
+
+- [ ] All 4 test executables green (`tst_applet_panel_set_visible`, `tst_applet_visibility_controller`, `tst_applet_panel_gutter` (extended), `tst_applet_visibility_menu_wiring`)
+- [ ] Manual verification matrix passes
+- [ ] Full ctest suite green
+- [ ] All commits GPG-signed
+- [ ] Pre-commit hooks pass on every commit (Thetis header check, port attribution, inline cite check, compliance inventory, tag preservation)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -280,6 +280,7 @@ warren@wpratt.com
 #include "applets/AppletPanelWidget.h"
 #include "SMeterWidget.h"            // Task 41 (Phase 3P-II): SMeterWidget header wiring
 #include "applets/AmpApplet.h"
+#include "applets/AppletVisibilityController.h"
 #include "applets/RxApplet.h"
 #include "core/PgxlConnection.h"
 #include "core/TgxlConnection.h"
@@ -2510,6 +2511,61 @@ void MainWindow::populateDefaultMeter()
             }
         });
     }
+
+    // ── Applet visibility controller (Containers > Applets + ☰ menus) ──
+    // NereusSDR-original. Backs the show/hide menu surfaces. Registration
+    // order matches the order the applets were added above; toggle
+    // defaults are all true (existing layout preserved on first launch).
+    //
+    // TCI applets (Phase 23, above) keep their own AppSettings keys
+    // (TciApplet_Visible / ClientChainApplet_Visible) and direct setVisible
+    // — they are not registered with this controller in v1.
+    //
+    // AmpApplet and TunerApplet (Phase 3P-II Task 20, just above) are also
+    // not yet registered with this controller — both shipped on main while
+    // this branch was in development. Integrating Amp, Tuner, and TCI under
+    // the controller's roof is a follow-up; the current split means the ☰
+    // banner menu and Containers > Applets section show only the original
+    // 5 wired applets, and the others are managed via their own controls.
+    m_appletVis = new AppletVisibilityController(this);
+
+    m_appletsById[QStringLiteral("Rx")]         = m_rxApplet;
+    m_appletsById[QStringLiteral("Tx")]         = m_txApplet;
+    m_appletsById[QStringLiteral("PhoneCw")]    = m_phoneCwApplet;
+    m_appletsById[QStringLiteral("Vax")]        = m_vaxApplet;
+    m_appletsById[QStringLiteral("PureSignal")] = m_pureSignalApplet;
+
+    // Display names match each applet's appletTitle() — keep in sync if
+    // an applet's title changes.
+    m_appletVis->registerApplet(QStringLiteral("Rx"),
+                                QStringLiteral("RX"),         true);
+    m_appletVis->registerApplet(QStringLiteral("Tx"),
+                                QStringLiteral("TX"),         true);
+    m_appletVis->registerApplet(QStringLiteral("PhoneCw"),
+                                QStringLiteral("Phone / CW"), true);
+    m_appletVis->registerApplet(QStringLiteral("Vax"),
+                                QStringLiteral("VAX"),        true);
+    m_appletVis->registerApplet(QStringLiteral("PureSignal"),
+                                QStringLiteral("PureSignal"), true);
+
+    // Apply initial visibility state from the controller (in case
+    // AppSettings already had values from a prior session).
+    for (const QString& id : m_appletVis->registeredIds()) {
+        if (auto* a = m_appletsById.value(id, nullptr)) {
+            panel->setAppletVisible(a, m_appletVis->isVisible(id));
+        }
+    }
+
+    // Pump future visibility changes from the controller into the panel.
+    connect(m_appletVis, &AppletVisibilityController::visibilityChanged,
+            this, [this](const QString& id, bool visible) {
+        if (auto* a = m_appletsById.value(id, nullptr)) {
+            if (m_appletPanel) {
+                m_appletPanel->setAppletVisible(a, visible);
+            }
+        }
+    });
+
 
     // Ghost applets: constructed but not added to the panel or the Containers menu
     // until their feature phases ship. Uncomment the construction + addContainerToggle

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3391,37 +3391,47 @@ void MainWindow::buildMenuBar()
 
     containersMenu->addSeparator();
 
-    // Dynamic show/hide toggles for optional applets in Container #0.
-    // Checked = visible in panel; unchecked = hidden/removed.
-    // Currently commented out (ghost applets hidden per
-    // docs/superpowers/plans/2026-05-01-ui-polish-right-panel.md §Task 6).
-    // Re-enable by un-commenting the lambda AND the addContainerToggle calls below,
-    // alongside the construction block in buildDefaultContainerLayout().
+    // ── Containers > Applets section ─────────────────────────────────────
+    // Show/hide toggles for each currently-wired applet. Backed by
+    // m_appletVis (AppletVisibilityController). Two-way sync with the
+    // ☰ menu on AppletPanelWidget happens via the controller's
+    // visibilityChanged signal.
     //
-    // auto addContainerToggle = [&](const QString& name, AppletWidget* applet, bool defaultVisible) {
-    //     auto* action = containersMenu->addAction(name);
-    //     action->setCheckable(true);
-    //     action->setChecked(defaultVisible);
-    //     connect(action, &QAction::toggled, this, [this, applet](bool show) {
-    //         if (!m_appletPanel) { return; }
-    //         if (show) {
-    //             m_appletPanel->addApplet(applet);
-    //         } else {
-    //             m_appletPanel->removeApplet(applet);
-    //         }
-    //     });
-    // };
+    // Predecessor: dead lambda was disabled in 25597df because its 7
+    // entries were all ghost applets. The new section ships only
+    // currently-wired applets. Add new entries here as additional
+    // applets ship (default visible per design §5.2).
+    if (m_appletVis) {
+        // Section header. addSection is the idiomatic Qt API; falls back
+        // gracefully on platforms where it renders as a plain label.
+        containersMenu->addSection(QStringLiteral("Applets"));
 
-    // Ghost-applet Containers menu entries — disabled until feature phases ship.
-    // Re-enable alongside the construction block in buildDefaultContainerLayout().
-    //
-    // addContainerToggle(QStringLiteral("Digital / VAC"), m_digitalApplet,    false); // TODO 3-VAX
-    // addContainerToggle(QStringLiteral("PureSignal"),    m_pureSignalApplet, false); // TODO 3M-4
-    // addContainerToggle(QStringLiteral("Diversity"),     m_diversityApplet,  false); // TODO 3F
-    // addContainerToggle(QStringLiteral("CW Keyer"),      m_cwxApplet,        false); // TODO 3M-2
-    // addContainerToggle(QStringLiteral("Voice Keyer"),   m_dvkApplet,        false); // TODO 3M-1
-    // addContainerToggle(QStringLiteral("CAT / TCI"),     m_catApplet,        false); // TODO 3J/3K
-    // addContainerToggle(QStringLiteral("ATU Control"),   m_tunerApplet,      false); // TODO ATU
+        for (const QString& id : m_appletVis->registeredIds()) {
+            QAction* act = containersMenu->addAction(
+                m_appletVis->displayName(id));
+            act->setCheckable(true);
+            act->setChecked(m_appletVis->isVisible(id));
+            // User-visible tooltip — plain English, no source cites.
+            act->setToolTip(QStringLiteral("Show or hide the %1 applet")
+                            .arg(m_appletVis->displayName(id)));
+
+            connect(act, &QAction::toggled, this, [this, id](bool checked) {
+                if (m_appletVis) { m_appletVis->setVisible(id, checked); }
+            });
+            m_topMenuAppletActions.insert(id, act);
+        }
+
+        // Sync checkmark when the controller's state changes (e.g. via
+        // the banner ☰ menu in Task 6). QSignalBlocker prevents
+        // recursive toggle.
+        connect(m_appletVis, &AppletVisibilityController::visibilityChanged,
+                this, [this](const QString& id, bool visible) {
+            if (auto* act = m_topMenuAppletActions.value(id, nullptr)) {
+                QSignalBlocker block(act);
+                act->setChecked(visible);
+            }
+        });
+    }
 
     // =========================================================================
     // TOOLS

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2574,23 +2574,49 @@ void MainWindow::populateDefaultMeter()
     }
 #endif
 
+    // Capability gates: applets that depend on an external feature flag
+    // get their availability set here. When availability is false, the
+    // applet is hidden AND its menu entries are greyed out. The user's
+    // persisted visibility preference is preserved across availability
+    // changes (so re-enabling 4O3A pops the applet back if the user
+    // wanted it visible).
+    const bool fourO3AOn = m_radioModel && m_radioModel->fourO3AEnabled();
+    m_appletVis->setAvailable(QStringLiteral("Amp"),   fourO3AOn);
+    m_appletVis->setAvailable(QStringLiteral("Tuner"), fourO3AOn);
+
     // Apply initial visibility state from the controller (in case
     // AppSettings already had values from a prior session).
+    // Uses effective visibility (user pref AND available).
     for (const QString& id : m_appletVis->registeredIds()) {
         if (auto* a = m_appletsById.value(id, nullptr)) {
-            panel->setAppletVisible(a, m_appletVis->isVisible(id));
+            panel->setAppletVisible(a, m_appletVis->isEffectivelyVisible(id));
         }
     }
 
-    // Pump future visibility changes from the controller into the panel.
-    connect(m_appletVis, &AppletVisibilityController::visibilityChanged,
-            this, [this](const QString& id, bool visible) {
+    // Pump future EFFECTIVE-visibility changes from the controller into
+    // the panel. effectiveVisibilityChanged fires when either the user
+    // toggle or the availability gate flips the net visibility, so we
+    // catch both menu clicks and external capability changes (e.g. 4O3A).
+    connect(m_appletVis, &AppletVisibilityController::effectiveVisibilityChanged,
+            this, [this](const QString& id, bool effective) {
         if (auto* a = m_appletsById.value(id, nullptr)) {
             if (m_appletPanel) {
-                m_appletPanel->setAppletVisible(a, visible);
+                m_appletPanel->setAppletVisible(a, effective);
             }
         }
     });
+
+    // Live-track 4O3A master toggle so Amp/Tuner availability updates
+    // without an app restart. RadioModel::setFourO3AEnabled emits the
+    // signal whenever the persisted value changes.
+    if (m_radioModel) {
+        connect(m_radioModel, &RadioModel::fourO3AEnabledChanged,
+                this, [this](bool enabled) {
+            if (!m_appletVis) { return; }
+            m_appletVis->setAvailable(QStringLiteral("Amp"),   enabled);
+            m_appletVis->setAvailable(QStringLiteral("Tuner"), enabled);
+        });
+    }
 
     // ── Banner ☰ menu on AppletPanelWidget ──────────────────────────────
     if (m_appletVis && m_appletPanel) {
@@ -2601,6 +2627,10 @@ void MainWindow::populateDefaultMeter()
                 m_appletVis->displayName(id));
             act->setCheckable(true);
             act->setChecked(m_appletVis->isVisible(id));
+            // Grey out the entry when the applet is currently unavailable
+            // (e.g. Amp/Tuner when 4O3A is disabled). The check state still
+            // reflects the user preference so re-enabling restores it.
+            act->setEnabled(m_appletVis->isAvailable(id));
             // User-visible tooltip — plain English.
             act->setToolTip(QStringLiteral("Show or hide the %1 applet")
                             .arg(m_appletVis->displayName(id)));
@@ -2617,6 +2647,15 @@ void MainWindow::populateDefaultMeter()
             if (auto* act = m_bannerAppletActions.value(id, nullptr)) {
                 QSignalBlocker block(act);
                 act->setChecked(visible);
+            }
+        });
+
+        // Grey/un-grey banner entries when an applet's availability
+        // changes (e.g. 4O3A master toggle flipped).
+        connect(m_appletVis, &AppletVisibilityController::availabilityChanged,
+                this, [this](const QString& id, bool available) {
+            if (auto* act = m_bannerAppletActions.value(id, nullptr)) {
+                act->setEnabled(available);
             }
         });
 
@@ -3467,6 +3506,10 @@ void MainWindow::buildMenuBar()
                 m_appletVis->displayName(id));
             act->setCheckable(true);
             act->setChecked(m_appletVis->isVisible(id));
+            // Grey out when the applet is currently unavailable (e.g.
+            // Amp/Tuner when 4O3A is disabled). Check state still
+            // reflects the user preference.
+            act->setEnabled(m_appletVis->isAvailable(id));
             // User-visible tooltip — plain English, no source cites.
             act->setToolTip(QStringLiteral("Show or hide the %1 applet")
                             .arg(m_appletVis->displayName(id)));
@@ -3485,6 +3528,15 @@ void MainWindow::buildMenuBar()
             if (auto* act = m_topMenuAppletActions.value(id, nullptr)) {
                 QSignalBlocker block(act);
                 act->setChecked(visible);
+            }
+        });
+
+        // Grey/un-grey top-menu entries when an applet's availability
+        // changes (e.g. 4O3A master toggle flipped in Setup).
+        connect(m_appletVis, &AppletVisibilityController::availabilityChanged,
+                this, [this](const QString& id, bool available) {
+            if (auto* act = m_topMenuAppletActions.value(id, nullptr)) {
+                act->setEnabled(available);
             }
         });
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2423,39 +2423,31 @@ void MainWindow::populateDefaultMeter()
         m_radioModel->boardCapabilities().hasPureSignal);
 
     // Phase 23: TCI applets — live in Container #0 below the existing applets.
-    // Visibility default from AppSettings (TciApplet_Visible / ClientChainApplet_Visible).
+    // Visibility is now managed by AppletVisibilityController below
+    // (registered as ids "Tci" + "ClientChain", keys AppletTciVisible +
+    // AppletClientChainVisible). Legacy keys TciApplet_Visible /
+    // ClientChainApplet_Visible from earlier versions become orphans on
+    // upgrade; existing users get TCI applets back to default-visible.
 #ifdef HAVE_WEBSOCKETS
     if (m_tciServer) {
-        {
-            auto& s = AppSettings::instance();
-            const bool vis = s.value(QStringLiteral("TciApplet_Visible"),
-                                     QStringLiteral("True")).toString()
-                             == QStringLiteral("True");
-            m_tciApplet = new TciApplet(m_tciServer, nullptr);
-            panel->addApplet(m_tciApplet);
-            m_tciApplet->setVisible(vis);
-            connect(m_tciApplet, &TciApplet::setupRequested,
-                    this, &MainWindow::openTciSetupPage);
-            // showClientsRequested: scroll/show the ClientChainApplet.
-            // ClientChainApplet is constructed immediately below, so capture
-            // by pointer — the lambda runs only after full construction.
-            connect(m_tciApplet, &TciApplet::showClientsRequested,
-                    this, [this]() {
-                        if (m_clientChainApplet) {
-                            m_clientChainApplet->setVisible(true);
-                            m_clientChainApplet->raise();
-                        }
-                    });
-        }
-        {
-            auto& s = AppSettings::instance();
-            const bool vis = s.value(QStringLiteral("ClientChainApplet_Visible"),
-                                     QStringLiteral("True")).toString()
-                             == QStringLiteral("True");
-            m_clientChainApplet = new ClientChainApplet(m_tciServer, nullptr);
-            panel->addApplet(m_clientChainApplet);
-            m_clientChainApplet->setVisible(vis);
-        }
+        m_tciApplet = new TciApplet(m_tciServer, nullptr);
+        panel->addApplet(m_tciApplet);
+        connect(m_tciApplet, &TciApplet::setupRequested,
+                this, &MainWindow::openTciSetupPage);
+        // showClientsRequested: scroll/show the ClientChainApplet.
+        // ClientChainApplet is constructed immediately below, so capture
+        // by pointer — the lambda runs only after full construction.
+        connect(m_tciApplet, &TciApplet::showClientsRequested,
+                this, [this]() {
+                    if (m_clientChainApplet && m_appletVis) {
+                        m_appletVis->setVisible(
+                            QStringLiteral("ClientChain"), true);
+                        m_clientChainApplet->raise();
+                    }
+                });
+
+        m_clientChainApplet = new ClientChainApplet(m_tciServer, nullptr);
+        panel->addApplet(m_clientChainApplet);
     }
 #endif
 
@@ -2513,40 +2505,74 @@ void MainWindow::populateDefaultMeter()
     }
 
     // ── Applet visibility controller (Containers > Applets + ☰ menus) ──
-    // NereusSDR-original. Backs the show/hide menu surfaces. Registration
-    // order matches the order the applets were added above; toggle
-    // defaults are all true (existing layout preserved on first launch).
+    // NereusSDR-original. Backs the show/hide menu surfaces.
     //
-    // TCI applets (Phase 23, above) keep their own AppSettings keys
-    // (TciApplet_Visible / ClientChainApplet_Visible) and direct setVisible
-    // — they are not registered with this controller in v1.
+    // Registered applets get a checkable menu entry in Containers > Applets
+    // AND in the right-side panel's ☰ banner menu. Add new entries here as
+    // additional applets ship.
     //
-    // AmpApplet and TunerApplet (Phase 3P-II Task 20, just above) are also
-    // not yet registered with this controller — both shipped on main while
-    // this branch was in development. Integrating Amp, Tuner, and TCI under
-    // the controller's roof is a follow-up; the current split means the ☰
-    // banner menu and Containers > Applets section show only the original
-    // 5 wired applets, and the others are managed via their own controls.
+    // RadeApplet caveat: its visibility is mode-driven (auto-shown when
+    // the active slice is in DSPMode::RADE_U/_L; hidden otherwise) via
+    // the dspModeChanged lambda further down. The menu toggle here is a
+    // user override that lasts until the next mode change repopulates
+    // visibility. Acceptable for v1; tighter integration is a follow-up.
     m_appletVis = new AppletVisibilityController(this);
 
     m_appletsById[QStringLiteral("Rx")]         = m_rxApplet;
     m_appletsById[QStringLiteral("Tx")]         = m_txApplet;
     m_appletsById[QStringLiteral("PhoneCw")]    = m_phoneCwApplet;
+    m_appletsById[QStringLiteral("Rade")]       = m_radeApplet;
     m_appletsById[QStringLiteral("Vax")]        = m_vaxApplet;
     m_appletsById[QStringLiteral("PureSignal")] = m_pureSignalApplet;
+    m_appletsById[QStringLiteral("Amp")]        = m_ampApplet;
+    m_appletsById[QStringLiteral("Tuner")]      = m_tunerApplet;
+#ifdef HAVE_WEBSOCKETS
+    if (m_tciApplet) {
+        m_appletsById[QStringLiteral("Tci")]        = m_tciApplet;
+    }
+    if (m_clientChainApplet) {
+        m_appletsById[QStringLiteral("ClientChain")] = m_clientChainApplet;
+    }
+#endif
 
     // Display names match each applet's appletTitle() — keep in sync if
     // an applet's title changes.
+    //
+    // PureSignal defaults to visible. The existing onConnectionStateChanged
+    // handler still calls m_pureSignalApplet->setVisible(caps.hasPureSignal)
+    // on radio connect, which can hide the inner widget on HL2/Atlas; the
+    // menu entry stays available for users who want to force-show or
+    // permanently hide it. Defaulting to true here means new G2 users see
+    // PS immediately without having to discover the menu toggle.
     m_appletVis->registerApplet(QStringLiteral("Rx"),
-                                QStringLiteral("RX"),         true);
+                                QStringLiteral("RX"),           true);
     m_appletVis->registerApplet(QStringLiteral("Tx"),
-                                QStringLiteral("TX"),         true);
+                                QStringLiteral("TX"),           true);
     m_appletVis->registerApplet(QStringLiteral("PhoneCw"),
-                                QStringLiteral("Phone / CW"), true);
+                                QStringLiteral("Phone / CW"),   true);
+    // RADE default is hidden: at startup the active mode is USB and the
+    // mode lambda will keep the applet hidden until the user switches
+    // to a RADE mode. Persisted state still wins if the user opted in.
+    m_appletVis->registerApplet(QStringLiteral("Rade"),
+                                QStringLiteral("RADE"),         false);
     m_appletVis->registerApplet(QStringLiteral("Vax"),
-                                QStringLiteral("VAX"),        true);
+                                QStringLiteral("VAX"),          true);
     m_appletVis->registerApplet(QStringLiteral("PureSignal"),
-                                QStringLiteral("PureSignal"), true);
+                                QStringLiteral("PureSignal"),   true);
+    m_appletVis->registerApplet(QStringLiteral("Amp"),
+                                QStringLiteral("Amplifier"),    true);
+    m_appletVis->registerApplet(QStringLiteral("Tuner"),
+                                QStringLiteral("Tuner Genius"), true);
+#ifdef HAVE_WEBSOCKETS
+    if (m_tciApplet) {
+        m_appletVis->registerApplet(QStringLiteral("Tci"),
+                                    QStringLiteral("TCI Server"),  true);
+    }
+    if (m_clientChainApplet) {
+        m_appletVis->registerApplet(QStringLiteral("ClientChain"),
+                                    QStringLiteral("TCI Clients"), true);
+    }
+#endif
 
     // Apply initial visibility state from the controller (in case
     // AppSettings already had values from a prior session).

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2566,6 +2566,36 @@ void MainWindow::populateDefaultMeter()
         }
     });
 
+    // ── Banner ☰ menu on AppletPanelWidget ──────────────────────────────
+    if (m_appletVis && m_appletPanel) {
+        m_bannerAppletsMenu = new QMenu(this);
+
+        for (const QString& id : m_appletVis->registeredIds()) {
+            QAction* act = m_bannerAppletsMenu->addAction(
+                m_appletVis->displayName(id));
+            act->setCheckable(true);
+            act->setChecked(m_appletVis->isVisible(id));
+            // User-visible tooltip — plain English.
+            act->setToolTip(QStringLiteral("Show or hide the %1 applet")
+                            .arg(m_appletVis->displayName(id)));
+
+            connect(act, &QAction::toggled, this, [this, id](bool checked) {
+                if (m_appletVis) { m_appletVis->setVisible(id, checked); }
+            });
+            m_bannerAppletActions.insert(id, act);
+        }
+
+        // Sync banner checkmarks when state changes elsewhere (top menu).
+        connect(m_appletVis, &AppletVisibilityController::visibilityChanged,
+                this, [this](const QString& id, bool visible) {
+            if (auto* act = m_bannerAppletActions.value(id, nullptr)) {
+                QSignalBlocker block(act);
+                act->setChecked(visible);
+            }
+        });
+
+        m_appletPanel->setBannerMenu(m_bannerAppletsMenu);
+    }
 
     // Ghost applets: constructed but not added to the panel or the Containers menu
     // until their feature phases ship. Uncomment the construction + addContainerToggle

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2550,11 +2550,14 @@ void MainWindow::populateDefaultMeter()
                                 QStringLiteral("TX"),           true);
     m_appletVis->registerApplet(QStringLiteral("PhoneCw"),
                                 QStringLiteral("Phone / CW"),   true);
-    // RADE default is hidden: at startup the active mode is USB and the
-    // mode lambda will keep the applet hidden until the user switches
-    // to a RADE mode. Persisted state still wins if the user opted in.
+    // RADE: defaultVisible=true (user pref). Actual visibility is gated
+    // on the active slice's mode via the availability axis — the
+    // dspModeChanged lambda below calls setAvailable(true) only when
+    // mode is DSPMode::RADE_U/_L. Initial availability set to false here
+    // since the default startup mode is USB; the mode lambda fires
+    // shortly after to correct it if needed.
     m_appletVis->registerApplet(QStringLiteral("Rade"),
-                                QStringLiteral("RADE"),         false);
+                                QStringLiteral("RADE"),         true);
     m_appletVis->registerApplet(QStringLiteral("Vax"),
                                 QStringLiteral("VAX"),          true);
     m_appletVis->registerApplet(QStringLiteral("PureSignal"),
@@ -2583,6 +2586,10 @@ void MainWindow::populateDefaultMeter()
     const bool fourO3AOn = m_radioModel && m_radioModel->fourO3AEnabled();
     m_appletVis->setAvailable(QStringLiteral("Amp"),   fourO3AOn);
     m_appletVis->setAvailable(QStringLiteral("Tuner"), fourO3AOn);
+    // RADE: available only in RADE_U / RADE_L modes. Startup mode is
+    // USB, so initial availability=false. The dspModeChanged lambda
+    // below updates this on every mode change.
+    m_appletVis->setAvailable(QStringLiteral("Rade"),  false);
 
     // Apply initial visibility state from the controller (in case
     // AppSettings already had values from a prior session).
@@ -2969,58 +2976,13 @@ void MainWindow::buildMenuBar()
         }
     }
 
-    viewMenu->addSeparator();
-
-    // Phase 23: View → Network Applets ▶ submenu.
-    // TCI Server and TCI Clients toggles are enabled; CAT + MIDI are greyed
-    // placeholders until phases 3K-1 and 3K-3 ship.
-    {
-        QMenu* netAppletsMenu = viewMenu->addMenu(QStringLiteral("&Network Applets"));
-
-        auto* tciServerToggle = netAppletsMenu->addAction(QStringLiteral("&TCI Server"));
-        tciServerToggle->setCheckable(true);
-        {
-            auto& s = AppSettings::instance();
-            const bool dflt = s.value(QStringLiteral("TciApplet_Visible"),
-                                      QStringLiteral("True")).toString() == QStringLiteral("True");
-            tciServerToggle->setChecked(dflt);
-        }
-        connect(tciServerToggle, &QAction::toggled, this, [this](bool show) {
-            auto& s = AppSettings::instance();
-            s.setValue(QStringLiteral("TciApplet_Visible"),
-                       show ? QStringLiteral("True") : QStringLiteral("False"));
-#ifdef HAVE_WEBSOCKETS
-            if (m_tciApplet) { m_tciApplet->setVisible(show); }
-#endif
-        });
-
-        auto* tciClientsToggle = netAppletsMenu->addAction(QStringLiteral("TCI &Clients"));
-        tciClientsToggle->setCheckable(true);
-        {
-            auto& s = AppSettings::instance();
-            const bool dflt = s.value(QStringLiteral("ClientChainApplet_Visible"),
-                                      QStringLiteral("True")).toString() == QStringLiteral("True");
-            tciClientsToggle->setChecked(dflt);
-        }
-        connect(tciClientsToggle, &QAction::toggled, this, [this](bool show) {
-            auto& s = AppSettings::instance();
-            s.setValue(QStringLiteral("ClientChainApplet_Visible"),
-                       show ? QStringLiteral("True") : QStringLiteral("False"));
-#ifdef HAVE_WEBSOCKETS
-            if (m_clientChainApplet) { m_clientChainApplet->setVisible(show); }
-#endif
-        });
-
-        netAppletsMenu->addSeparator();
-
-        auto* catItem = netAppletsMenu->addAction(QStringLiteral("&CAT"));
-        catItem->setEnabled(false);
-        catItem->setToolTip(QStringLiteral("Phase 3K-1 (post-3J)"));
-
-        auto* midiItem = netAppletsMenu->addAction(QStringLiteral("&MIDI"));
-        midiItem->setEnabled(false);
-        midiItem->setToolTip(QStringLiteral("Phase 3K-3 (post-3K-2)"));
-    }
+    // Phase 23 "View > Network Applets" submenu removed: TCI Server and
+    // TCI Clients are now driven by AppletVisibilityController, accessible
+    // via Containers > Applets and the panel's ☰ banner menu. Two
+    // independent controls (old direct-setVisible + new controller path)
+    // would drift out of sync. CAT + MIDI greyed placeholders deferred to
+    // their feature phases (3K-1 / 3K-3) — re-add at that time wired
+    // through the controller.
 
     viewMenu->addSeparator();
 
@@ -5000,8 +4962,12 @@ void MainWindow::wireSliceToSpectrum()
         // rides a USB/LSB carrier.
         const bool isRade = (mode == DSPMode::RADE_U
                              || mode == DSPMode::RADE_L);
-        if (m_radeApplet) {
-            m_radeApplet->setVisible(isRade);
+        // Route through the visibility controller so the wrapper (not
+        // just the inner widget) shows/hides AND the menu entries grey
+        // out when not in RADE mode. The user's persisted visibility
+        // preference is preserved across mode changes.
+        if (m_appletVis) {
+            m_appletVis->setAvailable(QStringLiteral("Rade"), isRade);
         }
         if (m_phoneCwApplet) {
             m_phoneCwApplet->setVisible(true);  // always visible

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2560,7 +2560,7 @@ void MainWindow::populateDefaultMeter()
     m_appletVis->registerApplet(QStringLiteral("PureSignal"),
                                 QStringLiteral("PureSignal"),   true);
     m_appletVis->registerApplet(QStringLiteral("Amp"),
-                                QStringLiteral("Amplifier"),    true);
+                                QStringLiteral("Power Genius"), true);
     m_appletVis->registerApplet(QStringLiteral("Tuner"),
                                 QStringLiteral("Tuner Genius"), true);
 #ifdef HAVE_WEBSOCKETS

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6474,7 +6474,15 @@ void MainWindow::onConnectionStateChanged()
 
         // Phase 3P-II Task 20: auto-connect PGXL / TGXL when a Manual IP is
         // configured and the peripheral is not already connected.
-        {
+        //
+        // Gated on FourO3A_Enabled: when the master toggle is off, skip the
+        // auto-connect entirely (matches the FourO3APage.h contract
+        // "PGXL/TGXL auto-connect skipped"). Without this gate, a saved
+        // PGXL_ManualIp would dial out even with 4O3A disabled, get a
+        // statusUpdated back, flip m_hasAmplifier=true, and snap the
+        // S-Meter to the 2 kW PGXL scale — surprising the operator who
+        // explicitly turned 4O3A off.
+        if (m_radioModel->fourO3AEnabled()) {
             auto& s = AppSettings::instance();
 
             QString pgxlIp = s.value(QStringLiteral("PGXL_ManualIp"),

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -579,6 +579,7 @@ private:
     // Constructed in the layout-build path after the panel is wired.
     AppletVisibilityController* m_appletVis{nullptr};
     QHash<QString, AppletWidget*> m_appletsById;
+    QHash<QString, QAction*> m_topMenuAppletActions;
 
     // Phase 3O Sub-Phase 10 Task 10c: host strip for the menu bar +
     // MasterOutputWidget. Owned by QMainWindow via setMenuWidget().

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -580,6 +580,8 @@ private:
     AppletVisibilityController* m_appletVis{nullptr};
     QHash<QString, AppletWidget*> m_appletsById;
     QHash<QString, QAction*> m_topMenuAppletActions;
+    QMenu* m_bannerAppletsMenu{nullptr};
+    QHash<QString, QAction*> m_bannerAppletActions;
 
     // Phase 3O Sub-Phase 10 Task 10c: host strip for the menu bar +
     // MasterOutputWidget. Owned by QMainWindow via setMenuWidget().

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -75,6 +75,7 @@
 #include <QActionGroup>
 #include <QPointer>
 #include <QTimer>
+#include <QHash>
 
 class QProgressDialog;
 class QThread;
@@ -107,6 +108,8 @@ class StatusBadge;
 class AdcOverloadBadge;
 class OverflowChip;
 class PsaIndicatorWidget;
+class AppletVisibilityController;
+class AppletWidget;
 
 // Phase 23: TCI server + applets forward declarations (all inside NereusSDR
 // namespace — TciServer only exists when HAVE_WEBSOCKETS is defined but we
@@ -570,6 +573,12 @@ private:
 
     // Applet panel — scrollable content widget inside Container #0
     class AppletPanelWidget* m_appletPanel{nullptr};
+
+    // Applet visibility controller (NereusSDR-original) — backs the
+    // Containers > Applets top menu and the panel banner ☰ menu.
+    // Constructed in the layout-build path after the panel is wired.
+    AppletVisibilityController* m_appletVis{nullptr};
+    QHash<QString, AppletWidget*> m_appletsById;
 
     // Phase 3O Sub-Phase 10 Task 10c: host strip for the menu bar +
     // MasterOutputWidget. Owned by QMainWindow via setMenuWidget().

--- a/src/gui/applets/AmpApplet.cpp
+++ b/src/gui/applets/AmpApplet.cpp
@@ -36,7 +36,10 @@ AmpApplet::AmpApplet(RadioModel* model, QWidget* parent)
     auto* topLayout = new QVBoxLayout(this);
     topLayout->setContentsMargins(0, 0, 0, 0);
     topLayout->setSpacing(0);
-    topLayout->addWidget(appletTitleBar(appletTitle()));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // (AppletPanelWidget.cpp:155) already prepends a host-side title bar from
+    // appletTitle(). Adding our own here results in a double header. Same fix
+    // applied to PureSignalApplet (PureSignalApplet.cpp:156-160 comment).
     topLayout->addWidget(root);
 
     auto* vbox = new QVBoxLayout(root);

--- a/src/gui/applets/AmpApplet.h
+++ b/src/gui/applets/AmpApplet.h
@@ -55,7 +55,7 @@ public:
     explicit AmpApplet(RadioModel* model, QWidget* parent = nullptr);
 
     QString appletId()    const override { return QStringLiteral("amp"); }
-    QString appletTitle() const override { return QStringLiteral("AMP"); }
+    QString appletTitle() const override { return QStringLiteral("Power Genius"); }
     void    syncFromModel() override {}
 
     // Test seam: returns a heap-allocated QMenu* without exec()-ing it.

--- a/src/gui/applets/AppletPanelWidget.cpp
+++ b/src/gui/applets/AppletPanelWidget.cpp
@@ -199,6 +199,14 @@ void AppletPanelWidget::removeApplet(AppletWidget* applet)
     m_applets.removeOne(applet);
 }
 
+void AppletPanelWidget::setAppletVisible(AppletWidget* applet, bool visible)
+{
+    if (!applet) { return; }
+    QWidget* wrapper = m_wrappers.value(applet, nullptr);
+    if (!wrapper) { return; }  // applet not in this panel
+    wrapper->setVisible(visible);
+}
+
 void AppletPanelWidget::addWidget(QWidget* widget, const QString& title)
 {
     if (!widget) { return; }

--- a/src/gui/applets/AppletPanelWidget.cpp
+++ b/src/gui/applets/AppletPanelWidget.cpp
@@ -38,6 +38,8 @@
 #include <QLabel>
 #include <QSizePolicy>
 #include <QResizeEvent>
+#include <QPushButton>
+#include <QMenu>
 
 namespace NereusSDR {
 
@@ -53,6 +55,33 @@ AppletPanelWidget::AppletPanelWidget(QWidget* parent)
     m_rootLayout = new QVBoxLayout(this);
     m_rootLayout->setContentsMargins(0, 0, 0, 0);
     m_rootLayout->setSpacing(0);
+
+    // Banner row at the very top — hosts the ☰ menu button (hidden
+    // until setBannerMenu installs a menu).
+    m_bannerRow = new QWidget(this);
+    m_bannerRow->setFixedHeight(22);
+    m_bannerRow->setStyleSheet(Style::titleBarStyle());
+    auto* bannerLayout = new QHBoxLayout(m_bannerRow);
+    bannerLayout->setContentsMargins(2, 0, 4, 0);
+    bannerLayout->setSpacing(4);
+    bannerLayout->addStretch();
+
+    m_bannerMenuButton = new QPushButton(QStringLiteral("☰"), m_bannerRow);
+    m_bannerMenuButton->setObjectName(QStringLiteral("appletPanelBannerButton"));
+    m_bannerMenuButton->setFixedSize(22, 18);
+    // User-visible tooltip — plain English, no source cites.
+    m_bannerMenuButton->setToolTip(QStringLiteral("Show or hide applets"));
+    m_bannerMenuButton->setStyleSheet(QStringLiteral(
+        "QPushButton {"
+        "  background: transparent; color: %1;"
+        "  border: none; font-size: 12px;"
+        "}"
+        "QPushButton:hover { color: %2; }"
+    ).arg(Style::kTitleText, Style::kAccent));
+    m_bannerMenuButton->hide();   // hidden until setBannerMenu called
+    bannerLayout->addWidget(m_bannerMenuButton);
+
+    m_rootLayout->addWidget(m_bannerRow);
 
     // Fixed header area (above scroll) — for MeterWidget / S-Meter
     m_headerLayout = new QVBoxLayout;
@@ -205,6 +234,13 @@ void AppletPanelWidget::setAppletVisible(AppletWidget* applet, bool visible)
     QWidget* wrapper = m_wrappers.value(applet, nullptr);
     if (!wrapper) { return; }  // applet not in this panel
     wrapper->setVisible(visible);
+}
+
+void AppletPanelWidget::setBannerMenu(QMenu* menu)
+{
+    if (!m_bannerMenuButton) { return; }
+    m_bannerMenuButton->setMenu(menu);
+    m_bannerMenuButton->setVisible(menu != nullptr);
 }
 
 void AppletPanelWidget::addWidget(QWidget* widget, const QString& title)

--- a/src/gui/applets/AppletPanelWidget.cpp
+++ b/src/gui/applets/AppletPanelWidget.cpp
@@ -56,17 +56,12 @@ AppletPanelWidget::AppletPanelWidget(QWidget* parent)
     m_rootLayout->setContentsMargins(0, 0, 0, 0);
     m_rootLayout->setSpacing(0);
 
-    // Banner row at the very top — hosts the ☰ menu button (hidden
-    // until setBannerMenu installs a menu).
-    m_bannerRow = new QWidget(this);
-    m_bannerRow->setFixedHeight(22);
-    m_bannerRow->setStyleSheet(Style::titleBarStyle());
-    auto* bannerLayout = new QHBoxLayout(m_bannerRow);
-    bannerLayout->setContentsMargins(2, 0, 4, 0);
-    bannerLayout->setSpacing(4);
-    bannerLayout->addStretch();
-
-    m_bannerMenuButton = new QPushButton(QStringLiteral("☰"), m_bannerRow);
+    // ☰ menu button — created here as a hidden child of `this`. When
+    // setHeaderWidget runs, wrapWithTitleBar will reparent it into the
+    // S-Meter title bar (right end, after the title label). This avoids
+    // a dedicated banner row that would compete for clicks with the
+    // master-volume strip above the panel.
+    m_bannerMenuButton = new QPushButton(QStringLiteral("☰"), this);
     m_bannerMenuButton->setObjectName(QStringLiteral("appletPanelBannerButton"));
     m_bannerMenuButton->setFixedSize(22, 18);
     // User-visible tooltip — plain English, no source cites.
@@ -77,11 +72,9 @@ AppletPanelWidget::AppletPanelWidget(QWidget* parent)
         "  border: none; font-size: 12px;"
         "}"
         "QPushButton:hover { color: %2; }"
+        "QPushButton::menu-indicator { image: none; width: 0; }"
     ).arg(Style::kTitleText, Style::kAccent));
     m_bannerMenuButton->hide();   // hidden until setBannerMenu called
-    bannerLayout->addWidget(m_bannerMenuButton);
-
-    m_rootLayout->addWidget(m_bannerRow);
 
     // Fixed header area (above scroll) — for MeterWidget / S-Meter
     m_headerLayout = new QVBoxLayout;
@@ -152,7 +145,10 @@ void AppletPanelWidget::setHeaderWidget(QWidget* widget, const QString& title,
     // Let the widget expand to fill width; height set dynamically in resizeEvent
     widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
-    QWidget* wrapped = wrapWithTitleBar(widget, title);
+    // Pass the ☰ menu button as the trailing widget so it lives in the
+    // S-Meter title bar (right end). See AppletPanelWidget.h comment for
+    // why we don't use a dedicated banner row.
+    QWidget* wrapped = wrapWithTitleBar(widget, title, m_bannerMenuButton);
     wrapped->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     m_headerWrapper = wrapped;
     m_headerLayout->addWidget(wrapped);
@@ -254,7 +250,8 @@ void AppletPanelWidget::addWidget(QWidget* widget, const QString& title)
     m_stackLayout->insertWidget(idx, wrapped);
 }
 
-QWidget* AppletPanelWidget::wrapWithTitleBar(QWidget* child, const QString& title)
+QWidget* AppletPanelWidget::wrapWithTitleBar(QWidget* child, const QString& title,
+                                              QWidget* trailing)
 {
     // Wrapper container
     auto* wrapper = new QWidget(this);
@@ -263,9 +260,12 @@ QWidget* AppletPanelWidget::wrapWithTitleBar(QWidget* child, const QString& titl
     wrapLayout->setSpacing(0);
 
     // Title bar — from AetherSDR AppletTitleBar:
-    // 16px height, gradient, grip dots + title label
+    // 16px height, gradient, grip dots + title label.
+    // Bumped to 22px when a trailing widget is hosted (the S-Meter
+    // header gets the ☰ menu button on its right end).
     auto* titleBar = new QWidget(wrapper);
-    titleBar->setFixedHeight(Style::kTitleBarH);
+    const int titleBarHeight = trailing ? 22 : Style::kTitleBarH;
+    titleBar->setFixedHeight(titleBarHeight);
     titleBar->setStyleSheet(Style::titleBarStyle());
 
     auto* titleLayout = new QHBoxLayout(titleBar);
@@ -287,6 +287,14 @@ QWidget* AppletPanelWidget::wrapWithTitleBar(QWidget* child, const QString& titl
     ).arg(Style::kTitleText));
     titleLayout->addWidget(label);
     titleLayout->addStretch();
+
+    if (trailing) {
+        // Reparent under the title bar (Qt does this automatically on
+        // addWidget). The trailing widget keeps its current visibility
+        // state — callers manage show/hide via their own API (e.g.
+        // setBannerMenu for the ☰ button).
+        titleLayout->addWidget(trailing);
+    }
 
     wrapLayout->addWidget(titleBar);
     wrapLayout->addWidget(child);

--- a/src/gui/applets/AppletPanelWidget.h
+++ b/src/gui/applets/AppletPanelWidget.h
@@ -99,7 +99,14 @@ protected:
     void resizeEvent(QResizeEvent* event) override;
 
 private:
-    QWidget* wrapWithTitleBar(QWidget* child, const QString& title);
+    // Wrap a child widget with a 16 px title bar (grip dots + label).
+    // When `trailing` is non-null, the title bar is bumped to 22 px to
+    // accommodate the trailing widget (right-aligned, after the stretch).
+    // Used by setHeaderWidget to embed the ☰ menu button in the S-Meter
+    // title bar — keeps the button reachable without a dedicated row
+    // that competes with the master-volume strip above.
+    QWidget* wrapWithTitleBar(QWidget* child, const QString& title,
+                              QWidget* trailing = nullptr);
 
     QVBoxLayout* m_rootLayout = nullptr;     // top-level: header + scroll
     QVBoxLayout* m_headerLayout = nullptr;   // fixed header above scroll area
@@ -115,8 +122,10 @@ private:
     // Accessed by MainWindow via smeterWidget() for Task 41/43 wiring.
     SMeterWidget* m_sMeter        = nullptr;
 
-    QWidget*      m_bannerRow{nullptr};        // 22 px top header row
-    QPushButton*  m_bannerMenuButton{nullptr}; // ☰ button (right-aligned)
+    // ☰ menu button. Created in the constructor (hidden, parented to
+    // `this` for memory management). When setHeaderWidget runs it gets
+    // re-parented into the S-Meter title bar via wrapWithTitleBar.
+    QPushButton*  m_bannerMenuButton{nullptr};
 };
 
 } // namespace NereusSDR

--- a/src/gui/applets/AppletPanelWidget.h
+++ b/src/gui/applets/AppletPanelWidget.h
@@ -78,6 +78,11 @@ public:
     // The applet widget itself is hidden and reparented to nullptr (not deleted).
     void removeApplet(AppletWidget* applet);
 
+    // Toggle visibility of an already-added applet without removing it
+    // from the layout. Preserves stack position when re-shown. No-op for
+    // null or unknown applets. NereusSDR-original (no Thetis equivalent).
+    void setAppletVisible(AppletWidget* applet, bool visible);
+
     // Add a raw widget (e.g., MeterWidget) with a custom title to the scroll area
     void addWidget(QWidget* widget, const QString& title);
 

--- a/src/gui/applets/AppletPanelWidget.h
+++ b/src/gui/applets/AppletPanelWidget.h
@@ -31,6 +31,8 @@
 
 class QVBoxLayout;
 class QScrollArea;
+class QPushButton;
+class QMenu;
 
 namespace NereusSDR {
 
@@ -83,6 +85,11 @@ public:
     // null or unknown applets. NereusSDR-original (no Thetis equivalent).
     void setAppletVisible(AppletWidget* applet, bool visible);
 
+    // Install a menu on the panel's top-right ☰ button. Until this is
+    // called, the button is hidden. Pass nullptr to remove the menu and
+    // re-hide the button.
+    void setBannerMenu(QMenu* menu);
+
     // Add a raw widget (e.g., MeterWidget) with a custom title to the scroll area
     void addWidget(QWidget* widget, const QString& title);
 
@@ -107,6 +114,9 @@ private:
     // Non-owning after setHeaderWidget(); the title-bar wrapper owns the tree.
     // Accessed by MainWindow via smeterWidget() for Task 41/43 wiring.
     SMeterWidget* m_sMeter        = nullptr;
+
+    QWidget*      m_bannerRow{nullptr};        // 22 px top header row
+    QPushButton*  m_bannerMenuButton{nullptr}; // ☰ button (right-aligned)
 };
 
 } // namespace NereusSDR

--- a/src/gui/applets/AppletVisibilityController.cpp
+++ b/src/gui/applets/AppletVisibilityController.cpp
@@ -51,6 +51,19 @@ bool AppletVisibilityController::isVisible(const QString& id) const
     return it != m_entries.end() ? it->visible : false;
 }
 
+bool AppletVisibilityController::isAvailable(const QString& id) const
+{
+    auto it = m_entries.find(id);
+    return it != m_entries.end() ? it->available : false;
+}
+
+bool AppletVisibilityController::isEffectivelyVisible(const QString& id) const
+{
+    auto it = m_entries.find(id);
+    if (it == m_entries.end()) { return false; }
+    return it->visible && it->available;
+}
+
 QStringList AppletVisibilityController::registeredIds() const
 {
     return m_order;
@@ -68,11 +81,33 @@ void AppletVisibilityController::setVisible(const QString& id, bool visible)
     if (it == m_entries.end()) { return; }
     if (it->visible == visible) { return; }
 
+    const bool wasEffective = it->visible && it->available;
     it->visible = visible;
+    const bool nowEffective = it->visible && it->available;
+
     AppSettings::instance().setValue(
         settingsKey(id),
         visible ? QStringLiteral("True") : QStringLiteral("False"));
     emit visibilityChanged(id, visible);
+    if (wasEffective != nowEffective) {
+        emit effectiveVisibilityChanged(id, nowEffective);
+    }
+}
+
+void AppletVisibilityController::setAvailable(const QString& id, bool available)
+{
+    auto it = m_entries.find(id);
+    if (it == m_entries.end()) { return; }
+    if (it->available == available) { return; }
+
+    const bool wasEffective = it->visible && it->available;
+    it->available = available;
+    const bool nowEffective = it->visible && it->available;
+
+    emit availabilityChanged(id, available);
+    if (wasEffective != nowEffective) {
+        emit effectiveVisibilityChanged(id, nowEffective);
+    }
 }
 
 } // namespace NereusSDR

--- a/src/gui/applets/AppletVisibilityController.cpp
+++ b/src/gui/applets/AppletVisibilityController.cpp
@@ -1,0 +1,78 @@
+// =================================================================
+// src/gui/applets/AppletVisibilityController.cpp  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original. See header for attribution.
+//
+// =================================================================
+
+#include "AppletVisibilityController.h"
+#include "core/AppSettings.h"
+
+namespace NereusSDR {
+
+AppletVisibilityController::AppletVisibilityController(QObject* parent)
+    : QObject(parent)
+{
+}
+
+QString AppletVisibilityController::settingsKey(const QString& id)
+{
+    return QStringLiteral("Applet") + id + QStringLiteral("Visible");
+}
+
+void AppletVisibilityController::registerApplet(const QString& id,
+                                                 const QString& displayName,
+                                                 bool defaultVisible)
+{
+    if (id.isEmpty()) { return; }
+
+    if (!m_entries.contains(id)) {
+        m_order.append(id);
+    }
+
+    Entry& e = m_entries[id];
+    e.displayName = displayName;
+
+    const QString stored = AppSettings::instance()
+        .value(settingsKey(id), QString{}).toString();
+    if (stored == QStringLiteral("True")) {
+        e.visible = true;
+    } else if (stored == QStringLiteral("False")) {
+        e.visible = false;
+    } else {
+        e.visible = defaultVisible;
+    }
+}
+
+bool AppletVisibilityController::isVisible(const QString& id) const
+{
+    auto it = m_entries.find(id);
+    return it != m_entries.end() ? it->visible : false;
+}
+
+QStringList AppletVisibilityController::registeredIds() const
+{
+    return m_order;
+}
+
+QString AppletVisibilityController::displayName(const QString& id) const
+{
+    auto it = m_entries.find(id);
+    return it != m_entries.end() ? it->displayName : QString{};
+}
+
+void AppletVisibilityController::setVisible(const QString& id, bool visible)
+{
+    auto it = m_entries.find(id);
+    if (it == m_entries.end()) { return; }
+    if (it->visible == visible) { return; }
+
+    it->visible = visible;
+    AppSettings::instance().setValue(
+        settingsKey(id),
+        visible ? QStringLiteral("True") : QStringLiteral("False"));
+    emit visibilityChanged(id, visible);
+}
+
+} // namespace NereusSDR

--- a/src/gui/applets/AppletVisibilityController.h
+++ b/src/gui/applets/AppletVisibilityController.h
@@ -36,23 +36,44 @@ public:
                         const QString& displayName,
                         bool defaultVisible);
 
-    bool isVisible(const QString& id) const;
+    bool isVisible(const QString& id) const;          // user preference
+    bool isAvailable(const QString& id) const;        // capability gate
+    bool isEffectivelyVisible(const QString& id) const; // visible && available
     QStringList registeredIds() const;       // insertion order preserved
     QString displayName(const QString& id) const;
 
 public slots:
+    // User preference — persisted to AppSettings.
     void setVisible(const QString& id, bool visible);
 
+    // Capability gate — NOT persisted. Lets the controller hide an
+    // applet (and grey its menu entry) when an external feature flag
+    // says the applet shouldn't be reachable. Example: when the 4O3A
+    // master toggle is off, the Amplifier and Tuner applets become
+    // unavailable. The user's persisted visibility preference is
+    // preserved across availability changes, so re-enabling 4O3A pops
+    // the applet back if the user wanted it visible.
+    void setAvailable(const QString& id, bool available);
+
 signals:
-    // Emitted only when the value actually changes.
+    // User preference changed (e.g., user clicked the menu).
     void visibilityChanged(const QString& id, bool visible);
+
+    // Capability gate changed (e.g., 4O3A master toggle flipped).
+    void availabilityChanged(const QString& id, bool available);
+
+    // Convenience signal: fires when EITHER axis changes if it caused
+    // the effective visibility to flip. Consumers that just want to
+    // show/hide the wrapper should connect here.
+    void effectiveVisibilityChanged(const QString& id, bool effective);
 
 private:
     static QString settingsKey(const QString& id);  // "AppletRxVisible" etc.
 
     struct Entry {
         QString displayName;
-        bool visible{true};
+        bool visible{true};       // user pref (persisted)
+        bool available{true};     // capability gate (runtime)
     };
     QHash<QString, Entry> m_entries;   // id -> entry
     QStringList m_order;               // registration order

--- a/src/gui/applets/AppletVisibilityController.h
+++ b/src/gui/applets/AppletVisibilityController.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// =================================================================
+// src/gui/applets/AppletVisibilityController.h  (NereusSDR)
+// =================================================================
+//
+// NereusSDR-original. No Thetis equivalent — Thetis exposes
+// container-level show/hide via setup checkboxes, not per-applet
+// toggles. AetherSDR has no equivalent.
+//
+// =================================================================
+// Modification history (NereusSDR):
+//   2026-05-10 — Created in C++20/Qt6 for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via
+//                 Anthropic Claude Code. Backs the Containers >
+//                 Applets menu and the right-side panel ☰ menu.
+// =================================================================
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QHash>
+
+namespace NereusSDR {
+
+class AppletVisibilityController : public QObject {
+    Q_OBJECT
+public:
+    explicit AppletVisibilityController(QObject* parent = nullptr);
+
+    // Register an applet's id, display name, and default visibility.
+    // If an AppSettings key for this id already exists, the persisted
+    // value wins over defaultVisible. Idempotent on the same id; later
+    // calls overwrite the display name but preserve current state.
+    void registerApplet(const QString& id,
+                        const QString& displayName,
+                        bool defaultVisible);
+
+    bool isVisible(const QString& id) const;
+    QStringList registeredIds() const;       // insertion order preserved
+    QString displayName(const QString& id) const;
+
+public slots:
+    void setVisible(const QString& id, bool visible);
+
+signals:
+    // Emitted only when the value actually changes.
+    void visibilityChanged(const QString& id, bool visible);
+
+private:
+    static QString settingsKey(const QString& id);  // "AppletRxVisible" etc.
+
+    struct Entry {
+        QString displayName;
+        bool visible{true};
+    };
+    QHash<QString, Entry> m_entries;   // id -> entry
+    QStringList m_order;               // registration order
+};
+
+} // namespace NereusSDR

--- a/src/gui/applets/CatApplet.cpp
+++ b/src/gui/applets/CatApplet.cpp
@@ -67,7 +67,9 @@ void CatApplet::buildUI()
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
-    root->addWidget(appletTitleBar(QStringLiteral("CAT")));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // already prepends a host-side title bar from appletTitle(). Adding our
+    // own here results in a double header. Same fix in PureSignalApplet.
 
     auto* body = new QWidget(this);
     auto* vbox = new QVBoxLayout(body);

--- a/src/gui/applets/ClientChainApplet.cpp
+++ b/src/gui/applets/ClientChainApplet.cpp
@@ -114,7 +114,9 @@ ClientChainApplet::ClientChainApplet(TciServer* server, QWidget* parent)
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
-    root->addWidget(appletTitleBar(QStringLiteral("TCI Clients")));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // already prepends a host-side title bar from appletTitle(). Adding our
+    // own here results in a double header. Same fix in PureSignalApplet.
 
     // ── Top bar: auto-refresh checkbox + bind info ────────────────────────────
     auto* topBar = new QWidget(this);

--- a/src/gui/applets/CwxApplet.cpp
+++ b/src/gui/applets/CwxApplet.cpp
@@ -46,7 +46,9 @@ void CwxApplet::buildUI()
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
-    root->addWidget(appletTitleBar(QStringLiteral("CW Keyer")));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // already prepends a host-side title bar from appletTitle(). Adding our
+    // own here results in a double header. Same fix in PureSignalApplet.
 
     auto* body = new QWidget(this);
     auto* vbox = new QVBoxLayout(body);

--- a/src/gui/applets/DigitalApplet.cpp
+++ b/src/gui/applets/DigitalApplet.cpp
@@ -165,7 +165,9 @@ void DigitalApplet::buildUI()
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
-    root->addWidget(appletTitleBar(QStringLiteral("Digital / VAC")));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // already prepends a host-side title bar from appletTitle(). Adding our
+    // own here results in a double header. Same fix in PureSignalApplet.
 
     auto* body = new QWidget(this);
     auto* vbox = new QVBoxLayout(body);

--- a/src/gui/applets/DiversityApplet.cpp
+++ b/src/gui/applets/DiversityApplet.cpp
@@ -74,7 +74,9 @@ DiversityApplet::DiversityApplet(RadioModel* model, QWidget* parent)
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
-    root->addWidget(appletTitleBar(QStringLiteral("Diversity")));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // already prepends a host-side title bar from appletTitle(). Adding our
+    // own here results in a double header. Same fix in PureSignalApplet.
 
     auto* body = new QWidget(this);
     auto* vbox = new QVBoxLayout(body);

--- a/src/gui/applets/DvkApplet.cpp
+++ b/src/gui/applets/DvkApplet.cpp
@@ -46,7 +46,9 @@ void DvkApplet::buildUI()
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
-    root->addWidget(appletTitleBar(QStringLiteral("Voice Keyer")));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // already prepends a host-side title bar from appletTitle(). Adding our
+    // own here results in a double header. Same fix in PureSignalApplet.
 
     auto* body = new QWidget(this);
     auto* vbox = new QVBoxLayout(body);

--- a/src/gui/applets/RadeApplet.cpp
+++ b/src/gui/applets/RadeApplet.cpp
@@ -76,7 +76,9 @@ void RadeApplet::buildUI()
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
 
-    root->addWidget(appletTitleBar(appletTitle()));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // already prepends a host-side title bar from appletTitle(). Adding our
+    // own here results in a double header. Same fix in PureSignalApplet.
 
     auto* body = new QWidget(this);
     body->setStyleSheet(

--- a/src/gui/applets/TciApplet.cpp
+++ b/src/gui/applets/TciApplet.cpp
@@ -152,7 +152,9 @@ void TciApplet::buildUI()
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
-    root->addWidget(appletTitleBar(QStringLiteral("TCI Server")));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // already prepends a host-side title bar from appletTitle(). Adding our
+    // own here results in a double header. Same fix in PureSignalApplet.
 
     // ── Main content (header + slice + tx + footer) ───────────────────────────
     m_mainContent = new QWidget(this);

--- a/src/gui/applets/TunerApplet.cpp
+++ b/src/gui/applets/TunerApplet.cpp
@@ -85,7 +85,9 @@ void TunerApplet::buildUI()
     auto* root = new QVBoxLayout(this);
     root->setContentsMargins(0, 0, 0, 0);
     root->setSpacing(0);
-    root->addWidget(appletTitleBar(QStringLiteral("Tuner Genius")));
+    // Do NOT add appletTitleBar() here — AppletPanelWidget::wrapWithTitleBar
+    // already prepends a host-side title bar from appletTitle(). Adding our
+    // own here results in a double header. Same fix in PureSignalApplet.
 
     auto* body = new QWidget(this);
     auto* vbox = new QVBoxLayout(body);

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2332,6 +2332,8 @@ void RadioModel::setFourO3AEnabled(bool enabled)
             qCInfo(lcConnection) << "4O3A disabled: SmartSDR API listener stopped";
         }
     }
+
+    emit fourO3AEnabledChanged(enabled);
 }
 
 bool RadioModel::fourO3AEnabled() const

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -2331,6 +2331,33 @@ void RadioModel::setFourO3AEnabled(bool enabled)
             m_smartSdrListener->stop();
             qCInfo(lcConnection) << "4O3A disabled: SmartSDR API listener stopped";
         }
+
+        // Tear down any live PGXL / TGXL TCP socket. Without this, an
+        // already-connected PGXL keeps sending statusUpdated frames,
+        // m_hasAmplifier stays true, and the S-Meter keeps showing the
+        // 2 kW PGXL scale even though the operator just disabled 4O3A.
+        if (m_pgxlConnection && m_pgxlConnection->isConnected()) {
+            m_pgxlConnection->disconnect();
+            qCInfo(lcConnection) << "4O3A disabled: PGXL TCP disconnected";
+        }
+        if (m_tgxlConnection && m_tgxlConnection->isConnected()) {
+            m_tgxlConnection->disconnect();
+            qCInfo(lcConnection) << "4O3A disabled: TGXL TCP disconnected";
+        }
+
+        // Reset amp-presence cache. m_hasAmplifier is sticky-true after
+        // any PGXL statusUpdated (see onPgxlStatus); resetting it here
+        // lets the SMeterWidget / TunerApplet revert their power scales
+        // to barefoot via the amplifierChanged(false) + ampStateChanged
+        // emissions below. m_ampOperate also clears so STANDBY/OPERATE
+        // consumers see the amp gone.
+        if (m_hasAmplifier || m_ampOperate) {
+            m_hasAmplifier = false;
+            const bool wasOperate = m_ampOperate;
+            m_ampOperate = false;
+            emit amplifierChanged(false);
+            if (wasOperate) { emit ampStateChanged(); }
+        }
     }
 
     emit fourO3AEnabledChanged(enabled);

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -1407,6 +1407,12 @@ signals:
     // Task 1.7: emitted after setActiveRxCountLive() successfully applies
     // the new receiver count to both hardware and WDSP channels.
     void activeRxCountChanged(int newCount);
+
+    // Fires when the 4O3A master toggle flips (Setup → CAT & Network →
+    // 4O3A → General). Consumers (e.g., MainWindow's applet visibility
+    // wiring) react to grey out / hide the Amplifier and Tuner applets
+    // when 4O3A is off.
+    void fourO3AEnabledChanged(bool enabled);
     // Fires on each transition to Connected with the RadioInfo of the live
     // connection. HardwarePage (Phase 3I) listens to this to repopulate
     // sub-tabs with per-radio fields.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4071,6 +4071,9 @@ nereus_add_test(tst_applet_panel_gutter)
 # -- AppletPanelWidget setAppletVisible: order-preserving show/hide --
 nereus_add_test(tst_applet_panel_set_visible)
 
+# -- AppletVisibilityController: state, persistence, signal emission --
+nereus_add_test(tst_applet_visibility_controller)
+
 # ── UI Polish Foundation B3: AntennaPopupBuilder capability-gated popup factory ──
 # 5 tests cover Tier 1 (full Alex + bypass), Tier 2 (mid Alex, no bypass),
 # Tier 3 (no Alex, at most 1 entry), TX mode (no RX-only section), and

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4074,6 +4074,9 @@ nereus_add_test(tst_applet_panel_set_visible)
 # -- AppletVisibilityController: state, persistence, signal emission --
 nereus_add_test(tst_applet_visibility_controller)
 
+# -- Two-way sync between top-menu and banner-menu applet toggles --
+nereus_add_test(tst_applet_visibility_menu_wiring)
+
 # ── UI Polish Foundation B3: AntennaPopupBuilder capability-gated popup factory ──
 # 5 tests cover Tier 1 (full Alex + bypass), Tier 2 (mid Alex, no bypass),
 # Tier 3 (no Alex, at most 1 entry), TX mode (no RX-only section), and

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4068,6 +4068,9 @@ nereus_add_test(tst_tx_applet_hl2_slider)
 # -- UI Polish Foundation A1: AppletPanelWidget scrollbar gutter --
 nereus_add_test(tst_applet_panel_gutter)
 
+# -- AppletPanelWidget setAppletVisible: order-preserving show/hide --
+nereus_add_test(tst_applet_panel_set_visible)
+
 # ── UI Polish Foundation B3: AntennaPopupBuilder capability-gated popup factory ──
 # 5 tests cover Tier 1 (full Alex + bypass), Tier 2 (mid Alex, no bypass),
 # Tier 3 (no Alex, at most 1 entry), TX mode (no RX-only section), and

--- a/tests/tst_applet_panel_gutter.cpp
+++ b/tests/tst_applet_panel_gutter.cpp
@@ -6,6 +6,8 @@
 #include "gui/applets/AppletPanelWidget.h"
 #include <QVBoxLayout>
 #include <QScrollArea>
+#include <QMenu>
+#include <QPushButton>
 
 using NereusSDR::AppletPanelWidget;
 
@@ -13,6 +15,8 @@ class TstAppletPanelGutter : public QObject {
     Q_OBJECT
 private slots:
     void stackLayoutReservesEightPxRightMargin();
+    void bannerButtonHiddenUntilMenuSet();
+    void bannerButtonShownAndOpensMenuOnceSet();
 };
 
 void TstAppletPanelGutter::stackLayoutReservesEightPxRightMargin()
@@ -30,6 +34,30 @@ void TstAppletPanelGutter::stackLayoutReservesEightPxRightMargin()
     QCOMPARE(m.left(), 0);
     QCOMPARE(m.top(), 0);
     QCOMPARE(m.bottom(), 0);
+}
+
+void TstAppletPanelGutter::bannerButtonHiddenUntilMenuSet()
+{
+    AppletPanelWidget panel;
+    auto* btn = panel.findChild<QPushButton*>(
+        QStringLiteral("appletPanelBannerButton"));
+    QVERIFY(btn != nullptr);
+    QVERIFY(!btn->isVisible());
+}
+
+void TstAppletPanelGutter::bannerButtonShownAndOpensMenuOnceSet()
+{
+    AppletPanelWidget panel;
+    panel.show();
+    auto* menu = new QMenu(&panel);
+    menu->addAction(QStringLiteral("dummy"));
+    panel.setBannerMenu(menu);
+
+    auto* btn = panel.findChild<QPushButton*>(
+        QStringLiteral("appletPanelBannerButton"));
+    QVERIFY(btn != nullptr);
+    QVERIFY(btn->isVisible());
+    QCOMPARE(btn->menu(), menu);
 }
 
 QTEST_MAIN(TstAppletPanelGutter)

--- a/tests/tst_applet_panel_set_visible.cpp
+++ b/tests/tst_applet_panel_set_visible.cpp
@@ -1,0 +1,111 @@
+// Verify AppletPanelWidget::setAppletVisible toggles wrapper visibility
+// while keeping the applet's position in the stack layout intact.
+
+#include <QApplication>
+#include <QtTest/QtTest>
+#include <QVBoxLayout>
+#include <QScrollArea>
+#include "gui/applets/AppletPanelWidget.h"
+#include "gui/applets/AppletWidget.h"
+
+using namespace NereusSDR;
+
+namespace {
+class FakeApplet : public AppletWidget {
+public:
+    explicit FakeApplet(const QString& title)
+        : AppletWidget(nullptr), m_title(title) {}
+    QString appletId() const override { return m_title; }
+    QString appletTitle() const override { return m_title; }
+    void syncFromModel() override {}
+private:
+    QString m_title;
+};
+} // anon
+
+class TstAppletPanelSetVisible : public QObject {
+    Q_OBJECT
+private slots:
+    void hides_wrapper_without_changing_layout_index();
+    void shows_wrapper_again_at_same_index();
+    void null_applet_is_noop();
+    void unknown_applet_is_noop();
+};
+
+static QWidget* wrapperFor(AppletPanelWidget& panel, AppletWidget* applet)
+{
+    auto* scroll = panel.findChild<QScrollArea*>();
+    if (!scroll) { return nullptr; }
+    auto* stackWidget = scroll->widget();
+    if (!stackWidget) { return nullptr; }
+    auto* layout = qobject_cast<QVBoxLayout*>(stackWidget->layout());
+    if (!layout) { return nullptr; }
+    for (int i = 0; i < layout->count(); ++i) {
+        auto* w = layout->itemAt(i)->widget();
+        if (w && w->isAncestorOf(applet)) { return w; }
+    }
+    return nullptr;
+}
+
+static int indexOf(AppletPanelWidget& panel, QWidget* wrapper)
+{
+    auto* scroll = panel.findChild<QScrollArea*>();
+    auto* stackWidget = scroll->widget();
+    auto* layout = qobject_cast<QVBoxLayout*>(stackWidget->layout());
+    return layout->indexOf(wrapper);
+}
+
+void TstAppletPanelSetVisible::hides_wrapper_without_changing_layout_index()
+{
+    AppletPanelWidget panel;
+    auto* a = new FakeApplet(QStringLiteral("A"));
+    auto* b = new FakeApplet(QStringLiteral("B"));
+    panel.addApplet(a);
+    panel.addApplet(b);
+
+    QWidget* wrapperB = wrapperFor(panel, b);
+    QVERIFY(wrapperB);
+    int idxBefore = indexOf(panel, wrapperB);
+
+    panel.setAppletVisible(b, false);
+
+    QVERIFY(!wrapperB->isVisible());
+    QCOMPARE(indexOf(panel, wrapperB), idxBefore);
+}
+
+void TstAppletPanelSetVisible::shows_wrapper_again_at_same_index()
+{
+    AppletPanelWidget panel;
+    panel.show();
+    auto* a = new FakeApplet(QStringLiteral("A"));
+    auto* b = new FakeApplet(QStringLiteral("B"));
+    panel.addApplet(a);
+    panel.addApplet(b);
+
+    QWidget* wrapperB = wrapperFor(panel, b);
+    int idxBefore = indexOf(panel, wrapperB);
+
+    panel.setAppletVisible(b, false);
+    panel.setAppletVisible(b, true);
+
+    QVERIFY(wrapperB->isVisible());
+    QCOMPARE(indexOf(panel, wrapperB), idxBefore);
+}
+
+void TstAppletPanelSetVisible::null_applet_is_noop()
+{
+    AppletPanelWidget panel;
+    panel.setAppletVisible(nullptr, false);
+    panel.setAppletVisible(nullptr, true);
+}
+
+void TstAppletPanelSetVisible::unknown_applet_is_noop()
+{
+    AppletPanelWidget panel;
+    auto* orphan = new FakeApplet(QStringLiteral("Orphan"));
+    panel.setAppletVisible(orphan, false);
+    delete orphan;
+}
+
+QTEST_MAIN(TstAppletPanelSetVisible)
+#include "tst_applet_panel_set_visible.moc"

--- a/tests/tst_applet_visibility_controller.cpp
+++ b/tests/tst_applet_visibility_controller.cpp
@@ -1,0 +1,110 @@
+// Verify AppletVisibilityController state, persistence, and signal emission.
+// no-port-check: NereusSDR-original — no Thetis source.
+
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+#include "gui/applets/AppletVisibilityController.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstAppletVisibilityController : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase()    { AppSettings::instance().clear(); }
+    void cleanup()         { AppSettings::instance().clear(); }
+
+    void default_visible_when_no_settings_key();
+    void default_hidden_when_no_settings_key();
+    void persisted_value_overrides_default();
+    void setVisible_persists_and_emits();
+    void setVisible_idempotent_no_emit_on_same_value();
+    void registeredIds_returns_insertion_order();
+    void displayName_round_trip();
+};
+
+void TstAppletVisibilityController::default_visible_when_no_settings_key()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Rx"), QStringLiteral("RX"), true);
+    QVERIFY(c.isVisible(QStringLiteral("Rx")));
+}
+
+void TstAppletVisibilityController::default_hidden_when_no_settings_key()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Cwx"), QStringLiteral("CW Keyer"), false);
+    QVERIFY(!c.isVisible(QStringLiteral("Cwx")));
+}
+
+void TstAppletVisibilityController::persisted_value_overrides_default()
+{
+    AppSettings::instance().setValue(QStringLiteral("AppletRxVisible"),
+                                     QStringLiteral("False"));
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Rx"), QStringLiteral("RX"), true);
+    QVERIFY(!c.isVisible(QStringLiteral("Rx")));
+}
+
+void TstAppletVisibilityController::setVisible_persists_and_emits()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Tx"), QStringLiteral("TX"), true);
+    QSignalSpy spy(&c, &AppletVisibilityController::visibilityChanged);
+
+    c.setVisible(QStringLiteral("Tx"), false);
+
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.first().at(0).toString(), QStringLiteral("Tx"));
+    QCOMPARE(spy.first().at(1).toBool(), false);
+    QCOMPARE(AppSettings::instance().value(QStringLiteral("AppletTxVisible"))
+             .toString(), QStringLiteral("False"));
+
+    AppletVisibilityController c2;
+    c2.registerApplet(QStringLiteral("Tx"), QStringLiteral("TX"), true);
+    QVERIFY(!c2.isVisible(QStringLiteral("Tx")));
+}
+
+void TstAppletVisibilityController::setVisible_idempotent_no_emit_on_same_value()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Vax"), QStringLiteral("VAX"), true);
+    QSignalSpy spy(&c, &AppletVisibilityController::visibilityChanged);
+
+    c.setVisible(QStringLiteral("Vax"), true);
+    QCOMPARE(spy.count(), 0);
+
+    c.setVisible(QStringLiteral("Vax"), false);
+    QCOMPARE(spy.count(), 1);
+
+    c.setVisible(QStringLiteral("Vax"), false);
+    QCOMPARE(spy.count(), 1);
+}
+
+void TstAppletVisibilityController::registeredIds_returns_insertion_order()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("Rx"),         QStringLiteral("RX"),          true);
+    c.registerApplet(QStringLiteral("Tx"),         QStringLiteral("TX"),          true);
+    c.registerApplet(QStringLiteral("PhoneCw"),    QStringLiteral("Phone / CW"),  true);
+    c.registerApplet(QStringLiteral("Vax"),        QStringLiteral("VAX"),         true);
+    c.registerApplet(QStringLiteral("PureSignal"), QStringLiteral("PureSignal"),  true);
+
+    QStringList expected{
+        QStringLiteral("Rx"), QStringLiteral("Tx"), QStringLiteral("PhoneCw"),
+        QStringLiteral("Vax"), QStringLiteral("PureSignal")
+    };
+    QCOMPARE(c.registeredIds(), expected);
+}
+
+void TstAppletVisibilityController::displayName_round_trip()
+{
+    AppletVisibilityController c;
+    c.registerApplet(QStringLiteral("PhoneCw"), QStringLiteral("Phone / CW"), true);
+    QCOMPARE(c.displayName(QStringLiteral("PhoneCw")),
+             QStringLiteral("Phone / CW"));
+    QCOMPARE(c.displayName(QStringLiteral("Unknown")), QString{});
+}
+
+QTEST_MAIN(TstAppletVisibilityController)
+#include "tst_applet_visibility_controller.moc"

--- a/tests/tst_applet_visibility_menu_wiring.cpp
+++ b/tests/tst_applet_visibility_menu_wiring.cpp
@@ -1,0 +1,139 @@
+// Verify the two QMenu structures (top menu + banner menu) wired in
+// MainWindow stay in sync via AppletVisibilityController. This test
+// builds the menu structures the same way MainWindow does, without
+// instantiating MainWindow itself.
+// no-port-check: NereusSDR-original — no Thetis source.
+
+#include <QtTest/QtTest>
+#include <QApplication>
+#include <QMenu>
+#include <QAction>
+#include <QHash>
+#include <QSignalSpy>
+#include "gui/applets/AppletVisibilityController.h"
+#include "core/AppSettings.h"
+
+using namespace NereusSDR;
+
+class TstAppletVisibilityMenuWiring : public QObject {
+    Q_OBJECT
+private slots:
+    void initTestCase() { AppSettings::instance().clear(); }
+    void cleanup()      { AppSettings::instance().clear(); }
+
+    void both_menus_have_5_actions_initially_checked();
+    void toggling_top_menu_action_updates_banner_menu();
+    void toggling_banner_action_updates_top_menu();
+    void no_recursive_emit_loop();
+};
+
+namespace {
+struct Wired {
+    AppletVisibilityController* ctl;
+    QMenu* topMenu;
+    QMenu* bannerMenu;
+    QHash<QString, QAction*> topActions;
+    QHash<QString, QAction*> bannerActions;
+};
+
+// Mirror of the MainWindow setup, in test scope.
+Wired buildMenus(QObject* parent)
+{
+    Wired w;
+    w.ctl = new AppletVisibilityController(parent);
+    w.ctl->registerApplet(QStringLiteral("Rx"),
+                          QStringLiteral("RX"), true);
+    w.ctl->registerApplet(QStringLiteral("Tx"),
+                          QStringLiteral("TX"), true);
+    w.ctl->registerApplet(QStringLiteral("PhoneCw"),
+                          QStringLiteral("Phone / CW"), true);
+    w.ctl->registerApplet(QStringLiteral("Vax"),
+                          QStringLiteral("VAX"), true);
+    w.ctl->registerApplet(QStringLiteral("PureSignal"),
+                          QStringLiteral("PureSignal"), true);
+
+    w.topMenu = new QMenu(qobject_cast<QWidget*>(parent));
+    w.bannerMenu = new QMenu(qobject_cast<QWidget*>(parent));
+
+    auto wireMenu = [&w](QMenu* menu, QHash<QString, QAction*>& sink) {
+        for (const QString& id : w.ctl->registeredIds()) {
+            QAction* act = menu->addAction(w.ctl->displayName(id));
+            act->setCheckable(true);
+            act->setChecked(w.ctl->isVisible(id));
+            QObject::connect(act, &QAction::toggled,
+                             [w, id](bool checked) {
+                w.ctl->setVisible(id, checked);
+            });
+            sink.insert(id, act);
+        }
+    };
+    wireMenu(w.topMenu,    w.topActions);
+    wireMenu(w.bannerMenu, w.bannerActions);
+
+    auto syncMenu = [&w](QHash<QString, QAction*>& sink) {
+        QObject::connect(w.ctl, &AppletVisibilityController::visibilityChanged,
+                         [sink](const QString& id, bool v) {
+            if (auto* act = sink.value(id, nullptr)) {
+                QSignalBlocker block(act);
+                act->setChecked(v);
+            }
+        });
+    };
+    syncMenu(w.topActions);
+    syncMenu(w.bannerActions);
+
+    return w;
+}
+} // anon
+
+void TstAppletVisibilityMenuWiring::both_menus_have_5_actions_initially_checked()
+{
+    QObject parent;
+    Wired w = buildMenus(&parent);
+    QCOMPARE(w.topMenu->actions().size(),    5);
+    QCOMPARE(w.bannerMenu->actions().size(), 5);
+    for (QAction* a : w.topMenu->actions())    { QVERIFY(a->isChecked()); }
+    for (QAction* a : w.bannerMenu->actions()) { QVERIFY(a->isChecked()); }
+}
+
+void TstAppletVisibilityMenuWiring::toggling_top_menu_action_updates_banner_menu()
+{
+    QObject parent;
+    Wired w = buildMenus(&parent);
+    QAction* topTx = w.topActions.value(QStringLiteral("Tx"));
+    QAction* banTx = w.bannerActions.value(QStringLiteral("Tx"));
+
+    topTx->toggle();
+    QVERIFY(!topTx->isChecked());
+    QVERIFY(!banTx->isChecked());
+    QVERIFY(!w.ctl->isVisible(QStringLiteral("Tx")));
+}
+
+void TstAppletVisibilityMenuWiring::toggling_banner_action_updates_top_menu()
+{
+    QObject parent;
+    Wired w = buildMenus(&parent);
+    QAction* topPs = w.topActions.value(QStringLiteral("PureSignal"));
+    QAction* banPs = w.bannerActions.value(QStringLiteral("PureSignal"));
+
+    banPs->toggle();
+    QVERIFY(!banPs->isChecked());
+    QVERIFY(!topPs->isChecked());
+    QVERIFY(!w.ctl->isVisible(QStringLiteral("PureSignal")));
+}
+
+void TstAppletVisibilityMenuWiring::no_recursive_emit_loop()
+{
+    QObject parent;
+    Wired w = buildMenus(&parent);
+    QSignalSpy spy(w.ctl, &AppletVisibilityController::visibilityChanged);
+
+    w.topActions.value(QStringLiteral("Vax"))->toggle();
+    QCOMPARE(spy.count(), 1);
+
+    w.bannerActions.value(QStringLiteral("Vax"))->toggle();
+    QCOMPARE(spy.count(), 2);
+}
+
+QTEST_MAIN(TstAppletVisibilityMenuWiring)
+#include "tst_applet_visibility_menu_wiring.moc"


### PR DESCRIPTION
## Summary

- Restores the per-applet show/hide menu that was disabled in `25597df`, now
  driven by a new `AppletVisibilityController` with both a user-pref axis
  (persisted) and a capability-gate axis (runtime). Surfaces in **Containers
  > Applets** (top menu) and a ☰ button embedded in the S-Meter title bar.
- Registers every currently-wired applet (10 total: RX, TX, Phone / CW, RADE,
  VAX, PureSignal, Power Genius, Tuner Genius, TCI Server, TCI Clients).
- Gates Power Genius + Tuner Genius on the 4O3A master toggle: when 4O3A is
  off, both applets disappear from the right-side panel and grey out in both
  menus, live (no app restart). User's check-state preference is preserved
  across the gate flip.

## Notable changes

- **New class `AppletVisibilityController`** (`src/gui/applets/`): registry +
  persistence + two-axis visibility model. ~140 lines + unit tests.
- **`AppletPanelWidget` gains `setAppletVisible(applet, bool)`** — order-
  preserving show/hide (no widget churn, no reparent), plus a `setBannerMenu`
  hook for the ☰ button embedded in the S-Meter title bar.
- **Double-header bug sweep across 10 applets** — `appletTitleBar()` was
  being called internally on top of the host-side wrapper title bar, causing
  visible double headers on Power Genius, Tuner Genius, TCI Clients, RADE,
  TCI Server. PureSignalApplet had this fix already; the comment there
  flagged the others for follow-up. Fixed across all 10 (4 wired + 6 ghost).
- **`AmpApplet` renamed** from "AMP" to "Power Genius" to match the PGXL brand.
- **`RadioModel::fourO3AEnabledChanged(bool)` signal** added (one-line) so the
  visibility wiring can react live without a restart.

## Architecture notes

- The controller exposes three states per applet: `isVisible` (user wants),
  `isAvailable` (capability gate), `isEffectivelyVisible` (the AND of both).
  Three signals: `visibilityChanged`, `availabilityChanged`,
  `effectiveVisibilityChanged`.
- TCI applets (Phase 23) migrated off their legacy `TciApplet_Visible` /
  `ClientChainApplet_Visible` AppSettings keys onto the controller's standard
  `AppletXxxVisible` keys. Legacy keys become orphans on upgrade; existing
  users get TCI applets back to default-visible.
- RADE is registered with `defaultVisible=false` because its visibility is
  mode-driven (auto-shown only when the active slice is DSPMode::RADE_U/_L).
  User menu toggle is a one-shot override until the next mode change.

## Test plan

- [ ] Build clean: \`cmake --build build -j\`
- [ ] Unit tests green: \`ctest -R "applet_visibility|applet_panel_set_visible|applet_panel_gutter"\` (4 tests)
- [ ] Launch app — all 9 default-visible applets render with single headers
- [ ] Open \`Containers > Applets\` — all 10 entries present, RADE unchecked, others checked
- [ ] Click ☰ button on S-Meter title bar — same 10 entries
- [ ] Toggle TX from top menu — TX hides; banner menu's TX checkmark mirrors
- [ ] Toggle TX from ☰ — TX reappears in its original stack position
- [ ] Setup → CAT & Network → 4O3A → turn off — Power Genius + Tuner Genius
      grey out in both menus AND disappear from the panel (live, no restart)
- [ ] Turn 4O3A back on — both applets reappear, menu entries un-grey
- [ ] Quit, relaunch — hidden states from before the quit are restored

J.J. Boyd ~ KG4VCF