### PR TITLE
fix(p2,discovery): stop wedging the ANAN-G2E on disconnect

### DIFF
--- a/captures/g2e-disconnect-NOTES.md
+++ b/captures/g2e-disconnect-NOTES.md
@@ -155,18 +155,89 @@ period and it is what feeds the board's 2 s deadman.
 
 ---
 
-## Status
+## Second change: the P1 discovery probe
 
-**Unproven.** Cadence is the last wire-level difference standing after the others
-were eliminated against the gateware, not a demonstrated cause. The mechanism by
-which excess C&C traffic would leave the board's Ethernet path dead is not
-established; `sdr_send.v:138` (`if (!run && state > SEND) state <= IDLE`) is the
-only escape from a stalled send state and ARP shares a single TX arbiter with UDP
-(`network.v:341-344, 416-421`), which would explain total layer-2 silence, but
-that remains a hypothesis.
+Found after the cadence work, and the stronger suspect of the two.
 
-Next bench run: connect, use, disconnect, then confirm the radio still answers
-ARP and accepts a reconnect without a power cycle.
+Our P1 probe is broadcast to UDP 1024, which is also the P2 General command
+port. `General_CC.v:90/106` claims any port-1024 datagram whose byte 4 is zero
+and parses the rest as a General command. Our probe is `EF FE 02` followed by 60
+zero bytes, so a P2 radio accepts it and latches the padding as config: byte 38
+clears `HW_timer_enable` (freezing the ~2 s deadman), bytes 58/59 clear
+`PA_enable` and `Alex_enable`. `RadioDiscovery.cpp:441-445` sends it to both the
+directed subnet broadcast and 255.255.255.255 on every scan, and the app log
+shows a scan immediately precedes every connect, so it fired **every time** —
+matching the 100%-reproducible symptom far better than cadence does.
+
+Fix: byte 4 = `0x02`, so `General_CC` bails at its command check. Verified that
+no P1 gateware reads byte 4 (Hermes v3.3, Angelia, Orion, ANAN-10E/100B,
+HermesC10 all match only the command byte in `Rx_MAC.v`).
+
+This one was invisible in every capture we took: the mirror filter was
+`filter-ip-address=192.168.109.198/32`, which cannot match a broadcast
+destination. It was found in the application log instead. **If you are hunting a
+discovery-related problem, do not trust an IP-filtered capture.**
+
+---
+
+## Status: NOT FIXED — but the failure window is now pinned
+
+Bench run 2026-07-27 with both changes in. One cycle survived, the next did not,
+so the bug is **not deterministic** as originally believed, and neither change
+is sufficient.
+
+| session | duration | I/Q packets | outcome |
+|---|---|---|---|
+| 16:38:44 → 16:38:54 | 10 s | 2087 | reconnect OK |
+| 16:39:03 → 16:39:51 | 48 s | 9568 | **locked up** |
+
+### The important new fact
+
+**The radio survives the disconnect and dies roughly one second later, while
+idle, during the post-disconnect scan.** It is not dying at the disconnect.
+
+```
+16:39:51.448  P2: Disconnected. I/Q packets: 9568
+16:39:51.455  Scanning NIC "feth3169"
+16:39:51.497  P2 response from .198  ANAN-G2E fw: 110    <- alive, replies x4
+16:39:52.325  P2 response from .45   (Saturn only)       <- G2E gone
+16:39:53.141  P2 response from .45   (Saturn only)       <- G2E gone
+```
+
+The surviving cycle looks identical through the first scan attempt (four G2E
+replies) and then keeps answering attempts 2 and 3. The failing one answers
+attempt 1 and is dead by attempt 2. So the kill happens in a sub-second window
+after `run=0`, with the radio otherwise idle and only discovery traffic on the
+wire.
+
+This retires every "the stop frame is malformed" theory for good: the stop frame
+is byte-correct, the radio acts on it, answers discovery afterwards, and *then*
+dies.
+
+### A regression this run introduced, since fixed
+
+The first version of the probe pad used byte 4 = `0x02`. Byte 4 is also the P2
+*command* byte in `sdr_receive.v`, and `2` is the discovery command, so every P1
+probe became a second discovery request. Verified in the app log: 2 replies per
+scan attempt on the old build, 4 on the new one. Now `0xFF`, which falls through
+to `ST_WAIT`.
+
+Note for anyone touching this byte: `0x03` on a broadcast probe reaches
+`ST_SETIP`, which writes the radio's IP to EEPROM. The safe range excludes
+`0x00` and `0x02`-`0x06`.
+
+### Still unexplained
+
+Why an idle radio, one second after a clean stop, stops answering ARP entirely.
+`sdr_send.v:138` (`if (!run && state > SEND) state <= IDLE`) is the only escape
+from a stalled send state, and ARP shares a single TX arbiter with UDP
+(`network.v:341-344, 416-421`), which would explain total layer-2 silence — but
+that is still a hypothesis, and the trigger inside that one-second window is not
+identified.
+
+Next evidence needed: a capture filtered on the **router IP** (so broadcast is
+visible) spanning disconnect through the following scan, to see the last frames
+the radio emits and exactly which probe it fails to answer.
 
 ---
 

--- a/captures/g2e-disconnect-NOTES.md
+++ b/captures/g2e-disconnect-NOTES.md
@@ -1,0 +1,182 @@
+# ANAN-G2E disconnect lockup — wire capture analysis
+
+**Date:** 2026-07-27
+**Radio:** ANAN-G2E (HermesC10), Protocol 2, firmware 110, `192.168.109.198`
+**Clients:** NereusSDR on macOS `192.168.109.52`; Thetis on Windows `192.168.109.58`
+**Capture method:** MikroTik `/tool sniffer` TZSP mirror (`filter-ip-address=192.168.109.198/32`)
+streamed to the Mac on UDP 37008, collected with `tcpdump`.
+
+Captures themselves are not committed (`captures/.gitignore` excludes `*.pcap*`).
+This file is the durable record. A previous round of this same investigation
+(2026-05-22) lost its `g2e-tzsp.pcap` and left findings only in commit messages;
+see "Prior art" below.
+
+---
+
+## Symptom
+
+Power-cycle the G2E and it works. Connect NereusSDR, use it, then disconnect or
+close the app. From that moment the radio will not connect again until it is
+physically power cycled. It "starts to connect then nothing happens." Thetis on
+the same radio, same network, does not cause this.
+
+---
+
+## Reading the captures
+
+Two gotchas cost a round each:
+
+1. **Capture filter must be by host, not by UDP port.** The 1444-byte
+   `CmdHighPriority` frames get IP-fragmented inside TZSP, and continuation
+   fragments carry no UDP header, so `udp port 37008` silently drops them and
+   every large frame arrives as an unreassemblable offset-0 orphan. Use
+   `host <router-ip>`.
+2. **The mirror duplicates frames.** Measured factor 2.9x-3.4x, arriving within
+   a few hundred microseconds with identical payloads. Any rate measurement must
+   deduplicate on (dst port, payload) inside a ~2 ms window first.
+
+---
+
+## Established facts
+
+### The disconnect is not the bug
+
+Stop frames are byte-equivalent between the two clients:
+
+```
+THETIS  t=1941.852380  port 1027  seq=00000000  byte4=00  rx0=0ecee101
+NEREUS  t=1986.382217  port 1027  seq=00000000  byte4=00  rx0=0f1b3333
+```
+
+`byte4=00` is `run=0`; the RX0 frequency is preserved rather than zeroed in both.
+In all three captured sessions the radio's last packet coincides with the
+client's last packet to the microsecond, so `run=0` is received and honoured and
+the radio stops streaming cleanly.
+
+Three prior fixes (`a0514cb1`, `f0e30f20`, `a4cda4e3`) all modified this frame.
+It was already correct.
+
+### After our disconnect the radio is dead at layer 2
+
+Confirmed independently twice. The Mac ARPs for `192.168.109.198` and gets no
+reply at all:
+
+```
+12:52:30.961308  ARP  Who has 192.168.109.198 (40:84:32:b0:b0:8d)? Tell 192.168.109.52
+12:52:31.512147  ARP  Who has 192.168.109.198? Tell 192.168.109.52
+12:52:32.503097  ARP  Who has 192.168.109.198? Tell 192.168.109.52
+```
+
+Zero inbound frames of any kind. Because ARP never resolves, macOS never
+transmits our UDP, which is exactly why the connect appears to hang: our packets
+never reach the wire. No UDP-level change can recover a radio in this state.
+
+Thetis's disconnect leaves the radio healthy — proven in the same capture, since
+NereusSDR connected successfully 22 s after Thetis's second disconnect.
+
+---
+
+## Divergences found, and why each was eliminated
+
+Each was checked against the actual G2E gateware, extracted from
+`TAPR/OpenHPSDR-Firmware` → `Protocol 2/HermesC10 (ANAN-G2E)/Hermes_Protocol_2_C10_v11.0.5.qar`
+(matches the reported firmware 110). Gateware cited as fact only, per CLAUDE.md.
+
+| Divergence | Verdict |
+|---|---|
+| `CmdGeneral` bytes 33-36 (Envelope PWM): Thetis 800/100, ours 0/0 | **Dead.** `Envelope_PWM_max/min` are commented out in the `Hermes.v:1511-1512` instantiation and `.EER()` is unconnected |
+| `CmdRx`: we set 48 kHz on disabled DDC1-3, Thetis sets 0 | **Harmless.** `Hermes.v:717/741` hold a DDC FIFO in reset from `!C122_EnableRx0_7[d]` regardless of rate, so `fifo_ready` never asserts and `sdr_send` skips it |
+| `CmdHighPriority` sequence always 0 | **Not a divergence.** Thetis also sends `00000000` on all four command ports (it never writes the field; `memset` leaves it). Ours is 0 by accident — `composeCmdHighPriority` memcpy's a zero-filled codec buffer over the stamped `m_seqHighPri++`. Left alone deliberately: matching the proven-working baseline beats "fixing" it into a new divergence |
+| P1 discovery probe disarming the deadman | **Did not fire.** NereusSDR sent no discovery probe at all during the captured session. Still a latent hazard, see below |
+
+### Latent hazard worth knowing (not this bug)
+
+`General_CC.v:90/106/141` accepts any packet on port 1024 whose byte 4 is `0x00`
+as a General command and loads byte 38 bit 0 into `HW_timer_enable`. Our P1
+discovery probe (`RadioDiscovery.cpp:601`, 63 zero bytes plus `EF FE 02`) has
+byte 4 = 0 and byte 38 = 0, so it would disarm the board's ~2 s deadman
+(`Hermes.v:398-414`), which `High_Priority_CC.v:145-147` shows is the only
+automatic path that can clear a stuck `run`. Thetis's probes use byte 4 = `0x02`,
+which `General_CC` rejects. The ICMP destination-unreachable fallback is detected
+at `icmp.v:129` and exported by `network.v:587` but is **never connected** in
+`Hermes.v`, so it cannot help either. Not the cause of this bug, but it means a
+scan can switch off the radio's last safety net.
+
+---
+
+## The surviving difference: command cadence
+
+Deduplicated for the mirror factor:
+
+| Command | Thetis | NereusSDR (before fix) | ratio |
+|---|---|---|---|
+| `CmdGeneral` (1024) | 1.03/s, median gap 1001 ms | 3.41/s, median 293 ms | 3x |
+| `CmdRx` (1025) | 1.28/s, **bursty** (gaps 2 ms to 5.5 s) | 5.70/s, steady 199 ms | 4.5x |
+| `CmdTx` (1026) | **1 per session** | 5.11/s, steady 200 ms | ~110x |
+| `CmdHighPriority` (1027) | **1 per session** | 12.47/s, steady 98 ms | ~280x |
+
+Thetis does not poll. In `network.c [v2.10.3.15]`, `CmdHighPriority()` is reached
+only from `SendStart():362-369`, `SendStop():372-376`, and per-control state
+changes. The only periodic command is `CmdGeneral()` from
+`KeepAliveLoop():1428-1437` (`if (prn->run && prn->wdt) CmdGeneral();`), whose
+job is feeding the deadman.
+
+Safety check before changing ours: Thetis sends `CmdHighPriority` once per
+session yet still receives high-priority status from the radio (src port 1025) at
+~2.8/s. The radio's status stream is autonomous, **not** a reply to our polling,
+so reducing our cadence costs no status updates.
+
+The capture also shows NereusSDR emitting a `CmdRx` **4.4 ms before** the stop
+frame — the last 100 ms heartbeat tick landing between the timer stops and the
+send. Each `CmdRx` re-latches `EnableRx0_7` and the per-DDC rates. Thetis's stop
+frame arrives with no other command traffic near it.
+
+---
+
+## Change made
+
+`src/core/P2RadioConnection.cpp`:
+
+1. **The 100 ms heartbeat wheel is gated on MOX.** It is preserved verbatim for
+   transmit, where its original 3M-1a rationale applies ("keep TX state fresh ...
+   never engages the PA"), and does not run during receive, where there is no PA
+   state to keep fresh. In the captured session `mox=false` throughout, so all
+   278 `CmdHighPriority` frames were idle polling. Every state change is already
+   pushed immediately by 11 change-driven `sendCmdHighPriority` sites, 4 for
+   `CmdRx` and 10 for `CmdTx`, so the wheel was purely additive.
+2. **`writeDatagram`'s return is checked** in `sendCmdHighPriority`. Previously
+   discarded, so `"SendStop complete"` was logged whether or not the frame ever
+   reached the wire. Three rounds of debugging treated that line as evidence.
+3. **`kStopQuiesceMs` settle before the stop frame**, so nothing lands on top of
+   it if a disconnect is taken during TX.
+
+The 500 ms `CmdGeneral` keepalive is retained — it is Thetis's `network.c:1428`
+period and it is what feeds the board's 2 s deadman.
+
+---
+
+## Status
+
+**Unproven.** Cadence is the last wire-level difference standing after the others
+were eliminated against the gateware, not a demonstrated cause. The mechanism by
+which excess C&C traffic would leave the board's Ethernet path dead is not
+established; `sdr_send.v:138` (`if (!run && state > SEND) state <= IDLE`) is the
+only escape from a stalled send state and ARP shares a single TX arbiter with UDP
+(`network.v:341-344, 416-421`), which would explain total layer-2 silence, but
+that remains a hypothesis.
+
+Next bench run: connect, use, disconnect, then confirm the radio still answers
+ARP and accepts a reconnect without a power cycle.
+
+---
+
+## Prior art
+
+- `a0514cb1` (2026-05-22) 3x SendStop retry — superseded
+- `f0e30f20` 5x CmdGeneral winddown, no run=0 — wrong, based on a partial pcap; retracted
+- `a4cda4e3` reverted to 1x `CmdHighPriority` run=0 — current stop-frame behaviour, confirmed correct by this capture
+
+`a4cda4e3` closed by asking for exactly the byte-diff performed here. Note its
+commit message describes Thetis's stop as "ONE CmdHighPriority frame"; this
+capture shows four on the wire, but that is the mirror duplicating a single send,
+not four sends.

--- a/captures/g2e-disconnect-NOTES.md
+++ b/captures/g2e-disconnect-NOTES.md
@@ -241,6 +241,46 @@ the radio emits and exactly which probe it fails to answer.
 
 ---
 
+## Update, 2026-07-27 evening: post-disconnect quiet period. Bench result GOOD.
+
+The delta analysis (Thetis is totally silent after its stop; NereusSDR fired a
+broadcast discovery burst 7-15 ms after run=0, and both deaths landed in that
+window) led to `RadioDiscovery::holdOffScans()`: every teardown now defers all
+discovery, broadcast and unicast, for 3 s. Probing a radio while its
+stop-transition state machines are settling is a race Thetis never enters, and
+now neither do we.
+
+Bench, same G2E, same network, one power cycle to clear the prior wedge:
+
+| | cycle 1 | cycle 2 |
+|---|---|---|
+| session length | ~7 s | 54 s (longer than the 48 s fatal session) |
+| scan after run=0 | +2.3 s | +2.3 s |
+| discovery after stop | answers | answers |
+| reconnect | clean | clean |
+
+Two consecutive clean cycles. The pre-fix build never survived two in a row
+(best observed: one). Attribution note: this build also carries the 0xFF probe
+pad and the MOX-gated cadence, but both fatal runs already had the cadence fix
+and death #2 involved no mid-session scan, so the quiet period is the change
+that separates wedge from no-wedge.
+
+Still true and worth remembering:
+
+* The underlying gateware race presumably still exists. Any OTHER host that
+  broadcasts discovery at the wrong instant (another PC running an SDR console,
+  a scanner) could in principle wedge a stopping radio. Client-side silence
+  narrows the trigger; it does not fix the firmware. Candidate upstream report
+  to TAPR / N1GP once more cycles confirm.
+* The exact wedged state machine inside the C10 gateware was never pinned.
+  udp_send / ip_send / mac_send / the TX arbiter all read orphan-tolerant;
+  arp.v and the icmp sending_sync handshake remain unread.
+* Confidence: two cycles is strong but not proof against a ~25% survival rate
+  observed pre-fix (P of 2 clean by luck is roughly 6%). A day of normal use
+  without a power cycle closes this for good.
+
+---
+
 ## Prior art
 
 - `a0514cb1` (2026-05-22) 3x SendStop retry — superseded

--- a/src/core/P2RadioConnection.cpp
+++ b/src/core/P2RadioConnection.cpp
@@ -468,7 +468,10 @@ void P2RadioConnection::init()
     m_p2HeartbeatTimer->setTimerType(Qt::PreciseTimer);
     connect(m_p2HeartbeatTimer, &QTimer::timeout, this, [this]() {
         if (!m_running) { return; }
-        if (!m_mox) { return; }               // RX: Thetis-faithful, event-driven only
+        // RX: Thetis-faithful, event-driven only.  The MOX-off grace window
+        // keeps the wheel turning briefly after unkey so a lost MOX-off frame
+        // is retransmitted rather than leaving the radio keyed — see setMox().
+        if (!m_mox && !withinMoxOffGrace()) { return; }
         sendCmdHighPriority();                // every 100 ms (every cycle)
         switch (m_p2HeartbeatCycle) {
             case 0: case 2: case 4: case 6:   // odd-numbered cycles → TX-spec
@@ -865,12 +868,36 @@ void P2RadioConnection::setMox(bool enabled)
     // m_tx[0].pttOut remains for the rear-panel PTT-out relay (TX-confirmation
     // output, deferred to 3M-3 per the plan); it is NOT the MOX source here.
     if (m_mox == enabled) {
-        return;  // idempotent — periodic cadence covers any state drift
+        return;  // idempotent — see the MOX-off grace window below
     }
     m_mox = enabled;
+    if (!enabled) {
+        // 2026-07-27 (Codex review, PR #306): open a bounded grace window so
+        // the heartbeat keeps re-emitting MOX-off for a short while after
+        // unkey.
+        //
+        // The idempotent early-return above was justified by the 100 ms
+        // cadence "already re-emitting the current m_mox state on every tick"
+        // — but that cadence is now gated on m_mox, so it stops the instant
+        // MOX drops.  Without this window a single lost MOX-off datagram
+        // leaves the radio keyed: repeat setMox(false) calls early-return
+        // without sending, and the CmdGeneral keepalive keeps feeding the
+        // firmware deadman so it will not self-clear either.  A stuck
+        // transmitter is a PA and interference hazard, so cover transient
+        // loss with retransmissions rather than a single unacknowledged frame.
+        m_moxOffGraceUntilMs =
+            QDateTime::currentMSecsSinceEpoch() + kMoxOffGraceMs;
+    }
     if (m_running) {
         sendCmdHighPriority();  // immediate emit on state change for low latency
     }
+}
+
+// True while the post-unkey grace window is open.  See setMox().
+bool P2RadioConnection::withinMoxOffGrace() const
+{
+    return m_moxOffGraceUntilMs != 0
+           && QDateTime::currentMSecsSinceEpoch() < m_moxOffGraceUntilMs;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/P2RadioConnection.cpp
+++ b/src/core/P2RadioConnection.cpp
@@ -885,8 +885,13 @@ void P2RadioConnection::setMox(bool enabled)
         // firmware deadman so it will not self-clear either.  A stuck
         // transmitter is a PA and interference hazard, so cover transient
         // loss with retransmissions rather than a single unacknowledged frame.
-        m_moxOffGraceUntilMs =
-            QDateTime::currentMSecsSinceEpoch() + kMoxOffGraceMs;
+        //
+        // Monotonic deadline (Codex review, PR #306): a wall-clock window can
+        // be stepped shut by NTP mid-unkey, which would strand a lost MOX-off
+        // frame unretransmitted.  Qt::PreciseTimer because this bounds a
+        // transmitter-safety window.
+        m_moxOffGrace = QDeadlineTimer(
+            std::chrono::milliseconds(kMoxOffGraceMs), Qt::PreciseTimer);
     }
     if (m_running) {
         sendCmdHighPriority();  // immediate emit on state change for low latency
@@ -896,8 +901,9 @@ void P2RadioConnection::setMox(bool enabled)
 // True while the post-unkey grace window is open.  See setMox().
 bool P2RadioConnection::withinMoxOffGrace() const
 {
-    return m_moxOffGraceUntilMs != 0
-           && QDateTime::currentMSecsSinceEpoch() < m_moxOffGraceUntilMs;
+    // Default-constructed QDeadlineTimer is already expired, so the
+    // never-armed case needs no separate sentinel check.
+    return !m_moxOffGrace.hasExpired();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/P2RadioConnection.cpp
+++ b/src/core/P2RadioConnection.cpp
@@ -438,11 +438,37 @@ void P2RadioConnection::init()
     //
     // Dispatch table over an 8-cycle wheel (0..7) — matches deskhpsdr's
     // `switch (cycling)` cases 1..8 (we're 0-indexed).
+    //
+    // 2026-07-27 (ANAN-G2E lockup): the wheel is now gated on MOX, so it
+    // only runs while transmitting.  Rationale, from a TZSP wire capture of
+    // Thetis and NereusSDR against the same ANAN-G2E (analysis in
+    // captures/g2e-disconnect-NOTES.md):
+    //
+    //   command          Thetis            NereusSDR (before)
+    //   CmdHighPriority  1 per session     12.47/s
+    //   CmdTx            1 per session     5.11/s
+    //   CmdRx            1.28/s bursty     5.70/s
+    //
+    // Thetis never polls.  From Thetis network.c [v2.10.3.15], CmdHighPriority()
+    // is reached only from SendStart():362-369, SendStop():372-376, and
+    // per-control state changes; only CmdGeneral() is periodic, from
+    // KeepAliveLoop():1428-1437 (`if (prn->run && prn->wdt) CmdGeneral();`),
+    // whose job is feeding the board's ~2 s deadman.
+    //
+    // NereusSDR already pushes every state change immediately (11 change-driven
+    // sendCmdHighPriority sites, 4 for CmdRx, 10 for CmdTx), so the wheel was
+    // purely additive polling.  The original 3M-1a rationale above is a TX
+    // concern ("keep TX state fresh ... never engages the PA"), so it is
+    // preserved verbatim for the transmit case and simply not run during RX,
+    // where there is no PA state to keep fresh.  On MOX transitions
+    // setMox() already emits an immediate CmdHighPriority (see below), so the
+    // first TX frame does not wait on this timer.
     m_p2HeartbeatTimer = new QTimer(this);
     m_p2HeartbeatTimer->setInterval(100);
     m_p2HeartbeatTimer->setTimerType(Qt::PreciseTimer);
     connect(m_p2HeartbeatTimer, &QTimer::timeout, this, [this]() {
         if (!m_running) { return; }
+        if (!m_mox) { return; }               // RX: Thetis-faithful, event-driven only
         sendCmdHighPriority();                // every 100 ms (every cycle)
         switch (m_p2HeartbeatCycle) {
             case 0: case 2: case 4: case 6:   // odd-numbered cycles → TX-spec
@@ -650,11 +676,26 @@ void P2RadioConnection::disconnect()
         //
         // Defensive: flush + 20 ms sleep before close so the run=0 frame
         // is actually on the wire before the socket goes away.
+        // 2026-07-27: quiesce before the stop frame.  A TZSP capture of a
+        // NereusSDR disconnect showed a CmdRx leaving 4.4 ms ahead of the
+        // run=0 frame — the last 100 ms heartbeat tick firing between the
+        // timer stops above and the send below.  Each CmdRx re-latches
+        // EnableRx0_7 and the per-DDC rates in the gateware
+        // (Hermes.v:717/741 hold a DDC FIFO in reset from its enable bit),
+        // so landing one immediately before the stop reconfigures the DDCs
+        // as they are being shut down.  Thetis never does this: its capture
+        // shows the stop frame arriving with no other command traffic near
+        // it.  The heartbeat is now MOX-gated so this cannot happen on an RX
+        // disconnect, and the settle covers a disconnect taken during TX.
+        QThread::msleep(kStopQuiesceMs);
+
         m_running = false;       // prn->run = 0;
         sendCmdHighPriority();   // From Thetis SendStop() network.c:372-376
         m_socket->flush();
-        QThread::msleep(20);
-        qCDebug(lcConnection) << "P2: SendStop complete (1x CmdHighPriority run=0, Thetis-faithful)";
+        QThread::msleep(kStopDrainMs);
+        qCDebug(lcConnection)
+            << "P2: SendStop sent (1x CmdHighPriority run=0, Thetis-faithful);"
+            << "any send failure is logged separately above";
     }
 
     m_running = false;
@@ -2332,7 +2373,17 @@ void P2RadioConnection::sendCmdHighPriority()
     // From Thetis network.c:1062
     // sendPacket(listenSock, packetbuf, BUFLEN, prn->base_outbound_port + 3);
     QByteArray pkt(buf, sizeof(buf));
-    m_socket->writeDatagram(pkt, m_radioInfo.address, m_baseOutboundPort + 3);
+    // 2026-07-27: check the send result.  Previously the return was discarded,
+    // so disconnect() logged "SendStop complete" whether or not the run=0 frame
+    // ever reached the wire — three rounds of ANAN-G2E lockup debugging trusted
+    // that line as evidence the stop had been sent.  It was not evidence.
+    const qint64 written =
+        m_socket->writeDatagram(pkt, m_radioInfo.address, m_baseOutboundPort + 3);
+    if (written != pkt.size()) {
+        qCWarning(lcConnection)
+            << "P2: CmdHighPriority send failed — wrote" << written
+            << "of" << pkt.size() << "bytes:" << m_socket->errorString();
+    }
     // Shell-chrome sub-PR-2 B.1: record egress bytes for ▲ Mbps readout.
     recordBytesSent(static_cast<qint64>(pkt.size()));
     // Shell-chrome sub-PR-2 B.2: bracket C&C round-trip for ping RTT.

--- a/src/core/P2RadioConnection.h
+++ b/src/core/P2RadioConnection.h
@@ -382,6 +382,16 @@ private:
     static constexpr int kBufLen = 1444;      // Thetis BUFLEN
     static constexpr int kKeepAliveIntervalMs = 500; // network.c:1428
 
+    // Disconnect timing (2026-07-27, ANAN-G2E lockup investigation).
+    // kStopQuiesceMs: settle after stopping the command timers and before
+    //   emitting run=0, so no CmdRx/CmdTx lands on top of the stop frame.
+    //   One 100 ms heartbeat period covers the worst-case in-flight tick.
+    // kStopDrainMs: let the kernel put the run=0 datagram on the wire before
+    //   close(); Thetis keeps listenSock open across SendStop
+    //   (network.c:398-404 StopReadThread) so it needs no equivalent.
+    static constexpr int kStopQuiesceMs = 100;
+    static constexpr int kStopDrainMs   = 20;
+
     // --- Board capabilities (set in connectToRadio, used for clamp/dispatch) ---
     const BoardCapabilities* m_caps{nullptr};
 

--- a/src/core/P2RadioConnection.h
+++ b/src/core/P2RadioConnection.h
@@ -175,6 +175,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "BoardCapabilities.h"
 
 #include <QDateTime>
+#include <QDeadlineTimer>
 #include <QUdpSocket>
 #include <QTimer>
 #include <QVector>
@@ -398,8 +399,17 @@ private:
     // otherwise leave the radio keyed indefinitely.  Only ever active
     // immediately after a transmission, so it does not reintroduce RX-idle
     // polling.  See setMox() for the full rationale.
+    //
+    // MONOTONIC, not wall-clock (Codex review, PR #306).  This was
+    // QDateTime::currentMSecsSinceEpoch() arithmetic.  An NTP step forward
+    // inside the window would make the grace read as already expired, so a
+    // lost MOX-off datagram would stop being retransmitted and the radio
+    // could stay keyed — precisely the hazard the window exists to close.
+    // A step backward would hold RX polling open far past one second.
+    // QDeadlineTimer measures against a monotonic source.  Default-constructed
+    // is already expired, which is the "never armed" state.
     static constexpr qint64 kMoxOffGraceMs = 1000;
-    qint64 m_moxOffGraceUntilMs{0};
+    QDeadlineTimer m_moxOffGrace;
     bool withinMoxOffGrace() const;
 
     // --- Board capabilities (set in connectToRadio, used for clamp/dispatch) ---

--- a/src/core/P2RadioConnection.h
+++ b/src/core/P2RadioConnection.h
@@ -392,6 +392,16 @@ private:
     static constexpr int kStopQuiesceMs = 100;
     static constexpr int kStopDrainMs   = 20;
 
+    // MOX-off grace window (2026-07-27, Codex review PR #306).  After unkey
+    // the 100 ms heartbeat keeps running this long so the MOX-off state is
+    // retransmitted ~10 times instead of once; a single lost datagram would
+    // otherwise leave the radio keyed indefinitely.  Only ever active
+    // immediately after a transmission, so it does not reintroduce RX-idle
+    // polling.  See setMox() for the full rationale.
+    static constexpr qint64 kMoxOffGraceMs = 1000;
+    qint64 m_moxOffGraceUntilMs{0};
+    bool withinMoxOffGrace() const;
+
     // --- Board capabilities (set in connectToRadio, used for clamp/dispatch) ---
     const BoardCapabilities* m_caps{nullptr};
 

--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -147,12 +147,16 @@ RadioDiscovery::~RadioDiscovery()
     stopDiscovery();
 }
 
+// Process-wide quiet deadline — see the declaration for why this is not
+// per-instance.
+qint64 RadioDiscovery::s_scanHoldOffUntilMs = 0;
+
 void RadioDiscovery::holdOffScans(std::chrono::milliseconds quiet)
 {
     const qint64 until =
         QDateTime::currentMSecsSinceEpoch() + qint64(quiet.count());
-    if (until > m_scanHoldOffUntilMs) {
-        m_scanHoldOffUntilMs = until;
+    if (until > s_scanHoldOffUntilMs) {
+        s_scanHoldOffUntilMs = until;
     }
 }
 
@@ -161,7 +165,7 @@ void RadioDiscovery::holdOffScans(std::chrono::milliseconds quiet)
 qint64 RadioDiscovery::holdOffRemainingMs() const
 {
     const qint64 remaining =
-        m_scanHoldOffUntilMs - QDateTime::currentMSecsSinceEpoch();
+        s_scanHoldOffUntilMs - QDateTime::currentMSecsSinceEpoch();
     return remaining > 0 ? remaining : 0;
 }
 

--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -355,13 +355,55 @@ bool RadioDiscovery::parseP2Reply(const QByteArray& bytes, const QHostAddress& s
 //   3. Poll up to quietPollsBeforeResend × pollTimeoutMs for replies.
 //   4. Parse replies, de-duplicate by MAC, emit radioDiscovered / radioUpdated.
 // ---------------------------------------------------------------------------
+
+// Byte 4 of the P1 discovery frame. Thetis leaves the whole tail zeroed
+// (clsRadioDiscovery.cs:1301-1309 buildDiscoveryPacketP1); NereusSDR sets a
+// non-zero pad here deliberately.
+//
+// Why: a P1 discovery probe is broadcast to UDP 1024, which is also the P2
+// "General" command port. Protocol 2 gateware claims any port-1024 datagram
+// whose byte 4 is zero and parses the rest as a General command --
+// General_CC.v:90/106 [TAPR OpenHPSDR-Firmware, Hermes_Protocol_2_C10_v11.0.5,
+// ANAN-G2E]:
+//
+//     if (udp_rx_active && to_port == port)              // 1024
+//         4: if (udp_rx_data != 8'd0)  state <= END;     // not for this module
+//
+// Our all-zero tail then lands as a valid config: byte 38 clears
+// HW_timer_enable (General_CC.v:141), which freezes the board's ~2 s deadman
+// (Hermes.v:406-411) -- the only automatic path that can clear a stuck `run`
+// (High_Priority_CC.v:145-147). Bytes 58/59 clear PA_enable and Alex_enable.
+// So merely scanning the LAN reconfigures every P2 radio on it and disarms
+// their watchdog.
+//
+// A non-zero byte 4 makes General_CC bail at the command check while leaving
+// P1 discovery untouched: every P1 gateware tests only the command byte and
+// never reads byte 4. Verified across the TAPR P1 archives for Hermes v3.3,
+// Angelia (ANAN-100D), Orion (ANAN-200D), ANAN-10E/100B and HermesC10
+// (ANAN-G2E) -- all are `if (PHY_output[47:40] == 8'h02) // check for Metis
+// Discovery` in Rx_MAC.v, which then captures only the requester's IP/MAC/port.
+//
+// Value 0x02 mirrors the P1 command byte so the frame reads as deliberate
+// rather than corrupt on the wire.
+//
+// Gateware cited as hardware fact only, per CLAUDE.md; no gateware logic is
+// translated here.
+static constexpr char kP1ProbeByte4Pad = 0x02;
+
+static QByteArray buildP1DiscoveryProbe()
+{
+    QByteArray p(63, 0);
+    p[0] = static_cast<char>(0xEF);
+    p[1] = static_cast<char>(0xFE);
+    p[2] = static_cast<char>(0x02);
+    p[4] = kP1ProbeByte4Pad;   // keep P2 General_CC from claiming this frame
+    return p;
+}
+
 void RadioDiscovery::scanAllNics()
 {
     // From Thetis clsRadioDiscovery.cs buildDiscoveryPacketP1()
-    QByteArray p1Packet(63, 0);
-    p1Packet[0] = static_cast<char>(0xEF);
-    p1Packet[1] = static_cast<char>(0xFE);
-    p1Packet[2] = static_cast<char>(0x02);
+    QByteArray p1Packet = buildP1DiscoveryProbe();
 
     // From Thetis clsRadioDiscovery.cs buildDiscoveryPacketP2()
     QByteArray p2Packet(60, 0);
@@ -595,10 +637,9 @@ void RadioDiscovery::probeAddress(const QHostAddress& addr,
     // Both must be padded to the full discovery-frame size — real OpenHPSDR
     // firmware ignores short probes (only the broadcast scan path was sending
     // padded frames before; this matches scanAllNics's p1Packet/p2Packet shape).
-    QByteArray p1Packet(63, 0);
-    p1Packet[0] = static_cast<char>(0xEF);
-    p1Packet[1] = static_cast<char>(0xFE);
-    p1Packet[2] = static_cast<char>(0x02);
+    // Same byte-4 pad as the broadcast scan path; rationale at
+    // buildP1DiscoveryProbe() above.
+    QByteArray p1Packet = buildP1DiscoveryProbe();
 
     QByteArray p2Packet(60, 0);
     p2Packet[4] = static_cast<char>(0x02);

--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -148,15 +148,17 @@ RadioDiscovery::~RadioDiscovery()
 }
 
 // Process-wide quiet deadline — see the declaration for why this is not
-// per-instance.
-qint64 RadioDiscovery::s_scanHoldOffUntilMs = 0;
+// per-instance, and why it is monotonic rather than wall-clock.
+QDeadlineTimer RadioDiscovery::s_scanHoldOff;
 
 void RadioDiscovery::holdOffScans(std::chrono::milliseconds quiet)
 {
-    const qint64 until =
-        QDateTime::currentMSecsSinceEpoch() + qint64(quiet.count());
-    if (until > s_scanHoldOffUntilMs) {
-        s_scanHoldOffUntilMs = until;
+    // Keep whichever deadline is later so a short holdoff can never pull in a
+    // longer one already in flight.  Qt::PreciseTimer because this bounds a
+    // radio-safety interval, not a UI refresh.
+    const QDeadlineTimer candidate(quiet, Qt::PreciseTimer);
+    if (candidate > s_scanHoldOff) {
+        s_scanHoldOff = candidate;
     }
 }
 
@@ -164,8 +166,9 @@ void RadioDiscovery::holdOffScans(std::chrono::milliseconds quiet)
 // for the ANAN-G2E rationale.
 qint64 RadioDiscovery::holdOffRemainingMs() const
 {
-    const qint64 remaining =
-        s_scanHoldOffUntilMs - QDateTime::currentMSecsSinceEpoch();
+    // remainingTime() is monotonic and already clamps to 0 once expired; the
+    // guard covers the -1 "forever" encoding, which we never construct.
+    const qint64 remaining = s_scanHoldOff.remainingTime();
     return remaining > 0 ? remaining : 0;
 }
 

--- a/src/core/RadioDiscovery.cpp
+++ b/src/core/RadioDiscovery.cpp
@@ -147,8 +147,38 @@ RadioDiscovery::~RadioDiscovery()
     stopDiscovery();
 }
 
+void RadioDiscovery::holdOffScans(std::chrono::milliseconds quiet)
+{
+    const qint64 until =
+        QDateTime::currentMSecsSinceEpoch() + qint64(quiet.count());
+    if (until > m_scanHoldOffUntilMs) {
+        m_scanHoldOffUntilMs = until;
+    }
+}
+
+// Remaining quiet time, 0 when scans may run now.  See holdOffScans() decl
+// for the ANAN-G2E rationale.
+qint64 RadioDiscovery::holdOffRemainingMs() const
+{
+    const qint64 remaining =
+        m_scanHoldOffUntilMs - QDateTime::currentMSecsSinceEpoch();
+    return remaining > 0 ? remaining : 0;
+}
+
 void RadioDiscovery::startDiscovery()
 {
+    // Post-disconnect quiet period: defer, never drop.  One pending deferred
+    // scan is enough — the scan that eventually runs walks every NIC anyway.
+    if (const qint64 waitMs = holdOffRemainingMs(); waitMs > 0) {
+        if (!m_deferredScanPending) {
+            m_deferredScanPending = true;
+            QTimer::singleShot(int(waitMs), this, [this]() {
+                m_deferredScanPending = false;
+                startDiscovery();
+            });
+        }
+        return;
+    }
     // Phase 3I rewrote discovery to walk all NICs per scan with ephemeral
     // per-NIC sockets (mi0bot clsRadioDiscovery pattern). Main's older
     // single-persistent-m_socket path was replaced entirely in Task 4;
@@ -383,12 +413,28 @@ bool RadioDiscovery::parseP2Reply(const QByteArray& bytes, const QHostAddress& s
 // (ANAN-G2E) -- all are `if (PHY_output[47:40] == 8'h02) // check for Metis
 // Discovery` in Rx_MAC.v, which then captures only the requester's IP/MAC/port.
 //
-// Value 0x02 mirrors the P1 command byte so the frame reads as deliberate
-// rather than corrupt on the wire.
+// Choosing the value: byte 4 is also the *P2 command* byte, decoded in
+// sdr_receive.v (same archive) as
+//
+//     3: case (udp_rx_data)          // packet byte 4
+//         2: state <= ST_DISCOVERY;
+//         3: if (broadcast)  state <= ST_SETIP;          // writes IP to EEPROM
+//         4: if (!broadcast) state <= ST_ERASE;
+//         5: if (!broadcast) state <= ST_PROGRAM_FIFO;
+//         6: if (!broadcast) state <= ST_RESET;          // resets the FPGA
+//         default: state <= ST_WAIT;
+//
+// so the pad must avoid 0x00 (General_CC claims it) *and* 0x02..0x06. These
+// probes go to the subnet broadcast, which is exactly the case ST_SETIP is
+// gated on. An earlier revision used 0x02 to "mirror the P1 command byte";
+// that made every P1 probe read as a second discovery request and doubled the
+// discovery replies each radio emits per scan (verified in the app log: 2 per
+// attempt before, 4 after). 0xFF falls through to ST_WAIT and is claimed by
+// nothing.
 //
 // Gateware cited as hardware fact only, per CLAUDE.md; no gateware logic is
 // translated here.
-static constexpr char kP1ProbeByte4Pad = 0x02;
+static constexpr char kP1ProbeByte4Pad = static_cast<char>(0xFF);
 
 static QByteArray buildP1DiscoveryProbe()
 {
@@ -593,6 +639,17 @@ void RadioDiscovery::probeAddress(const QHostAddress& addr,
                                   quint16 port,
                                   std::chrono::milliseconds timeout)
 {
+    // Same post-disconnect quiet period as startDiscovery(): a unicast probe
+    // at a radio mid-stop-transition is the same race as a broadcast one.
+    // Defer the whole call; the caller's timeout starts when the probe is
+    // actually sent, so Connect flows just see a slightly longer probe.
+    if (const qint64 waitMs = holdOffRemainingMs(); waitMs > 0) {
+        QTimer::singleShot(int(waitMs), this, [this, addr, port, timeout]() {
+            probeAddress(addr, port, timeout);
+        });
+        return;
+    }
+
     auto* sock = new QUdpSocket(this);
     sock->bind(QHostAddress::AnyIPv4, 0);
 

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -59,6 +59,7 @@ mw0lge@grange-lane.co.uk
 #include "HpsdrModel.h"
 
 #include <QObject>
+#include <QDeadlineTimer>
 #include <QHostAddress>
 #include <QUdpSocket>
 #include <QTimer>
@@ -225,10 +226,10 @@ public:
     }
     void forceStaleCheckForTest() { onStaleCheck(); }
 
-    // The holdOffScans deadline is process-wide (see s_scanHoldOffUntilMs),
-    // so it survives across test functions and would defer probes in
-    // unrelated cases. Call from a QTest init() for a clean slate.
-    static void clearHoldOffForTest() { s_scanHoldOffUntilMs = 0; }
+    // The holdOffScans deadline is process-wide (see s_scanHoldOff), so it
+    // survives across test functions and would defer probes in unrelated
+    // cases. Call from a QTest init() for a clean slate.
+    static void clearHoldOffForTest() { s_scanHoldOff = QDeadlineTimer(); }
 #endif
 
     // Public static parsers — exposed for unit-testing in Task 5.
@@ -281,7 +282,8 @@ private:
     QTimer m_continuousTimer;   // drives ongoing NIC re-scans while monitoring
     QTimer m_staleTimer;
 
-    // holdOffScans deadline (ms since epoch, 0 = none).
+    // holdOffScans deadline.  Default-constructed QDeadlineTimer is already
+    // expired, which is the "no holdoff armed" state.
     //
     // PROCESS-WIDE, not per-instance (Codex review, PR #306).  The constraint
     // belongs to the radio and the wire, not to any one RadioDiscovery object,
@@ -289,7 +291,16 @@ private:
     // AddCustomRadioDialog.cpp:589 constructs its own.  A per-object deadline
     // would let that dialog probe a just-disconnected radio inside the quiet
     // window and re-enter the post-stop race this exists to prevent.
-    static qint64 s_scanHoldOffUntilMs;
+    //
+    // MONOTONIC, not wall-clock (Codex review, PR #306).  This was
+    // QDateTime::currentMSecsSinceEpoch() arithmetic, which an NTP step could
+    // move underneath us: a forward correction expires the holdoff early and
+    // lets a probe land inside the G2E stop-transition window this exists to
+    // avoid, and a backward correction defers discovery for as long as the
+    // correction was large.  QDeadlineTimer measures against a monotonic
+    // source, so clock synchronisation cannot shorten a radio-safety interval
+    // or wedge discovery.
+    static QDeadlineTimer s_scanHoldOff;
 
     // Per-instance: stops a burst of startDiscovery() calls on THIS object
     // from queueing multiple delayed scans.

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -179,6 +179,22 @@ public:
     void startDiscovery();
     void stopDiscovery();
 
+    // Post-disconnect quiet period (2026-07-27, ANAN-G2E lockup).
+    //
+    // Wire captures show NereusSDR fires a broadcast discovery burst 7-15 ms
+    // after sending run=0 (disconnect reopens the ConnectionPanel, whose ctor
+    // auto-scans) and both observed G2E lockups happened inside that window,
+    // while Thetis goes completely silent after its stop frame and never
+    // wedges the same radio.  Probing a radio while its stop-transition state
+    // machines are still settling is a race Thetis never enters.
+    //
+    // Calling holdOffScans() defers — never drops — any startDiscovery() or
+    // probeAddress() issued before the deadline: the work runs when the quiet
+    // period expires, so the panel still populates and Connect flows still
+    // probe, just after the radio has finished stopping.
+    void holdOffScans(std::chrono::milliseconds quiet);
+    qint64 holdOffRemainingMs() const;
+
     DiscoveryProfile profile() const { return m_profile; }
     void setProfile(DiscoveryProfile profile) { m_profile = profile; }
 
@@ -259,6 +275,12 @@ private:
 
     QTimer m_continuousTimer;   // drives ongoing NIC re-scans while monitoring
     QTimer m_staleTimer;
+
+    // holdOffScans deadline (ms since epoch, 0 = none).  Deferred-scan flag
+    // stops a burst of startDiscovery() calls during the quiet period from
+    // queueing multiple delayed scans.
+    qint64 m_scanHoldOffUntilMs{0};
+    bool m_deferredScanPending{false};
     QMap<QString, RadioInfo> m_radios;   // keyed by MAC address
     QMap<QString, qint64> m_lastSeen;    // MAC -> timestamp
     QString m_connectedMac;              // MAC currently in use by a RadioConnection; exempt from stale-removal

--- a/src/core/RadioDiscovery.h
+++ b/src/core/RadioDiscovery.h
@@ -224,6 +224,11 @@ public:
         m_lastSeen.insert(mac, lastSeenMs);
     }
     void forceStaleCheckForTest() { onStaleCheck(); }
+
+    // The holdOffScans deadline is process-wide (see s_scanHoldOffUntilMs),
+    // so it survives across test functions and would defer probes in
+    // unrelated cases. Call from a QTest init() for a clean slate.
+    static void clearHoldOffForTest() { s_scanHoldOffUntilMs = 0; }
 #endif
 
     // Public static parsers — exposed for unit-testing in Task 5.
@@ -276,10 +281,18 @@ private:
     QTimer m_continuousTimer;   // drives ongoing NIC re-scans while monitoring
     QTimer m_staleTimer;
 
-    // holdOffScans deadline (ms since epoch, 0 = none).  Deferred-scan flag
-    // stops a burst of startDiscovery() calls during the quiet period from
-    // queueing multiple delayed scans.
-    qint64 m_scanHoldOffUntilMs{0};
+    // holdOffScans deadline (ms since epoch, 0 = none).
+    //
+    // PROCESS-WIDE, not per-instance (Codex review, PR #306).  The constraint
+    // belongs to the radio and the wire, not to any one RadioDiscovery object,
+    // and RadioModel::discovery() is not the only instance: e.g.
+    // AddCustomRadioDialog.cpp:589 constructs its own.  A per-object deadline
+    // would let that dialog probe a just-disconnected radio inside the quiet
+    // window and re-enter the post-stop race this exists to prevent.
+    static qint64 s_scanHoldOffUntilMs;
+
+    // Per-instance: stops a burst of startDiscovery() calls on THIS object
+    // from queueing multiple delayed scans.
     bool m_deferredScanPending{false};
     QMap<QString, RadioInfo> m_radios;   // keyed by MAC address
     QMap<QString, qint64> m_lastSeen;    // MAC -> timestamp

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -7504,6 +7504,10 @@ void RadioModel::teardownConnection()
     // discovery off (defer, not drop) until the radio's stop transition and
     // its ~2 s firmware deadman window have passed.  Applies to every
     // teardown flavor: user disconnect, failed-connect watchdog, quit.
+    //
+    // Armed here so nothing scans *during* teardown, and armed again after
+    // the protocol disconnect completes below — that second arm is the one
+    // that guarantees a full quiet period measured from the stop frame.
     if (m_discovery) {
         m_discovery->holdOffScans(kPostDisconnectScanQuietMs);
     }
@@ -7796,6 +7800,23 @@ void RadioModel::teardownConnection()
     // are thread-affined to the worker and destroying them on any other
     // thread emits cross-thread warnings and can crash on Windows.
     teardownWorkerThreadedConnection(m_connection, m_connThread);
+
+    // Re-arm the discovery quiet period now that the protocol disconnect has
+    // actually completed.  The arm at the top of this function starts the
+    // clock at teardown *entry*, but run=0 does not leave until
+    // teardownWorkerThreadedConnection() dispatches
+    // P2RadioConnection::disconnect() onto the connection thread — after the
+    // audio/WDSP/TX shutdown above.  Measured on the 2026-07-27 bench that
+    // cost 680 ms of the intended 3 s window (SendStop 17:31:38.149, scan
+    // 17:31:40.473), and teardownWorkerThreadedConnection alone may block up
+    // to kDispatchTimeoutMs (3000 ms) if the connection thread is stuck in
+    // onReadyRead — which would expire the whole holdoff before the stop
+    // frame is even sent, re-entering the exact window this guards.
+    // holdOffScans() keeps the later deadline, so arming twice only extends.
+    // Codex review, PR #306.
+    if (m_discovery) {
+        m_discovery->holdOffScans(kPostDisconnectScanQuietMs);
+    }
 
     // Phase 3Q polish: above disconnect() severed connectionStateChanged
     // before the RadioConnection's own setState(Disconnected) ran, so the

--- a/src/models/RadioModel.cpp
+++ b/src/models/RadioModel.cpp
@@ -7496,6 +7496,18 @@ void RadioModel::teardownConnection()
         return;
     }
 
+    // 2026-07-27 (ANAN-G2E lockup): quiet period for discovery.  Disconnect
+    // reopens the ConnectionPanel, whose ctor auto-scans — wire captures show
+    // the broadcast probe burst landing 7-15 ms after our run=0 frame, and
+    // both observed G2E lockups happened inside that window.  Thetis sends
+    // nothing after its stop frame and never wedges the same radio.  Hold
+    // discovery off (defer, not drop) until the radio's stop transition and
+    // its ~2 s firmware deadman window have passed.  Applies to every
+    // teardown flavor: user disconnect, failed-connect watchdog, quit.
+    if (m_discovery) {
+        m_discovery->holdOffScans(kPostDisconnectScanQuietMs);
+    }
+
     // Flush any pending coalesced slice save FIRST so the user's last
     // AF / step / freq / lock / RIT tweak isn't lost to the 500 ms
     // debounce in scheduleSettingsSave(). The QTimer there can't fire

--- a/src/models/RadioModel.h
+++ b/src/models/RadioModel.h
@@ -2322,6 +2322,16 @@ private:
     QHash<int, QDateTime> m_radeSyncDropAt;
     static constexpr int kRadeSyncDropClearDebounceMs = 2000;
 
+    // 2026-07-27 (ANAN-G2E lockup): discovery quiet period after any
+    // teardown.  Must outlast (a) the radio's stop-transition settling
+    // (observed death window: up to ~1 s after run=0 in the 2026-07-27 TZSP
+    // captures) and (b) the gateware's ~2 s C&C deadman edge
+    // (Hermes.v:398-414, HW_TIMEOUT at 250e6 cycles @ 125 MHz), so the first
+    // probe a stopped radio hears arrives with its state machines fully
+    // settled.  Thetis's post-stop behaviour is total silence; 3 s of quiet
+    // approximates that without making the reopened panel feel dead.
+    static constexpr std::chrono::milliseconds kPostDisconnectScanQuietMs{3000};
+
     // 2026-05-12 bench: FreeDV Reporter freq-publish throttle.
     //
     // Spinning the VFO would otherwise fire a Socket.IO freq_change

--- a/tests/tst_radio_discovery_probe.cpp
+++ b/tests/tst_radio_discovery_probe.cpp
@@ -111,6 +111,10 @@ private:
 class TstRadioDiscoveryProbe : public QObject {
     Q_OBJECT
 private slots:
+    // The post-disconnect quiet deadline is process-wide, so an arm in one
+    // test function would otherwise defer probes in every later one.
+    void init() { RadioDiscovery::clearHoldOffForTest(); }
+
     void probeReplyFillsRadioInfo() {
         FakeP1Probe radio;
         RadioDiscovery disc;
@@ -225,6 +229,21 @@ private slots:
         disc.holdOffScans(std::chrono::milliseconds(9000));
         QVERIFY2(disc.holdOffRemainingMs() > 8000,
                  "holdOffScans() failed to extend the deadline");
+    }
+
+    // Codex review, PR #306.  RadioModel::discovery() is not the only
+    // RadioDiscovery in the process — AddCustomRadioDialog.cpp:589 builds its
+    // own.  A per-object deadline would let that dialog probe a
+    // just-disconnected radio inside the quiet window, re-entering the
+    // post-stop race.  The deadline must be process-wide.
+    void holdOffIsSharedAcrossInstances() {
+        RadioDiscovery armer;
+        armer.holdOffScans(std::chrono::milliseconds(5000));
+
+        RadioDiscovery other;   // e.g. the one AddCustomRadioDialog creates
+        QVERIFY2(other.holdOffRemainingMs() > 4000,
+                 "a second RadioDiscovery instance ignored the quiet period — "
+                 "the Add Radio dialog could probe a stopping radio");
     }
 
     void timeoutEmitsProbeFailed() {

--- a/tests/tst_radio_discovery_probe.cpp
+++ b/tests/tst_radio_discovery_probe.cpp
@@ -76,6 +76,8 @@ public:
         connect(m_socket, &QUdpSocket::readyRead, this, &FakeP1Probe::onReadyRead);
     }
     quint16 port() const { return m_socket->localPort(); }
+    // Raw P1 probe as it arrived on the wire, for byte-level assertions.
+    QByteArray lastP1Probe() const { return m_lastP1Probe; }
 private slots:
     void onReadyRead() {
         while (m_socket->hasPendingDatagrams()) {
@@ -89,6 +91,7 @@ private slots:
             if (buf.size() >= 3 && static_cast<quint8>(buf[0]) == 0xEF
                 && static_cast<quint8>(buf[1]) == 0xFE
                 && static_cast<quint8>(buf[2]) == 0x02) {
+                m_lastP1Probe = buf;
                 QByteArray reply(63, 0);
                 reply[0] = char(0xEF); reply[1] = char(0xFE); reply[2] = 0x02;
                 // MAC bytes 3..8
@@ -102,6 +105,7 @@ private slots:
     }
 private:
     QUdpSocket* m_socket;
+    QByteArray  m_lastP1Probe;
 };
 
 class TstRadioDiscoveryProbe : public QObject {
@@ -121,6 +125,41 @@ private slots:
         QCOMPARE(info.firmwareVersion, 75);
         QCOMPARE(info.macAddress, QStringLiteral("00:1C:C0:A2:14:8B"));
         QCOMPARE(info.protocol, ProtocolVersion::Protocol1);
+    }
+
+    // Regression guard, 2026-07-27 (ANAN-G2E disconnect lockup).
+    //
+    // The P1 discovery probe goes to UDP 1024, which is also the Protocol 2
+    // "General" command port.  P2 gateware claims any port-1024 datagram whose
+    // byte 4 is zero and parses the remainder as a General command
+    // (General_CC.v:90/106, TAPR Hermes_Protocol_2_C10_v11.0.5 for ANAN-G2E).
+    // With an all-zero tail that write clears HW_timer_enable (byte 38),
+    // freezing the board's ~2 s deadman, plus PA_enable and Alex_enable
+    // (bytes 58/59) — so a plain LAN scan reconfigures every P2 radio on the
+    // subnet and disarms its watchdog.
+    //
+    // Byte 4 must therefore stay non-zero.  P1 discovery is unaffected: every
+    // P1 gateware matches only the command byte and never reads byte 4.
+    void p1ProbeDoesNotImpersonateP2GeneralCommand() {
+        FakeP1Probe radio;
+        RadioDiscovery disc;
+        QSignalSpy spy(&disc, &RadioDiscovery::radioDiscovered);
+
+        disc.probeAddress(QHostAddress::LocalHost, radio.port(),
+                          std::chrono::milliseconds(500));
+        QVERIFY(spy.wait(1000));
+
+        const QByteArray probe = radio.lastP1Probe();
+        // Still a well-formed P1 discovery frame.
+        QCOMPARE(probe.size(), 63);
+        QCOMPARE(static_cast<quint8>(probe[0]), quint8(0xEF));
+        QCOMPARE(static_cast<quint8>(probe[1]), quint8(0xFE));
+        QCOMPARE(static_cast<quint8>(probe[2]), quint8(0x02));
+        // ...but byte 4 is non-zero, so P2 General_CC bails at its command
+        // check instead of latching our padding as a config write.
+        QVERIFY2(static_cast<quint8>(probe[4]) != 0x00,
+                 "P1 probe byte 4 is zero — P2 gateware will accept this frame "
+                 "as a General command and disarm its watchdog");
     }
 
     void timeoutEmitsProbeFailed() {

--- a/tests/tst_radio_discovery_probe.cpp
+++ b/tests/tst_radio_discovery_probe.cpp
@@ -201,6 +201,32 @@ private slots:
                      .arg(clock.elapsed()).arg(kQuietMs)));
     }
 
+    // Codex review, PR #306.  teardownConnection() arms the quiet period
+    // twice: once on entry (so nothing scans during teardown) and again after
+    // the protocol disconnect completes (so the window is measured from the
+    // stop frame, not from teardown entry, which cost 680 ms on the bench).
+    // That is only safe because holdOffScans keeps the LATER deadline — a
+    // second, shorter arm must never pull the deadline in.
+    void holdOffScansExtendsButNeverShortens() {
+        RadioDiscovery disc;
+
+        disc.holdOffScans(std::chrono::milliseconds(5000));
+        const qint64 afterLong = disc.holdOffRemainingMs();
+        QVERIFY(afterLong > 4000);
+
+        // Shorter arm must not shorten the window.
+        disc.holdOffScans(std::chrono::milliseconds(50));
+        QVERIFY2(disc.holdOffRemainingMs() > 4000,
+                 "a shorter holdOffScans() pulled the deadline in — the "
+                 "second arm in teardownConnection() would truncate the "
+                 "post-stop quiet period");
+
+        // Longer arm must extend it.
+        disc.holdOffScans(std::chrono::milliseconds(9000));
+        QVERIFY2(disc.holdOffRemainingMs() > 8000,
+                 "holdOffScans() failed to extend the deadline");
+    }
+
     void timeoutEmitsProbeFailed() {
         RadioDiscovery disc;
         QSignalSpy spy(&disc, &RadioDiscovery::probeFailed);

--- a/tests/tst_radio_discovery_probe.cpp
+++ b/tests/tst_radio_discovery_probe.cpp
@@ -157,9 +157,48 @@ private slots:
         QCOMPARE(static_cast<quint8>(probe[2]), quint8(0x02));
         // ...but byte 4 is non-zero, so P2 General_CC bails at its command
         // check instead of latching our padding as a config write.
-        QVERIFY2(static_cast<quint8>(probe[4]) != 0x00,
+        const quint8 b4 = static_cast<quint8>(probe[4]);
+        QVERIFY2(b4 != 0x00,
                  "P1 probe byte 4 is zero — P2 gateware will accept this frame "
                  "as a General command and disarm its watchdog");
+        // Byte 4 is also the P2 *command* byte (sdr_receive.v): 2=discovery,
+        // 3=set-IP (broadcast-gated, writes EEPROM), 4=erase, 5=program,
+        // 6=FPGA reset. Our probes are broadcast, so the pad must not collide
+        // with any of them or a plain LAN scan starts issuing P2 commands.
+        QVERIFY2(b4 < 0x02 || b4 > 0x06,
+                 "P1 probe byte 4 collides with a P2 command (2..6) — a "
+                 "broadcast scan would issue discovery/set-IP/erase/reset");
+    }
+
+    // Regression guard, 2026-07-27 (ANAN-G2E disconnect lockup).
+    //
+    // After a disconnect the radio's stop-transition and ~2 s firmware
+    // deadman must settle before any probe reaches it (Thetis is silent
+    // after its stop; our auto-scan fired 7-15 ms after run=0 and both
+    // observed G2E lockups happened in that window).  holdOffScans() must
+    // DEFER a probe — it still completes, but only after the quiet period.
+    void probeDuringHoldOffIsDeferredNotDropped() {
+        FakeP1Probe radio;
+        RadioDiscovery disc;
+        QSignalSpy spy(&disc, &RadioDiscovery::radioDiscovered);
+
+        constexpr int kQuietMs = 400;
+        disc.holdOffScans(std::chrono::milliseconds(kQuietMs));
+
+        QElapsedTimer clock;
+        clock.start();
+        disc.probeAddress(QHostAddress::LocalHost, radio.port(),
+                          std::chrono::milliseconds(500));
+
+        // Not dropped: the reply still arrives...
+        QVERIFY(spy.wait(2000));
+        QCOMPARE(spy.count(), 1);
+        // ...and not early: the probe waited out the quiet period first.
+        QVERIFY2(clock.elapsed() >= kQuietMs,
+                 qPrintable(QStringLiteral(
+                     "probe completed %1 ms after holdOffScans(%2) — it was "
+                     "sent inside the post-disconnect quiet period")
+                     .arg(clock.elapsed()).arg(kQuietMs)));
     }
 
     void timeoutEmitsProbeFailed() {


### PR DESCRIPTION
## Problem

Disconnecting from an ANAN-G2E (HermesC10, fw 110, Protocol 2) left the radio
unreachable at layer 2. Not just discovery: the MikroTik on the same segment
could not ARP or ping it either, and the switch port showed no traffic at all.
Only a physical power cycle recovered it. Thetis on the same radio and the same
network never triggered it. Not reproducible on HL2, ANAN-G2 (Saturn), or
Anvelina PRO3.

## Root cause

Our disconnect was fine. The stop frame is byte-identical to Thetis's
(`byte4=00`, frequencies preserved, seq 0) and the radio acts on it, stopping
its stream cleanly between bursts.

What differed is what came next. Teardown reopens the ConnectionPanel, whose
constructor auto-scans, so a broadcast discovery burst hit the radio 7-15 ms
after `run=0`. Thetis goes completely silent after its stop frame. Both
observed lockups landed inside that window: one radio died before answering the
first burst, the other answered burst 1 and was dead before burst 2 ~850 ms
later. Probing a radio while its stop-transition state machines are still
settling is a race Thetis never enters.

## Changes

**1. Post-disconnect discovery quiet period.** `RadioDiscovery::holdOffScans()`
defers, never drops, any `startDiscovery()` or `probeAddress()` issued within
3 s of a teardown. The panel still populates and Connect flows still probe,
just after the radio has finished stopping. Covers every teardown path: user
disconnect, failed-connect watchdog, and quit.

**2. P1 discovery probe no longer impersonates P2 commands.** The probe is
broadcast to UDP 1024, which is also the P2 General command port. P2 gateware
claims any port-1024 datagram whose byte 4 is zero and parses the rest as
config, so our all-zero tail was clearing `HW_timer_enable` (the board's ~2 s
deadman), `PA_enable`, and `Alex_enable` on every P2 radio on the subnet, every
scan. Byte 4 is now `0xFF`, which no P2 command claims. Deliberately not `0x02`
(the P2 discovery command, doubles every radio's reply load) and not `0x03`
(reaches the EEPROM set-IP path on a broadcast frame). Verified no P1 gateware
reads byte 4: Hermes v3.3, Angelia, Orion, ANAN-10E/100B and HermesC10 all
match only the command byte in `Rx_MAC.v`. Confirmed on hardware after the
change: HL2 still discovered over P1, Saturn reply count back to normal.

**3. Stop polling the radio during RX.** Wire capture showed our command
cadence at 27-280x Thetis's. Thetis never polls; only `CmdGeneral` is periodic,
from `KeepAliveLoop()`, to feed the deadman. Our 100 ms heartbeat wheel was
purely additive, since every state change is already pushed immediately. The
wheel is gated on MOX rather than removed, preserving the 3M-1a bench finding
about TX carrier, which is a transmit concern only.

**4. `writeDatagram` return is now checked.** It was discarded, so
`"SendStop complete"` was logged whether or not the frame reached the wire.
Three rounds of debugging treated that line as evidence. It caught
`wrote -1 "Unable to send a message"` on the first run and proved the radio was
ARP-dead rather than ignoring us.

## Verification

Two consecutive disconnect/reconnect cycles on the G2E, no power cycle:

| | cycle 1 | cycle 2 |
|---|---|---|
| session | ~7 s | 54 s |
| scan after `run=0` | +2.32 s | +2.33 s |
| reconnect | clean | clean |

Cycle 2 ran longer than the 48 s session that wedged the radio before. The old
build never survived two cycles in a row.

Tests: `tst_p2_regression_freeze`, `tst_p2_mox_wire`, `tst_p2_codec_orionmkii`,
`tst_radio_discovery_probe`, `tst_radio_discovery_parse`,
`tst_flex_radio_discovery_broadcaster` all pass. Two new regression cases cover
the probe pad (asserts byte 4 avoids `0x00` and the whole `0x02`-`0x06` command
range) and the quiet period (probe completes, but only after it expires).

## Known limits

The gateware race itself was never pinned. The full TX chain reads
orphan-tolerant: `udp_send`, `ip_send`, `mac_send`, and `arp.v` all
self-complete, and the discovery handshake has a timeout. The one structural
suspect that could not be cleared is the TX arbiter in `network.v`, which
commits without a timeout: once `tx_ready` latches, only wire activity releases
it. That matches "mute with link up" exactly, but no requester was found that
can hang it.

So this stops us tripping the fault; it does not fix the firmware. Another host
broadcasting discovery at the wrong instant could in principle still wedge a
stopping G2E. Full investigation, including everything eliminated and its
gateware citations, is in `captures/g2e-disconnect-NOTES.md`. A report to
N1GP/TAPR is worth sending separately once the mitigation has a day of normal
use behind it.

Two unrelated defects found while diffing and deliberately left for follow-up:
`CmdTx` byte 50 bit 5 (documented by Thetis as Saturn balanced-input) is set by
default on Hermes-class boards, and RX2/RX3 NCO phase words are sent as zero
where Thetis sends real values.

J.J. Boyd ~ KG4VCF
