### PR TITLE
build: exclude test executables from the default build target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,6 +493,23 @@ jobs:
         shell: bash
         run: cmake --build build -j$NUMBER_OF_PROCESSORS
 
+      # Build the test executables explicitly.  Every tst_* executable is
+      # now EXCLUDE_FROM_ALL, so a routine `cmake --build build` builds
+      # only the main app (seconds, not the ~32 minutes it takes to link
+      # 513 test binaries).  CI must therefore ask for the `all_tests`
+      # aggregate before invoking ctest, or ctest finds the registered
+      # test definitions but no binaries and reports every one as
+      # "Not Run" -- which exits 0 and would silently pass.
+      #
+      # Gated on Linux to match the configure step: only the Linux job
+      # passes -DNEREUS_BUILD_TESTS=ON (ci.yml:458), and `all_tests` is
+      # created by tests/CMakeLists.txt, which is only add_subdirectory'd
+      # when that option is ON.  Asking for the target elsewhere would
+      # fail with "No rule to make target".
+      - name: Build test executables (Linux)
+        if: runner.os == 'Linux'
+        run: cmake --build build -j$(nproc) --target all_tests
+
       # ------------------------------------------------------------------
       # Test
       # ------------------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,13 @@ that matches our conventions.
    unit-test suite, read
    [docs/development/fast-test-loop.md](docs/development/fast-test-loop.md)
    first: every test executable statically links the whole application, so
-   building all of them costs about 32 minutes. Build the one target you
-   care about, or use `ctest -L <subsystem>`.
+   building all of them costs about 32 minutes. Test binaries are
+   `EXCLUDE_FROM_ALL`, so always build a target before running `ctest` --
+   otherwise you are testing stale binaries:
+
+   ```bash
+   cmake --build build --target tests_core && ctest --test-dir build -L core
+   ```
 5. **Sign your commits** with GPG when contributing back to this repository's `main` branch (required by this repo's branch protection — not a license obligation; downstream forks and redistributions are not required to sign).
 6. **Open a pull request** against `main` with a clear description.
 

--- a/docs/development/fast-test-loop.md
+++ b/docs/development/fast-test-loop.md
@@ -20,8 +20,17 @@ Run a subsystem. Labels are derived automatically at configure time from
 each test's own `#include` lines, so they never need hand-maintenance:
 
 ```bash
-ctest --test-dir build -L core
+cmake --build build --target tests_core && ctest --test-dir build -L core
 ```
+
+**Always build the matching `tests_<label>` target first.** Test
+executables are `EXCLUDE_FROM_ALL`, so a plain `cmake --build build` does
+not rebuild them. Running `ctest -L core` on its own is unsafe: on a clean
+tree every selected test reports "Not Run", and on an already-populated
+tree it silently executes **stale binaries built from your previous code**
+and returns a false green. There is one `tests_<label>` target per label,
+generated from the same derivation that produces the labels, so the two
+cannot drift apart.
 
 Current distribution:
 
@@ -53,32 +62,27 @@ Until the Phase 1 library split lands, every test depends on every source
 file. Use `-L` to get fast feedback while iterating; use the full suite
 before you call something done.
 
-## Known wart on this branch: a plain build builds everything
+## Building tests is opt-in
 
-On this branch, test executables are **not** `EXCLUDE_FROM_ALL`, so:
-
-```bash
-cmake --build build        # builds the app AND all 513 test binaries
-```
-
-That is the 32-minute path, and it triggers on any source change. Until the
-fix lands, name your target explicitly:
+Test executables are `EXCLUDE_FROM_ALL`, so a routine build only builds the
+app. Measured after touching `src/core/AppSettings.cpp`:
 
 ```bash
-cmake --build build --target NereusSDR              # app only
-cmake --build build --target tst_slice_auto_agc     # one test
+cmake --build build        # 1.64 s, links 0 test binaries
 ```
 
-The fix already exists in commit `6ed89682` (`EXCLUDE_FROM_ALL` on tests
-plus an `all_tests` aggregate target) but is not yet on `main`. It lives on
-`feature/rfkit-rf2ks-applet`, `feature/phase3f-sub-epic-a-foundation`, and
-`claude/adoring-elgamal-24e14e`. Once merged, a plain
-`cmake --build build` builds only the app, and the full suite becomes an
-explicit opt-in:
+Everything that runs tests must therefore name a target first:
 
 ```bash
-cmake --build build --target all_tests && ctest --test-dir build
+cmake --build build --target tst_slice_auto_agc   # one test
+cmake --build build --target tests_core           # one subsystem
+cmake --build build --target all_tests            # the lot (~32 min cold)
 ```
+
+Then run `ctest`. **Skipping the build step is the one real footgun here**:
+`ctest` on its own will happily run whatever binaries are already on disk,
+which after a source change means testing your previous code and getting a
+green that means nothing.
 
 ## macOS: the first-run scan
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,8 +145,25 @@ function(nereus_add_test name)
     # path instead of the real user config file. Without this, ctest
     # runs can (and have — see v0.1.1 alpha) silently wipe the
     # developer's NereusSDR.settings via P1FakeRadio-keyed test writes.
-    add_executable(${name} ${name}.cpp $<TARGET_OBJECTS:nereus_test_sandbox> ${ARGN})
+    # 2026-05-26 KG4VCF: EXCLUDE_FROM_ALL makes test executables NOT
+    # part of the default `cmake --build build` target.  513 test
+    # binaries × non-trivial link time = real dev-loop pain when a
+    # single source change forces all of them to relink.  Devs who
+    # want to run tests use:
+    #
+    #   cmake --build build --target tst_specific_name  # one test
+    #   cmake --build build --target all_tests          # the lot
+    #
+    # CI uses `all_tests` followed by `ctest`.  Pre-commit hooks
+    # currently don't invoke ctest (they're verification scripts,
+    # not test runs), so nothing in the existing workflow breaks.
+    #
+    # The aggregate `all_tests` target is created at the bottom of
+    # this file from a global property each nereus_add_test() call
+    # appends to.
+    add_executable(${name} EXCLUDE_FROM_ALL ${name}.cpp $<TARGET_OBJECTS:nereus_test_sandbox> ${ARGN})
     target_link_libraries(${name} PRIVATE NereusSDRObjs Qt6::Test)
+    set_property(GLOBAL APPEND PROPERTY NEREUS_ALL_TESTS ${name})
 
     # Reuse the NereusSDRObjs precompiled header (CMakeLists.txt §PCH).
     # 451 test executables × per-target PCH compile would burn the wins;
@@ -5272,3 +5289,20 @@ target_link_libraries(tst_rf2ks_connection_poll PRIVATE Qt6::Network)
 # Tests: backoffSequenceFollowsSchedule (1s->2s->4s->8s->...->cap 60s);
 #   successResetsBackoff (testForceBackoffReset resets to 1s).
 nereus_add_test(tst_rf2ks_connection_reconnect)
+
+# --------------------------------------------------------------------------
+# Aggregate "all_tests" target  (2026-05-26 KG4VCF dev-loop fix)
+# --------------------------------------------------------------------------
+# All individual tst_* executables are EXCLUDE_FROM_ALL so a routine
+# `cmake --build build` builds only the main NereusSDR app (seconds,
+# not minutes).  When the operator -- or CI, or pre-merge -- needs to
+# build the full test suite, they invoke:
+#
+#   cmake --build build --target all_tests
+#   ctest
+#
+# The GLOBAL property NEREUS_ALL_TESTS is appended to by every
+# nereus_add_test() call above.  add_custom_target then bundles them
+# into a single buildable target.
+get_property(_all_tests GLOBAL PROPERTY NEREUS_ALL_TESTS)
+add_custom_target(all_tests DEPENDS ${_all_tests})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,12 +181,25 @@ function(nereus_add_test name)
     # Labels let `ctest -L core` request a subset; TIMEOUT converts a hung
     # test from an indefinite block into a failure. 120s is deliberately
     # generous: the slowest test in the suite as of 2026-07-25 is
-    # tst_reconnect_on_silence at 53.5s, and a later task brings that
-    # under 1s.
+    # tst_ps_feedback_channel at ~30s.
     _nereus_derive_test_labels(_test_labels "${name}.cpp")
     set_tests_properties(${name} PROPERTIES
         LABELS "${_test_labels}"
         TIMEOUT 120)
+
+    # Per-label build aggregates, so `ctest -L core` has a matching
+    # `tests_core` target that actually builds what it is about to run.
+    #
+    # Without these, the documented subset workflow is unsafe: test
+    # executables are EXCLUDE_FROM_ALL, so a routine `cmake --build build`
+    # does not rebuild them.  On a clean tree `ctest -L core` then reports
+    # every selected test as Not Run, and -- worse -- on an already
+    # populated build tree it silently runs STALE binaries and returns a
+    # false green after a source change.  Codex review, PR #305.
+    foreach(_label IN LISTS _test_labels)
+        set_property(GLOBAL APPEND PROPERTY NEREUS_TESTS_LABEL_${_label} ${name})
+        set_property(GLOBAL APPEND PROPERTY NEREUS_TEST_LABEL_NAMES ${_label})
+    endforeach()
 endfunction()
 
 # ── Pre-existing tests from main (smoke + 3G-9 meter suite) ────────────────
@@ -5306,3 +5319,27 @@ nereus_add_test(tst_rf2ks_connection_reconnect)
 # into a single buildable target.
 get_property(_all_tests GLOBAL PROPERTY NEREUS_ALL_TESTS)
 add_custom_target(all_tests DEPENDS ${_all_tests})
+
+# --------------------------------------------------------------------------
+# Per-label build aggregates: tests_core / tests_models / tests_gui / ...
+# --------------------------------------------------------------------------
+# One buildable target per derived ctest label, so the documented subset
+# workflow builds what it runs:
+#
+#   cmake --build build --target tests_core && ctest -L core
+#
+# Without these, `ctest -L core` after a routine `cmake --build build`
+# either reports Not Run (clean tree) or silently executes STALE test
+# binaries and returns a false green (populated tree), because every
+# tst_* target is EXCLUDE_FROM_ALL.  Raised by Codex review on PR #305.
+get_property(_label_names GLOBAL PROPERTY NEREUS_TEST_LABEL_NAMES)
+if(_label_names)
+    list(REMOVE_DUPLICATES _label_names)
+    foreach(_label IN LISTS _label_names)
+        get_property(_label_tests GLOBAL PROPERTY NEREUS_TESTS_LABEL_${_label})
+        if(_label_tests)
+            add_custom_target(tests_${_label} DEPENDS ${_label_tests})
+        endif()
+    endforeach()
+    message(STATUS "NereusSDR: per-label test targets: ${_label_names}")
+endif()

--- a/tests/tst_reconnect_on_silence.cpp
+++ b/tests/tst_reconnect_on_silence.cpp
@@ -42,24 +42,34 @@ private slots:
 
         P1RadioConnection conn;
         conn.init();
-        // Compress the reconnect timeline 100x: watchdog 2000ms -> 20ms,
-        // reconnect interval 5000ms -> 50ms. Without this the second test
+        // Compress the reconnect timeline ~13x: watchdog 2000ms -> 150ms,
+        // reconnect interval 5000ms -> 300ms. Without this the second test
         // method sleeps 42 real seconds and sets the parallel floor for
         // the entire suite.
-        conn.setReconnectTimingForTest(20, 50);
+        //
+        // 150ms is deliberately NOT tighter. The silence threshold must sit
+        // comfortably above BOTH the watchdog's own sampling period
+        // (kWatchdogTickMs = 25ms) and P1FakeRadio's ep6 stream cadence
+        // (10ms, P1FakeRadio.cpp:54), because a frame is only observed
+        // after a subsequent UDP readyRead dispatch. An earlier revision
+        // used 20ms, which is BELOW the 25ms watchdog tick: any event-loop
+        // stall past 20ms would trip a spurious LinkLost while the fake was
+        // still streaming. That passes on an idle dev machine and goes
+        // flaky on loaded CI. 150ms leaves 6 watchdog ticks of margin.
+        conn.setReconnectTimingForTest(150, 300);
         conn.connectToRadio(makeInfo(fake));
         QTRY_VERIFY_WITH_TIMEOUT(
-            conn.state() == ConnectionState::Connected, 500);
+            conn.state() == ConnectionState::Connected, 2000);
 
         // Wait for the fake to see the metis-start and begin streaming.
-        QTRY_VERIFY_WITH_TIMEOUT(fake.isRunning(), 500);
+        QTRY_VERIFY_WITH_TIMEOUT(fake.isRunning(), 2000);
 
         // Kick the fake into silence — it stops replying to ep2 and stops ep6.
         fake.goSilent();
 
         // Watchdog should trip after 2s → LinkLost.
         QTRY_VERIFY_WITH_TIMEOUT(
-            conn.state() == ConnectionState::LinkLost, 500);
+            conn.state() == ConnectionState::LinkLost, 2000);
 
         // Resume the fake before the reconnect window closes.
         // The reconnect timer fires after 5s — resume immediately so the next
@@ -68,7 +78,7 @@ private slots:
 
         // Within the reconnect cycle (5s × up to 3 = 15s max), should recover.
         QTRY_VERIFY_WITH_TIMEOUT(
-            conn.state() == ConnectionState::Connected, 500);
+            conn.state() == ConnectionState::Connected, 2000);
 
         conn.disconnect();
         fake.stop();
@@ -80,11 +90,21 @@ private slots:
 
         P1RadioConnection conn;
         conn.init();
-        // Compress the reconnect timeline 100x: watchdog 2000ms -> 20ms,
-        // reconnect interval 5000ms -> 50ms. Without this the second test
+        // Compress the reconnect timeline ~13x: watchdog 2000ms -> 150ms,
+        // reconnect interval 5000ms -> 300ms. Without this the second test
         // method sleeps 42 real seconds and sets the parallel floor for
         // the entire suite.
-        conn.setReconnectTimingForTest(20, 50);
+        //
+        // 150ms is deliberately NOT tighter. The silence threshold must sit
+        // comfortably above BOTH the watchdog's own sampling period
+        // (kWatchdogTickMs = 25ms) and P1FakeRadio's ep6 stream cadence
+        // (10ms, P1FakeRadio.cpp:54), because a frame is only observed
+        // after a subsequent UDP readyRead dispatch. An earlier revision
+        // used 20ms, which is BELOW the 25ms watchdog tick: any event-loop
+        // stall past 20ms would trip a spurious LinkLost while the fake was
+        // still streaming. That passes on an idle dev machine and goes
+        // flaky on loaded CI. 150ms leaves 6 watchdog ticks of margin.
+        conn.setReconnectTimingForTest(150, 300);
         conn.connectToRadio(makeInfo(fake));
         QTRY_VERIFY_WITH_TIMEOUT(
             conn.state() == ConnectionState::Connected, 3000);
@@ -103,9 +123,9 @@ private slots:
         fake.stop();
 
         // Timeline is driven by two P1RadioConnection timing values that
-        // the test compresses 100x via setReconnectTimingForTest():
-        //   watchdog silence  2000ms -> 20ms
-        //   reconnect interval 5000ms -> 50ms
+        // the test compresses ~13x via setReconnectTimingForTest():
+        //   watchdog silence  2000ms -> 150ms
+        //   reconnect interval 5000ms -> 300ms
         //
         // kMaxReconnectAttempts is 3, so the bounded chain produces exactly
         // 7 transitions after fake.stop() — LinkLost, then (Connecting,
@@ -117,24 +137,24 @@ private slots:
         // The next reconnect timeout finds attempts == kMaxReconnectAttempts
         // and returns without a transition, so the chain terminates here.
         //
-        // Measured wall time for those 7 transitions on an idle machine is
-        // ~420ms (each cycle is the 50ms reconnect interval plus the
-        // watchdog re-trip, which costs a few 25ms kWatchdogTickMs ticks
-        // because onReconnectTimeout does not reset m_lastEp6At). The 4000ms
-        // ceiling is a generous upper bound only — QTRY returns as soon as
-        // the count is reached, so a healthy run still finishes in well
-        // under a second.
-        QTRY_VERIFY_WITH_TIMEOUT(transitions.count() >= 7, 4000);
+        // Expected wall time for those 7 transitions is ~1.9s: each cycle is
+        // the 300ms reconnect interval plus the watchdog re-trip, which costs
+        // 150ms plus a few 25ms kWatchdogTickMs ticks because
+        // onReconnectTimeout does not reset m_lastEp6At. The 10000ms ceiling
+        // is a generous upper bound only — QTRY returns as soon as the count
+        // is reached, so a healthy run still finishes in ~2s. The headroom is
+        // for loaded CI, where every timer in the chain stretches.
+        QTRY_VERIFY_WITH_TIMEOUT(transitions.count() >= 7, 10000);
         QCOMPARE(transitions.count(), 7);
         QCOMPARE(conn.state(), ConnectionState::LinkLost);
 
-        // Confirm the retries really are bounded: wait 250ms (5x the
+        // Confirm the retries really are bounded: wait 1500ms (5x the
         // compressed reconnect interval) and require that NO further
         // transition occurred. Asserting on the spy count rather than on
         // state() alone is deliberate — an unbounded 4th retry would go
         // Connecting → LinkLost and could leave state() reading LinkLost
         // again by the time we sampled it.
-        QTest::qWait(250);
+        QTest::qWait(1500);
         QCOMPARE(transitions.count(), 7);
         QCOMPARE(conn.state(), ConnectionState::LinkLost);
 


### PR DESCRIPTION
Every `tst_*` executable was part of the default `all` target, so any source change touching `NereusSDRObjs` relinked all 513 of them. Each test statically links the whole application (~22 MB of `__TEXT`), so verifying a one-line edit cost roughly 32 minutes of linking.

Measured on this branch, after touching `src/core/AppSettings.cpp`:

| | Before | After |
|---|---|---|
| `cmake --build build` | ~32 min | **1.64 s** |
| Test binaries linked | 513 | **0** |

Ported by hand from `6ed89682` on `feature/rfkit-rf2ks-applet` rather than cherry-picked, because that commit bundles three unrelated changes and only one applies here:

- **`EXCLUDE_FROM_ALL` + `all_tests` aggregate** — taken.
- **LTO default ON→OFF** — skipped. `main` has no `NEREUSSDR_ENABLE_LTO` option at all; it's added by an earlier commit on that branch. Every `CMakeLists.txt` hunk in `6ed89682` is LTO-related.
- **Partial-region Metal overlay upload** (`SpectrumWidget.cpp`) — skipped. Unrelated GPU perf work that belongs with its own branch and wants bench verification.

The `add_executable` line needed adapting: `main` now passes `$<TARGET_OBJECTS:nereus_test_sandbox>` where that branch still lists `TestSandboxInit.cpp`.

Also includes the CI fix from `1d3650cc`, which is **not optional**. Without it this change reintroduces the exact P1 raised in review on #291: ctest finds the registered test definitions but no binaries, reports every one as "Not Run", and **exits 0** — silently green CI.

The Linux gate is correct because `ci.yml:458` is the only place `-DNEREUS_BUILD_TESTS=ON` is passed, so `all_tests` doesn't exist on the macOS or Windows jobs. I reworded the comment to say that, rather than the original claim that those jobs configure tests OFF.

Verified: `cmake --build build --target all_tests` then `ctest` gives 513/513 passed, 0 failed, nothing reported Not Run.

J.J. Boyd ~ KG4VCF
