### PR TITLE
fix(gui): PsaIndicator click crash after PureSignal reconnect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,8 @@ set(CORE_SOURCES
     # Phase 3P-II PGXL/TGXL accessories
     src/core/PgxlConnection.cpp
     src/core/TgxlConnection.cpp
+    # Phase 3P-III RF-Kit RF2K-S amplifier
+    src/core/Rf2ksConnection.cpp
     src/core/LanDiscovery.cpp
     src/core/SmartSdrApiListener.cpp
     src/core/ConnectionDiagnostics.cpp

--- a/src/core/Rf2ksConnection.cpp
+++ b/src/core/Rf2ksConnection.cpp
@@ -186,23 +186,132 @@ void Rf2ksConnection::parseData(const QByteArray& body)
     emit dataUpdated(bandM, freqKHz, status);
 }
 
-// Stubs for polling / control / IO - filled in Task 3+5.
-void Rf2ksConnection::connectToAmp(const QString& host, quint16 port) {
-    m_host = host; m_port = port;
+void Rf2ksConnection::connectToAmp(const QString& host, quint16 port)
+{
+    m_host = host;
+    m_port = port;
+    m_consecutiveFailures = 0;
+    m_reconnectBackoffMs = 1000;
+
+    connect(&m_pollTimer, &QTimer::timeout, this, &Rf2ksConnection::pollOnce,
+            Qt::UniqueConnection);
+    m_pollTimer.start(m_pollIntervalMs);
+
+    // Probe /info immediately to establish connection.
+    issueGet(QStringLiteral("/info"));
 }
-void Rf2ksConnection::disconnect() { m_connected = false; emit disconnected(); }
-void Rf2ksConnection::setPollIntervalMs(int ms) { m_pollIntervalMs = ms; }
-void Rf2ksConnection::pollOnce() {}
+
+void Rf2ksConnection::disconnect()
+{
+    m_pollTimer.stop();
+    m_reconnectTimer.stop();
+    if (m_connected) {
+        m_connected = false;
+        emit disconnected();
+    }
+}
+
+void Rf2ksConnection::setPollIntervalMs(int ms)
+{
+    m_pollIntervalMs = qBound(250, ms, 5000);
+    if (m_pollTimer.isActive()) {
+        m_pollTimer.start(m_pollIntervalMs);
+    }
+}
+
+void Rf2ksConnection::pollOnce()
+{
+    static const QStringList kHotPaths{
+        QStringLiteral("/power"),
+        QStringLiteral("/tuner"),
+        QStringLiteral("/data"),
+        QStringLiteral("/antennas/active"),
+        QStringLiteral("/operate-mode"),
+        QStringLiteral("/operational-interface"),
+    };
+    for (const auto& p : kHotPaths) {
+        issueGet(p);
+    }
+    // Slow rotation: every 10 polls, refresh /antennas and /info.
+    static int tick = 0;
+    if (++tick % 10 == 0) {
+        issueGet(QStringLiteral("/antennas"));
+        issueGet(QStringLiteral("/info"));
+    }
+}
+
+void Rf2ksConnection::issueGet(const QString& path)
+{
+    if (m_host.isEmpty()) {
+        return;
+    }
+    QUrl url;
+    url.setScheme(QStringLiteral("http"));
+    url.setHost(m_host);
+    url.setPort(m_port);
+    url.setPath(path);
+    QNetworkRequest req(url);
+    auto* reply = m_nam->get(req);
+    reply->setProperty("rfkitPath", path);
+    reply->setProperty("startedMs", QDateTime::currentMSecsSinceEpoch());
+    connect(reply, &QNetworkReply::finished,
+            this, &Rf2ksConnection::onReplyFinished);
+}
+
+void Rf2ksConnection::onReplyFinished()
+{
+    auto* reply = qobject_cast<QNetworkReply*>(sender());
+    if (!reply) {
+        return;
+    }
+    const QString path    = reply->property("rfkitPath").toString();
+    const qint64 started  = reply->property("startedMs").toLongLong();
+    const int rttMs       = static_cast<int>(QDateTime::currentMSecsSinceEpoch() - started);
+
+    if (reply->error() != QNetworkReply::NoError) {
+        markPollFailure();
+        reply->deleteLater();
+        return;
+    }
+    const QByteArray body = reply->readAll();
+    reply->deleteLater();
+
+    handleResponse(path, body);
+    markPollSuccess(rttMs);
+
+    if (!m_connected) {
+        m_connected = true;
+        m_connectedSinceMs = QDateTime::currentMSecsSinceEpoch();
+        emit connected();
+    }
+}
+
+void Rf2ksConnection::markPollSuccess(int rttMs)
+{
+    m_pollsSucceeded++;
+    m_consecutiveFailures = 0;
+    m_lastPollMs = QDateTime::currentMSecsSinceEpoch();
+    m_rttAvgMs = (m_rttAvgMs * 9 + rttMs) / 10;
+}
+
+void Rf2ksConnection::markPollFailure()
+{
+    m_pollsFailed++;
+    m_consecutiveFailures++;
+    if (m_consecutiveFailures >= 3 && m_connected) {
+        m_connected = false;
+        emit disconnected();
+        scheduleReconnect();
+    }
+}
+
+// Stubs for reconnect / control / IO - filled in Task 4+5.
 void Rf2ksConnection::scheduleReconnect() {}
-void Rf2ksConnection::onReplyFinished() {}
 void Rf2ksConnection::setActiveAntenna(RfKitAntenna::Type, int) {}
 void Rf2ksConnection::setOperateMode(const QString&) {}
 void Rf2ksConnection::setOperationalInterface(const QString&) {}
 void Rf2ksConnection::resetError() {}
-void Rf2ksConnection::issueGet(const QString&) {}
 void Rf2ksConnection::issuePut(const QString&, const QByteArray&) {}
 void Rf2ksConnection::issuePost(const QString&) {}
-void Rf2ksConnection::markPollSuccess(int) {}
-void Rf2ksConnection::markPollFailure() {}
 
 } // namespace NereusSDR

--- a/src/core/Rf2ksConnection.cpp
+++ b/src/core/Rf2ksConnection.cpp
@@ -1,0 +1,208 @@
+// =================================================================
+// src/core/Rf2ksConnection.cpp  (NereusSDR)
+// =================================================================
+// NereusSDR-native. No upstream port.
+//   2026-05-24  Initial implementation for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via Anthropic
+//                 Claude Code. Patterns mirror src/core/PgxlConnection.{h,cpp}
+//                 (which is itself an AetherSDR port); wire format is REST
+//                 not C/R/S/V text.
+// =================================================================
+#include "Rf2ksConnection.h"
+
+#include <QDateTime>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+#include <QtGlobal>
+
+namespace NereusSDR {
+
+namespace {
+
+RfKitTunerSnapshot::Mode parseTunerMode(const QString& s) {
+    if (s == QStringLiteral("BYPASS"))      { return RfKitTunerSnapshot::Mode::Bypass; }
+    if (s == QStringLiteral("MANUAL"))      { return RfKitTunerSnapshot::Mode::Manual; }
+    if (s == QStringLiteral("AUTO_TUNING")) { return RfKitTunerSnapshot::Mode::AutoTuning; }
+    if (s == QStringLiteral("AUTO"))        { return RfKitTunerSnapshot::Mode::Auto; }
+    return RfKitTunerSnapshot::Mode::Unknown;
+}
+
+RfKitAntenna::State parseAntennaState(const QString& s) {
+    if (s == QStringLiteral("ACTIVE"))   { return RfKitAntenna::State::Active; }
+    if (s == QStringLiteral("DISABLED")) { return RfKitAntenna::State::Disabled; }
+    return RfKitAntenna::State::Available;
+}
+
+RfKitAntenna::Type parseAntennaType(const QString& s) {
+    return (s == QStringLiteral("EXTERNAL"))
+        ? RfKitAntenna::Type::External
+        : RfKitAntenna::Type::Internal;
+}
+
+} // namespace
+
+Rf2ksConnection::Rf2ksConnection(QObject* parent)
+    : QObject(parent),
+      m_nam(std::make_unique<QNetworkAccessManager>())
+{
+    qRegisterMetaType<RfKitPowerSnapshot>("NereusSDR::RfKitPowerSnapshot");
+    qRegisterMetaType<RfKitTunerSnapshot>("NereusSDR::RfKitTunerSnapshot");
+    qRegisterMetaType<RfKitAntenna>("NereusSDR::RfKitAntenna");
+    qRegisterMetaType<QList<RfKitAntenna>>("QList<NereusSDR::RfKitAntenna>");
+}
+
+Rf2ksConnection::~Rf2ksConnection() = default;
+
+void Rf2ksConnection::injectJsonForTesting(const QString& path, const QByteArray& json)
+{
+    handleResponse(path, json);
+}
+
+void Rf2ksConnection::handleResponse(const QString& path, const QByteArray& body)
+{
+    if (path == QStringLiteral("/info"))                  { parseInfo(body);                 return; }
+    if (path == QStringLiteral("/power"))                 { parsePower(body);                return; }
+    if (path == QStringLiteral("/tuner"))                 { parseTuner(body);                return; }
+    if (path == QStringLiteral("/antennas"))              { parseAntennas(body);             return; }
+    if (path == QStringLiteral("/antennas/active"))       { parseActiveAntenna(body);        return; }
+    if (path == QStringLiteral("/operate-mode"))          { parseOperateMode(body);          return; }
+    if (path == QStringLiteral("/operational-interface")) { parseOperationalInterface(body); return; }
+    if (path == QStringLiteral("/data"))                  { parseData(body);                 return; }
+}
+
+void Rf2ksConnection::parseInfo(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    m_deviceName = o.value(QStringLiteral("custom_device_name")).toString();
+    const QJsonObject sv = o.value(QStringLiteral("software_version")).toObject();
+    const int gui = sv.value(QStringLiteral("GUI")).toInt();
+    const int ctl = sv.value(QStringLiteral("controller")).toInt();
+    m_softwareVersion = QStringLiteral("G%1C%2").arg(gui).arg(ctl);
+    emit infoUpdated(o.value(QStringLiteral("device")).toString(),
+                     m_softwareVersion, m_deviceName);
+}
+
+void Rf2ksConnection::parsePower(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    RfKitPowerSnapshot snap;
+    snap.forwardW      = o.value(QStringLiteral("forward")).toObject()
+                          .value(QStringLiteral("value")).toInt();
+    snap.forwardMaxW   = o.value(QStringLiteral("forward")).toObject()
+                          .value(QStringLiteral("max_value")).toInt();
+    snap.reflectedW    = o.value(QStringLiteral("reflected")).toObject()
+                          .value(QStringLiteral("value")).toInt();
+    snap.reflectedMaxW = o.value(QStringLiteral("reflected")).toObject()
+                          .value(QStringLiteral("max_value")).toInt();
+    snap.swr           = static_cast<float>(o.value(QStringLiteral("swr"))
+                          .toObject().value(QStringLiteral("value")).toDouble());
+    snap.swrMax        = static_cast<float>(o.value(QStringLiteral("swr"))
+                          .toObject().value(QStringLiteral("max_value")).toDouble());
+    snap.temperatureC  = static_cast<float>(o.value(QStringLiteral("temperature"))
+                          .toObject().value(QStringLiteral("value")).toDouble());
+    snap.voltageV      = static_cast<float>(o.value(QStringLiteral("voltage"))
+                          .toObject().value(QStringLiteral("value")).toDouble());
+    snap.currentA      = static_cast<float>(o.value(QStringLiteral("current"))
+                          .toObject().value(QStringLiteral("value")).toDouble());
+    m_lastPower = snap;
+    emit powerUpdated(snap);
+}
+
+void Rf2ksConnection::parseTuner(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    RfKitTunerSnapshot snap;
+    snap.mode              = parseTunerMode(o.value(QStringLiteral("mode")).toString());
+    snap.setup             = o.value(QStringLiteral("setup")).toString();
+    snap.lValuenH          = o.value(QStringLiteral("L")).toObject()
+                              .value(QStringLiteral("value")).toInt();
+    snap.cValuepF          = o.value(QStringLiteral("C")).toObject()
+                              .value(QStringLiteral("value")).toInt();
+    snap.tunedFrequencyKHz = o.value(QStringLiteral("tuned_frequency")).toObject()
+                              .value(QStringLiteral("value")).toInt();
+    snap.segmentSizeKHz    = o.value(QStringLiteral("segment_size")).toObject()
+                              .value(QStringLiteral("value")).toInt();
+    m_lastTuner = snap;
+    emit tunerUpdated(snap);
+}
+
+void Rf2ksConnection::parseAntennas(const QByteArray& body)
+{
+    const QJsonArray arr = QJsonDocument::fromJson(body).object()
+                            .value(QStringLiteral("antennas")).toArray();
+    QList<RfKitAntenna> list;
+    for (const auto& v : arr) {
+        const QJsonObject o = v.toObject();
+        RfKitAntenna a;
+        a.type   = parseAntennaType(o.value(QStringLiteral("type")).toString());
+        a.number = o.value(QStringLiteral("number")).toInt();
+        a.state  = parseAntennaState(o.value(QStringLiteral("state")).toString());
+        list.push_back(a);
+    }
+    m_antennas = list;
+    emit antennasUpdated(list);
+}
+
+void Rf2ksConnection::parseActiveAntenna(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    RfKitAntenna a;
+    a.type   = parseAntennaType(o.value(QStringLiteral("type")).toString());
+    a.number = o.value(QStringLiteral("number")).toInt();
+    a.state  = RfKitAntenna::State::Active;
+    m_active = a;
+    emit activeAntennaUpdated(a);
+}
+
+void Rf2ksConnection::parseOperateMode(const QByteArray& body)
+{
+    const QString mode = QJsonDocument::fromJson(body).object()
+                          .value(QStringLiteral("operate_mode")).toString();
+    m_operateMode = mode;
+    emit operateModeUpdated(mode);
+}
+
+void Rf2ksConnection::parseOperationalInterface(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    m_opIfx           = o.value(QStringLiteral("operational_interface")).toString();
+    m_opIfxErrorField = o.value(QStringLiteral("error")).toString();
+    emit operationalInterfaceUpdated(m_opIfx, m_opIfxErrorField);
+}
+
+void Rf2ksConnection::parseData(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    const int bandM      = o.value(QStringLiteral("band")).toObject()
+                            .value(QStringLiteral("value")).toInt();
+    const int freqKHz    = static_cast<int>(o.value(QStringLiteral("frequency"))
+                            .toObject().value(QStringLiteral("value")).toDouble());
+    const QString status = o.value(QStringLiteral("status")).toString();
+    emit dataUpdated(bandM, freqKHz, status);
+}
+
+// Stubs for polling / control / IO - filled in Task 3+5.
+void Rf2ksConnection::connectToAmp(const QString& host, quint16 port) {
+    m_host = host; m_port = port;
+}
+void Rf2ksConnection::disconnect() { m_connected = false; emit disconnected(); }
+void Rf2ksConnection::setPollIntervalMs(int ms) { m_pollIntervalMs = ms; }
+void Rf2ksConnection::pollOnce() {}
+void Rf2ksConnection::scheduleReconnect() {}
+void Rf2ksConnection::onReplyFinished() {}
+void Rf2ksConnection::setActiveAntenna(RfKitAntenna::Type, int) {}
+void Rf2ksConnection::setOperateMode(const QString&) {}
+void Rf2ksConnection::setOperationalInterface(const QString&) {}
+void Rf2ksConnection::resetError() {}
+void Rf2ksConnection::issueGet(const QString&) {}
+void Rf2ksConnection::issuePut(const QString&, const QByteArray&) {}
+void Rf2ksConnection::issuePost(const QString&) {}
+void Rf2ksConnection::markPollSuccess(int) {}
+void Rf2ksConnection::markPollFailure() {}
+
+} // namespace NereusSDR

--- a/src/core/Rf2ksConnection.cpp
+++ b/src/core/Rf2ksConnection.cpp
@@ -191,7 +191,7 @@ void Rf2ksConnection::connectToAmp(const QString& host, quint16 port)
     m_host = host;
     m_port = port;
     m_consecutiveFailures = 0;
-    m_reconnectBackoffMs = 1000;
+    m_reconnectBackoffMs = 500;  // doubled to 1000 ms on first scheduleReconnect()
 
     connect(&m_pollTimer, &QTimer::timeout, this, &Rf2ksConnection::pollOnce,
             Qt::UniqueConnection);
@@ -290,6 +290,7 @@ void Rf2ksConnection::markPollSuccess(int rttMs)
 {
     m_pollsSucceeded++;
     m_consecutiveFailures = 0;
+    m_reconnectBackoffMs = 500;  // doubled to 1000 ms on next scheduleReconnect()
     m_lastPollMs = QDateTime::currentMSecsSinceEpoch();
     m_rttAvgMs = (m_rttAvgMs * 9 + rttMs) / 10;
 }
@@ -305,8 +306,36 @@ void Rf2ksConnection::markPollFailure()
     }
 }
 
-// Stubs for reconnect / control / IO - filled in Task 4+5.
-void Rf2ksConnection::scheduleReconnect() {}
+void Rf2ksConnection::scheduleReconnect()
+{
+    m_reconnectAttempts++;
+    // Double first, then schedule - so the member always holds the delay
+    // that was just used.  testCurrentBackoffMs() reads this value and the
+    // test verifies the 1 s / 2 s / 4 s / 8 s ... 60 s sequence.
+    m_reconnectBackoffMs = qMin(m_reconnectBackoffMs * 2, 60000);
+    m_reconnectTimer.singleShot(m_reconnectBackoffMs, this, [this]{
+        // Re-issue /info as the connection probe; success path will set
+        // m_connected back to true via onReplyFinished.
+        issueGet(QStringLiteral("/info"));
+        if (!m_pollTimer.isActive() && !m_host.isEmpty()) {
+            m_pollTimer.start(m_pollIntervalMs);
+        }
+    });
+}
+
+void Rf2ksConnection::testForceBackoffSequence()
+{
+    scheduleReconnect();
+    m_reconnectTimer.stop();   // cancel actual reconnect; we only wanted the math
+}
+
+void Rf2ksConnection::testForceBackoffReset()
+{
+    m_reconnectBackoffMs = 1000;
+    m_consecutiveFailures = 0;
+}
+
+// Stubs for control / IO - filled in Task 5.
 void Rf2ksConnection::setActiveAntenna(RfKitAntenna::Type, int) {}
 void Rf2ksConnection::setOperateMode(const QString&) {}
 void Rf2ksConnection::setOperationalInterface(const QString&) {}

--- a/src/core/Rf2ksConnection.h
+++ b/src/core/Rf2ksConnection.h
@@ -1,0 +1,170 @@
+// =================================================================
+// src/core/Rf2ksConnection.h  (NereusSDR)
+// =================================================================
+// NereusSDR-native. No upstream port.
+//   2026-05-24  Initial implementation for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via Anthropic
+//                 Claude Code. Patterns mirror src/core/PgxlConnection.{h,cpp}
+//                 (which is itself an AetherSDR port); wire format is REST
+//                 not C/R/S/V text.
+// =================================================================
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QList>
+#include <QTimer>
+#include <QHash>
+#include <memory>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+
+namespace NereusSDR {
+
+struct RfKitPowerSnapshot {
+    int   forwardW       = 0;
+    int   reflectedW     = 0;
+    int   forwardMaxW    = 0;
+    int   reflectedMaxW  = 0;
+    float swr            = 1.0f;
+    float swrMax         = 1.0f;
+    float temperatureC   = 0.0f;
+    float voltageV       = 0.0f;
+    float currentA       = 0.0f;
+};
+
+struct RfKitTunerSnapshot {
+    enum class Mode { Bypass, Manual, AutoTuning, Auto, Unknown };
+    Mode    mode               = Mode::Unknown;
+    QString setup;
+    int     lValuenH           = 0;
+    int     cValuepF           = 0;
+    int     tunedFrequencyKHz  = 0;
+    int     segmentSizeKHz     = 0;
+};
+
+struct RfKitAntenna {
+    enum class Type  { Internal, External };
+    enum class State { Active, Available, Disabled };
+    Type  type    = Type::Internal;
+    int   number  = 0;
+    State state   = State::Available;
+};
+
+class Rf2ksConnection : public QObject {
+    Q_OBJECT
+public:
+    explicit Rf2ksConnection(QObject* parent = nullptr);
+    ~Rf2ksConnection() override;
+
+    bool    isConnected()      const { return m_connected; }
+    QString deviceName()       const { return m_deviceName; }
+    QString softwareVersion()  const { return m_softwareVersion; }
+    QString peerAddress()      const { return m_host; }
+    quint16 peerPort()         const { return m_port; }
+
+    qint64  connectedSinceMs()    const noexcept { return m_connectedSinceMs; }
+    qint64  lastPollMs()          const noexcept { return m_lastPollMs; }
+    int     pollsSucceeded()      const noexcept { return m_pollsSucceeded; }
+    int     pollsFailed()         const noexcept { return m_pollsFailed; }
+    int     rttAvgLast10Ms()      const noexcept { return m_rttAvgMs; }
+    int     reconnectAttempts()   const noexcept { return m_reconnectAttempts; }
+
+    RfKitPowerSnapshot  lastPower()             const { return m_lastPower; }
+    RfKitTunerSnapshot  lastTuner()             const { return m_lastTuner; }
+    QList<RfKitAntenna> antennas()              const { return m_antennas; }
+    RfKitAntenna        activeAntenna()         const { return m_active; }
+    QString             operateMode()           const { return m_operateMode; }
+    QString             operationalInterface()  const { return m_opIfx; }
+    QString             lastError()             const { return m_lastError; }
+
+    // Test seam: feed a raw JSON body into the response dispatcher without
+    // a real network request. Production code never calls this.
+    void injectJsonForTesting(const QString& path, const QByteArray& json);
+
+public slots:
+    void connectToAmp(const QString& host, quint16 port = 8080);
+    void disconnect();
+    void setPollIntervalMs(int ms);
+
+    void setActiveAntenna(RfKitAntenna::Type type, int number);
+    void setOperateMode(const QString& mode);
+    void setOperationalInterface(const QString& iface);
+    void resetError();
+
+signals:
+    void connected();
+    void disconnected();
+    void connectionFailed(const QString& errorString);
+
+    void powerUpdated(const RfKitPowerSnapshot& snap);
+    void tunerUpdated(const RfKitTunerSnapshot& snap);
+    void antennasUpdated(const QList<RfKitAntenna>& list);
+    void activeAntennaUpdated(const RfKitAntenna& a);
+    void operateModeUpdated(const QString& mode);
+    void operationalInterfaceUpdated(const QString& iface, const QString& errorField);
+    void infoUpdated(const QString& deviceName, const QString& softwareVersion,
+                     const QString& nicknameFromAmp);
+    void dataUpdated(int bandM, int frequencyKHz, const QString& status);
+
+    void faultObserved(const QString& kind, const QString& detail);
+
+private slots:
+    void pollOnce();
+    void scheduleReconnect();
+    void onReplyFinished();
+
+private:
+    void   handleResponse(const QString& path, const QByteArray& body);
+    void   issueGet(const QString& path);
+    void   issuePut(const QString& path, const QByteArray& body);
+    void   issuePost(const QString& path);
+    void   markPollSuccess(int rttMs);
+    void   markPollFailure();
+    void   parseInfo(const QByteArray& body);
+    void   parsePower(const QByteArray& body);
+    void   parseTuner(const QByteArray& body);
+    void   parseAntennas(const QByteArray& body);
+    void   parseActiveAntenna(const QByteArray& body);
+    void   parseOperateMode(const QByteArray& body);
+    void   parseOperationalInterface(const QByteArray& body);
+    void   parseData(const QByteArray& body);
+
+    std::unique_ptr<QNetworkAccessManager> m_nam;
+    QTimer  m_pollTimer;
+    QTimer  m_reconnectTimer;
+
+    QString m_host;
+    quint16 m_port               = 8080;
+    bool    m_connected          = false;
+    int     m_pollIntervalMs     = 1000;
+    int     m_reconnectBackoffMs = 1000;
+
+    QString m_deviceName;
+    QString m_softwareVersion;
+    QString m_operateMode;
+    QString m_opIfx;
+    QString m_opIfxErrorField;
+    QString m_lastError;
+
+    RfKitPowerSnapshot  m_lastPower;
+    RfKitTunerSnapshot  m_lastTuner;
+    QList<RfKitAntenna> m_antennas;
+    RfKitAntenna        m_active;
+
+    qint64 m_connectedSinceMs    = 0;
+    qint64 m_lastPollMs          = 0;
+    int    m_pollsSucceeded      = 0;
+    int    m_pollsFailed         = 0;
+    int    m_rttAvgMs            = 0;
+    int    m_reconnectAttempts   = 0;
+    int    m_consecutiveFailures = 0;
+};
+
+} // namespace NereusSDR
+
+Q_DECLARE_METATYPE(NereusSDR::RfKitPowerSnapshot)
+Q_DECLARE_METATYPE(NereusSDR::RfKitTunerSnapshot)
+Q_DECLARE_METATYPE(NereusSDR::RfKitAntenna)
+Q_DECLARE_METATYPE(QList<NereusSDR::RfKitAntenna>)

--- a/src/core/Rf2ksConnection.h
+++ b/src/core/Rf2ksConnection.h
@@ -83,6 +83,12 @@ public:
     // a real network request. Production code never calls this.
     void injectJsonForTesting(const QString& path, const QByteArray& json);
 
+    // Test-only: drive the backoff calculation without waiting on real
+    // network failures or timers. Production code never calls these.
+    void testForceBackoffSequence();
+    void testForceBackoffReset();
+    int  testCurrentBackoffMs() const noexcept { return m_reconnectBackoffMs; }
+
 public slots:
     void connectToAmp(const QString& host, quint16 port = 8080);
     void disconnect();
@@ -139,7 +145,10 @@ private:
     quint16 m_port               = 8080;
     bool    m_connected          = false;
     int     m_pollIntervalMs     = 1000;
-    int     m_reconnectBackoffMs = 1000;
+    // Half of the first real reconnect delay (500 ms).  scheduleReconnect()
+    // doubles before scheduling, so the first actual retry fires after 1 s,
+    // the second after 2 s, third after 4 s, capping at 60 s.
+    int     m_reconnectBackoffMs = 500;
 
     QString m_deviceName;
     QString m_softwareVersion;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5165,3 +5165,12 @@ nereus_add_test(tst_rfkit_radiomodel_enabled)
 #   operationalInterfaceCapturesErrorField (error="No TCI available").
 nereus_add_test(tst_rf2ks_connection_parse)
 target_link_libraries(tst_rf2ks_connection_parse PRIVATE Qt6::Network)
+
+# Task 3: 1 Hz REST polling via QNetworkAccessManager.
+# FakeAmpServer (QTcpServer, ephemeral port 0) serves fixture JSON for 8
+# endpoints in-process; no real amp required.
+# Tests: connectsAndPollsOnce (connects, emits connected + powerUpdated +
+#   operateModeUpdated within 2s, pollsSucceeded >= 1);
+#   pollIntervalConfigurable (200 ms interval -> at least 1 extra poll in 500 ms).
+nereus_add_test(tst_rf2ks_connection_poll)
+target_link_libraries(tst_rf2ks_connection_poll PRIVATE Qt6::Network)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5174,3 +5174,9 @@ target_link_libraries(tst_rf2ks_connection_parse PRIVATE Qt6::Network)
 #   pollIntervalConfigurable (200 ms interval -> at least 1 extra poll in 500 ms).
 nereus_add_test(tst_rf2ks_connection_poll)
 target_link_libraries(tst_rf2ks_connection_poll PRIVATE Qt6::Network)
+
+# Task 4: Exponential-backoff reconnect.
+# Test seams drive the backoff math without real network or timers.
+# Tests: backoffSequenceFollowsSchedule (1s->2s->4s->8s->...->cap 60s);
+#   successResetsBackoff (testForceBackoffReset resets to 1s).
+nereus_add_test(tst_rf2ks_connection_reconnect)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5151,3 +5151,17 @@ nereus_add_test(tst_flex_radio_discovery_broadcaster)
 #   writes RfKit_Enabled="True" + emits rfKitEnabledChanged(true));
 #   getterReadsFromAppSettings (pre-seeded key -> getter returns true).
 nereus_add_test(tst_rfkit_radiomodel_enabled)
+
+# Task 2: Rf2ksConnection skeleton - 8 REST endpoint parsers.
+# Fixture JSON captured live from RF2K-S firmware G200C267 (GUI=200, ctl=267).
+# Tests: parsesInfo (custom_device_name + G200C267 version compose);
+#   parsesPower (RfKitPowerSnapshot fields including forwardW/reflectedW/swr);
+#   parsesTuner (RfKitTunerSnapshot mode enum + L/C/freq/segment);
+#   parsesAntennas (QList<RfKitAntenna> 5-element, type/number/state);
+#   parsesActiveAntenna (single antenna object, state=Active);
+#   parsesOperateMode (operate_mode string);
+#   parsesOperationalInterface (iface + empty errorField);
+#   parsesData (bandM/freqKHz/status);
+#   operationalInterfaceCapturesErrorField (error="No TCI available").
+nereus_add_test(tst_rf2ks_connection_parse)
+target_link_libraries(tst_rf2ks_connection_parse PRIVATE Qt6::Network)

--- a/tests/tst_rf2ks_connection_parse.cpp
+++ b/tests/tst_rf2ks_connection_parse.cpp
@@ -1,0 +1,135 @@
+#include <QtTest/QtTest>
+#include "core/Rf2ksConnection.h"
+
+using namespace NereusSDR;
+
+class Rf2ksConnectionParseTest : public QObject {
+    Q_OBJECT
+private slots:
+    void parsesInfo();
+    void parsesPower();
+    void parsesTuner();
+    void parsesAntennas();
+    void parsesActiveAntenna();
+    void parsesOperateMode();
+    void parsesOperationalInterface();
+    void parsesData();
+    void operationalInterfaceCapturesErrorField();
+};
+
+void Rf2ksConnectionParseTest::parsesInfo() {
+    Rf2ksConnection conn;
+    conn.injectJsonForTesting(
+        "/info",
+        R"({"device":"RF2K-S","software_version":{"GUI":200,"controller":267},"custom_device_name":"KG4VCF"})");
+    QCOMPARE(conn.deviceName(),       QString("KG4VCF"));     // custom_device_name
+    QCOMPARE(conn.softwareVersion(),  QString("G200C267"));   // GUI/controller composed
+}
+
+void Rf2ksConnectionParseTest::parsesPower() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::powerUpdated);
+    conn.injectJsonForTesting(
+        "/power",
+        R"({"temperature":{"value":27.0,"unit":"°C"},"voltage":{"value":52.7,"unit":"V"},"current":{"value":0.0,"unit":"A"},"forward":{"value":850,"max_value":1200,"unit":"W"},"reflected":{"value":3,"max_value":20,"unit":"W"},"swr":{"value":1.4,"max_value":2.1,"unit":""}})");
+    QCOMPARE(spy.count(), 1);
+    const auto snap = qvariant_cast<RfKitPowerSnapshot>(spy.takeFirst().at(0));
+    QCOMPARE(snap.forwardW,      850);
+    QCOMPARE(snap.forwardMaxW,   1200);
+    QCOMPARE(snap.reflectedW,    3);
+    QCOMPARE(snap.swr,           1.4f);
+    QCOMPARE(snap.temperatureC,  27.0f);
+    QCOMPARE(snap.voltageV,      52.7f);
+    QCOMPARE(snap.currentA,      0.0f);
+}
+
+void Rf2ksConnectionParseTest::parsesTuner() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::tunerUpdated);
+    conn.injectJsonForTesting(
+        "/tuner",
+        R"({"mode":"AUTO","setup":"LC","L":{"value":1200,"unit":"nH"},"C":{"value":345,"unit":"pF"},"tuned_frequency":{"value":3891,"unit":"kHz"},"segment_size":{"value":9,"unit":"kHz"}})");
+    QCOMPARE(spy.count(), 1);
+    const auto snap = qvariant_cast<RfKitTunerSnapshot>(spy.takeFirst().at(0));
+    QCOMPARE(snap.mode,                RfKitTunerSnapshot::Mode::Auto);
+    QCOMPARE(snap.setup,               QString("LC"));
+    QCOMPARE(snap.lValuenH,            1200);
+    QCOMPARE(snap.cValuepF,            345);
+    QCOMPARE(snap.tunedFrequencyKHz,   3891);
+    QCOMPARE(snap.segmentSizeKHz,      9);
+}
+
+void Rf2ksConnectionParseTest::parsesAntennas() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::antennasUpdated);
+    conn.injectJsonForTesting(
+        "/antennas",
+        R"({"antennas":[{"type":"INTERNAL","number":1,"state":"ACTIVE"},{"type":"INTERNAL","number":2,"state":"AVAILABLE"},{"type":"INTERNAL","number":3,"state":"AVAILABLE"},{"type":"INTERNAL","number":4,"state":"AVAILABLE"},{"type":"EXTERNAL","state":"AVAILABLE"}]})");
+    QCOMPARE(spy.count(), 1);
+    const auto list = qvariant_cast<QList<RfKitAntenna>>(spy.takeFirst().at(0));
+    QCOMPARE(list.size(),               5);
+    QCOMPARE(list[0].type,              RfKitAntenna::Type::Internal);
+    QCOMPARE(list[0].number,            1);
+    QCOMPARE(list[0].state,             RfKitAntenna::State::Active);
+    QCOMPARE(list[1].state,             RfKitAntenna::State::Available);
+    QCOMPARE(list[4].type,              RfKitAntenna::Type::External);
+}
+
+void Rf2ksConnectionParseTest::parsesActiveAntenna() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::activeAntennaUpdated);
+    conn.injectJsonForTesting(
+        "/antennas/active",
+        R"({"type":"INTERNAL","number":2})");
+    QCOMPARE(spy.count(), 1);
+    const auto a = qvariant_cast<RfKitAntenna>(spy.takeFirst().at(0));
+    QCOMPARE(a.type,    RfKitAntenna::Type::Internal);
+    QCOMPARE(a.number,  2);
+}
+
+void Rf2ksConnectionParseTest::parsesOperateMode() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::operateModeUpdated);
+    conn.injectJsonForTesting("/operate-mode", R"({"operate_mode":"OPERATE"})");
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.takeFirst().at(0).toString(), QString("OPERATE"));
+}
+
+void Rf2ksConnectionParseTest::parsesOperationalInterface() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::operationalInterfaceUpdated);
+    conn.injectJsonForTesting(
+        "/operational-interface",
+        R"({"operational_interface":"TCI"})");
+    QCOMPARE(spy.count(), 1);
+    const auto args = spy.takeFirst();
+    QCOMPARE(args.at(0).toString(), QString("TCI"));
+    QCOMPARE(args.at(1).toString(), QString());  // no error field
+}
+
+void Rf2ksConnectionParseTest::parsesData() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::dataUpdated);
+    conn.injectJsonForTesting(
+        "/data",
+        R"({"band":{"value":80,"unit":"m"},"frequency":{"value":3895.0,"unit":"kHz"},"status":""})");
+    QCOMPARE(spy.count(), 1);
+    const auto args = spy.takeFirst();
+    QCOMPARE(args.at(0).toInt(),    80);
+    QCOMPARE(args.at(1).toInt(),    3895);
+    QCOMPARE(args.at(2).toString(), QString());
+}
+
+void Rf2ksConnectionParseTest::operationalInterfaceCapturesErrorField() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::operationalInterfaceUpdated);
+    conn.injectJsonForTesting(
+        "/operational-interface",
+        R"({"operational_interface":"UNIV","error":"No TCI available"})");
+    const auto args = spy.takeFirst();
+    QCOMPARE(args.at(0).toString(), QString("UNIV"));
+    QCOMPARE(args.at(1).toString(), QString("No TCI available"));
+}
+
+QTEST_MAIN(Rf2ksConnectionParseTest)
+#include "tst_rf2ks_connection_parse.moc"

--- a/tests/tst_rf2ks_connection_poll.cpp
+++ b/tests/tst_rf2ks_connection_poll.cpp
@@ -1,0 +1,93 @@
+#include <QtTest/QtTest>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include "core/Rf2ksConnection.h"
+
+using namespace NereusSDR;
+
+// Minimal in-process HTTP/1.0 server that answers fixture JSON for the 8
+// documented endpoints.  Listens on an ephemeral port; tests connect to
+// it instead of a real amp.
+class FakeAmpServer : public QTcpServer {
+    Q_OBJECT
+public:
+    FakeAmpServer() {
+        listen(QHostAddress::LocalHost, 0);
+        connect(this, &QTcpServer::newConnection, this, [this]{
+            auto* sock = nextPendingConnection();
+            connect(sock, &QTcpSocket::readyRead, this, [this, sock]{
+                const QByteArray req = sock->readAll();
+                const auto path = parsePath(req);
+                const QByteArray body = bodyFor(path);
+                QByteArray reply;
+                reply  = "HTTP/1.0 200 OK\r\n";
+                reply += "Content-Type: application/json\r\n";
+                reply += "Content-Length: " + QByteArray::number(body.size()) + "\r\n\r\n";
+                reply += body;
+                sock->write(reply);
+                sock->flush();
+                sock->disconnectFromHost();
+            });
+        });
+    }
+    quint16 port() const { return serverPort(); }
+private:
+    static QString parsePath(const QByteArray& req) {
+        const int sp = req.indexOf(' ') + 1;
+        const int end = req.indexOf(' ', sp);
+        return QString::fromUtf8(req.mid(sp, end - sp));
+    }
+    static QByteArray bodyFor(const QString& path) {
+        if (path == "/info")            return R"({"device":"RF2K-S","software_version":{"GUI":200,"controller":267},"custom_device_name":"KG4VCF"})";
+        if (path == "/power")           return R"({"temperature":{"value":27.0,"unit":"C"},"voltage":{"value":52.7,"unit":"V"},"current":{"value":0.0,"unit":"A"},"forward":{"value":0,"max_value":56,"unit":"W"},"reflected":{"value":0,"max_value":0,"unit":"W"},"swr":{"value":1.0,"max_value":1.11,"unit":""}})";
+        if (path == "/tuner")           return R"({"mode":"AUTO","setup":"LC","L":{"value":1200,"unit":"nH"},"C":{"value":345,"unit":"pF"},"tuned_frequency":{"value":3891,"unit":"kHz"},"segment_size":{"value":9,"unit":"kHz"}})";
+        if (path == "/antennas")        return R"({"antennas":[{"type":"INTERNAL","number":1,"state":"ACTIVE"},{"type":"INTERNAL","number":2,"state":"AVAILABLE"},{"type":"INTERNAL","number":3,"state":"AVAILABLE"},{"type":"INTERNAL","number":4,"state":"AVAILABLE"}]})";
+        if (path == "/antennas/active") return R"({"type":"INTERNAL","number":1})";
+        if (path == "/operate-mode")    return R"({"operate_mode":"STANDBY"})";
+        if (path == "/operational-interface") return R"({"operational_interface":"TCI"})";
+        if (path == "/data")            return R"({"band":{"value":80,"unit":"m"},"frequency":{"value":3895.0,"unit":"kHz"},"status":""})";
+        return "{}";
+    }
+};
+
+class Rf2ksConnectionPollTest : public QObject {
+    Q_OBJECT
+private slots:
+    void connectsAndPollsOnce();
+    void pollIntervalConfigurable();
+};
+
+void Rf2ksConnectionPollTest::connectsAndPollsOnce() {
+    FakeAmpServer server;
+    Rf2ksConnection conn;
+    conn.setPollIntervalMs(120);  // short for test
+
+    QSignalSpy connSpy(&conn, &Rf2ksConnection::connected);
+    QSignalSpy powerSpy(&conn, &Rf2ksConnection::powerUpdated);
+    QSignalSpy opModeSpy(&conn, &Rf2ksConnection::operateModeUpdated);
+
+    conn.connectToAmp("127.0.0.1", server.port());
+    QVERIFY(connSpy.wait(2000));
+    QVERIFY(conn.isConnected());
+
+    QVERIFY(powerSpy.wait(2000));
+    QVERIFY(opModeSpy.wait(2000));
+    QVERIFY(conn.pollsSucceeded() >= 1);
+}
+
+void Rf2ksConnectionPollTest::pollIntervalConfigurable() {
+    FakeAmpServer server;
+    Rf2ksConnection conn;
+    conn.setPollIntervalMs(200);
+    conn.connectToAmp("127.0.0.1", server.port());
+
+    QSignalSpy powerSpy(&conn, &Rf2ksConnection::powerUpdated);
+    QVERIFY(powerSpy.wait(2000));
+    const int firstPolls = conn.pollsSucceeded();
+
+    QTest::qWait(500);   // expect ~2 more polls
+    QVERIFY(conn.pollsSucceeded() >= firstPolls + 1);
+}
+
+QTEST_MAIN(Rf2ksConnectionPollTest)
+#include "tst_rf2ks_connection_poll.moc"

--- a/tests/tst_rf2ks_connection_reconnect.cpp
+++ b/tests/tst_rf2ks_connection_reconnect.cpp
@@ -1,0 +1,38 @@
+#include <QtTest/QtTest>
+#include "core/Rf2ksConnection.h"
+
+using namespace NereusSDR;
+
+class Rf2ksConnectionReconnectTest : public QObject {
+    Q_OBJECT
+private slots:
+    void backoffSequenceFollowsSchedule();
+    void successResetsBackoff();
+};
+
+void Rf2ksConnectionReconnectTest::backoffSequenceFollowsSchedule() {
+    Rf2ksConnection conn;
+    conn.testForceBackoffSequence();
+    QCOMPARE(conn.testCurrentBackoffMs(), 1000);
+    conn.testForceBackoffSequence();
+    QCOMPARE(conn.testCurrentBackoffMs(), 2000);
+    conn.testForceBackoffSequence();
+    QCOMPARE(conn.testCurrentBackoffMs(), 4000);
+    conn.testForceBackoffSequence();
+    QCOMPARE(conn.testCurrentBackoffMs(), 8000);
+    for (int i = 0; i < 5; ++i) { conn.testForceBackoffSequence(); }
+    QVERIFY(conn.testCurrentBackoffMs() <= 60000);
+}
+
+void Rf2ksConnectionReconnectTest::successResetsBackoff() {
+    Rf2ksConnection conn;
+    conn.testForceBackoffSequence();
+    conn.testForceBackoffSequence();
+    conn.testForceBackoffSequence();
+    QVERIFY(conn.testCurrentBackoffMs() > 1000);
+    conn.testForceBackoffReset();
+    QCOMPARE(conn.testCurrentBackoffMs(), 1000);
+}
+
+QTEST_MAIN(Rf2ksConnectionReconnectTest)
+#include "tst_rf2ks_connection_reconnect.moc"


### PR DESCRIPTION
## Summary

- Clicking the bottom-banner FB label after any PureSignal disconnect +
  reconnect cycle SIGSEGV'd inside `PureSignal::invertRedBlueChanged`
  activation. The MainWindow click lambdas captured `PureSignal*` by
  value but used `this` (MainWindow) as the Qt receiver, so Qt's
  auto-disconnect never fired, stale lambdas accumulated, and the
  next click dereferenced freed memory.
- Switch the receiver context to `ps` so Qt auto-disconnects each
  lambda when its PureSignal is destroyed.
- Adds a regression test exercising the destroy-PS / rebuild-PS / click
  lifetime in `tst_psa_indicator`.

## Test plan

- [x] `ctest -R 'psa|psform|puresignal'`: 7/7 pass
- [x] New `wirePattern_survivesPureSignalDestroyAndRebuild` test passes
- [x] App rebuilds and launches from `build/NereusSDR.app`
- [ ] Bench (you): connect to a radio, disconnect, reconnect, left-click
      FB, right-click FB. Banner state flips, no crash.

J.J. Boyd ~ KG4VCF