### PR TITLE
Audio ring overrun protection + latency tightening + spectrum perf wins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,6 +498,8 @@ set(CORE_SOURCES
     # Phase 3P-II PGXL/TGXL accessories
     src/core/PgxlConnection.cpp
     src/core/TgxlConnection.cpp
+    # Phase 3P-III RF-Kit RF2K-S amplifier
+    src/core/Rf2ksConnection.cpp
     src/core/LanDiscovery.cpp
     src/core/SmartSdrApiListener.cpp
     src/core/ConnectionDiagnostics.cpp

--- a/src/core/AudioDeviceConfig.h
+++ b/src/core/AudioDeviceConfig.h
@@ -29,7 +29,13 @@ struct AudioDeviceConfig {
     QString deviceName;            // empty = platform default
     int     sampleRate    = 48000;
     int     channels      = 2;
-    int     bufferSamples = 256;
+    // 128 frames @ 48 kHz = 2.67 ms callback period.  Drops PortAudio
+    // / CoreAudio HAL output latency from ~22 ms (was 256) to ~11 ms
+    // on Apple Silicon.  Safe lower bound across CoreAudio / WASAPI /
+    // PulseAudio / PipeWire on modern hardware.  Persisted users may
+    // still see their saved value via loadFromSettings; new installs
+    // and unconfigured endpoints pick this default.
+    int     bufferSamples = 128;
     bool    exclusiveMode = false; // WASAPI only
     int     hostApiIndex  = -1;    // -1 = PortAudio default host API
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -127,9 +127,6 @@
 #include <portaudio.h>
 
 #include <algorithm>
-#include <array>
-#include <cmath>
-#include <cstdio>
 #include <vector>
 
 namespace NereusSDR {
@@ -934,86 +931,6 @@ void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
         return;
     }
 
-    // Bench diagnostic 2026-05-24: per-slice sample-level discontinuity
-    // detector.  Compares the first sample of this block with the last
-    // sample of the previous block; a large step in a single sample is
-    // a click in the audio data ARRIVING at AudioEngine (i.e. coming
-    // out of WDSP or whatever upstream component produced this block).
-    // Confirms or rules out whether the user-reported crackle is in
-    // the data before our ring path or introduced later.
-    {
-        static thread_local std::array<float, 16> s_lastSample{};
-        static thread_local std::array<bool, 16>  s_haveLast{};
-        static thread_local int s_boundaryDiscCount = 0;
-        static thread_local int s_midBlockSpikeCount = 0;
-        // Block-boundary check (first sample of this block vs last of
-        // previous).  Mid-block spike scan looks for any sample-to-sample
-        // step within the block that significantly exceeds the running
-        // average step size in this block.  Threshold raised 0.05 → 0.20
-        // after bench (2026-05-24) showed 0.05 fires ~2-8 times/sec on
-        // normal SSB voice content (peak-to-peak swings around 0.05-0.10
-        // are routine for a full-scale signal at 1-3 kHz).  0.20 is a
-        // 20%-full-scale single-sample jump — that IS a real click and
-        // does not occur from normal modulation envelopes.  Threshold
-        // is a sensitivity dial only; the underlying drop-oldest and
-        // PortAudio underflow counters remain the authoritative signal.
-        constexpr float kStepThreshold = 0.20f;
-        if (sliceId >= 0 && static_cast<size_t>(sliceId) < s_lastSample.size()) {
-            if (s_haveLast[sliceId]) {
-                const float step = std::abs(samples[0] - s_lastSample[sliceId]);
-                if (step > kStepThreshold) {
-                    const int prior = s_boundaryDiscCount++;
-                    if (prior == 0) {
-                        std::fprintf(stderr,
-                            "[audio] AudioEngine INPUT boundary discontinuity "
-                            "(slice=%d step=%.4f) — click is at block "
-                            "boundaries in data from WDSP\n", sliceId, step);
-                    }
-                }
-            }
-            // Mid-block spike scan.  Stereo interleaved.  Compute
-            // adjacent-sample step deltas for both channels; if any one
-            // exceeds threshold AND is > 4x the median step in this
-            // block, treat as a spike.  4x heuristic avoids false-flagging
-            // normal audio waveform peaks (which have smooth slope) vs
-            // genuine clicks (sudden anomaly).
-            const int channels = 2;
-            const int sampleCount = frames * channels;
-            if (sampleCount > 16) {
-                // Pass 1: compute median step (approx via mean for cheapness).
-                float sumStep = 0.0f;
-                float maxStep = 0.0f;
-                int   maxIdx  = -1;
-                for (int i = channels; i < sampleCount; i += channels) {
-                    // Compare same-channel samples (skip channel interleave).
-                    const float s = std::abs(samples[i] - samples[i - channels]);
-                    sumStep += s;
-                    if (s > maxStep) { maxStep = s; maxIdx = i; }
-                }
-                const float avgStep = sumStep / static_cast<float>(frames - 1);
-                if (maxStep > kStepThreshold && maxStep > 4.0f * avgStep) {
-                    const int prior = s_midBlockSpikeCount++;
-                    if (prior == 0) {
-                        std::fprintf(stderr,
-                            "[audio] AudioEngine INPUT mid-block spike "
-                            "(slice=%d maxStep=%.4f avgStep=%.4f idx=%d/%d) "
-                            "— click is INSIDE a WDSP audio block, not "
-                            "at boundaries\n",
-                            sliceId, maxStep, avgStep, maxIdx, sampleCount);
-                    } else if ((prior % 20) == 0) {
-                        std::fprintf(stderr,
-                            "[audio] AudioEngine mid-block spike count=%d "
-                            "latest maxStep=%.4f avgStep=%.4f\n",
-                            prior + 1, maxStep, avgStep);
-                    }
-                }
-            }
-            // Last sample of this block (R channel of last frame).
-            s_lastSample[sliceId] = samples[sampleCount - 1];
-            s_haveLast[sliceId]   = true;
-        }
-    }
-
     // SliceModel exposes muted() / setMuted() plus vaxChannel(). The
     // design spec uses audioMuted() as shorthand for the same property;
     // the alias is intentionally not introduced here (design-decision D5,
@@ -1171,58 +1088,17 @@ void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
         if (speakersLk.owns_lock()) {
             IAudioBus* speakersBus = m_speakersBus.get();
             if (speakersBus != nullptr && speakersBus->isOpen()) {
-                // Output-side discontinuity detector + drop-block counter.
-                // Confirms whether the final mix delivered to the speakers
-                // bus already contains the rhythmic click the user reports.
-                static thread_local float s_lastMixOutSample = 0.0f;
-                static thread_local bool  s_haveLastMixOut   = false;
-                static thread_local int   s_outDiscontCount  = 0;
-                if (s_haveLastMixOut && stereoFloats > 0) {
-                    const float step = std::abs(mix[0] - s_lastMixOutSample);
-                    // Match input-side threshold (0.20f, see kStepThreshold
-                    // comment above) — 0.05 was firing on normal SSB voice
-                    // peaks.  A real audible click is 20%+ full scale.
-                    if (step > 0.20f) {
-                        const int prior = s_outDiscontCount++;
-                        if (prior == 0) {
-                            std::fprintf(stderr,
-                                "[audio] AudioEngine OUTPUT first sample "
-                                "discontinuity at speakers-bus push "
-                                "(step=%.4f) — click is in the post-mix "
-                                "data before PortAudioBus\n", step);
-                        } else if ((prior % 50) == 0) {
-                            std::fprintf(stderr,
-                                "[audio] AudioEngine OUTPUT discontinuity "
-                                "count=%d latest step=%.4f\n", prior + 1, step);
-                        }
-                    }
-                }
-                s_lastMixOutSample = mix[stereoFloats - 1];
-                s_haveLastMixOut   = true;
-
                 speakersBus->push(
                     reinterpret_cast<const char*>(mix.data()),
                     static_cast<qint64>(stereoFloats) * sizeof(float));
             }
-        } else {
-            // Mutex contention dropped this block.  Track and one-shot-log.
-            // A contending writer holds m_speakersBusMutex (setSpeakersConfig,
-            // master-mute flush).  If this fires periodically it's an
-            // audible click source: the listener gets a silent gap where
-            // a full audio block should have been.
-            static thread_local int s_lockMissCount = 0;
-            const int prior = s_lockMissCount++;
-            if (prior == 0) {
-                std::fprintf(stderr,
-                    "[audio] AudioEngine FIRST speakers-bus mutex miss "
-                    "(block dropped silently) — m_speakersBusMutex was "
-                    "held by another caller\n");
-            } else if ((prior % 50) == 0) {
-                std::fprintf(stderr,
-                    "[audio] AudioEngine speakers-bus mutex miss count=%d "
-                    "(blocks dropped silently)\n", prior + 1);
-            }
         }
+        // A contending writer holding m_speakersBusMutex
+        // (setSpeakersConfig, master-mute flush) silently drops the
+        // current block.  The try_to_lock scope is narrowed to just
+        // the push specifically to keep that drop window short and
+        // bounded; we no longer trace mutex misses since the bench
+        // confirmed the contention is rare enough to be inaudible.
     }
 }
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -127,6 +127,9 @@
 #include <portaudio.h>
 
 #include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
 #include <vector>
 
 namespace NereusSDR {
@@ -931,6 +934,86 @@ void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
         return;
     }
 
+    // Bench diagnostic 2026-05-24: per-slice sample-level discontinuity
+    // detector.  Compares the first sample of this block with the last
+    // sample of the previous block; a large step in a single sample is
+    // a click in the audio data ARRIVING at AudioEngine (i.e. coming
+    // out of WDSP or whatever upstream component produced this block).
+    // Confirms or rules out whether the user-reported crackle is in
+    // the data before our ring path or introduced later.
+    {
+        static thread_local std::array<float, 16> s_lastSample{};
+        static thread_local std::array<bool, 16>  s_haveLast{};
+        static thread_local int s_boundaryDiscCount = 0;
+        static thread_local int s_midBlockSpikeCount = 0;
+        // Block-boundary check (first sample of this block vs last of
+        // previous).  Mid-block spike scan looks for any sample-to-sample
+        // step within the block that significantly exceeds the running
+        // average step size in this block.  Threshold raised 0.05 → 0.20
+        // after bench (2026-05-24) showed 0.05 fires ~2-8 times/sec on
+        // normal SSB voice content (peak-to-peak swings around 0.05-0.10
+        // are routine for a full-scale signal at 1-3 kHz).  0.20 is a
+        // 20%-full-scale single-sample jump — that IS a real click and
+        // does not occur from normal modulation envelopes.  Threshold
+        // is a sensitivity dial only; the underlying drop-oldest and
+        // PortAudio underflow counters remain the authoritative signal.
+        constexpr float kStepThreshold = 0.20f;
+        if (sliceId >= 0 && static_cast<size_t>(sliceId) < s_lastSample.size()) {
+            if (s_haveLast[sliceId]) {
+                const float step = std::abs(samples[0] - s_lastSample[sliceId]);
+                if (step > kStepThreshold) {
+                    const int prior = s_boundaryDiscCount++;
+                    if (prior == 0) {
+                        std::fprintf(stderr,
+                            "[audio] AudioEngine INPUT boundary discontinuity "
+                            "(slice=%d step=%.4f) — click is at block "
+                            "boundaries in data from WDSP\n", sliceId, step);
+                    }
+                }
+            }
+            // Mid-block spike scan.  Stereo interleaved.  Compute
+            // adjacent-sample step deltas for both channels; if any one
+            // exceeds threshold AND is > 4x the median step in this
+            // block, treat as a spike.  4x heuristic avoids false-flagging
+            // normal audio waveform peaks (which have smooth slope) vs
+            // genuine clicks (sudden anomaly).
+            const int channels = 2;
+            const int sampleCount = frames * channels;
+            if (sampleCount > 16) {
+                // Pass 1: compute median step (approx via mean for cheapness).
+                float sumStep = 0.0f;
+                float maxStep = 0.0f;
+                int   maxIdx  = -1;
+                for (int i = channels; i < sampleCount; i += channels) {
+                    // Compare same-channel samples (skip channel interleave).
+                    const float s = std::abs(samples[i] - samples[i - channels]);
+                    sumStep += s;
+                    if (s > maxStep) { maxStep = s; maxIdx = i; }
+                }
+                const float avgStep = sumStep / static_cast<float>(frames - 1);
+                if (maxStep > kStepThreshold && maxStep > 4.0f * avgStep) {
+                    const int prior = s_midBlockSpikeCount++;
+                    if (prior == 0) {
+                        std::fprintf(stderr,
+                            "[audio] AudioEngine INPUT mid-block spike "
+                            "(slice=%d maxStep=%.4f avgStep=%.4f idx=%d/%d) "
+                            "— click is INSIDE a WDSP audio block, not "
+                            "at boundaries\n",
+                            sliceId, maxStep, avgStep, maxIdx, sampleCount);
+                    } else if ((prior % 20) == 0) {
+                        std::fprintf(stderr,
+                            "[audio] AudioEngine mid-block spike count=%d "
+                            "latest maxStep=%.4f avgStep=%.4f\n",
+                            prior + 1, maxStep, avgStep);
+                    }
+                }
+            }
+            // Last sample of this block (R channel of last frame).
+            s_lastSample[sliceId] = samples[sampleCount - 1];
+            s_haveLast[sliceId]   = true;
+        }
+    }
+
     // SliceModel exposes muted() / setMuted() plus vaxChannel(). The
     // design spec uses audioMuted() as shorthand for the same property;
     // the alias is intentionally not introduced here (design-decision D5,
@@ -1088,9 +1171,56 @@ void AudioEngine::rxBlockReady(int sliceId, const float* samples, int frames)
         if (speakersLk.owns_lock()) {
             IAudioBus* speakersBus = m_speakersBus.get();
             if (speakersBus != nullptr && speakersBus->isOpen()) {
+                // Output-side discontinuity detector + drop-block counter.
+                // Confirms whether the final mix delivered to the speakers
+                // bus already contains the rhythmic click the user reports.
+                static thread_local float s_lastMixOutSample = 0.0f;
+                static thread_local bool  s_haveLastMixOut   = false;
+                static thread_local int   s_outDiscontCount  = 0;
+                if (s_haveLastMixOut && stereoFloats > 0) {
+                    const float step = std::abs(mix[0] - s_lastMixOutSample);
+                    // Match input-side threshold (0.20f, see kStepThreshold
+                    // comment above) — 0.05 was firing on normal SSB voice
+                    // peaks.  A real audible click is 20%+ full scale.
+                    if (step > 0.20f) {
+                        const int prior = s_outDiscontCount++;
+                        if (prior == 0) {
+                            std::fprintf(stderr,
+                                "[audio] AudioEngine OUTPUT first sample "
+                                "discontinuity at speakers-bus push "
+                                "(step=%.4f) — click is in the post-mix "
+                                "data before PortAudioBus\n", step);
+                        } else if ((prior % 50) == 0) {
+                            std::fprintf(stderr,
+                                "[audio] AudioEngine OUTPUT discontinuity "
+                                "count=%d latest step=%.4f\n", prior + 1, step);
+                        }
+                    }
+                }
+                s_lastMixOutSample = mix[stereoFloats - 1];
+                s_haveLastMixOut   = true;
+
                 speakersBus->push(
                     reinterpret_cast<const char*>(mix.data()),
                     static_cast<qint64>(stereoFloats) * sizeof(float));
+            }
+        } else {
+            // Mutex contention dropped this block.  Track and one-shot-log.
+            // A contending writer holds m_speakersBusMutex (setSpeakersConfig,
+            // master-mute flush).  If this fires periodically it's an
+            // audible click source: the listener gets a silent gap where
+            // a full audio block should have been.
+            static thread_local int s_lockMissCount = 0;
+            const int prior = s_lockMissCount++;
+            if (prior == 0) {
+                std::fprintf(stderr,
+                    "[audio] AudioEngine FIRST speakers-bus mutex miss "
+                    "(block dropped silently) — m_speakersBusMutex was "
+                    "held by another caller\n");
+            } else if ((prior % 50) == 0) {
+                std::fprintf(stderr,
+                    "[audio] AudioEngine speakers-bus mutex miss count=%d "
+                    "(blocks dropped silently)\n", prior + 1);
             }
         }
     }

--- a/src/core/ReceiverManager.cpp
+++ b/src/core/ReceiverManager.cpp
@@ -87,6 +87,7 @@ void ReceiverManager::setMaxReceivers(int max)
 
 int ReceiverManager::createReceiver()
 {
+    QMutexLocker locker(&m_routingMutex);
     if (m_receivers.size() >= m_maxReceivers) {
         qCWarning(lcReceiver) << "Cannot create receiver: at maximum" << m_maxReceivers;
         return -1;
@@ -107,6 +108,7 @@ int ReceiverManager::createReceiver()
 
 void ReceiverManager::destroyReceiver(int receiverIndex)
 {
+    QMutexLocker locker(&m_routingMutex);
     if (!m_receivers.contains(receiverIndex)) {
         return;
     }
@@ -124,6 +126,7 @@ void ReceiverManager::destroyReceiver(int receiverIndex)
 
 void ReceiverManager::reset()
 {
+    QMutexLocker locker(&m_routingMutex);
     const int priorCount = m_receivers.size();
     const QList<int> indices = m_receivers.keys();
 
@@ -286,6 +289,15 @@ void ReceiverManager::setAdcForReceiver(int receiverIndex, int adcIndex)
 
 void ReceiverManager::feedIqData(int hwReceiverIndex, const QVector<float>& samples)
 {
+    // Lever 2 (2026-05-24): this function now runs on the Connection thread
+    // via Qt::DirectConnection from RadioConnection::iqDataReceived (see the
+    // wire-up in RadioModel.cpp).  Main-thread writers of m_hwToLogical /
+    // m_receivers (createReceiver / destroyReceiver / reset / rebuildHardwareMapping)
+    // serialize through m_routingMutex; the read here takes the same lock so
+    // the hash structure can not flip mid-lookup.  Hot-path cost: one
+    // uncontended mutex acquire per packet (~100 ns) plus the existing
+    // hash lookups + emit setup.
+    QMutexLocker locker(&m_routingMutex);
     auto it = m_hwToLogical.constFind(hwReceiverIndex);
     if (it == m_hwToLogical.constEnd()) {
         if (!m_firstDropLogged) {
@@ -321,6 +333,7 @@ void ReceiverManager::feedIqData(int hwReceiverIndex, const QVector<float>& samp
 
 void ReceiverManager::rebuildHardwareMapping()
 {
+    QMutexLocker locker(&m_routingMutex);
     m_hwToLogical.clear();
 
     // Assign hardware DDC indices to active receivers.

--- a/src/core/ReceiverManager.h
+++ b/src/core/ReceiverManager.h
@@ -68,6 +68,7 @@
 #include <QObject>
 #include <QVector>
 #include <QMap>
+#include <QMutex>
 
 #include "codec/CodecContext.h"   // PsDdcConfig + Q_DECLARE_METATYPE
 #include "HpsdrModel.h"           // HPSDRModel
@@ -268,6 +269,16 @@ private:
 
     // Mapping from hardware DDC index to logical receiver index
     QMap<int, int> m_hwToLogical;
+
+    // Audio-rate-fix 2026-05-24 (Lever 2): feedIqData runs on the radio
+    // Connection thread via Qt::DirectConnection so the I/Q packet path
+    // never touches the main thread.  Main-thread mutations of m_receivers
+    // and m_hwToLogical (createReceiver, destroyReceiver, setMaxReceivers,
+    // rebuildHardwareMapping) need to be serialized against the Connection-
+    // thread read in feedIqData.  Recursive so internal call paths like
+    // destroyReceiver -> rebuildHardwareMapping do not deadlock.  Mutable
+    // so the reader can take it.
+    mutable QRecursiveMutex m_routingMutex;
 
     // Diagnostic: one-shot logging of first successful and first dropped feedIqData
     bool m_firstForwardLogged{false};

--- a/src/core/Rf2ksConnection.cpp
+++ b/src/core/Rf2ksConnection.cpp
@@ -186,23 +186,132 @@ void Rf2ksConnection::parseData(const QByteArray& body)
     emit dataUpdated(bandM, freqKHz, status);
 }
 
-// Stubs for polling / control / IO - filled in Task 3+5.
-void Rf2ksConnection::connectToAmp(const QString& host, quint16 port) {
-    m_host = host; m_port = port;
+void Rf2ksConnection::connectToAmp(const QString& host, quint16 port)
+{
+    m_host = host;
+    m_port = port;
+    m_consecutiveFailures = 0;
+    m_reconnectBackoffMs = 1000;
+
+    connect(&m_pollTimer, &QTimer::timeout, this, &Rf2ksConnection::pollOnce,
+            Qt::UniqueConnection);
+    m_pollTimer.start(m_pollIntervalMs);
+
+    // Probe /info immediately to establish connection.
+    issueGet(QStringLiteral("/info"));
 }
-void Rf2ksConnection::disconnect() { m_connected = false; emit disconnected(); }
-void Rf2ksConnection::setPollIntervalMs(int ms) { m_pollIntervalMs = ms; }
-void Rf2ksConnection::pollOnce() {}
+
+void Rf2ksConnection::disconnect()
+{
+    m_pollTimer.stop();
+    m_reconnectTimer.stop();
+    if (m_connected) {
+        m_connected = false;
+        emit disconnected();
+    }
+}
+
+void Rf2ksConnection::setPollIntervalMs(int ms)
+{
+    m_pollIntervalMs = qBound(250, ms, 5000);
+    if (m_pollTimer.isActive()) {
+        m_pollTimer.start(m_pollIntervalMs);
+    }
+}
+
+void Rf2ksConnection::pollOnce()
+{
+    static const QStringList kHotPaths{
+        QStringLiteral("/power"),
+        QStringLiteral("/tuner"),
+        QStringLiteral("/data"),
+        QStringLiteral("/antennas/active"),
+        QStringLiteral("/operate-mode"),
+        QStringLiteral("/operational-interface"),
+    };
+    for (const auto& p : kHotPaths) {
+        issueGet(p);
+    }
+    // Slow rotation: every 10 polls, refresh /antennas and /info.
+    static int tick = 0;
+    if (++tick % 10 == 0) {
+        issueGet(QStringLiteral("/antennas"));
+        issueGet(QStringLiteral("/info"));
+    }
+}
+
+void Rf2ksConnection::issueGet(const QString& path)
+{
+    if (m_host.isEmpty()) {
+        return;
+    }
+    QUrl url;
+    url.setScheme(QStringLiteral("http"));
+    url.setHost(m_host);
+    url.setPort(m_port);
+    url.setPath(path);
+    QNetworkRequest req(url);
+    auto* reply = m_nam->get(req);
+    reply->setProperty("rfkitPath", path);
+    reply->setProperty("startedMs", QDateTime::currentMSecsSinceEpoch());
+    connect(reply, &QNetworkReply::finished,
+            this, &Rf2ksConnection::onReplyFinished);
+}
+
+void Rf2ksConnection::onReplyFinished()
+{
+    auto* reply = qobject_cast<QNetworkReply*>(sender());
+    if (!reply) {
+        return;
+    }
+    const QString path    = reply->property("rfkitPath").toString();
+    const qint64 started  = reply->property("startedMs").toLongLong();
+    const int rttMs       = static_cast<int>(QDateTime::currentMSecsSinceEpoch() - started);
+
+    if (reply->error() != QNetworkReply::NoError) {
+        markPollFailure();
+        reply->deleteLater();
+        return;
+    }
+    const QByteArray body = reply->readAll();
+    reply->deleteLater();
+
+    handleResponse(path, body);
+    markPollSuccess(rttMs);
+
+    if (!m_connected) {
+        m_connected = true;
+        m_connectedSinceMs = QDateTime::currentMSecsSinceEpoch();
+        emit connected();
+    }
+}
+
+void Rf2ksConnection::markPollSuccess(int rttMs)
+{
+    m_pollsSucceeded++;
+    m_consecutiveFailures = 0;
+    m_lastPollMs = QDateTime::currentMSecsSinceEpoch();
+    m_rttAvgMs = (m_rttAvgMs * 9 + rttMs) / 10;
+}
+
+void Rf2ksConnection::markPollFailure()
+{
+    m_pollsFailed++;
+    m_consecutiveFailures++;
+    if (m_consecutiveFailures >= 3 && m_connected) {
+        m_connected = false;
+        emit disconnected();
+        scheduleReconnect();
+    }
+}
+
+// Stubs for reconnect / control / IO - filled in Task 4+5.
 void Rf2ksConnection::scheduleReconnect() {}
-void Rf2ksConnection::onReplyFinished() {}
 void Rf2ksConnection::setActiveAntenna(RfKitAntenna::Type, int) {}
 void Rf2ksConnection::setOperateMode(const QString&) {}
 void Rf2ksConnection::setOperationalInterface(const QString&) {}
 void Rf2ksConnection::resetError() {}
-void Rf2ksConnection::issueGet(const QString&) {}
 void Rf2ksConnection::issuePut(const QString&, const QByteArray&) {}
 void Rf2ksConnection::issuePost(const QString&) {}
-void Rf2ksConnection::markPollSuccess(int) {}
-void Rf2ksConnection::markPollFailure() {}
 
 } // namespace NereusSDR

--- a/src/core/Rf2ksConnection.cpp
+++ b/src/core/Rf2ksConnection.cpp
@@ -1,0 +1,208 @@
+// =================================================================
+// src/core/Rf2ksConnection.cpp  (NereusSDR)
+// =================================================================
+// NereusSDR-native. No upstream port.
+//   2026-05-24  Initial implementation for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via Anthropic
+//                 Claude Code. Patterns mirror src/core/PgxlConnection.{h,cpp}
+//                 (which is itself an AetherSDR port); wire format is REST
+//                 not C/R/S/V text.
+// =================================================================
+#include "Rf2ksConnection.h"
+
+#include <QDateTime>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QUrl>
+#include <QtGlobal>
+
+namespace NereusSDR {
+
+namespace {
+
+RfKitTunerSnapshot::Mode parseTunerMode(const QString& s) {
+    if (s == QStringLiteral("BYPASS"))      { return RfKitTunerSnapshot::Mode::Bypass; }
+    if (s == QStringLiteral("MANUAL"))      { return RfKitTunerSnapshot::Mode::Manual; }
+    if (s == QStringLiteral("AUTO_TUNING")) { return RfKitTunerSnapshot::Mode::AutoTuning; }
+    if (s == QStringLiteral("AUTO"))        { return RfKitTunerSnapshot::Mode::Auto; }
+    return RfKitTunerSnapshot::Mode::Unknown;
+}
+
+RfKitAntenna::State parseAntennaState(const QString& s) {
+    if (s == QStringLiteral("ACTIVE"))   { return RfKitAntenna::State::Active; }
+    if (s == QStringLiteral("DISABLED")) { return RfKitAntenna::State::Disabled; }
+    return RfKitAntenna::State::Available;
+}
+
+RfKitAntenna::Type parseAntennaType(const QString& s) {
+    return (s == QStringLiteral("EXTERNAL"))
+        ? RfKitAntenna::Type::External
+        : RfKitAntenna::Type::Internal;
+}
+
+} // namespace
+
+Rf2ksConnection::Rf2ksConnection(QObject* parent)
+    : QObject(parent),
+      m_nam(std::make_unique<QNetworkAccessManager>())
+{
+    qRegisterMetaType<RfKitPowerSnapshot>("NereusSDR::RfKitPowerSnapshot");
+    qRegisterMetaType<RfKitTunerSnapshot>("NereusSDR::RfKitTunerSnapshot");
+    qRegisterMetaType<RfKitAntenna>("NereusSDR::RfKitAntenna");
+    qRegisterMetaType<QList<RfKitAntenna>>("QList<NereusSDR::RfKitAntenna>");
+}
+
+Rf2ksConnection::~Rf2ksConnection() = default;
+
+void Rf2ksConnection::injectJsonForTesting(const QString& path, const QByteArray& json)
+{
+    handleResponse(path, json);
+}
+
+void Rf2ksConnection::handleResponse(const QString& path, const QByteArray& body)
+{
+    if (path == QStringLiteral("/info"))                  { parseInfo(body);                 return; }
+    if (path == QStringLiteral("/power"))                 { parsePower(body);                return; }
+    if (path == QStringLiteral("/tuner"))                 { parseTuner(body);                return; }
+    if (path == QStringLiteral("/antennas"))              { parseAntennas(body);             return; }
+    if (path == QStringLiteral("/antennas/active"))       { parseActiveAntenna(body);        return; }
+    if (path == QStringLiteral("/operate-mode"))          { parseOperateMode(body);          return; }
+    if (path == QStringLiteral("/operational-interface")) { parseOperationalInterface(body); return; }
+    if (path == QStringLiteral("/data"))                  { parseData(body);                 return; }
+}
+
+void Rf2ksConnection::parseInfo(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    m_deviceName = o.value(QStringLiteral("custom_device_name")).toString();
+    const QJsonObject sv = o.value(QStringLiteral("software_version")).toObject();
+    const int gui = sv.value(QStringLiteral("GUI")).toInt();
+    const int ctl = sv.value(QStringLiteral("controller")).toInt();
+    m_softwareVersion = QStringLiteral("G%1C%2").arg(gui).arg(ctl);
+    emit infoUpdated(o.value(QStringLiteral("device")).toString(),
+                     m_softwareVersion, m_deviceName);
+}
+
+void Rf2ksConnection::parsePower(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    RfKitPowerSnapshot snap;
+    snap.forwardW      = o.value(QStringLiteral("forward")).toObject()
+                          .value(QStringLiteral("value")).toInt();
+    snap.forwardMaxW   = o.value(QStringLiteral("forward")).toObject()
+                          .value(QStringLiteral("max_value")).toInt();
+    snap.reflectedW    = o.value(QStringLiteral("reflected")).toObject()
+                          .value(QStringLiteral("value")).toInt();
+    snap.reflectedMaxW = o.value(QStringLiteral("reflected")).toObject()
+                          .value(QStringLiteral("max_value")).toInt();
+    snap.swr           = static_cast<float>(o.value(QStringLiteral("swr"))
+                          .toObject().value(QStringLiteral("value")).toDouble());
+    snap.swrMax        = static_cast<float>(o.value(QStringLiteral("swr"))
+                          .toObject().value(QStringLiteral("max_value")).toDouble());
+    snap.temperatureC  = static_cast<float>(o.value(QStringLiteral("temperature"))
+                          .toObject().value(QStringLiteral("value")).toDouble());
+    snap.voltageV      = static_cast<float>(o.value(QStringLiteral("voltage"))
+                          .toObject().value(QStringLiteral("value")).toDouble());
+    snap.currentA      = static_cast<float>(o.value(QStringLiteral("current"))
+                          .toObject().value(QStringLiteral("value")).toDouble());
+    m_lastPower = snap;
+    emit powerUpdated(snap);
+}
+
+void Rf2ksConnection::parseTuner(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    RfKitTunerSnapshot snap;
+    snap.mode              = parseTunerMode(o.value(QStringLiteral("mode")).toString());
+    snap.setup             = o.value(QStringLiteral("setup")).toString();
+    snap.lValuenH          = o.value(QStringLiteral("L")).toObject()
+                              .value(QStringLiteral("value")).toInt();
+    snap.cValuepF          = o.value(QStringLiteral("C")).toObject()
+                              .value(QStringLiteral("value")).toInt();
+    snap.tunedFrequencyKHz = o.value(QStringLiteral("tuned_frequency")).toObject()
+                              .value(QStringLiteral("value")).toInt();
+    snap.segmentSizeKHz    = o.value(QStringLiteral("segment_size")).toObject()
+                              .value(QStringLiteral("value")).toInt();
+    m_lastTuner = snap;
+    emit tunerUpdated(snap);
+}
+
+void Rf2ksConnection::parseAntennas(const QByteArray& body)
+{
+    const QJsonArray arr = QJsonDocument::fromJson(body).object()
+                            .value(QStringLiteral("antennas")).toArray();
+    QList<RfKitAntenna> list;
+    for (const auto& v : arr) {
+        const QJsonObject o = v.toObject();
+        RfKitAntenna a;
+        a.type   = parseAntennaType(o.value(QStringLiteral("type")).toString());
+        a.number = o.value(QStringLiteral("number")).toInt();
+        a.state  = parseAntennaState(o.value(QStringLiteral("state")).toString());
+        list.push_back(a);
+    }
+    m_antennas = list;
+    emit antennasUpdated(list);
+}
+
+void Rf2ksConnection::parseActiveAntenna(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    RfKitAntenna a;
+    a.type   = parseAntennaType(o.value(QStringLiteral("type")).toString());
+    a.number = o.value(QStringLiteral("number")).toInt();
+    a.state  = RfKitAntenna::State::Active;
+    m_active = a;
+    emit activeAntennaUpdated(a);
+}
+
+void Rf2ksConnection::parseOperateMode(const QByteArray& body)
+{
+    const QString mode = QJsonDocument::fromJson(body).object()
+                          .value(QStringLiteral("operate_mode")).toString();
+    m_operateMode = mode;
+    emit operateModeUpdated(mode);
+}
+
+void Rf2ksConnection::parseOperationalInterface(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    m_opIfx           = o.value(QStringLiteral("operational_interface")).toString();
+    m_opIfxErrorField = o.value(QStringLiteral("error")).toString();
+    emit operationalInterfaceUpdated(m_opIfx, m_opIfxErrorField);
+}
+
+void Rf2ksConnection::parseData(const QByteArray& body)
+{
+    const QJsonObject o = QJsonDocument::fromJson(body).object();
+    const int bandM      = o.value(QStringLiteral("band")).toObject()
+                            .value(QStringLiteral("value")).toInt();
+    const int freqKHz    = static_cast<int>(o.value(QStringLiteral("frequency"))
+                            .toObject().value(QStringLiteral("value")).toDouble());
+    const QString status = o.value(QStringLiteral("status")).toString();
+    emit dataUpdated(bandM, freqKHz, status);
+}
+
+// Stubs for polling / control / IO - filled in Task 3+5.
+void Rf2ksConnection::connectToAmp(const QString& host, quint16 port) {
+    m_host = host; m_port = port;
+}
+void Rf2ksConnection::disconnect() { m_connected = false; emit disconnected(); }
+void Rf2ksConnection::setPollIntervalMs(int ms) { m_pollIntervalMs = ms; }
+void Rf2ksConnection::pollOnce() {}
+void Rf2ksConnection::scheduleReconnect() {}
+void Rf2ksConnection::onReplyFinished() {}
+void Rf2ksConnection::setActiveAntenna(RfKitAntenna::Type, int) {}
+void Rf2ksConnection::setOperateMode(const QString&) {}
+void Rf2ksConnection::setOperationalInterface(const QString&) {}
+void Rf2ksConnection::resetError() {}
+void Rf2ksConnection::issueGet(const QString&) {}
+void Rf2ksConnection::issuePut(const QString&, const QByteArray&) {}
+void Rf2ksConnection::issuePost(const QString&) {}
+void Rf2ksConnection::markPollSuccess(int) {}
+void Rf2ksConnection::markPollFailure() {}
+
+} // namespace NereusSDR

--- a/src/core/Rf2ksConnection.cpp
+++ b/src/core/Rf2ksConnection.cpp
@@ -191,7 +191,7 @@ void Rf2ksConnection::connectToAmp(const QString& host, quint16 port)
     m_host = host;
     m_port = port;
     m_consecutiveFailures = 0;
-    m_reconnectBackoffMs = 1000;
+    m_reconnectBackoffMs = 500;  // doubled to 1000 ms on first scheduleReconnect()
 
     connect(&m_pollTimer, &QTimer::timeout, this, &Rf2ksConnection::pollOnce,
             Qt::UniqueConnection);
@@ -290,6 +290,7 @@ void Rf2ksConnection::markPollSuccess(int rttMs)
 {
     m_pollsSucceeded++;
     m_consecutiveFailures = 0;
+    m_reconnectBackoffMs = 500;  // doubled to 1000 ms on next scheduleReconnect()
     m_lastPollMs = QDateTime::currentMSecsSinceEpoch();
     m_rttAvgMs = (m_rttAvgMs * 9 + rttMs) / 10;
 }
@@ -305,8 +306,36 @@ void Rf2ksConnection::markPollFailure()
     }
 }
 
-// Stubs for reconnect / control / IO - filled in Task 4+5.
-void Rf2ksConnection::scheduleReconnect() {}
+void Rf2ksConnection::scheduleReconnect()
+{
+    m_reconnectAttempts++;
+    // Double first, then schedule - so the member always holds the delay
+    // that was just used.  testCurrentBackoffMs() reads this value and the
+    // test verifies the 1 s / 2 s / 4 s / 8 s ... 60 s sequence.
+    m_reconnectBackoffMs = qMin(m_reconnectBackoffMs * 2, 60000);
+    m_reconnectTimer.singleShot(m_reconnectBackoffMs, this, [this]{
+        // Re-issue /info as the connection probe; success path will set
+        // m_connected back to true via onReplyFinished.
+        issueGet(QStringLiteral("/info"));
+        if (!m_pollTimer.isActive() && !m_host.isEmpty()) {
+            m_pollTimer.start(m_pollIntervalMs);
+        }
+    });
+}
+
+void Rf2ksConnection::testForceBackoffSequence()
+{
+    scheduleReconnect();
+    m_reconnectTimer.stop();   // cancel actual reconnect; we only wanted the math
+}
+
+void Rf2ksConnection::testForceBackoffReset()
+{
+    m_reconnectBackoffMs = 1000;
+    m_consecutiveFailures = 0;
+}
+
+// Stubs for control / IO - filled in Task 5.
 void Rf2ksConnection::setActiveAntenna(RfKitAntenna::Type, int) {}
 void Rf2ksConnection::setOperateMode(const QString&) {}
 void Rf2ksConnection::setOperationalInterface(const QString&) {}

--- a/src/core/Rf2ksConnection.h
+++ b/src/core/Rf2ksConnection.h
@@ -1,0 +1,170 @@
+// =================================================================
+// src/core/Rf2ksConnection.h  (NereusSDR)
+// =================================================================
+// NereusSDR-native. No upstream port.
+//   2026-05-24  Initial implementation for NereusSDR by J.J. Boyd
+//                 (KG4VCF), with AI-assisted transformation via Anthropic
+//                 Claude Code. Patterns mirror src/core/PgxlConnection.{h,cpp}
+//                 (which is itself an AetherSDR port); wire format is REST
+//                 not C/R/S/V text.
+// =================================================================
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QList>
+#include <QTimer>
+#include <QHash>
+#include <memory>
+
+class QNetworkAccessManager;
+class QNetworkReply;
+
+namespace NereusSDR {
+
+struct RfKitPowerSnapshot {
+    int   forwardW       = 0;
+    int   reflectedW     = 0;
+    int   forwardMaxW    = 0;
+    int   reflectedMaxW  = 0;
+    float swr            = 1.0f;
+    float swrMax         = 1.0f;
+    float temperatureC   = 0.0f;
+    float voltageV       = 0.0f;
+    float currentA       = 0.0f;
+};
+
+struct RfKitTunerSnapshot {
+    enum class Mode { Bypass, Manual, AutoTuning, Auto, Unknown };
+    Mode    mode               = Mode::Unknown;
+    QString setup;
+    int     lValuenH           = 0;
+    int     cValuepF           = 0;
+    int     tunedFrequencyKHz  = 0;
+    int     segmentSizeKHz     = 0;
+};
+
+struct RfKitAntenna {
+    enum class Type  { Internal, External };
+    enum class State { Active, Available, Disabled };
+    Type  type    = Type::Internal;
+    int   number  = 0;
+    State state   = State::Available;
+};
+
+class Rf2ksConnection : public QObject {
+    Q_OBJECT
+public:
+    explicit Rf2ksConnection(QObject* parent = nullptr);
+    ~Rf2ksConnection() override;
+
+    bool    isConnected()      const { return m_connected; }
+    QString deviceName()       const { return m_deviceName; }
+    QString softwareVersion()  const { return m_softwareVersion; }
+    QString peerAddress()      const { return m_host; }
+    quint16 peerPort()         const { return m_port; }
+
+    qint64  connectedSinceMs()    const noexcept { return m_connectedSinceMs; }
+    qint64  lastPollMs()          const noexcept { return m_lastPollMs; }
+    int     pollsSucceeded()      const noexcept { return m_pollsSucceeded; }
+    int     pollsFailed()         const noexcept { return m_pollsFailed; }
+    int     rttAvgLast10Ms()      const noexcept { return m_rttAvgMs; }
+    int     reconnectAttempts()   const noexcept { return m_reconnectAttempts; }
+
+    RfKitPowerSnapshot  lastPower()             const { return m_lastPower; }
+    RfKitTunerSnapshot  lastTuner()             const { return m_lastTuner; }
+    QList<RfKitAntenna> antennas()              const { return m_antennas; }
+    RfKitAntenna        activeAntenna()         const { return m_active; }
+    QString             operateMode()           const { return m_operateMode; }
+    QString             operationalInterface()  const { return m_opIfx; }
+    QString             lastError()             const { return m_lastError; }
+
+    // Test seam: feed a raw JSON body into the response dispatcher without
+    // a real network request. Production code never calls this.
+    void injectJsonForTesting(const QString& path, const QByteArray& json);
+
+public slots:
+    void connectToAmp(const QString& host, quint16 port = 8080);
+    void disconnect();
+    void setPollIntervalMs(int ms);
+
+    void setActiveAntenna(RfKitAntenna::Type type, int number);
+    void setOperateMode(const QString& mode);
+    void setOperationalInterface(const QString& iface);
+    void resetError();
+
+signals:
+    void connected();
+    void disconnected();
+    void connectionFailed(const QString& errorString);
+
+    void powerUpdated(const RfKitPowerSnapshot& snap);
+    void tunerUpdated(const RfKitTunerSnapshot& snap);
+    void antennasUpdated(const QList<RfKitAntenna>& list);
+    void activeAntennaUpdated(const RfKitAntenna& a);
+    void operateModeUpdated(const QString& mode);
+    void operationalInterfaceUpdated(const QString& iface, const QString& errorField);
+    void infoUpdated(const QString& deviceName, const QString& softwareVersion,
+                     const QString& nicknameFromAmp);
+    void dataUpdated(int bandM, int frequencyKHz, const QString& status);
+
+    void faultObserved(const QString& kind, const QString& detail);
+
+private slots:
+    void pollOnce();
+    void scheduleReconnect();
+    void onReplyFinished();
+
+private:
+    void   handleResponse(const QString& path, const QByteArray& body);
+    void   issueGet(const QString& path);
+    void   issuePut(const QString& path, const QByteArray& body);
+    void   issuePost(const QString& path);
+    void   markPollSuccess(int rttMs);
+    void   markPollFailure();
+    void   parseInfo(const QByteArray& body);
+    void   parsePower(const QByteArray& body);
+    void   parseTuner(const QByteArray& body);
+    void   parseAntennas(const QByteArray& body);
+    void   parseActiveAntenna(const QByteArray& body);
+    void   parseOperateMode(const QByteArray& body);
+    void   parseOperationalInterface(const QByteArray& body);
+    void   parseData(const QByteArray& body);
+
+    std::unique_ptr<QNetworkAccessManager> m_nam;
+    QTimer  m_pollTimer;
+    QTimer  m_reconnectTimer;
+
+    QString m_host;
+    quint16 m_port               = 8080;
+    bool    m_connected          = false;
+    int     m_pollIntervalMs     = 1000;
+    int     m_reconnectBackoffMs = 1000;
+
+    QString m_deviceName;
+    QString m_softwareVersion;
+    QString m_operateMode;
+    QString m_opIfx;
+    QString m_opIfxErrorField;
+    QString m_lastError;
+
+    RfKitPowerSnapshot  m_lastPower;
+    RfKitTunerSnapshot  m_lastTuner;
+    QList<RfKitAntenna> m_antennas;
+    RfKitAntenna        m_active;
+
+    qint64 m_connectedSinceMs    = 0;
+    qint64 m_lastPollMs          = 0;
+    int    m_pollsSucceeded      = 0;
+    int    m_pollsFailed         = 0;
+    int    m_rttAvgMs            = 0;
+    int    m_reconnectAttempts   = 0;
+    int    m_consecutiveFailures = 0;
+};
+
+} // namespace NereusSDR
+
+Q_DECLARE_METATYPE(NereusSDR::RfKitPowerSnapshot)
+Q_DECLARE_METATYPE(NereusSDR::RfKitTunerSnapshot)
+Q_DECLARE_METATYPE(NereusSDR::RfKitAntenna)
+Q_DECLARE_METATYPE(QList<NereusSDR::RfKitAntenna>)

--- a/src/core/Rf2ksConnection.h
+++ b/src/core/Rf2ksConnection.h
@@ -83,6 +83,12 @@ public:
     // a real network request. Production code never calls this.
     void injectJsonForTesting(const QString& path, const QByteArray& json);
 
+    // Test-only: drive the backoff calculation without waiting on real
+    // network failures or timers. Production code never calls these.
+    void testForceBackoffSequence();
+    void testForceBackoffReset();
+    int  testCurrentBackoffMs() const noexcept { return m_reconnectBackoffMs; }
+
 public slots:
     void connectToAmp(const QString& host, quint16 port = 8080);
     void disconnect();
@@ -139,7 +145,10 @@ private:
     quint16 m_port               = 8080;
     bool    m_connected          = false;
     int     m_pollIntervalMs     = 1000;
-    int     m_reconnectBackoffMs = 1000;
+    // Half of the first real reconnect delay (500 ms).  scheduleReconnect()
+    // doubles before scheduling, so the first actual retry fires after 1 s,
+    // the second after 2 s, third after 4 s, capping at 60 s.
+    int     m_reconnectBackoffMs = 500;
 
     QString m_deviceName;
     QString m_softwareVersion;

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdio>
 #include <cstring>
 
 namespace NereusSDR {
@@ -301,25 +300,6 @@ bool PortAudioBus::open(const AudioFormat& format) {
     m_negFormat = format;
     m_negFormat.channels = effectiveChannels;
 
-    // Bench diagnostic 2026-05-24: dump what we actually negotiated with
-    // PortAudio so we can confirm there is no rate / buffer / device-name
-    // surprise that would explain continuous audio crackle that the
-    // sample-discontinuity detectors do not catch.
-    if (wantOutput) {
-        const PaStreamInfo* si = Pa_GetStreamInfo(m_stream);
-        std::fprintf(stderr,
-            "[audio] PortAudioBus OPEN (output) device=\"%s\" hostApi=%d "
-            "format.sampleRate=%d (requested) actualOutLatency=%.4f "
-            "negotiated_sampleRate=%.1f bufferSamples=%d channels=%d\n",
-            (di && di->name) ? di->name : "?",
-            di ? di->hostApi : -1,
-            format.sampleRate,
-            si ? si->outputLatency : -1.0,
-            si ? si->sampleRate : -1.0,
-            m_cfg.bufferSamples,
-            effectiveChannels);
-    }
-
     // Defensive null-check on host-API lookup. With a device handed back
     // by Pa_GetDefault{Output,Input}Device this should never be null, but
     // keep the backend name well-defined if it ever is.
@@ -339,33 +319,11 @@ void PortAudioBus::close() {
     Pa_StopStream(m_stream);
     Pa_CloseStream(m_stream);
     m_stream = nullptr;
-
-    // Bench diagnostic: dump cumulative drop / underrun counts at close.
-    // Gives the operator an objective post-session check on whether the
-    // jitter / crackle came from ring overrun (drops), underrun, or
-    // neither.
-    const quint32 drops      = m_dropEvents.load(std::memory_order_relaxed);
-    const quint64 dropSamps  = m_dropSamples.load(std::memory_order_relaxed);
-    const quint32 underruns  = m_underrunEvents.load(std::memory_order_relaxed);
-    if (drops != 0 || underruns != 0) {
-        std::fprintf(stderr,
-                     "[audio] PortAudioBus close stats: drop_events=%u "
-                     "drop_samples=%llu underrun_events=%u\n",
-                     drops,
-                     static_cast<unsigned long long>(dropSamps),
-                     underruns);
-    } else {
-        std::fprintf(stderr, "[audio] PortAudioBus close: clean (no drops "
-                             "or underruns)\n");
-    }
-    const quint32 paUf = m_paOutputUnderflowEvents.load(std::memory_order_relaxed);
-    const quint32 paOf = m_paOutputOverflowEvents.load(std::memory_order_relaxed);
-    if (paUf != 0 || paOf != 0) {
-        std::fprintf(stderr,
-                     "[audio] PortAudioBus PA flag stats: "
-                     "paOutputUnderflow=%u paOutputOverflow=%u\n",
-                     paUf, paOf);
-    }
+    // Cumulative drop / underrun / PA-flag counters remain queryable
+    // via ringOverrunEvents() / ringOverrunSamples() /
+    // ringUnderrunEvents() and the m_paOutputUnderflowEvents /
+    // m_paOutputOverflowEvents members.  Used by future support
+    // tooling; no per-close log spam.
 }
 
 qint64 PortAudioBus::push(const char* data, qint64 bytes) {
@@ -387,18 +345,14 @@ qint64 PortAudioBus::push(const char* data, qint64 bytes) {
     const qint64 readPos = m_ringRead.load(std::memory_order_acquire);
     const qint64 afterWrite = w + floatCount;
     if (afterWrite - readPos > ringSize) {
-        const quint32 prior = m_dropEvents.fetch_add(1, std::memory_order_relaxed);
+        m_dropEvents.fetch_add(1, std::memory_order_relaxed);
         m_dropSamples.fetch_add(
             static_cast<quint64>(afterWrite - readPos - ringSize),
             std::memory_order_relaxed);
-        if (prior == 0) {
-            // One-shot marker so the bench operator can correlate
-            // crackle-onset with the first drop-oldest event.  fprintf
-            // is async-signal-safe; qCWarning would allocate.
-            std::fprintf(stderr, "[audio] PortAudioBus first drop-oldest "
-                                 "event (writer outran reader by more "
-                                 "than ring size)\n");
-        }
+        // Counters are observable via ringOverrunEvents() /
+        // ringOverrunSamples().  paCallback performs the catch-up jump
+        // on its next entry; the crossfade ramp on resume keeps the
+        // event inaudible to the listener.
     }
 
     float peak = 0.0f;
@@ -469,29 +423,20 @@ int PortAudioBus::paCallback(const void* in, void* out,
     PortAudioBus* self = static_cast<PortAudioBus*>(userData);
     const qint64 ringSize = static_cast<qint64>(self->m_ring.size());
 
-    // Bench diagnostic 2026-05-24: PortAudio reports backend-level
-    // anomalies via the `flags` parameter.  We previously ignored these
-    // entirely.  paOutputUnderflow = the audio device played silence
-    // because we did not supply samples fast enough at the OS layer
-    // (independent of our internal ring); paOutputOverflow = data we
-    // pushed was discarded.  Either would produce continuous audible
-    // clicks that none of our ring-side diagnostics catch.
+    // PortAudio reports backend-level anomalies via the callback's
+    // `flags` parameter.  paOutputUnderflow = the OS audio device
+    // played silence because we did not supply samples fast enough
+    // at the host-API layer (independent of our internal ring);
+    // paOutputOverflow = data we supplied was discarded.  We count
+    // both into atomic event counters that are queryable through the
+    // PortAudioBus public API for support tooling.
     if (flags & paOutputUnderflow) {
-        const quint32 prior = self->m_paOutputUnderflowEvents.fetch_add(
+        self->m_paOutputUnderflowEvents.fetch_add(
             1, std::memory_order_relaxed);
-        if (prior == 0) {
-            std::fprintf(stderr, "[audio] PortAudioBus FIRST paOutputUnderflow "
-                                 "flag from device (CoreAudio reported it ran "
-                                 "out of samples to play)\n");
-        }
     }
     if (flags & paOutputOverflow) {
-        const quint32 prior = self->m_paOutputOverflowEvents.fetch_add(
+        self->m_paOutputOverflowEvents.fetch_add(
             1, std::memory_order_relaxed);
-        if (prior == 0) {
-            std::fprintf(stderr, "[audio] PortAudioBus FIRST paOutputOverflow "
-                                 "flag from device\n");
-        }
     }
     if (flags & paPrimingOutput) {
         // Expected during stream startup; not a problem.
@@ -538,17 +483,8 @@ int PortAudioBus::paCallback(const void* in, void* out,
         // with an empty ring) counts as one event.
         bool sawSilenceStart = false;
         if (wasUnderrun) {
-            const quint32 prior = self->m_underrunEvents.fetch_add(
+            self->m_underrunEvents.fetch_add(
                 1, std::memory_order_relaxed);
-            if (prior == 0) {
-                // One-shot leading-edge marker so the bench operator can
-                // see in the log whether the audio crackle correlates
-                // with ring-underrun events at all.  fprintf is async-
-                // signal-safe and OK here; qCWarning would allocate.
-                std::fprintf(stderr, "[audio] PortAudioBus first underrun "
-                             "detected (ring empty when device asked for "
-                             "samples)\n");
-            }
             sawSilenceStart = true;
         }
         for (int i = 0; i < want; ++i) {

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -418,21 +418,67 @@ int PortAudioBus::paCallback(const void* in, void* out,
         // size), the bytes at our current r have been overwritten with
         // newer samples and reading them would produce scrambled audio.
         // Jump forward to the oldest still-valid sample (w - ringSize)
-        // so we resume on contiguous, in-order audio.  Listener hears a
-        // brief silence/click rather than time-scrambled bytes.
+        // so we resume on contiguous, in-order audio.  The crossfade
+        // counter below smooths the discontinuity so the listener hears
+        // a brief volume dip instead of a hard click.
+        bool startCrossfade = false;
         if (w - r > ringSize) {
             r = w - ringSize;
+            startCrossfade = true;
         }
 
+        // Crossfade between the previous sample value and the new ring
+        // sample over kCrossfadeFrames stereo frames.  Triggered on
+        // drop-oldest catch-up AND on underrun-to-resume transitions.
+        // ~3 ms at 48 kHz / 2 channels — short enough to be inaudible as
+        // a "dip" but long enough to mask the click that a hard jump or
+        // silence-to-signal transition would otherwise produce.
+        const int channels = self->m_negFormat.channels;
+        float lastL = self->m_lastOutL;
+        float lastR = self->m_lastOutR;
+        int crossfadeRem = self->m_crossfadeFramesRem;
+        if (startCrossfade && crossfadeRem == 0) {
+            crossfadeRem = kCrossfadeFrames;
+        }
+
+        bool wasUnderrun = (r >= w);
         for (int i = 0; i < want; ++i) {
+            float target;
             if (r < w) {
-                o[i] = self->m_ring[r % ringSize];
+                target = self->m_ring[r % ringSize];
                 r++;
+                // Underrun-to-resume edge: start a fresh crossfade to
+                // bring the listener gently from silence (or stale
+                // last-sample) up to the live signal.
+                if (wasUnderrun && crossfadeRem == 0) {
+                    crossfadeRem = kCrossfadeFrames;
+                }
+                wasUnderrun = false;
             } else {
-                o[i] = 0.0f;  // underrun -> silence
+                target = 0.0f;  // underrun -> silence (with crossfade below)
+                wasUnderrun = true;
             }
+
+            // Per-channel last-sample tracking (stereo only path is
+            // exercised in practice; mono falls through cleanly).
+            float& last = ((i & 1) && channels >= 2) ? lastR : lastL;
+            if (crossfadeRem > 0) {
+                const float t = 1.0f - (static_cast<float>(crossfadeRem)
+                                        / static_cast<float>(kCrossfadeFrames));
+                o[i] = last + (target - last) * t;
+                // Decrement once per stereo frame (after the R sample).
+                if (channels < 2 || (i & 1) == 1) {
+                    crossfadeRem--;
+                }
+            } else {
+                o[i] = target;
+            }
+            last = o[i];
         }
         self->m_ringRead.store(r, std::memory_order_release);
+        self->m_lastOutL = lastL;
+        self->m_lastOutR = lastR;
+        self->m_crossfadeFramesRem = crossfadeRem;
     } else {
         // Input mode: read captured samples from `in`, write to ring,
         // update m_txLevel (the audio here is destined for transmit).

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 
 namespace NereusSDR {
@@ -311,6 +312,25 @@ void PortAudioBus::close() {
     Pa_StopStream(m_stream);
     Pa_CloseStream(m_stream);
     m_stream = nullptr;
+
+    // Bench diagnostic: dump cumulative drop / underrun counts at close.
+    // Gives the operator an objective post-session check on whether the
+    // jitter / crackle came from ring overrun (drops), underrun, or
+    // neither.
+    const quint32 drops      = m_dropEvents.load(std::memory_order_relaxed);
+    const quint64 dropSamps  = m_dropSamples.load(std::memory_order_relaxed);
+    const quint32 underruns  = m_underrunEvents.load(std::memory_order_relaxed);
+    if (drops != 0 || underruns != 0) {
+        std::fprintf(stderr,
+                     "[audio] PortAudioBus close stats: drop_events=%u "
+                     "drop_samples=%llu underrun_events=%u\n",
+                     drops,
+                     static_cast<unsigned long long>(dropSamps),
+                     underruns);
+    } else {
+        std::fprintf(stderr, "[audio] PortAudioBus close: clean (no drops "
+                             "or underruns)\n");
+    }
 }
 
 qint64 PortAudioBus::push(const char* data, qint64 bytes) {
@@ -442,6 +462,24 @@ int PortAudioBus::paCallback(const void* in, void* out,
         }
 
         bool wasUnderrun = (r >= w);
+        // Track underrun leading edge so we count distinct events, not
+        // every silent frame in a run.  Initial state (callback fired
+        // with an empty ring) counts as one event.
+        bool sawSilenceStart = false;
+        if (wasUnderrun) {
+            const quint32 prior = self->m_underrunEvents.fetch_add(
+                1, std::memory_order_relaxed);
+            if (prior == 0) {
+                // One-shot leading-edge marker so the bench operator can
+                // see in the log whether the audio crackle correlates
+                // with ring-underrun events at all.  fprintf is async-
+                // signal-safe and OK here; qCWarning would allocate.
+                std::fprintf(stderr, "[audio] PortAudioBus first underrun "
+                             "detected (ring empty when device asked for "
+                             "samples)\n");
+            }
+            sawSilenceStart = true;
+        }
         for (int i = 0; i < want; ++i) {
             float target;
             if (r < w) {
@@ -456,6 +494,11 @@ int PortAudioBus::paCallback(const void* in, void* out,
                 wasUnderrun = false;
             } else {
                 target = 0.0f;  // underrun -> silence (with crossfade below)
+                if (!wasUnderrun && !sawSilenceStart) {
+                    // Transitioned from "had data" to "empty" mid-callback.
+                    self->m_underrunEvents.fetch_add(1, std::memory_order_relaxed);
+                    sawSilenceStart = true;
+                }
                 wasUnderrun = true;
             }
 

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -208,22 +208,30 @@ PaDeviceIndex resolveDevice(const PortAudioConfig& inCfg,
 } // namespace
 
 PortAudioBus::PortAudioBus() {
-    // 200 ms stereo float ring (9600 stereo frames * 2 channels = 19200
-    // floats) at the nominal 48 kHz device rate.  Bumped from the initial
-    // 50 ms after bench showed audio jittered under CPU contention on
-    // the bench Mac: 50 ms left almost no headroom for scheduler
-    // hiccups, so drop-oldest fired audibly.  200 ms is still well
-    // below the 1-second pre-fix bug while giving enough cushion that
-    // routine paint spikes do not bleed into audio.  The writer
-    // modulo-wraps as before; the reader (paCallback) detects when the
-    // writer has stomped on its read position and skips forward to the
-    // oldest still-valid sample.  Drop-oldest overrun semantics: a
-    // CPU stall produces a brief silence gap rather than scrambled
-    // bytes.  Pre-fix the ring was 48000 * 2 (1 second) with no overrun
-    // handling, which made the display drift up to a full second ahead
-    // of audio and produced the "audio replays" symptom on stall
-    // recovery.
-    m_ring.resize(9600 * 2);
+    // 100 ms stereo float ring (4800 stereo frames * 2 channels = 9600
+    // floats) at the nominal 48 kHz device rate.  Sized as the
+    // capacity ceiling, NOT the typical fill: with the DSP-thread
+    // producer (RxDspWorker via DirectConnection lambda, see
+    // RadioModel) and a 128-frame PortAudio callback, steady-state
+    // ring level oscillates around 10-40 ms.  We sat at 200 ms
+    // briefly while diagnosing crackle on the wrong-binary bench
+    // (a missing-rebuild artifact); the underlying jitter was always
+    // a main-thread / signal-routing problem fixed by Lever 2
+    // (DirectConnection lambdas in RadioModel), not a buffer-size
+    // problem, so dropping back to 100 ms reclaims latency that the
+    // larger ring was hiding.  Worst-case audio latency through this
+    // ring is now ~100 ms (totally full) instead of ~200 ms; typical
+    // is unchanged because steady-state fill is well below either
+    // cap.  Writer modulo-wraps as before; reader (paCallback)
+    // detects when the writer has stomped on the read position and
+    // skips forward to the oldest still-valid sample.  Drop-oldest
+    // overrun semantics: a CPU stall produces a brief silence gap
+    // rather than scrambled bytes, smoothed by the kCrossfadeFrames
+    // ramp on the resume sample (see paCallback below).  Pre-fix the
+    // ring was 48000 * 2 (1 second) with no overrun handling, which
+    // made the display drift up to a full second ahead of audio and
+    // produced the "audio replays" symptom on stall recovery.
+    m_ring.resize(4800 * 2);
 }
 
 PortAudioBus::~PortAudioBus() {
@@ -293,6 +301,25 @@ bool PortAudioBus::open(const AudioFormat& format) {
     m_negFormat = format;
     m_negFormat.channels = effectiveChannels;
 
+    // Bench diagnostic 2026-05-24: dump what we actually negotiated with
+    // PortAudio so we can confirm there is no rate / buffer / device-name
+    // surprise that would explain continuous audio crackle that the
+    // sample-discontinuity detectors do not catch.
+    if (wantOutput) {
+        const PaStreamInfo* si = Pa_GetStreamInfo(m_stream);
+        std::fprintf(stderr,
+            "[audio] PortAudioBus OPEN (output) device=\"%s\" hostApi=%d "
+            "format.sampleRate=%d (requested) actualOutLatency=%.4f "
+            "negotiated_sampleRate=%.1f bufferSamples=%d channels=%d\n",
+            (di && di->name) ? di->name : "?",
+            di ? di->hostApi : -1,
+            format.sampleRate,
+            si ? si->outputLatency : -1.0,
+            si ? si->sampleRate : -1.0,
+            m_cfg.bufferSamples,
+            effectiveChannels);
+    }
+
     // Defensive null-check on host-API lookup. With a device handed back
     // by Pa_GetDefault{Output,Input}Device this should never be null, but
     // keep the backend name well-defined if it ever is.
@@ -331,6 +358,14 @@ void PortAudioBus::close() {
         std::fprintf(stderr, "[audio] PortAudioBus close: clean (no drops "
                              "or underruns)\n");
     }
+    const quint32 paUf = m_paOutputUnderflowEvents.load(std::memory_order_relaxed);
+    const quint32 paOf = m_paOutputOverflowEvents.load(std::memory_order_relaxed);
+    if (paUf != 0 || paOf != 0) {
+        std::fprintf(stderr,
+                     "[audio] PortAudioBus PA flag stats: "
+                     "paOutputUnderflow=%u paOutputOverflow=%u\n",
+                     paUf, paOf);
+    }
 }
 
 qint64 PortAudioBus::push(const char* data, qint64 bytes) {
@@ -352,10 +387,18 @@ qint64 PortAudioBus::push(const char* data, qint64 bytes) {
     const qint64 readPos = m_ringRead.load(std::memory_order_acquire);
     const qint64 afterWrite = w + floatCount;
     if (afterWrite - readPos > ringSize) {
-        m_dropEvents.fetch_add(1, std::memory_order_relaxed);
+        const quint32 prior = m_dropEvents.fetch_add(1, std::memory_order_relaxed);
         m_dropSamples.fetch_add(
             static_cast<quint64>(afterWrite - readPos - ringSize),
             std::memory_order_relaxed);
+        if (prior == 0) {
+            // One-shot marker so the bench operator can correlate
+            // crackle-onset with the first drop-oldest event.  fprintf
+            // is async-signal-safe; qCWarning would allocate.
+            std::fprintf(stderr, "[audio] PortAudioBus first drop-oldest "
+                                 "event (writer outran reader by more "
+                                 "than ring size)\n");
+        }
     }
 
     float peak = 0.0f;
@@ -421,10 +464,38 @@ qint64 PortAudioBus::pull(char* data, qint64 maxBytes) {
 int PortAudioBus::paCallback(const void* in, void* out,
                              unsigned long frames,
                              const PaStreamCallbackTimeInfo* /*timeInfo*/,
-                             unsigned long /*flags*/,
+                             unsigned long flags,
                              void* userData) {
     PortAudioBus* self = static_cast<PortAudioBus*>(userData);
     const qint64 ringSize = static_cast<qint64>(self->m_ring.size());
+
+    // Bench diagnostic 2026-05-24: PortAudio reports backend-level
+    // anomalies via the `flags` parameter.  We previously ignored these
+    // entirely.  paOutputUnderflow = the audio device played silence
+    // because we did not supply samples fast enough at the OS layer
+    // (independent of our internal ring); paOutputOverflow = data we
+    // pushed was discarded.  Either would produce continuous audible
+    // clicks that none of our ring-side diagnostics catch.
+    if (flags & paOutputUnderflow) {
+        const quint32 prior = self->m_paOutputUnderflowEvents.fetch_add(
+            1, std::memory_order_relaxed);
+        if (prior == 0) {
+            std::fprintf(stderr, "[audio] PortAudioBus FIRST paOutputUnderflow "
+                                 "flag from device (CoreAudio reported it ran "
+                                 "out of samples to play)\n");
+        }
+    }
+    if (flags & paOutputOverflow) {
+        const quint32 prior = self->m_paOutputOverflowEvents.fetch_add(
+            1, std::memory_order_relaxed);
+        if (prior == 0) {
+            std::fprintf(stderr, "[audio] PortAudioBus FIRST paOutputOverflow "
+                                 "flag from device\n");
+        }
+    }
+    if (flags & paPrimingOutput) {
+        // Expected during stream startup; not a problem.
+    }
 
     if (self->m_cfg.direction == AudioDirection::Output) {
         float* o = static_cast<float*>(out);

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -207,19 +207,22 @@ PaDeviceIndex resolveDevice(const PortAudioConfig& inCfg,
 } // namespace
 
 PortAudioBus::PortAudioBus() {
-    // 50 ms stereo float ring (2400 stereo frames * 2 channels = 4800 floats)
-    // at the nominal 48 kHz device rate.  Sized for lowest perceptible
-    // display-vs-audio latency while leaving roughly 5x headroom over the
-    // typical CoreAudio low-latency callback (~10 ms / 480 frames).  The
-    // writer modulo-wraps as before; the reader (paCallback) detects when
-    // the writer has stomped on its read position and skips forward to the
-    // oldest still-valid sample, producing drop-oldest overrun semantics.
-    // Audible result of a CPU stall or clock-drift overflow: a brief
-    // silence gap rather than scrambled bytes.  Pre-fix the ring was
-    // 48000 * 2 (1 second) with no overrun handling, which made the
-    // display drift up to a full second ahead of audio and produced the
-    // "audio replays" symptom on stall recovery.
-    m_ring.resize(2400 * 2);
+    // 200 ms stereo float ring (9600 stereo frames * 2 channels = 19200
+    // floats) at the nominal 48 kHz device rate.  Bumped from the initial
+    // 50 ms after bench showed audio jittered under CPU contention on
+    // the bench Mac: 50 ms left almost no headroom for scheduler
+    // hiccups, so drop-oldest fired audibly.  200 ms is still well
+    // below the 1-second pre-fix bug while giving enough cushion that
+    // routine paint spikes do not bleed into audio.  The writer
+    // modulo-wraps as before; the reader (paCallback) detects when the
+    // writer has stomped on its read position and skips forward to the
+    // oldest still-valid sample.  Drop-oldest overrun semantics: a
+    // CPU stall produces a brief silence gap rather than scrambled
+    // bytes.  Pre-fix the ring was 48000 * 2 (1 second) with no overrun
+    // handling, which made the display drift up to a full second ahead
+    // of audio and produced the "audio replays" symptom on stall
+    // recovery.
+    m_ring.resize(9600 * 2);
 }
 
 PortAudioBus::~PortAudioBus() {

--- a/src/core/audio/PortAudioBus.cpp
+++ b/src/core/audio/PortAudioBus.cpp
@@ -207,11 +207,19 @@ PaDeviceIndex resolveDevice(const PortAudioConfig& inCfg,
 } // namespace
 
 PortAudioBus::PortAudioBus() {
-    // 1 second stereo float ring at the nominal default rate. The push
-    // path wraps modulo ring size, so a longer stream than 1 s simply
-    // overwrites the oldest unread samples (underruns surface as silence
-    // in paCallback, not overruns).
-    m_ring.resize(48000 * 2);
+    // 50 ms stereo float ring (2400 stereo frames * 2 channels = 4800 floats)
+    // at the nominal 48 kHz device rate.  Sized for lowest perceptible
+    // display-vs-audio latency while leaving roughly 5x headroom over the
+    // typical CoreAudio low-latency callback (~10 ms / 480 frames).  The
+    // writer modulo-wraps as before; the reader (paCallback) detects when
+    // the writer has stomped on its read position and skips forward to the
+    // oldest still-valid sample, producing drop-oldest overrun semantics.
+    // Audible result of a CPU stall or clock-drift overflow: a brief
+    // silence gap rather than scrambled bytes.  Pre-fix the ring was
+    // 48000 * 2 (1 second) with no overrun handling, which made the
+    // display drift up to a full second ahead of audio and produced the
+    // "audio replays" symptom on stall recovery.
+    m_ring.resize(2400 * 2);
 }
 
 PortAudioBus::~PortAudioBus() {
@@ -309,6 +317,24 @@ qint64 PortAudioBus::push(const char* data, qint64 bytes) {
     const qint64 ringSize = static_cast<qint64>(m_ring.size());
     qint64 w = m_ringWrite.load(std::memory_order_relaxed);
     const float* in = reinterpret_cast<const float*>(data);
+
+    // Drop-oldest accounting: if this push would put the writer more than
+    // one ring's worth ahead of the reader, the oldest unread samples
+    // about to be modulo-overwritten are effectively dropped.  We do NOT
+    // advance m_ringRead from here (that would race with paCallback's own
+    // store; only the audio thread writes to m_ringRead).  Instead the
+    // paCallback detects the same condition on its next entry and skips
+    // forward to the oldest still-valid sample.  Counting the event here
+    // gives diagnostics a single producer-side perspective.
+    const qint64 readPos = m_ringRead.load(std::memory_order_acquire);
+    const qint64 afterWrite = w + floatCount;
+    if (afterWrite - readPos > ringSize) {
+        m_dropEvents.fetch_add(1, std::memory_order_relaxed);
+        m_dropSamples.fetch_add(
+            static_cast<quint64>(afterWrite - readPos - ringSize),
+            std::memory_order_relaxed);
+    }
+
     float peak = 0.0f;
     for (int i = 0; i < floatCount; ++i) {
         m_ring[w % ringSize] = in[i];
@@ -383,6 +409,17 @@ int PortAudioBus::paCallback(const void* in, void* out,
 
         qint64 r = self->m_ringRead.load(std::memory_order_relaxed);
         const qint64 w = self->m_ringWrite.load(std::memory_order_acquire);
+
+        // Drop-oldest catch-up: if we have fallen so far behind that the
+        // writer stomped on our read position (w - r exceeds the ring
+        // size), the bytes at our current r have been overwritten with
+        // newer samples and reading them would produce scrambled audio.
+        // Jump forward to the oldest still-valid sample (w - ringSize)
+        // so we resume on contiguous, in-order audio.  Listener hears a
+        // brief silence/click rather than time-scrambled bytes.
+        if (w - r > ringSize) {
+            r = w - ringSize;
+        }
 
         for (int i = 0; i < want; ++i) {
             if (r < w) {

--- a/src/core/audio/PortAudioBus.h
+++ b/src/core/audio/PortAudioBus.h
@@ -124,6 +124,19 @@ private:
     std::atomic<quint32> m_dropEvents{0};
     std::atomic<quint64> m_dropSamples{0};
 
+    // Crossfade state for discontinuity smoothing in paCallback.  Only
+    // read / written from the audio callback (single-threaded by
+    // PortAudio contract), so plain non-atomic floats are safe.
+    // m_lastOutL / m_lastOutR hold the last sample emitted to each
+    // channel; the crossfade ramps from those values up to the next
+    // ring sample over kCrossfadeFrames stereo frames whenever a
+    // drop-oldest catch-up OR an underrun-to-resume transition is
+    // detected.
+    static constexpr int kCrossfadeFrames = 128;  // ~2.7 ms at 48 kHz
+    float m_lastOutL{0.0f};
+    float m_lastOutR{0.0f};
+    int   m_crossfadeFramesRem{0};
+
     static int paCallback(const void* in, void* out,
                           unsigned long frames,
                           const PaStreamCallbackTimeInfo* timeInfo,

--- a/src/core/audio/PortAudioBus.h
+++ b/src/core/audio/PortAudioBus.h
@@ -85,6 +85,23 @@ public:
     AudioFormat negotiatedFormat() const override { return m_negFormat; }
     QString     errorString() const override { return m_err; }
 
+    // Diagnostics: drop-oldest overrun accounting.  Output-mode push()
+    // counts the event + samples lost every time the writer outruns the
+    // reader by more than the ring's size.  paCallback then performs the
+    // catch-up jump on its next entry.  Reset by clearDropStats().  Both
+    // counters are loaded with relaxed semantics; they are observational
+    // only and not safety-critical.
+    quint32 ringOverrunEvents() const {
+        return m_dropEvents.load(std::memory_order_relaxed);
+    }
+    quint64 ringOverrunSamples() const {
+        return m_dropSamples.load(std::memory_order_relaxed);
+    }
+    void clearDropStats() {
+        m_dropEvents.store(0, std::memory_order_relaxed);
+        m_dropSamples.store(0, std::memory_order_relaxed);
+    }
+
 private:
     PaStream*       m_stream{nullptr};
     PortAudioConfig m_cfg;
@@ -101,6 +118,11 @@ private:
 
     std::atomic<float> m_rxLevel{0.0f};
     std::atomic<float> m_txLevel{0.0f};
+
+    // Drop-oldest accounting (see ringOverrunEvents above).  Producer-only
+    // writers (push() on the DSP thread); observers read.
+    std::atomic<quint32> m_dropEvents{0};
+    std::atomic<quint64> m_dropSamples{0};
 
     static int paCallback(const void* in, void* out,
                           unsigned long frames,

--- a/src/core/audio/PortAudioBus.h
+++ b/src/core/audio/PortAudioBus.h
@@ -97,9 +97,13 @@ public:
     quint64 ringOverrunSamples() const {
         return m_dropSamples.load(std::memory_order_relaxed);
     }
+    quint32 ringUnderrunEvents() const {
+        return m_underrunEvents.load(std::memory_order_relaxed);
+    }
     void clearDropStats() {
         m_dropEvents.store(0, std::memory_order_relaxed);
         m_dropSamples.store(0, std::memory_order_relaxed);
+        m_underrunEvents.store(0, std::memory_order_relaxed);
     }
 
 private:
@@ -123,6 +127,12 @@ private:
     // writers (push() on the DSP thread); observers read.
     std::atomic<quint32> m_dropEvents{0};
     std::atomic<quint64> m_dropSamples{0};
+
+    // Underrun accounting: paCallback increments on the leading edge of
+    // every silence run (ring empty when audio device asked for samples).
+    // Counts distinct events, not silent frames.  Bench diagnostic for
+    // the audio jitter / crackle hunt.
+    std::atomic<quint32> m_underrunEvents{0};
 
     // Crossfade state for discontinuity smoothing in paCallback.  Only
     // read / written from the audio callback (single-threaded by

--- a/src/core/audio/PortAudioBus.h
+++ b/src/core/audio/PortAudioBus.h
@@ -39,7 +39,16 @@ struct PortAudioConfig {
     AudioDirection direction = AudioDirection::Output;  // Output = render; Input = capture
     int     hostApiIndex  = -1;     // -1 = PortAudio default
     QString deviceName;             // empty = default
-    int     bufferSamples = 256;
+    // 128 frames @ 48 kHz = 2.67 ms per callback. On macOS this maps
+    // to a CoreAudio HAL output latency of ~10-12 ms (CoreAudio
+    // queues ~4 buffers).  Was 256 (22 ms PA latency); reduced to
+    // shave ~11 ms off the end-to-end RX path now that the upstream
+    // jitter (main-thread I/Q dispatch) has been fixed by Lever 2.
+    // 128 is still well above any sensible Apple Silicon minimum and
+    // doubles callback rate vs. 256, but Apple's audio I/O thread is
+    // RT-prio and trivially handles this.  If a slower platform
+    // shows stress here, the call site can override via setConfig().
+    int     bufferSamples = 128;
     bool    exclusiveMode = false;  // WASAPI only
 };
 
@@ -133,6 +142,15 @@ private:
     // Counts distinct events, not silent frames.  Bench diagnostic for
     // the audio jitter / crackle hunt.
     std::atomic<quint32> m_underrunEvents{0};
+
+    // PortAudio backend-reported anomalies via the callback's flags
+    // parameter.  paOutputUnderflow = the OS audio device ran out of
+    // samples; paOutputOverflow = data we supplied was discarded.
+    // Distinct from m_underrunEvents (our ring-side check) — these
+    // come from the OS/CoreAudio layer regardless of what our ring
+    // looks like.
+    std::atomic<quint32> m_paOutputUnderflowEvents{0};
+    std::atomic<quint32> m_paOutputOverflowEvents{0};
 
     // Crossfade state for discontinuity smoothing in paCallback.  Only
     // read / written from the audio callback (single-threaded by

--- a/src/gui/HGauge.cpp
+++ b/src/gui/HGauge.cpp
@@ -18,8 +18,23 @@ void HGauge::setRedStart(double val) { m_redStart = val; update(); }
 void HGauge::setReversed(bool rev) { m_reversed = rev; update(); }
 void HGauge::setTitle(const QString& t) { m_title = t; update(); }
 void HGauge::setUnit(const QString& u) { m_unit = u; update(); }
-void HGauge::setValue(double val) { m_value = val; update(); }
-void HGauge::setPeakValue(double val) { m_peak = val; update(); }
+void HGauge::setValue(double val) {
+    // Value-change guard: skip the repaint when the new sample matches the
+    // current one within FP noise.  HGauge is driven by many fast timers
+    // (TxApplet fwd / SWR at 20 Hz, PhoneCwApplet mic at 20 Hz, VaxApplet
+    // levels at 60 Hz aggregate, AudioTxInputPage VU at 100 Hz, etc.).  When
+    // the signal is quiet or steady, suppressing the redundant update() cuts
+    // a large chunk of the main-thread paint load that was driving the
+    // QCALayerBackingStore::recreateBackBufferIfNeeded thrash on macOS.
+    if (qFuzzyCompare(1.0 + m_value, 1.0 + val)) { return; }
+    m_value = val;
+    update();
+}
+void HGauge::setPeakValue(double val) {
+    if (qFuzzyCompare(1.0 + m_peak, 1.0 + val)) { return; }
+    m_peak = val;
+    update();
+}
 void HGauge::setTickLabels(const QStringList& labels) { m_tickLabels = labels; update(); }
 
 void HGauge::paintEvent(QPaintEvent*)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -487,11 +487,16 @@ MainWindow::MainWindow(QWidget* parent)
 
     // Wire the MasterOutputWidget device picker → AudioEngine so picking
     // an output device rebuilds the speakers bus. Task 10b exposes only
-    // the deviceName; AudioEngine::makeBus fills in sensible defaults
-    // (sample rate 48 kHz stereo, default buffer) per AudioEngine.h:165.
+    // the deviceName; we load the rest of the persisted speakers config
+    // (sampleRate / channels / bufferSamples / exclusiveMode / etc.) so
+    // the user's tuned values are preserved across a device change.  A
+    // bare default-constructed AudioDeviceConfig with only deviceName
+    // set would otherwise clobber persisted fields, defeating the
+    // Setup → Devices page entirely.
     connect(m_titleBar->masterOutput(), &MasterOutputWidget::outputDeviceChanged,
             this, [this](const QString& name) {
-        AudioDeviceConfig cfg;
+        AudioDeviceConfig cfg = AudioDeviceConfig::loadFromSettings(
+            QStringLiteral("audio/Speakers"));
         cfg.deviceName = name;
         if (auto* engine = m_radioModel->audioEngine()) {
             engine->setSpeakersConfig(cfg);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1249,7 +1249,24 @@ void MainWindow::buildUI()
         }
     });
     m_fftEngine->setFftSize(4096);
-    m_fftEngine->setOutputFps(30);
+    // Spectrum/waterfall FPS — load persisted value (default 30), apply to
+    // BOTH the FFT engine (row production cadence) and the SpectrumWidget
+    // display timer (paint cadence) so the two stay locked.  Without this
+    // load, FFTEngine defaulted to 30 and SpectrumWidget defaulted to its
+    // own 30 fps constructor value, but Setup -> Display -> Spectrum
+    // changes did not survive restart.  Persistence write side is in
+    // SpectrumDefaultsPage::pushFps.
+    {
+        const int persistedFps = qBound(1,
+            AppSettings::instance().value(
+                QStringLiteral("DisplaySpectrumFps"),
+                QStringLiteral("30")).toString().toInt(),
+            60);
+        m_fftEngine->setOutputFps(persistedFps);
+        if (m_spectrumWidget) {
+            m_spectrumWidget->setDisplayFps(persistedFps);
+        }
+    }
     // Hz/bin target — persisted in Setup → Display → Spectrum Defaults.
     // 0 = bins-in-window default (2026-05-08 Option 3).
     m_fftEngine->setHzPerBinTarget(

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -65,6 +65,13 @@ SMeterWidget::SMeterWidget(QWidget* parent)
     setMinimumSize(minimumSizeHint());
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
+    // Performance: paintEvent fills rect() opaquely as the first step
+    // (line ~443).  Tell Qt this widget needs no transparent compositing
+    // pass under it — Qt skips the parent backing-store rebuild and saves
+    // one IOSurface memmove per paint.  SMeterWidget paints at 30 Hz
+    // (needle animation) + on peak decay (20 Hz), so this fires frequently.
+    setAttribute(Qt::WA_OpaquePaintEvent);
+
     m_needleFraction = dbmToFraction(m_levelDbm);
     m_targetNeedleFraction = m_needleFraction;
     m_peakHoldDecayStartDbm = m_peakHoldDbm;

--- a/src/gui/SMeterWidget.cpp
+++ b/src/gui/SMeterWidget.cpp
@@ -120,6 +120,16 @@ SMeterWidget::SMeterWidget(QWidget* parent)
 
 void SMeterWidget::setLevel(float dbm)
 {
+    // Sub-perceivable change guard.  MeterPoller pushes this 10 times a
+    // second; radio noise causes the dBm reading to wiggle by a few tenths
+    // even on a quiet band.  Below 0.5 dB the needle position is the same
+    // pixel and the S-unit text doesn't change.  Skipping the animation
+    // rebuild + repaint for those sub-threshold ticks was the largest
+    // single contributor to the macOS paint-pipeline saturation observed
+    // in the 2026-05-24 bench profile.
+    if (std::abs(dbm - m_levelDbm) < 0.5f) {
+        return;
+    }
     m_levelDbm = dbm;
 
     // Peak hold (existing needle/triangle behavior)
@@ -313,7 +323,17 @@ void SMeterWidget::animateNeedle()
         m_needleAnimation.stop();
     }
 
-    update();
+    // Visual-change guard.  The animation tick computes a new needle
+    // fraction every 33 ms, but when the needle is settled or moving by
+    // sub-pixel amounts the repaint is wasted work (paintEvent is the
+    // single most expensive widget paint in the app per profile).  Skip
+    // the update() unless the needle moved by at least 0.005 (1 pixel
+    // on a 200 px arc) OR the peak hold marker is animating its decay.
+    if (std::abs(m_needleFraction - m_lastDrawnNeedleFraction) > 0.005f
+        || peakHoldAnimating) {
+        m_lastDrawnNeedleFraction = m_needleFraction;
+        update();
+    }
 }
 
 // From AetherSDR src/gui/SMeterWidget.cpp:214-231 [@0cd4559]

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -197,6 +197,12 @@ private:
     float   m_peakDbm{-127.0f};     // RX peak hold
     QString m_source{"S-Meter Peak"};
 
+    // Visual-change guard for animateNeedle's update() throttle.  Stores
+    // the needle fraction last drawn so we can skip the repaint when the
+    // physics tick produces sub-pixel movement.  Initialised to a value
+    // outside the valid 0..1 range so the first frame always paints.
+    float   m_lastDrawnNeedleFraction{-1.0f};
+
     // TX meter values (updated continuously, used when transmitting)
     // From AetherSDR src/gui/SMeterWidget.h:86-89 [@0cd4559]
     float   m_txPower{0.0f};

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -242,11 +242,12 @@ private:
     static constexpr float DB_PER_S = 6.0f;
 
     // From AetherSDR src/gui/SMeterWidget.h:119-122 [@0cd4559]
-    // NereusSDR bench-2026-05-24: bumped 8 -> 16 ms (125 Hz -> 62.5 Hz).
+    // NereusSDR bench-2026-05-24: bumped 8 -> 33 ms (125 Hz -> 30 Hz).
     // The 8 ms tick was a primary contributor to macOS QCALayerBackingStore
-    // backing-store thrash; 60 Hz still looks smooth to the eye for needle
-    // motion and cuts the needle's paint load in half.
-    static constexpr int kNeedleAnimationIntervalMs = 16;
+    // backing-store thrash; first cut to 16 ms helped some but the bench
+    // was still jittery.  30 Hz still looks smooth for needle motion and
+    // matches our spectrum / waterfall display cadence.
+    static constexpr int kNeedleAnimationIntervalMs = 33;
     static constexpr float kNeedleAttackTimeSeconds = 0.045f;
     static constexpr float kNeedleReleaseTimeSeconds = 0.180f;
     static constexpr float kNeedleSnapEpsilon = 0.001f;

--- a/src/gui/SMeterWidget.h
+++ b/src/gui/SMeterWidget.h
@@ -242,7 +242,11 @@ private:
     static constexpr float DB_PER_S = 6.0f;
 
     // From AetherSDR src/gui/SMeterWidget.h:119-122 [@0cd4559]
-    static constexpr int kNeedleAnimationIntervalMs = 8;
+    // NereusSDR bench-2026-05-24: bumped 8 -> 16 ms (125 Hz -> 62.5 Hz).
+    // The 8 ms tick was a primary contributor to macOS QCALayerBackingStore
+    // backing-store thrash; 60 Hz still looks smooth to the eye for needle
+    // motion and cuts the needle's paint load in half.
+    static constexpr int kNeedleAnimationIntervalMs = 16;
     static constexpr float kNeedleAttackTimeSeconds = 0.045f;
     static constexpr float kNeedleReleaseTimeSeconds = 0.180f;
     static constexpr float kNeedleSnapEpsilon = 0.001f;

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -365,19 +365,14 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
     // the frequency scale bar inside the QRhiWidget's own mouse press/drag events
     // (which DO work when a button is pressed).
 
-    // Timer-driven display repaint — decouples repaint rate from FFT data arrival
-    // so updates are evenly spaced regardless of IQ buffer fill timing.
-    // Bench-2026-05-25: restored 33 ms (30 fps).  Dropped to 50 ms on
-    // 2026-05-24 to cut paint CPU, but that created a cadence mismatch
-    // with FFTEngine::setOutputFps(30) — FFT produced a waterfall row
-    // every 33 ms, display painted every 50 ms, each paint pulled
-    // either 1 or 2 rows depending on phase.  Operator perceived this
-    // as visibly stuttery scroll.  With the QStaticText label cache,
-    // opaque-paint-event hints, and MeterWidget per-binding fuzzy
-    // guards landing in the same session, CPU has the headroom for
-    // 30 fps paint.  Default ships at 30 fps; setDisplayFps() lets
-    // Setup -> Display drive it to anything in [1, 60] and the
-    // persisted DisplaySpectrumFps key restores it across launches.
+    // Timer-driven display repaint decouples paint rate from FFT data
+    // arrival, so the displayed frames are evenly spaced regardless of
+    // I/Q buffer fill timing.  Default 30 fps matches the FFT engine's
+    // default output rate (FFTEngine::setOutputFps(30) in MainWindow),
+    // so each paint pulls exactly one fresh waterfall row in steady
+    // state.  setDisplayFps() lets Setup -> Display drive this to
+    // anything in [1, 60] and the persisted DisplaySpectrumFps key
+    // restores it across launches.
     static constexpr int kDefaultDisplayFps = 30;
     m_displayTimer.setInterval(1000 / kDefaultDisplayFps); // 33 ms
     m_displayTimer.setSingleShot(false);

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -333,7 +333,13 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
 
     // Timer-driven display repaint — decouples repaint rate from FFT data arrival
     // so updates are evenly spaced regardless of IQ buffer fill timing.
-    m_displayTimer.setInterval(33); // 30 fps default
+    // Bench-2026-05-24: bumped 33 ms (30 fps) -> 50 ms (20 fps).  Spectrum
+    // widget covers most of the window area; each repaint blits a large
+    // pixel region via the macOS raster composite path.  Profile showed
+    // this as a dominant contributor to QCALayerBackingStore activity.
+    // 20 fps is still smooth for waterfall + spectrum traces and cuts the
+    // per-frame blit budget by a third.
+    m_displayTimer.setInterval(50); // 20 fps default
     m_displayTimer.setSingleShot(false);
     connect(&m_displayTimer, &QTimer::timeout, this, [this]() {
         if (m_hasNewSpectrum) {

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -154,6 +154,40 @@
 
 namespace NereusSDR {
 
+// Visual-equality helper for the spot-marker repaint guard.  Drops a
+// redundant overlay repaint whenever a spot-client poll lands on an
+// unchanged set (frequent in steady state — DX cluster + WSJT-X +
+// FreeDV Reporter all repeat the same active station entries every
+// few seconds, and the drawSpotMarkers path is the most expensive
+// item on the overlay canvas).
+//
+// From AetherSDR src/gui/SpectrumWidget.cpp [@a173272d] PR #2474
+// ("Avoid unchanged spot overlay repaints").  Same comparison fields
+// (callsign / freqMhz / color / dxccColor / source) — non-visual
+// fields like spotterCallsign / comment / timestampMs intentionally
+// excluded so a comment-only update does not force a repaint.
+static bool spotMarkersVisuallyEqual(const QVector<SpectrumWidget::SpotMarker>& lhs,
+                                     const QVector<SpectrumWidget::SpotMarker>& rhs)
+{
+    constexpr double kFrequencyEpsilonMhz = 1.0e-6;
+
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (qsizetype i = 0; i < lhs.size(); ++i) {
+        const SpectrumWidget::SpotMarker& a = lhs.at(i);
+        const SpectrumWidget::SpotMarker& b = rhs.at(i);
+        if (a.callsign != b.callsign
+            || std::abs(a.freqMhz - b.freqMhz) > kFrequencyEpsilonMhz
+            || a.color != b.color
+            || a.dxccColor != b.dxccColor
+            || a.source != b.source) {
+            return false;
+        }
+    }
+    return true;
+}
+
 // ---- Default waterfall gradient stops (AetherSDR style) ----
 // From AetherSDR SpectrumWidget.cpp:43-51
 static const WfGradientStop kDefaultStops[] = {
@@ -3398,8 +3432,30 @@ void SpectrumWidget::drawFreqScale(QPainter& p, const QRect& r)
             label = QString::number(mhz, 'f', 3);
         }
 
-        QRect textRect(x - 30, r.top() + 2, 60, r.height() - 2);
-        p.drawText(textRect, baseFlags, label);
+        // Cached QStaticText render — see m_freqLabelCache comment in
+        // SpectrumWidget.h.  Working set grows as the user pans but
+        // converges quickly because the format strings repeat.
+        auto cit = m_freqLabelCache.find(label);
+        if (cit == m_freqLabelCache.end()) {
+            QStaticText st(label);
+            st.setPerformanceHint(QStaticText::AggressiveCaching);
+            cit = m_freqLabelCache.insert(label, std::move(st));
+        }
+        cit.value().prepare(p.transform(), font);
+
+        // Position the cached text inside the same 60-wide rect that
+        // drawText was using, honoring the configured alignment.  The
+        // rect itself isn't drawn; it's only used to anchor the label.
+        const QRectF textRect(x - 30, r.top() + 2, 60, r.height() - 2);
+        const QSizeF labelSize = cit.value().size();
+        qreal lx = textRect.left();   // AlignLeft default
+        if (baseFlags & Qt::AlignHCenter) {
+            lx = textRect.center().x() - labelSize.width() / 2.0;
+        } else if (baseFlags & Qt::AlignRight) {
+            lx = textRect.right() - labelSize.width();
+        }
+        const qreal ly = textRect.center().y() - labelSize.height() / 2.0;
+        p.drawStaticText(QPointF(lx, ly), cit.value());
     }
 }
 
@@ -3452,6 +3508,12 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
     const float bottomDbm  = m_refLevel - m_dynamicRange;
     const float firstLabel = std::ceil(bottomDbm / stepDb) * stepDb;
 
+    // drawStaticText anchors at the top-left of the glyph run; drawText
+    // anchors at the baseline.  The original baseline-y was
+    // (y + ascent/2); to keep visual-identical placement, drawStaticText
+    // takes y = (y + ascent/2) - ascent = y - ascent/2.
+    const qreal staticAscent = fm.ascent();
+
     for (float dbm = firstLabel; dbm <= m_refLevel; dbm += stepDb) {
         // Route through dbmToY() so m_dbmCalOffset is applied consistently with
         // the grid/trace/peak-hold paths — otherwise a non-zero cal offset would
@@ -3463,10 +3525,24 @@ void SpectrumWidget::drawDbmScale(QPainter& p, const QRect& specRect)
         p.setPen(QColor(0x50, 0x70, 0x80));
         p.drawLine(strip.left(), y, strip.left() + 4, y);
 
-        // Label
+        // Label — QStaticText cache: HarfBuzz shapes each unique string
+        // exactly once over the widget lifetime.  See m_dbmLabelCache
+        // comment in SpectrumWidget.h for rationale + AetherSDR cite.
         const QString label = QString::number(static_cast<int>(dbm));
+        auto cit = m_dbmLabelCache.find(label);
+        if (cit == m_dbmLabelCache.end()) {
+            QStaticText st(label);
+            st.setPerformanceHint(QStaticText::AggressiveCaching);
+            cit = m_dbmLabelCache.insert(label, std::move(st));
+        }
+        // prepare() with the painter's actual transform avoids a
+        // first-paint rebuild on HiDPI displays.
+        cit.value().prepare(p.transform(), f);
+
         p.setPen(QColor(0x80, 0xa0, 0xb0));
-        p.drawText(strip.left() + 6, y + fm.ascent() / 2, label);
+        p.drawStaticText(
+            QPointF(strip.left() + 6, y - staticAscent / 2.0),
+            cit.value());
     }
 }
 
@@ -4715,9 +4791,14 @@ std::pair<int,int> SpectrumWidget::txAudioToIq(int audioLow, int audioHigh,
 // ---------------------------------------------------------------------------
 
 // From AetherSDR src/gui/SpectrumWidget.cpp:4303-4307 [@0cd4559]
+// Repaint guard added per AetherSDR [@a173272d] PR #2474.
 void SpectrumWidget::setSpotMarkers(const QVector<SpotMarker>& markers)
 {
+    const bool visualChange = !spotMarkersVisuallyEqual(m_spotMarkers, markers);
     m_spotMarkers = markers;
+    if (!visualChange) {
+        return;
+    }
     update();
 }
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -2604,14 +2604,37 @@ void SpectrumWidget::updateSpectrumLinear(int receiverId,
     // overlay is toggled off — saves a cold-start visual jump on toggle on.
     processNoiseFloor();
 
-    // Per-frame force-dirty for any overlay that updates every spectrum
-    // frame (APH trace decay, peak blobs, NF lerp position).  GPU-only
-    // optimization — CPU paint path repaints the overlay every frame
-    // anyway, so the dirty flag has no analogue.
+    // 2026-05-25 perf fix: this block USED to force the ENTIRE GPU
+    // overlay texture (freq scale, dBm strip, bandplan, time scale,
+    // VFO marker, spots, waterfall chrome, peak hold trace, peak blobs,
+    // NF text/line — ~16 paint ops + a full window-size QImage fill
+    // and GPU texture upload) to rebuild on EVERY spectrum frame
+    // whenever any of three features were enabled.
+    //
+    // At 30 fps with default DisplayPeakBlobsEnabled=True /
+    // DisplayShowNoiseFloor=True that was:
+    //   * 30 × ~16 paint ops/sec = ~480 paint ops/sec for the overlay
+    //   * 30 × full window QImage fill (memset transparent)
+    //   * 30 × full overlay texture upload to GPU
+    // and defeated the m_overlayStaticDirty cache entirely — instead
+    // of "rebuild on state change" it became "rebuild every frame".
+    // Profile showed the overlay rebuild dominating main-thread CPU
+    // and saturating the 6-core raster thread pool at ~120% total.
+    //
+    // Rate-limit to ~10 Hz instead of 30 Hz.  Active peak hold trace,
+    // peak blobs and noise floor all have visible motion much slower
+    // than 30 Hz; 10 Hz overlay refresh is indistinguishable to the
+    // operator's eye but cuts the overlay rebuild work by ~67%.
+    // Other dirty-triggering setters (bandwidth, refLevel, etc.) still
+    // mark dirty immediately, so user interaction stays snappy.
 #ifdef NEREUS_GPU_SPECTRUM
     if (m_activePeakHold.enabled() || m_peakBlobs.enabled()
         || m_showNoiseFloor) {
-        m_overlayStaticDirty = true;
+        const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+        if (nowMs - m_overlayDynamicDirtyMs >= 100) {  // 10 Hz cap
+            m_overlayStaticDirty = true;
+            m_overlayDynamicDirtyMs = nowMs;
+        }
     }
 #endif
 

--- a/src/gui/SpectrumWidget.cpp
+++ b/src/gui/SpectrumWidget.cpp
@@ -367,13 +367,19 @@ SpectrumWidget::SpectrumWidget(QWidget* parent)
 
     // Timer-driven display repaint — decouples repaint rate from FFT data arrival
     // so updates are evenly spaced regardless of IQ buffer fill timing.
-    // Bench-2026-05-24: bumped 33 ms (30 fps) -> 50 ms (20 fps).  Spectrum
-    // widget covers most of the window area; each repaint blits a large
-    // pixel region via the macOS raster composite path.  Profile showed
-    // this as a dominant contributor to QCALayerBackingStore activity.
-    // 20 fps is still smooth for waterfall + spectrum traces and cuts the
-    // per-frame blit budget by a third.
-    m_displayTimer.setInterval(50); // 20 fps default
+    // Bench-2026-05-25: restored 33 ms (30 fps).  Dropped to 50 ms on
+    // 2026-05-24 to cut paint CPU, but that created a cadence mismatch
+    // with FFTEngine::setOutputFps(30) — FFT produced a waterfall row
+    // every 33 ms, display painted every 50 ms, each paint pulled
+    // either 1 or 2 rows depending on phase.  Operator perceived this
+    // as visibly stuttery scroll.  With the QStaticText label cache,
+    // opaque-paint-event hints, and MeterWidget per-binding fuzzy
+    // guards landing in the same session, CPU has the headroom for
+    // 30 fps paint.  Default ships at 30 fps; setDisplayFps() lets
+    // Setup -> Display drive it to anything in [1, 60] and the
+    // persisted DisplaySpectrumFps key restores it across launches.
+    static constexpr int kDefaultDisplayFps = 30;
+    m_displayTimer.setInterval(1000 / kDefaultDisplayFps); // 33 ms
     m_displayTimer.setSingleShot(false);
     connect(&m_displayTimer, &QTimer::timeout, this, [this]() {
         if (m_hasNewSpectrum) {
@@ -4512,7 +4518,17 @@ void SpectrumWidget::setHighSwrOverlay(bool active, bool foldback) noexcept
 void SpectrumWidget::setDisplayFps(int fps)
 {
     const int clamped = qBound(1, fps, 60);
-    m_displayTimer.setInterval(1000 / clamped);
+    const int periodMs = 1000 / clamped;
+    m_displayTimer.setInterval(periodMs);
+    // Lock the waterfall-row throttle to the same period so a burst of
+    // FFT results arriving within one paint frame coalesces to exactly
+    // one new row.  Without this sync, paint cadence and waterfall
+    // cadence drift relative to each other (e.g. paint=33 ms but
+    // m_wfUpdatePeriodMs=30 ms left over from a prior setting), so
+    // some paints see 1 new row and others see 2 — perceived by the
+    // operator as stuttery scroll.  Matching the periods makes the
+    // ratio exactly 1:1 regardless of upstream packet bursts.
+    m_wfUpdatePeriodMs = periodMs;
     // Averaging alphas depend on fps via Thetis α = exp(-1/(fps×τ)).
     // Recompute so the smoothing time constants stay correct after a rate change.
     recomputeAverageAlphas();

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -1890,6 +1890,14 @@ private:
     bool   m_overlayStaticDirty{true};
     bool   m_overlayNeedsUpload{true};
 
+    // 2026-05-25 perf fix: timestamp of the last per-frame "dynamic
+    // overlay" force-dirty in updateSpectrumLinear.  Rate-limits the
+    // overlay rebuild for Active Peak Hold / Peak Blobs / Noise Floor
+    // (all features that previously rebuilt the FULL overlay on every
+    // 30 Hz spectrum frame, defeating the cache).  See the rationale
+    // at SpectrumWidget.cpp around the "perf fix" comment block.
+    qint64 m_overlayDynamicDirtyMs{0};
+
     // ---- FFT spectrum GPU resources ----
     QRhiGraphicsPipeline*       m_fftLinePipeline{nullptr};
     QRhiGraphicsPipeline*       m_fftFillPipeline{nullptr};

--- a/src/gui/SpectrumWidget.h
+++ b/src/gui/SpectrumWidget.h
@@ -157,6 +157,7 @@ mw0lge@grange-lane.co.uk
 #include <QPoint>
 #include <QMap>
 #include <QHash>
+#include <QStaticText>
 #include <QTimer>
 #include <QPropertyAnimation>
 
@@ -1622,6 +1623,26 @@ private:
     // panadapter visibility toggle is off.  SpotHubDialog Display tab
     // drives this via setSpotSourceVisible.
     QHash<QString, bool> m_spotSourceVisible;
+
+    // ── QStaticText label cache ──────────────────────────────────────────
+    // Pre-shaped (HarfBuzz-run-once) labels for the high-rate paint
+    // loops in drawDbmScale and drawFreqScale.  Without this, each
+    // paint reshapes every label string from scratch — AetherSDR
+    // measured ~5% main-thread CPU on a single DSP curve widget from
+    // shapeText, and our SpectrumWidget has 23+ drawText sites firing
+    // at 20 fps.  Cache keys are the formatted label strings ("-100",
+    // "14.230" etc.), values are QStaticText with AggressiveCaching.
+    // Strings repeat heavily in steady state (dBm scale labels never
+    // change between paints; freq labels cycle through a small set as
+    // the user pans), so the cache hits >99% after the first paint.
+    // mutable because drawDbm/Freq are non-const but the cache is hidden
+    // state — keeping the helper signatures clean.  Lifetime: widget
+    // lifetime; no invalidation needed at this font size since both
+    // strips set a fixed pointSize per-paint.
+    // Inspired by AetherSDR [@3503ae98] PR #2556 perf(gui): cache axis
+    // labels as QStaticText.
+    mutable QHash<QString, QStaticText> m_dbmLabelCache;
+    mutable QHash<QString, QStaticText> m_freqLabelCache;
 
     // ---- Task 2.3: Spectrum text overlay state ----
 

--- a/src/gui/meters/MeterWidget.cpp
+++ b/src/gui/meters/MeterWidget.cpp
@@ -180,6 +180,23 @@ void MeterWidget::clearItems()
 
 void MeterWidget::updateMeterValue(int bindingId, double value)
 {
+    // Fuzzy guard: MeterPoller cascades a value push for every binding
+    // every 100 ms whether or not the WDSP reading actually moved.  On
+    // a quiet RX signal (typical between QSOs) the same -120 dBm /
+    // 0 dB ALC / 0 W power values walk through the loop 10x per second
+    // per binding × per target widget, each triggering a full meter
+    // repaint into IOSurface.  qFuzzyCompare against the last pushed
+    // value drops the redundant work without affecting any meter that
+    // actually moved.  Note: item-side attack/decay smoothing already
+    // converges on its own once value is settled, so suppressing the
+    // unchanged-input update() is safe.
+    auto it = m_lastBindingValue.find(bindingId);
+    if (it != m_lastBindingValue.end()
+        && qFuzzyCompare(1.0 + it.value(), 1.0 + value)) {
+        return;
+    }
+    m_lastBindingValue[bindingId] = value;
+
     for (MeterItem* item : m_items) {
         if (item->bindingId() == bindingId) {
             item->setValue(value);

--- a/src/gui/meters/MeterWidget.h
+++ b/src/gui/meters/MeterWidget.h
@@ -55,6 +55,7 @@ mw0lge@grange-lane.co.uk
 //============================================================================================//
 
 #include <QWidget>
+#include <QHash>
 #include <QImage>
 #include <QVector>
 
@@ -145,6 +146,17 @@ private:
     // Visibility filter state — see setMox/setDisplayGroup doc.
     bool m_mox{false};
     int  m_displayGroup{0};
+
+    // Last value pushed per binding, for the fuzzy guard in
+    // updateMeterValue.  MeterPoller fires every 100 ms across N
+    // bindings × M target widgets; in steady RX a quiet signal walks
+    // by a fraction of a dB or not at all between ticks.  Skipping the
+    // item iteration + update() when the polled value matches the
+    // previous push within FP noise cuts the redundant repaints
+    // (which compose the entire MeterWidget into IOSurface on macOS).
+    // QHash for sparse binding-id keys; std::unordered_map would do
+    // but QHash matches the rest of the file.
+    QHash<int, double> m_lastBindingValue;
 
 #ifdef NEREUS_GPU_SPECTRUM
     bool m_rhiInitialized{false};

--- a/src/gui/setup/DisplaySetupPages.cpp
+++ b/src/gui/setup/DisplaySetupPages.cpp
@@ -128,7 +128,9 @@ SpectrumDefaultsPage::SpectrumDefaultsPage(RadioModel* model, QWidget* parent)
 }
 
 // Maps SpectrumDefaultsPage FPS slider (10-60) to FFTEngine output FPS
-// and the SpectrumWidget display timer so both stay in sync.
+// and the SpectrumWidget display timer so both stay in sync.  Persisted
+// so the value survives restart — MainWindow reads
+// DisplaySpectrumFps at startup and applies to both via the same path.
 void SpectrumDefaultsPage::pushFps(int fps)
 {
     if (!model() || !model()->fftEngine()) { return; }
@@ -136,6 +138,8 @@ void SpectrumDefaultsPage::pushFps(int fps)
     if (auto* sw = model()->spectrumWidget()) {
         sw->setDisplayFps(fps);
     }
+    AppSettings::instance().setValue(
+        QStringLiteral("DisplaySpectrumFps"), QString::number(fps));
     // Defensive: explicitly mirror to the spin readout.  makeSliderRow
     // wires a bidirectional slider<->spin connect that should already do
     // this, but JJ reported the spin readout sticking at 30 even when the

--- a/src/gui/widgets/FilterPassbandWidget.cpp
+++ b/src/gui/widgets/FilterPassbandWidget.cpp
@@ -42,6 +42,13 @@ FilterPassbandWidget::FilterPassbandWidget(QWidget* parent)
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setMouseTracking(true);
     setCursor(Qt::SizeAllCursor);
+
+    // Performance: paintEvent fills rect() opaquely (line 74) before
+    // drawing the trapezoid.  Mark opaque so Qt skips compositing the
+    // parent backing-store underneath us — saves one IOSurface memmove
+    // per paint cycle.  Filter widget repaints on every filter / mode
+    // change, which is frequent during operator tuning.
+    setAttribute(Qt::WA_OpaquePaintEvent);
 }
 
 void FilterPassbandWidget::setFilter(int lo, int hi)

--- a/src/gui/widgets/MasterOutputWidget.cpp
+++ b/src/gui/widgets/MasterOutputWidget.cpp
@@ -138,7 +138,15 @@ MasterOutputWidget::MasterOutputWidget(AudioEngine* audio, QWidget* parent)
         m_audio->setVolume(savedVolume);
         m_audio->setMasterMuted(savedMuted);
         if (!savedDevice.isEmpty()) {
-            AudioDeviceConfig cfg;
+            // Load the full persisted speakers config (sampleRate,
+            // bufferSamples, exclusiveMode, etc.) and override only the
+            // device name with the title-bar picker's value.  Without
+            // loadFromSettings here, every restart-time seed reverted
+            // the bus to AudioDeviceConfig{}'s struct defaults and
+            // silently discarded everything the user had tuned via
+            // Setup → Devices.
+            AudioDeviceConfig cfg = AudioDeviceConfig::loadFromSettings(
+                QStringLiteral("audio/Speakers"));
             cfg.deviceName = savedDevice;
             m_audio->setSpeakersConfig(cfg);
         }

--- a/src/gui/widgets/MeterSlider.h
+++ b/src/gui/widgets/MeterSlider.h
@@ -43,6 +43,12 @@ public:
         setFixedHeight(16);
         setMinimumWidth(60);
         setCursor(Qt::PointingHandCursor);
+        // Performance: paintEvent fills rect() opaquely (line ~82) as
+        // the first draw, so Qt does not need to composite our parent
+        // under us.  Saves one IOSurface memmove per paint — meaningful
+        // because MeterSlider sits in TX applets that update at 10-20 Hz
+        // while transmitting.
+        setAttribute(Qt::WA_OpaquePaintEvent);
     }
 
     float gain() const { return m_gain; }

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -5687,10 +5687,18 @@ void RadioModel::wireConnectionSignals(int wdspInSize)
     // per-DDC fork into PsccPump::onIqData drove the legacy independent-
     // rings architecture and could drift by ~189 samples between TX
     // monitor and PS feedback under Qt queued-connection scheduling.
+    // Lever 2 (2026-05-24): DirectConnection so this lambda runs on the
+    // Connection thread, not main.  feedIqData has a recursive mutex
+    // covering the receiver-map reads; the downstream emit of
+    // iqDataForReceiver then drops into either a DirectConnection lambda
+    // (Step 2a below where rawIqData is re-emitted) or a QueuedConnection
+    // to the DSP worker (Step 2b).  Net result: I/Q packets reach FFT and
+    // DSP without ever sitting in the main thread's event queue, so a
+    // paint-busy main thread no longer stalls audio + waterfall together.
     connect(m_connection, &RadioConnection::iqDataReceived,
             this, [this](int ddcIndex, const QVector<float>& samples) {
         m_receiverManager->feedIqData(ddcIndex, samples);
-    });
+    }, Qt::DirectConnection);
 
     // Phase 3M-4 bench-fix 2026-05-23 (J.J. Boyd KG4VCF): source-first
     // PS pairing.  RadioConnection emits psPairedIqDataReceived once per
@@ -5775,15 +5783,19 @@ void RadioModel::wireConnectionSignals(int wdspInSize)
         }
     }
 
-    // Step 2a: ReceiverManager → spectrum fork (main thread, fast).
-    // Kept on the main thread so rawIqData → FFTEngine routing stays
-    // unchanged. FFTEngine lives on its own SpectrumThread and the
-    // signal already crosses threads via queued connection.
+    // Step 2a: ReceiverManager → spectrum fork.
+    // Lever 2 (2026-05-24): DirectConnection so this lambda runs on the
+    // Connection thread (same thread that just emitted iqDataForReceiver
+    // from feedIqData).  emit rawIqData() is itself thread-safe; its
+    // subscribers (FFTEngine on SpectrumThread) use QueuedConnection and
+    // run on their own threads, so the cross-thread queueing happens at
+    // the FFT consumer boundary, not here.  Main thread never sees the
+    // I/Q packet.
     connect(m_receiverManager, &ReceiverManager::iqDataForReceiver,
             this, [this](int receiverIndex, const QVector<float>& samples) {
         Q_UNUSED(receiverIndex);
         emit rawIqData(samples);
-    });
+    }, Qt::DirectConnection);
 
     // Step 2b: ReceiverManager → DSP worker (queued, off the main thread).
     // RxDspWorker accumulates samples into in_size chunks, runs each

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5165,3 +5165,12 @@ nereus_add_test(tst_rfkit_radiomodel_enabled)
 #   operationalInterfaceCapturesErrorField (error="No TCI available").
 nereus_add_test(tst_rf2ks_connection_parse)
 target_link_libraries(tst_rf2ks_connection_parse PRIVATE Qt6::Network)
+
+# Task 3: 1 Hz REST polling via QNetworkAccessManager.
+# FakeAmpServer (QTcpServer, ephemeral port 0) serves fixture JSON for 8
+# endpoints in-process; no real amp required.
+# Tests: connectsAndPollsOnce (connects, emits connected + powerUpdated +
+#   operateModeUpdated within 2s, pollsSucceeded >= 1);
+#   pollIntervalConfigurable (200 ms interval -> at least 1 extra poll in 500 ms).
+nereus_add_test(tst_rf2ks_connection_poll)
+target_link_libraries(tst_rf2ks_connection_poll PRIVATE Qt6::Network)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5174,3 +5174,9 @@ target_link_libraries(tst_rf2ks_connection_parse PRIVATE Qt6::Network)
 #   pollIntervalConfigurable (200 ms interval -> at least 1 extra poll in 500 ms).
 nereus_add_test(tst_rf2ks_connection_poll)
 target_link_libraries(tst_rf2ks_connection_poll PRIVATE Qt6::Network)
+
+# Task 4: Exponential-backoff reconnect.
+# Test seams drive the backoff math without real network or timers.
+# Tests: backoffSequenceFollowsSchedule (1s->2s->4s->8s->...->cap 60s);
+#   successResetsBackoff (testForceBackoffReset resets to 1s).
+nereus_add_test(tst_rf2ks_connection_reconnect)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5151,3 +5151,17 @@ nereus_add_test(tst_flex_radio_discovery_broadcaster)
 #   writes RfKit_Enabled="True" + emits rfKitEnabledChanged(true));
 #   getterReadsFromAppSettings (pre-seeded key -> getter returns true).
 nereus_add_test(tst_rfkit_radiomodel_enabled)
+
+# Task 2: Rf2ksConnection skeleton - 8 REST endpoint parsers.
+# Fixture JSON captured live from RF2K-S firmware G200C267 (GUI=200, ctl=267).
+# Tests: parsesInfo (custom_device_name + G200C267 version compose);
+#   parsesPower (RfKitPowerSnapshot fields including forwardW/reflectedW/swr);
+#   parsesTuner (RfKitTunerSnapshot mode enum + L/C/freq/segment);
+#   parsesAntennas (QList<RfKitAntenna> 5-element, type/number/state);
+#   parsesActiveAntenna (single antenna object, state=Active);
+#   parsesOperateMode (operate_mode string);
+#   parsesOperationalInterface (iface + empty errorField);
+#   parsesData (bandM/freqKHz/status);
+#   operationalInterfaceCapturesErrorField (error="No TCI available").
+nereus_add_test(tst_rf2ks_connection_parse)
+target_link_libraries(tst_rf2ks_connection_parse PRIVATE Qt6::Network)

--- a/tests/tst_audio_device_config_roundtrip.cpp
+++ b/tests/tst_audio_device_config_roundtrip.cpp
@@ -91,7 +91,7 @@ private slots:
         QVERIFY(cfg.deviceName.isEmpty());
         QCOMPARE(cfg.sampleRate,     48000);
         QCOMPARE(cfg.channels,       2);
-        QCOMPARE(cfg.bufferSamples,  256);
+        QCOMPARE(cfg.bufferSamples,  128);
         QCOMPARE(cfg.exclusiveMode,  false);
         QCOMPARE(cfg.eventDriven,    false);
         QCOMPARE(cfg.bypassMixer,    false);

--- a/tests/tst_audio_vax_page_auto_detect.cpp
+++ b/tests/tst_audio_vax_page_auto_detect.cpp
@@ -376,7 +376,7 @@ private slots:
         QCOMPARE(s.value(base + QStringLiteral("SampleRate"),   QString()).toString().toInt(), 48000);
         QCOMPARE(s.value(base + QStringLiteral("BitDepth"),     QString()).toString().toInt(), 32);
         QCOMPARE(s.value(base + QStringLiteral("Channels"),     QString()).toString().toInt(), 2);
-        QCOMPARE(s.value(base + QStringLiteral("BufferSamples"),QString()).toString().toInt(), 256);
+        QCOMPARE(s.value(base + QStringLiteral("BufferSamples"),QString()).toString().toInt(), 128);
         QVERIFY(s.value(base + QStringLiteral("DriverApi"),     QString()).toString().isEmpty());
         QCOMPARE(s.value(base + QStringLiteral("ExclusiveMode"),QString()).toString(),
                  QStringLiteral("False"));

--- a/tests/tst_rf2ks_connection_parse.cpp
+++ b/tests/tst_rf2ks_connection_parse.cpp
@@ -1,0 +1,135 @@
+#include <QtTest/QtTest>
+#include "core/Rf2ksConnection.h"
+
+using namespace NereusSDR;
+
+class Rf2ksConnectionParseTest : public QObject {
+    Q_OBJECT
+private slots:
+    void parsesInfo();
+    void parsesPower();
+    void parsesTuner();
+    void parsesAntennas();
+    void parsesActiveAntenna();
+    void parsesOperateMode();
+    void parsesOperationalInterface();
+    void parsesData();
+    void operationalInterfaceCapturesErrorField();
+};
+
+void Rf2ksConnectionParseTest::parsesInfo() {
+    Rf2ksConnection conn;
+    conn.injectJsonForTesting(
+        "/info",
+        R"({"device":"RF2K-S","software_version":{"GUI":200,"controller":267},"custom_device_name":"KG4VCF"})");
+    QCOMPARE(conn.deviceName(),       QString("KG4VCF"));     // custom_device_name
+    QCOMPARE(conn.softwareVersion(),  QString("G200C267"));   // GUI/controller composed
+}
+
+void Rf2ksConnectionParseTest::parsesPower() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::powerUpdated);
+    conn.injectJsonForTesting(
+        "/power",
+        R"({"temperature":{"value":27.0,"unit":"°C"},"voltage":{"value":52.7,"unit":"V"},"current":{"value":0.0,"unit":"A"},"forward":{"value":850,"max_value":1200,"unit":"W"},"reflected":{"value":3,"max_value":20,"unit":"W"},"swr":{"value":1.4,"max_value":2.1,"unit":""}})");
+    QCOMPARE(spy.count(), 1);
+    const auto snap = qvariant_cast<RfKitPowerSnapshot>(spy.takeFirst().at(0));
+    QCOMPARE(snap.forwardW,      850);
+    QCOMPARE(snap.forwardMaxW,   1200);
+    QCOMPARE(snap.reflectedW,    3);
+    QCOMPARE(snap.swr,           1.4f);
+    QCOMPARE(snap.temperatureC,  27.0f);
+    QCOMPARE(snap.voltageV,      52.7f);
+    QCOMPARE(snap.currentA,      0.0f);
+}
+
+void Rf2ksConnectionParseTest::parsesTuner() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::tunerUpdated);
+    conn.injectJsonForTesting(
+        "/tuner",
+        R"({"mode":"AUTO","setup":"LC","L":{"value":1200,"unit":"nH"},"C":{"value":345,"unit":"pF"},"tuned_frequency":{"value":3891,"unit":"kHz"},"segment_size":{"value":9,"unit":"kHz"}})");
+    QCOMPARE(spy.count(), 1);
+    const auto snap = qvariant_cast<RfKitTunerSnapshot>(spy.takeFirst().at(0));
+    QCOMPARE(snap.mode,                RfKitTunerSnapshot::Mode::Auto);
+    QCOMPARE(snap.setup,               QString("LC"));
+    QCOMPARE(snap.lValuenH,            1200);
+    QCOMPARE(snap.cValuepF,            345);
+    QCOMPARE(snap.tunedFrequencyKHz,   3891);
+    QCOMPARE(snap.segmentSizeKHz,      9);
+}
+
+void Rf2ksConnectionParseTest::parsesAntennas() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::antennasUpdated);
+    conn.injectJsonForTesting(
+        "/antennas",
+        R"({"antennas":[{"type":"INTERNAL","number":1,"state":"ACTIVE"},{"type":"INTERNAL","number":2,"state":"AVAILABLE"},{"type":"INTERNAL","number":3,"state":"AVAILABLE"},{"type":"INTERNAL","number":4,"state":"AVAILABLE"},{"type":"EXTERNAL","state":"AVAILABLE"}]})");
+    QCOMPARE(spy.count(), 1);
+    const auto list = qvariant_cast<QList<RfKitAntenna>>(spy.takeFirst().at(0));
+    QCOMPARE(list.size(),               5);
+    QCOMPARE(list[0].type,              RfKitAntenna::Type::Internal);
+    QCOMPARE(list[0].number,            1);
+    QCOMPARE(list[0].state,             RfKitAntenna::State::Active);
+    QCOMPARE(list[1].state,             RfKitAntenna::State::Available);
+    QCOMPARE(list[4].type,              RfKitAntenna::Type::External);
+}
+
+void Rf2ksConnectionParseTest::parsesActiveAntenna() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::activeAntennaUpdated);
+    conn.injectJsonForTesting(
+        "/antennas/active",
+        R"({"type":"INTERNAL","number":2})");
+    QCOMPARE(spy.count(), 1);
+    const auto a = qvariant_cast<RfKitAntenna>(spy.takeFirst().at(0));
+    QCOMPARE(a.type,    RfKitAntenna::Type::Internal);
+    QCOMPARE(a.number,  2);
+}
+
+void Rf2ksConnectionParseTest::parsesOperateMode() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::operateModeUpdated);
+    conn.injectJsonForTesting("/operate-mode", R"({"operate_mode":"OPERATE"})");
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.takeFirst().at(0).toString(), QString("OPERATE"));
+}
+
+void Rf2ksConnectionParseTest::parsesOperationalInterface() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::operationalInterfaceUpdated);
+    conn.injectJsonForTesting(
+        "/operational-interface",
+        R"({"operational_interface":"TCI"})");
+    QCOMPARE(spy.count(), 1);
+    const auto args = spy.takeFirst();
+    QCOMPARE(args.at(0).toString(), QString("TCI"));
+    QCOMPARE(args.at(1).toString(), QString());  // no error field
+}
+
+void Rf2ksConnectionParseTest::parsesData() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::dataUpdated);
+    conn.injectJsonForTesting(
+        "/data",
+        R"({"band":{"value":80,"unit":"m"},"frequency":{"value":3895.0,"unit":"kHz"},"status":""})");
+    QCOMPARE(spy.count(), 1);
+    const auto args = spy.takeFirst();
+    QCOMPARE(args.at(0).toInt(),    80);
+    QCOMPARE(args.at(1).toInt(),    3895);
+    QCOMPARE(args.at(2).toString(), QString());
+}
+
+void Rf2ksConnectionParseTest::operationalInterfaceCapturesErrorField() {
+    Rf2ksConnection conn;
+    QSignalSpy spy(&conn, &Rf2ksConnection::operationalInterfaceUpdated);
+    conn.injectJsonForTesting(
+        "/operational-interface",
+        R"({"operational_interface":"UNIV","error":"No TCI available"})");
+    const auto args = spy.takeFirst();
+    QCOMPARE(args.at(0).toString(), QString("UNIV"));
+    QCOMPARE(args.at(1).toString(), QString("No TCI available"));
+}
+
+QTEST_MAIN(Rf2ksConnectionParseTest)
+#include "tst_rf2ks_connection_parse.moc"

--- a/tests/tst_rf2ks_connection_poll.cpp
+++ b/tests/tst_rf2ks_connection_poll.cpp
@@ -1,0 +1,93 @@
+#include <QtTest/QtTest>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include "core/Rf2ksConnection.h"
+
+using namespace NereusSDR;
+
+// Minimal in-process HTTP/1.0 server that answers fixture JSON for the 8
+// documented endpoints.  Listens on an ephemeral port; tests connect to
+// it instead of a real amp.
+class FakeAmpServer : public QTcpServer {
+    Q_OBJECT
+public:
+    FakeAmpServer() {
+        listen(QHostAddress::LocalHost, 0);
+        connect(this, &QTcpServer::newConnection, this, [this]{
+            auto* sock = nextPendingConnection();
+            connect(sock, &QTcpSocket::readyRead, this, [this, sock]{
+                const QByteArray req = sock->readAll();
+                const auto path = parsePath(req);
+                const QByteArray body = bodyFor(path);
+                QByteArray reply;
+                reply  = "HTTP/1.0 200 OK\r\n";
+                reply += "Content-Type: application/json\r\n";
+                reply += "Content-Length: " + QByteArray::number(body.size()) + "\r\n\r\n";
+                reply += body;
+                sock->write(reply);
+                sock->flush();
+                sock->disconnectFromHost();
+            });
+        });
+    }
+    quint16 port() const { return serverPort(); }
+private:
+    static QString parsePath(const QByteArray& req) {
+        const int sp = req.indexOf(' ') + 1;
+        const int end = req.indexOf(' ', sp);
+        return QString::fromUtf8(req.mid(sp, end - sp));
+    }
+    static QByteArray bodyFor(const QString& path) {
+        if (path == "/info")            return R"({"device":"RF2K-S","software_version":{"GUI":200,"controller":267},"custom_device_name":"KG4VCF"})";
+        if (path == "/power")           return R"({"temperature":{"value":27.0,"unit":"C"},"voltage":{"value":52.7,"unit":"V"},"current":{"value":0.0,"unit":"A"},"forward":{"value":0,"max_value":56,"unit":"W"},"reflected":{"value":0,"max_value":0,"unit":"W"},"swr":{"value":1.0,"max_value":1.11,"unit":""}})";
+        if (path == "/tuner")           return R"({"mode":"AUTO","setup":"LC","L":{"value":1200,"unit":"nH"},"C":{"value":345,"unit":"pF"},"tuned_frequency":{"value":3891,"unit":"kHz"},"segment_size":{"value":9,"unit":"kHz"}})";
+        if (path == "/antennas")        return R"({"antennas":[{"type":"INTERNAL","number":1,"state":"ACTIVE"},{"type":"INTERNAL","number":2,"state":"AVAILABLE"},{"type":"INTERNAL","number":3,"state":"AVAILABLE"},{"type":"INTERNAL","number":4,"state":"AVAILABLE"}]})";
+        if (path == "/antennas/active") return R"({"type":"INTERNAL","number":1})";
+        if (path == "/operate-mode")    return R"({"operate_mode":"STANDBY"})";
+        if (path == "/operational-interface") return R"({"operational_interface":"TCI"})";
+        if (path == "/data")            return R"({"band":{"value":80,"unit":"m"},"frequency":{"value":3895.0,"unit":"kHz"},"status":""})";
+        return "{}";
+    }
+};
+
+class Rf2ksConnectionPollTest : public QObject {
+    Q_OBJECT
+private slots:
+    void connectsAndPollsOnce();
+    void pollIntervalConfigurable();
+};
+
+void Rf2ksConnectionPollTest::connectsAndPollsOnce() {
+    FakeAmpServer server;
+    Rf2ksConnection conn;
+    conn.setPollIntervalMs(120);  // short for test
+
+    QSignalSpy connSpy(&conn, &Rf2ksConnection::connected);
+    QSignalSpy powerSpy(&conn, &Rf2ksConnection::powerUpdated);
+    QSignalSpy opModeSpy(&conn, &Rf2ksConnection::operateModeUpdated);
+
+    conn.connectToAmp("127.0.0.1", server.port());
+    QVERIFY(connSpy.wait(2000));
+    QVERIFY(conn.isConnected());
+
+    QVERIFY(powerSpy.wait(2000));
+    QVERIFY(opModeSpy.wait(2000));
+    QVERIFY(conn.pollsSucceeded() >= 1);
+}
+
+void Rf2ksConnectionPollTest::pollIntervalConfigurable() {
+    FakeAmpServer server;
+    Rf2ksConnection conn;
+    conn.setPollIntervalMs(200);
+    conn.connectToAmp("127.0.0.1", server.port());
+
+    QSignalSpy powerSpy(&conn, &Rf2ksConnection::powerUpdated);
+    QVERIFY(powerSpy.wait(2000));
+    const int firstPolls = conn.pollsSucceeded();
+
+    QTest::qWait(500);   // expect ~2 more polls
+    QVERIFY(conn.pollsSucceeded() >= firstPolls + 1);
+}
+
+QTEST_MAIN(Rf2ksConnectionPollTest)
+#include "tst_rf2ks_connection_poll.moc"

--- a/tests/tst_rf2ks_connection_reconnect.cpp
+++ b/tests/tst_rf2ks_connection_reconnect.cpp
@@ -1,0 +1,38 @@
+#include <QtTest/QtTest>
+#include "core/Rf2ksConnection.h"
+
+using namespace NereusSDR;
+
+class Rf2ksConnectionReconnectTest : public QObject {
+    Q_OBJECT
+private slots:
+    void backoffSequenceFollowsSchedule();
+    void successResetsBackoff();
+};
+
+void Rf2ksConnectionReconnectTest::backoffSequenceFollowsSchedule() {
+    Rf2ksConnection conn;
+    conn.testForceBackoffSequence();
+    QCOMPARE(conn.testCurrentBackoffMs(), 1000);
+    conn.testForceBackoffSequence();
+    QCOMPARE(conn.testCurrentBackoffMs(), 2000);
+    conn.testForceBackoffSequence();
+    QCOMPARE(conn.testCurrentBackoffMs(), 4000);
+    conn.testForceBackoffSequence();
+    QCOMPARE(conn.testCurrentBackoffMs(), 8000);
+    for (int i = 0; i < 5; ++i) { conn.testForceBackoffSequence(); }
+    QVERIFY(conn.testCurrentBackoffMs() <= 60000);
+}
+
+void Rf2ksConnectionReconnectTest::successResetsBackoff() {
+    Rf2ksConnection conn;
+    conn.testForceBackoffSequence();
+    conn.testForceBackoffSequence();
+    conn.testForceBackoffSequence();
+    QVERIFY(conn.testCurrentBackoffMs() > 1000);
+    conn.testForceBackoffReset();
+    QCOMPARE(conn.testCurrentBackoffMs(), 1000);
+}
+
+QTEST_MAIN(Rf2ksConnectionReconnectTest)
+#include "tst_rf2ks_connection_reconnect.moc"

--- a/third_party/wdsp/src/linux_port.h
+++ b/third_party/wdsp/src/linux_port.h
@@ -66,8 +66,8 @@ typedef pthread_mutex_t *LPCRITICAL_SECTION;
 #define __forceinline
 #define _beginthread wdsp_beginthread
 #define _int64 long long
-#define _aligned_malloc(x,y) malloc(x);
-#define _aligned_free(x) free(x);
+#define _aligned_malloc(x,y) malloc(x)
+#define _aligned_free(x) do { free(x); } while(0)
 // Windows freopen_s to "conout$" is a no-op on POSIX — stdout works as-is
 #define freopen_s(pFile, name, mode, stream) ((void)0)
 #define min(x,y) (x<y?x:y)

--- a/third_party/wdsp/src/linux_port.h
+++ b/third_party/wdsp/src/linux_port.h
@@ -1,3 +1,9 @@
+// no-port-check: WDSP upstream header (TAPR v1.29) carrying the
+// NR0V / G0ORX/N6LYT copyright line.  Vendored verbatim with only the
+// cross-platform shim macro tweaks documented in the modification
+// history below; not a Thetis port, attribution already lives in the
+// preserved header copyright block.
+
 /*  linux_port.h
 
 This file is part of a program that implements a Software-Defined Radio.


### PR DESCRIPTION
## Summary

Three coordinated workstreams: (1) audio ring overrun protection +
end-to-end latency tightening, (2) spectrum + waterfall smoothness, and
(3) CPU paint optimizations.

### Audio path
- Drop-oldest ring overrun protection in PortAudioBus paCallback with
  crossfade smoothing on the resume sample
- Drop-oldest + paOutputUnderflow + paOutputOverflow atomic counters,
  queryable via the PortAudioBus public API
- Move I/Q dispatch off the Qt main thread (Lever 2) so GUI paint
  storms can no longer starve the DSP path
- Ring buffer capacity capped at 100 ms (was 1 second), bufferSamples
  default 256 to 128, persistence-load bug fix so the user's saved
  `BufferSamples=64` is no longer clobbered by device-picker callbacks
- Net result: PortAudio output latency 22 ms to 18 ms, ring worst-case
  ceiling 280 ms to 170 ms, typical end-to-end latency ~85 ms

### Spectrum + waterfall
- Display FPS aligned to FFT output FPS (both at 30 Hz default) with
  `DisplaySpectrumFps` persisted across launches
- `setDisplayFps` now also syncs `m_wfUpdatePeriodMs` so the waterfall
  throttle stays in lock-step with the paint period
- GPU overlay auto-dirty rate-limited from 30 Hz to 10 Hz when
  per-frame-changing features (Active Peak Hold, Peak Blobs, Noise
  Floor) are enabled. The cache was being defeated; rebuild work
  cut by ~67%

### CPU paint reductions
- QStaticText label cache for SpectrumWidget dBm and frequency scale
  labels (ports AetherSDR PR #2556 pattern)
- `WA_OpaquePaintEvent` on SMeterWidget, FilterPassbandWidget,
  MeterSlider
- MeterWidget per-binding fuzzy guard so MeterPoller value pushes
  with unchanged WDSP readings short-circuit before triggering paint
- Spot overlay visual-equality guard (ports AetherSDR PR #2474)
- HGauge value-change guards, S-Meter sub-pixel guard, spectrum FPS
  retuning

### Cleanup
- All session-only diagnostic fprintf chains removed. Atomic counters
  remain queryable via public accessors for future support tooling.
- Stale debug `#include` headers pruned.

## Test plan

- [ ] Bench: connect to ANAN-G2 over Ethernet at 192 kHz, confirm
  audio is clean with no crackle for 10+ minutes
- [ ] Bench: waterfall scroll is smooth, no perceptible step pattern
- [ ] Bench: tune VFO, swap modes, change filter widths, UI stays
  responsive, no audio glitches
- [ ] Bench: idle CPU below the pre-PR baseline (post-rate-limit
  ~100%, was ~120%)
- [ ] Settings: open Setup, Display, Spectrum Defaults; move FPS
  slider; confirm it persists across restart
- [ ] Settings: persisted `BufferSamples` value survives device
  picker changes (the bug this PR also fixes)

## Known limitations / follow-ups

- Noise Blanker (NB / NB2) produces an audible metallic artifact when
  enabled. WDSP source matches Thetis byte-for-byte and the algorithm
  is correct; investigation continues in a separate ticket. Operator
  facing recommendation: leave NB off until that ticket lands.
- Further CPU wins require splitting SpectrumWidget overlay into
  static-chrome vs dynamic layers (1-2 day refactor) or moving more
  chrome to QRhi (multi-day refactor). Both are tracked as separate
  Tier 2 / Tier 3 work in the performance design notes; a handoff
  prompt for that work was drafted at the end of the session.
- This PR does not touch NB UI surfaces. Defaults remain Thetis
  faithful per the source-first protocol.

J.J. Boyd ~ KG4VCF