### PR TITLE
fix(setup): build Settings pages on demand, not all at once (#272, #301)

### DIFF
--- a/src/gui/ConnectionPanel.cpp
+++ b/src/gui/ConnectionPanel.cpp
@@ -116,10 +116,24 @@ mw0lge@grange-lane.co.uk
 #include <QColor>
 #include <QPainter>
 #include <QPixmap>
+#include <QElapsedTimer>
 #include <QIcon>
+#include <QLoggingCategory>
 #include <QTimer>
 
 namespace NereusSDR {
+
+// Timing instrumentation, sibling to SetupDialog.cpp's nereus.setup.timing.
+// Issue #301 reported the RX audio buffer looping when either the Settings
+// menu *or* the Connect-to-Radio dialog was opened, so both open paths need a
+// measurable construction cost. The Settings side was the multi-second
+// offender and is fixed by lazy page construction; this seam is what lets the
+// next repro say whether this dialog contributes at all, without a profiler.
+//
+// Disabled by default. Enable with either of:
+//   QT_LOGGING_RULES="nereus.connpanel.timing.debug=true"
+//   QT_LOGGING_RULES="*.timing.debug=true"   (covers nereus.setup.timing too)
+Q_LOGGING_CATEGORY(lcConnPanelTiming, "nereus.connpanel.timing")
 
 // ---------------------------------------------------------------------------
 // Color constants — from ucRadioList.cs ~:1115 (adapted to dark theme)
@@ -184,11 +198,16 @@ ConnectionPanel::ConnectionPanel(RadioModel* model, QWidget* parent)
     : QDialog(parent)
     , m_radioModel(model)
 {
+    // #301 instrumentation: total ctor cost, plus the buildUI() share of it.
+    QElapsedTimer ctorTimer;
+    ctorTimer.start();
+
     setWindowTitle(QStringLiteral("Connect to Radio"));
     setMinimumSize(800, 460);
     resize(900, 520);
 
     buildUI();
+    const qint64 buildUiMs = ctorTimer.elapsed();
 
     // Wire discovery signals
     RadioDiscovery* disc = m_radioModel->discovery();
@@ -262,6 +281,14 @@ ConnectionPanel::ConnectionPanel(RadioModel* model, QWidget* parent)
 
     // Initial status strip state
     updateStatusStrip();
+
+    // #301 instrumentation: see lcConnPanelTiming above. `rows` is the saved +
+    // already-discovered radio count, since per-row work is the only part of
+    // this ctor that scales with anything the operator controls.
+    qCDebug(lcConnPanelTiming)
+        << "ConnectionPanel ctor total elapsed (ms):" << ctorTimer.elapsed()
+        << "of which buildUI():" << buildUiMs
+        << "rows:" << m_radioTable->rowCount();
 }
 
 ConnectionPanel::~ConnectionPanel()

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -26,6 +26,26 @@
 //                 [v2.10.3.13+501e3f51]). Deferred from Phase 5 so
 //                 Agents 5A and 5B could land in parallel without
 //                 touching this file.
+//   2026-07-27: issues #272 + #301. Split buildTree() into a cheap
+//                 registration phase and an on-demand realization
+//                 phase. buildTree() previously constructed all 55
+//                 pages synchronously from the SetupDialog ctor, which
+//                 blocked the Qt main thread for seconds on every
+//                 Settings open. That stall starved the audio drain
+//                 timer (#301, repeated RX buffer on ANAN-10E/macOS)
+//                 and on slower hosts outlasted the Protocol 1 ep6
+//                 watchdog, so the link was declared lost and the
+//                 unclean audio teardown cascaded into a
+//                 CLOCK_WATCHDOG_TIMEOUT BSOD (#272, HL2/Windows 11).
+//                 Pages now build on first visit. Cross-page wiring
+//                 moved into the per-page factories; the two sites
+//                 that genuinely reach across pages (the PA
+//                 [Reset PA Values] button and MainWindow's
+//                 setTciServer()) are routed through the dialog so the
+//                 dependency is realized on demand rather than eagerly.
+//                 Construction-timing change only: no page's layout,
+//                 controls, defaults, or behaviour are touched.
+//                 AI-assisted transformation via Anthropic Claude Code.
 // =================================================================
 
 #include "SetupDialog.h"
@@ -90,7 +110,28 @@
 #include <QElapsedTimer>
 #include <QLoggingCategory>
 
+#include <utility>
+
 namespace NereusSDR {
+
+namespace {
+
+// Current board capabilities for the connected radio, with the same
+// conservative fallback the ctor has always used: boardCapabilities()
+// returns Unknown caps when no radio has ever connected, and Unknown sets
+// hasPaProfile=false so the PA category stays hidden.
+//
+// Factored out of the ctor so the lazily-built PA pages can pick up the
+// live caps at realization time without SetupDialog having to cache a
+// BoardCapabilities member (which would pull the struct definition into
+// SetupDialog.h).
+BoardCapabilities capsForModel(RadioModel* model)
+{
+    return model ? model->boardCapabilities()
+                 : BoardCapsTable::forBoard(HPSDRHW::Unknown);
+}
+
+} // namespace
 
 // Timing instrumentation added in response to #272, where a ~3-second build
 // + ~40-second click-time freeze stalled the audio engine long enough for
@@ -144,32 +185,43 @@ SetupDialog::SetupDialog(RadioModel* model, QWidget* parent)
 
     layout->addWidget(splitter, 1);
 
-    // ── Build the tree and pages ──────────────────────────────────────────────
+    // ── Build the tree, register the page factories ───────────────────────────
     // #272 instrumentation: track total buildTree() cost. Per-category
     // deltas are emitted from inside buildTree() via a local tick helper.
+    //
+    // #272 / #301: buildTree() no longer constructs any page. It registers
+    // one factory per leaf; realizePage() builds the widget on first visit.
     QElapsedTimer buildTimer;
     buildTimer.start();
     buildTree();
     qCDebug(lcSetupTiming)
         << "buildTree() total elapsed (ms):" << buildTimer.elapsed()
-        << "pages:" << m_stack->count();
+        << "pages registered:" << m_pages.size()
+        << "realized:" << m_stack->count();
 
     // Connect tree selection → stack page.
     // #272 instrumentation: time the page-switch path. The QStackedWidget
     // setCurrentIndex() will fire showEvent() on the destination page, which
     // is where any deferred / click-time work would surface.
+    //
+    // #272 / #301: the UserRole payload is now a m_pages registry index, not
+    // a stack index. showPageAt() resolves it, building the page on the first
+    // visit and reusing the cached widget afterwards.
     connect(m_tree, &QTreeWidget::currentItemChanged,
             this, [this](QTreeWidgetItem* current, QTreeWidgetItem* /*previous*/) {
                 if (current == nullptr) { return; }
-                const int index = current->data(0, Qt::UserRole).toInt();
-                if (index >= 0) {
+                const int entryIndex = current->data(0, Qt::UserRole).toInt();
+                if (entryIndex >= 0) {
+                    const bool wasRealized =
+                        entryIndex < static_cast<int>(m_pages.size())
+                        && m_pages[static_cast<std::size_t>(entryIndex)].widget != nullptr;
                     QElapsedTimer switchTimer;
                     switchTimer.start();
-                    m_stack->setCurrentIndex(index);
+                    showPageAt(entryIndex);
                     qCDebug(lcSetupTiming)
                         << "page switch ->" << current->text(0)
-                        << "(stack index" << index << ") elapsed (ms):"
-                        << switchTimer.elapsed();
+                        << (wasRealized ? "(cached)" : "(first visit, realized)")
+                        << "elapsed (ms):" << switchTimer.elapsed();
                 }
             });
 
@@ -187,8 +239,11 @@ SetupDialog::SetupDialog(RadioModel* model, QWidget* parent)
     // boardCapabilities() falls back to Unknown caps when no radio has
     // ever connected; Unknown sets hasPaProfile=false → PA category
     // hidden, matching the conservative default.
-    applyPaVisibility(m_model ? m_model->boardCapabilities()
-                              : BoardCapsTable::forBoard(HPSDRHW::Unknown));
+    //
+    // #272 / #301: this pass now only decides nav-tree row visibility, since
+    // the three PA page widgets do not exist yet. Each PA factory re-applies
+    // the live caps to its own page at realization time.
+    applyPaVisibility(capsForModel(m_model));
 }
 
 // ── showEvent ─────────────────────────────────────────────────────────────────
@@ -230,20 +285,113 @@ void SetupDialog::selectPage(const QString& label)
 //
 // Idempotent and nullptr-safe — see CatTciServerPage::setTciServer() for
 // the QPointer + disconnect-old-then-connect-new pattern.
+//
+// #272 / #301: MainWindow calls this from wireSetupDialog(), i.e. immediately
+// after construction and long before the operator navigates to CAT & Network
+// -> TCI Server. Record the pointer so the page factory can replay it when
+// the page is finally realized; forward straight through when the page is
+// already up (a later server start/stop while Setup is open).
 void SetupDialog::setTciServer(NereusSDR::TciServer* server)
 {
+    m_pendingTciServer = server;
     if (m_tciServerPage) {
         m_tciServerPage->setTciServer(server);
     }
+}
+
+// ── Lazy page registry (issues #272 + #301) ───────────────────────────────────
+
+QTreeWidgetItem* SetupDialog::registerPage(QTreeWidgetItem* parent,
+                                          const QString& label,
+                                          std::function<QWidget*()> factory)
+{
+    auto* item = new QTreeWidgetItem(parent, QStringList{label});
+    item->setData(0, Qt::UserRole, static_cast<int>(m_pages.size()));
+    m_pages.push_back(PageEntry{label, std::move(factory), nullptr, -1});
+    return item;
+}
+
+QWidget* SetupDialog::realizePage(int entryIndex)
+{
+    if (entryIndex < 0 || entryIndex >= static_cast<int>(m_pages.size())) {
+        return nullptr;
+    }
+
+    PageEntry& entry = m_pages[static_cast<std::size_t>(entryIndex)];
+    if (entry.widget != nullptr) {
+        return entry.widget;
+    }
+    if (!entry.factory) {
+        // Already attempted and yielded nothing; do not retry or re-warn.
+        return nullptr;
+    }
+
+    // Move the factory out before invoking it so a page whose construction
+    // re-enters realizePage() (e.g. a cross-page connect firing during the
+    // ctor) cannot recurse into building the same page twice.
+    const std::function<QWidget*()> factory = std::move(entry.factory);
+    entry.factory = nullptr;
+
+    QElapsedTimer realizeTimer;
+    realizeTimer.start();
+    QWidget* page = factory();
+    if (page == nullptr) {
+        qCWarning(lcSetupTiming) << "page factory yielded nothing for"
+                                 << entry.label;
+        return nullptr;
+    }
+
+    entry.widget     = page;
+    entry.stackIndex = m_stack->addWidget(page);
+    qCDebug(lcSetupTiming) << "realized page" << entry.label
+                           << "elapsed (ms):" << realizeTimer.elapsed();
+    return page;
+}
+
+void SetupDialog::showPageAt(int entryIndex)
+{
+    if (realizePage(entryIndex) == nullptr) {
+        return;
+    }
+    m_stack->setCurrentIndex(
+        m_pages[static_cast<std::size_t>(entryIndex)].stackIndex);
+}
+
+int SetupDialog::pageEntryIndex(const QString& label) const
+{
+    for (std::size_t i = 0; i < m_pages.size(); ++i) {
+        if (m_pages[i].label == label) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+QWidget* SetupDialog::wrapWithAudioBackendStrip(SetupPage* page)
+{
+    // Returns a margin-less container QWidget that owns both the strip and the
+    // page. Qt parent-ownership keeps memory clean — the container is
+    // reparented into the QStackedWidget by realizePage().
+    auto* container = new QWidget;
+    auto* lay = new QVBoxLayout(container);
+    lay->setContentsMargins(0, 0, 0, 0);
+    lay->setSpacing(0);
+    lay->addWidget(new AudioBackendStrip(m_model->audioEngine(), container));
+    lay->addWidget(page);
+    return container;
 }
 
 // ── Tree builder ──────────────────────────────────────────────────────────────
 
 void SetupDialog::buildTree()
 {
-    // #272 instrumentation: per-category construction-time tick. Each call
+    // #272 instrumentation: per-category registration-time tick. Each call
     // logs the elapsed time since the previous tick, so a slow category's
     // delta will stand out in the log. Resets the timer on each call.
+    //
+    // #272 / #301: these deltas now measure registration only (tree items +
+    // std::function construction). Per-page construction cost shows up in the
+    // "realized page <label>" lines emitted by realizePage() instead.
     QElapsedTimer sectionTimer;
     sectionTimer.start();
     auto tick = [&sectionTimer](const char* label) {
@@ -264,48 +412,22 @@ void SetupDialog::buildTree()
         return item;
     };
 
-    // ── Helper: add a page with its specialized class ─────────────────────────
-    auto add = [this](QTreeWidgetItem* parent, const QString& label,
-                      SetupPage* page) -> QTreeWidgetItem* {
-        auto* item = new QTreeWidgetItem(parent, QStringList{label});
-        const int idx = m_stack->count();
-        item->setData(0, Qt::UserRole, idx);
-        m_stack->addWidget(page);
-        return item;
-    };
-
-    // ── Helper: wrap a SetupPage with an AudioBackendStrip header ─────────────
-    // Returns a margin-less container QWidget that owns both the strip and the
-    // page. Qt parent-ownership keeps memory clean — the container is reparented
-    // into the QStackedWidget by addWrapped below.
-    auto wrapWithAudioBackendStrip = [this](SetupPage* page) -> QWidget* {
-        auto* container = new QWidget;
-        auto* lay = new QVBoxLayout(container);
-        lay->setContentsMargins(0, 0, 0, 0);
-        lay->setSpacing(0);
-        lay->addWidget(new AudioBackendStrip(m_model->audioEngine(), container));
-        lay->addWidget(page);
-        return container;
-    };
-
-    // ── Helper: add a wrapped (plain QWidget) page to the tree ────────────────
-    auto addWrapped = [this](QTreeWidgetItem* parent, const QString& label,
-                             QWidget* container) -> QTreeWidgetItem* {
-        auto* item = new QTreeWidgetItem(parent, QStringList{label});
-        const int idx = m_stack->count();
-        item->setData(0, Qt::UserRole, idx);
-        m_stack->addWidget(container);
-        return item;
-    };
+    // Pages are registered, not built: each registerPage() call records a
+    // factory that realizePage() invokes on the leaf's first visit. Cross-page
+    // connect() calls therefore live *inside* the factories, so they are set up
+    // when the page that owns the signal actually exists.
 
     tick("helpers");
 
     // ── General ──────────────────────────────────────────────────────────────
     QTreeWidgetItem* general = addCategory("General");
-    add(general, "Startup & Preferences", new StartupPrefsPage(m_model));
-    add(general, "UI Scale & Theme",       new UiScalePage(m_model));
-    add(general, "Navigation",             new NavigationPage(m_model));
-    {
+    registerPage(general, "Startup & Preferences",
+                 [this] { return new StartupPrefsPage(m_model); });
+    registerPage(general, "UI Scale & Theme",
+                 [this] { return new UiScalePage(m_model); });
+    registerPage(general, "Navigation",
+                 [this] { return new NavigationPage(m_model); });
+    registerPage(general, "Options", [this]() -> QWidget* {
         // Phase 3M-4 Task 11: forward GeneralOptionsPage's PureSignal Info
         // Bar checkbox signals to the live PureSignal coordinator so the
         // bottom-banner FB indicator reflects the new state without having
@@ -316,6 +438,9 @@ void SetupDialog::buildTree()
         //
         // Task 3.6 (origin/main): also forward CPU meter rate spinbox so
         // MainWindow's wireSetupDialog() can connect to setCpuTimerIntervalHz.
+        // The forward target is a SetupDialog signal, so MainWindow's
+        // wireSetupDialog() connection made at construction time stays valid
+        // however late this page is realized.
         auto* genOpts = new GeneralOptionsPage(m_model);
         if (m_model) {
             if (auto* ps = m_model->pureSignal()) {
@@ -327,8 +452,8 @@ void SetupDialog::buildTree()
         }
         connect(genOpts, &GeneralOptionsPage::cpuMeterRateChanged,
                 this,    &SetupDialog::cpuMeterRateChanged);
-        add(general, "Options", genOpts);
-    }
+        return genOpts;
+    });
 
     tick("General");
 
@@ -338,12 +463,12 @@ void SetupDialog::buildTree()
     // Task 3.6: ANAN-8000DLE volts/amps toggle — forward signal up to
     // SetupDialog so MainWindow's wireSetupDialog() can connect it to
     // setVoltsAmpsVisible().
-    {
+    registerPage(hardware, "Hardware Config", [this]() -> QWidget* {
         auto* hwPage = new HardwarePage(m_model);
-        add(hardware, "Hardware Config", hwPage);
         connect(hwPage, &HardwarePage::anan8000DleVoltsAmpsChanged,
                 this,   &SetupDialog::anan8000DleVoltsAmpsChanged);
-    }
+        return hwPage;
+    });
 
     // ── PA ────────────────────────────────────────────────────────────────────
     // Top-level PA category mirrors Thetis tpPowerAmplifier
@@ -367,34 +492,70 @@ void SetupDialog::buildTree()
     tick("Hardware");
 
     m_paCategoryItem  = addCategory("PA");
-    m_paGainPage      = new PaGainByBandPage(m_model);
-    m_paWattMeterPage = new PaWattMeterPage(m_model);
-    m_paValuesPage    = new PaValuesPage(m_model);
-    m_paGainItem      = add(m_paCategoryItem, "PA Gain",    m_paGainPage);
-    m_paWattMeterItem = add(m_paCategoryItem, "Watt Meter", m_paWattMeterPage);
-    m_paValuesItem    = add(m_paCategoryItem, "PA Values",  m_paValuesPage);
 
-    // Phase 9 of #167: cross-wire PaWattMeterPage's [Reset PA Values] button
-    // (Phase 5A — emits resetPaValuesRequested) to PaValuesPage's
-    // resetPaValues() public slot (Phase 5B — clears peak/min trackers).
-    // Deferred from Phase 5 to keep agents 5A and 5B mutually parallel and
-    // conflict-free; the connect lands here once both pages exist.
-    // Mirrors Thetis btnResetPAValues_Click (setup.cs:16346-16357
-    // [v2.10.3.13+501e3f51]) — Thetis blanks the textbox text directly
-    // from the same panel; NereusSDR fans out to a peer page since the
-    // PA Values readout was promoted to its own dedicated page.
-    connect(m_paWattMeterPage, &PaWattMeterPage::resetPaValuesRequested,
-            m_paValuesPage,    &PaValuesPage::resetPaValues);
+    // #272 / #301: each PA factory re-applies the live BoardCapabilities to
+    // its own page, because applyPaVisibility() ran in the ctor (or on an
+    // earlier currentRadioChanged) while the page pointer was still null.
+    m_paGainItem = registerPage(m_paCategoryItem, "PA Gain", [this]() -> QWidget* {
+        m_paGainPage = new PaGainByBandPage(m_model);
+        m_paGainPage->applyCapabilityVisibility(capsForModel(m_model));
+        return m_paGainPage;
+    });
+
+    m_paWattMeterItem = registerPage(m_paCategoryItem, "Watt Meter",
+                                     [this]() -> QWidget* {
+        m_paWattMeterPage = new PaWattMeterPage(m_model);
+        m_paWattMeterPage->applyCapabilityVisibility(capsForModel(m_model));
+
+        // Phase 9 of #167: cross-wire PaWattMeterPage's [Reset PA Values]
+        // button (Phase 5A — emits resetPaValuesRequested) to PaValuesPage's
+        // resetPaValues() public slot (Phase 5B — clears peak/min trackers).
+        // Deferred from Phase 5 to keep agents 5A and 5B mutually parallel and
+        // conflict-free; the connect lands here once both pages exist.
+        // Mirrors Thetis btnResetPAValues_Click (setup.cs:16346-16357
+        // [v2.10.3.13+501e3f51]) — Thetis blanks the textbox text directly
+        // from the same panel; NereusSDR fans out to a peer page since the
+        // PA Values readout was promoted to its own dedicated page.
+        //
+        // #272 / #301: this is the one connect() in the dialog that spans two
+        // sibling pages, so it now routes through the dialog. The Watt Meter
+        // page can be realized while PA Values still is not; realizing the
+        // sibling here (on button press, not on dialog open) keeps the fan-out
+        // working without forcing a second page build up front.
+        connect(m_paWattMeterPage, &PaWattMeterPage::resetPaValuesRequested,
+                this, [this]() {
+                    realizePage(m_paValuesEntry);
+                    if (m_paValuesPage) {
+                        m_paValuesPage->resetPaValues();
+                    }
+                });
+        return m_paWattMeterPage;
+    });
+
+    m_paValuesItem = registerPage(m_paCategoryItem, "PA Values", [this]() -> QWidget* {
+        m_paValuesPage = new PaValuesPage(m_model);
+        m_paValuesPage->applyCapabilityVisibility(capsForModel(m_model));
+        return m_paValuesPage;
+    });
+
+    // Cache the registry index so the Watt Meter cross-wire above can realize
+    // the PA Values page without a label lookup on every button press.
+    m_paValuesEntry = m_paValuesItem->data(0, Qt::UserRole).toInt();
 
     tick("PA");
 
     // ── Audio ─────────────────────────────────────────────────────────────────
     QTreeWidgetItem* audio = addCategory("Audio");
-    addWrapped(audio, "Devices",  wrapWithAudioBackendStrip(new AudioDevicesPage(m_model)));
-    addWrapped(audio, "TX Input", wrapWithAudioBackendStrip(new AudioTxInputPage(m_model)));  // I.1
-    addWrapped(audio, "VAX",      wrapWithAudioBackendStrip(new AudioVaxPage(m_model)));
-    addWrapped(audio, "TCI",      wrapWithAudioBackendStrip(new AudioTciPage(m_model)));
-    addWrapped(audio, "Advanced", wrapWithAudioBackendStrip(new AudioAdvancedPage(m_model)));
+    registerPage(audio, "Devices",
+                 [this] { return wrapWithAudioBackendStrip(new AudioDevicesPage(m_model)); });
+    registerPage(audio, "TX Input",  // I.1
+                 [this] { return wrapWithAudioBackendStrip(new AudioTxInputPage(m_model)); });
+    registerPage(audio, "VAX",
+                 [this] { return wrapWithAudioBackendStrip(new AudioVaxPage(m_model)); });
+    registerPage(audio, "TCI",
+                 [this] { return wrapWithAudioBackendStrip(new AudioTciPage(m_model)); });
+    registerPage(audio, "Advanced",
+                 [this] { return wrapWithAudioBackendStrip(new AudioAdvancedPage(m_model)); });
     // Phase 3M-1c J.3: TX Profile editor.
     //
     // 3M-1c L.1 update: RadioModel now constructs MicProfileManager in its
@@ -404,22 +565,23 @@ void SetupDialog::buildTree()
     // RadioModel::connectToRadio().  Before any radio has connected the
     // manager is unscoped and every mutator silently no-ops; the page still
     // renders correctly (combo is empty) and Setup → TX Profile is harmless.
-    add(audio, "TX Profile",
-        new TxProfileSetupPage(
+    registerPage(audio, "TX Profile", [this]() -> QWidget* {
+        return new TxProfileSetupPage(
             m_model,
             m_model ? m_model->micProfileManager() : nullptr,
-            m_model ? &m_model->transmitModel() : nullptr));
+            m_model ? &m_model->transmitModel() : nullptr);
+    });
 
     tick("Audio");
 
     // ── DSP ───────────────────────────────────────────────────────────────────
     QTreeWidgetItem* dsp = addCategory("DSP");
-    add(dsp, "AGC/ALC",  new AgcAlcSetupPage(m_model));
-    add(dsp, "NR/ANF",   new NrAnfSetupPage(m_model));
-    add(dsp, "NB/SNB",   new NbSnbSetupPage(m_model));
-    add(dsp, "CW",       new CwSetupPage(m_model));
-    add(dsp, "AM/SAM",   new AmSamSetupPage(m_model));
-    add(dsp, "FM",       new FmSetupPage(m_model));
+    registerPage(dsp, "AGC/ALC", [this] { return new AgcAlcSetupPage(m_model); });
+    registerPage(dsp, "NR/ANF",  [this] { return new NrAnfSetupPage(m_model);  });
+    registerPage(dsp, "NB/SNB",  [this] { return new NbSnbSetupPage(m_model);  });
+    registerPage(dsp, "CW",      [this] { return new CwSetupPage(m_model);     });
+    registerPage(dsp, "AM/SAM",  [this] { return new AmSamSetupPage(m_model);  });
+    registerPage(dsp, "FM",      [this] { return new FmSetupPage(m_model);     });
     // (DSP > "VOX/DEXP" placeholder removed in 3M-3a-iii Task 16 — the wired
     //  page lives at Transmit > "DEXP/VOX" (DexpVoxPage from Task 14).)
 
@@ -428,22 +590,25 @@ void SetupDialog::buildTree()
     // cfcDialogRequested signal so MainWindow can route it to the
     // TxApplet::requestOpenCfcDialog() slot (the same modeless dialog
     // instance is shared with the [CFC] right-click on the TxApplet).
-    auto* cfcPage = new CfcSetupPage(m_model);
-    add(dsp, "CFC", cfcPage);
-    connect(cfcPage, &CfcSetupPage::openCfcDialogRequested,
-            this,    &SetupDialog::cfcDialogRequested);
+    registerPage(dsp, "CFC", [this]() -> QWidget* {
+        auto* cfcPage = new CfcSetupPage(m_model);
+        connect(cfcPage, &CfcSetupPage::openCfcDialogRequested,
+                this,    &SetupDialog::cfcDialogRequested);
+        return cfcPage;
+    });
 
-    add(dsp, "MNF",      new MnfSetupPage(m_model));
+    registerPage(dsp, "MNF", [this] { return new MnfSetupPage(m_model); });
     // Stage C2: user-customisable filter preset editor (10 slots × 12 modes).
-    add(dsp, "Filter Presets",
-        new FilterPresetsSetupPage(
+    registerPage(dsp, "Filter Presets", [this]() -> QWidget* {
+        return new FilterPresetsSetupPage(
             m_model ? m_model->filterPresetStore() : nullptr,
-            m_model));
+            m_model);
+    });
 
     // Task 4.1: DSP → Options page (buffer/filter size+type, impulse cache,
     // high-res filter characteristics, time-to-last-change readout).
     // Mirrors Thetis tpDSPOptions tab (design Section 4A).
-    add(dsp, "Options",  new DspOptionsPage(m_model));
+    registerPage(dsp, "Options", [this] { return new DspOptionsPage(m_model); });
 
     tick("DSP");
 
@@ -452,50 +617,64 @@ void SetupDialog::buildTree()
 
     // Task 2.4: SpectrumDefaultsPage gains cross-link buttons to Spectrum Peaks
     // (and a forward-reference to Multimeter which lands in Task 3.1).
-    auto* specDefaultsPage = new SpectrumDefaultsPage(m_model);
-    add(display, "Spectrum Defaults", specDefaultsPage);
-    connect(specDefaultsPage, &SpectrumDefaultsPage::navigateToSpectrumPeaksRequested,
-            this, [this]() { selectPage(QStringLiteral("Spectrum Peaks")); });
-    // Task 3.1: Multimeter page now exists — wire the cross-link.
-    connect(specDefaultsPage, &SpectrumDefaultsPage::navigateToMultimeterRequested,
-            this, [this]() { selectPage(QStringLiteral("Multimeter")); });
+    //
+    // #272 / #301: the cross-links go through selectPage(), which drives the
+    // nav tree, so the destination page is realized by the tree-selection
+    // handler. No sibling-page pointer is needed here.
+    registerPage(display, "Spectrum Defaults", [this]() -> QWidget* {
+        auto* specDefaultsPage = new SpectrumDefaultsPage(m_model);
+        connect(specDefaultsPage, &SpectrumDefaultsPage::navigateToSpectrumPeaksRequested,
+                this, [this]() { selectPage(QStringLiteral("Spectrum Peaks")); });
+        // Task 3.1: Multimeter page now exists — wire the cross-link.
+        connect(specDefaultsPage, &SpectrumDefaultsPage::navigateToMultimeterRequested,
+                this, [this]() { selectPage(QStringLiteral("Multimeter")); });
+        return specDefaultsPage;
+    });
 
     // Task 2.4: Spectrum Peaks page — skeleton with APH + Blob controls + back cross-link.
-    auto* specPeaksPage = new SpectrumPeaksPage(m_model);
-    add(display, "Spectrum Peaks",    specPeaksPage);
-    connect(specPeaksPage, &SpectrumPeaksPage::backToSpectrumDefaultsRequested,
-            this, [this]() { selectPage(QStringLiteral("Spectrum Defaults")); });
+    registerPage(display, "Spectrum Peaks", [this]() -> QWidget* {
+        auto* specPeaksPage = new SpectrumPeaksPage(m_model);
+        connect(specPeaksPage, &SpectrumPeaksPage::backToSpectrumDefaultsRequested,
+                this, [this]() { selectPage(QStringLiteral("Spectrum Defaults")); });
+        return specPeaksPage;
+    });
 
-    add(display, "Waterfall Defaults", new WaterfallDefaultsPage(m_model));
-    add(display, "Grid & Scales",      new GridScalesPage(m_model));
+    registerPage(display, "Waterfall Defaults",
+                 [this] { return new WaterfallDefaultsPage(m_model); });
+    registerPage(display, "Grid & Scales",
+                 [this] { return new GridScalesPage(m_model); });
 
     // Task 3.1: Display → Multimeter — 8 multimeter globals + unit-mode + signal history.
     // Folded from Thetis Display→General Multimeter group per design Section 3A.
     // Cross-link: ← Spectrum Defaults / SpectrumDefaultsPage → Multimeter.
-    auto* multimeterPage = new MultimeterPage(m_model);
-    add(display, "Multimeter", multimeterPage);
-    connect(multimeterPage, &MultimeterPage::backToSpectrumDefaultsRequested,
-            this, [this]() { selectPage(QStringLiteral("Spectrum Defaults")); });
+    registerPage(display, "Multimeter", [this]() -> QWidget* {
+        auto* multimeterPage = new MultimeterPage(m_model);
+        connect(multimeterPage, &MultimeterPage::backToSpectrumDefaultsRequested,
+                this, [this]() { selectPage(QStringLiteral("Spectrum Defaults")); });
+        return multimeterPage;
+    });
 
-    add(display, "RX2 Display",        new Rx2DisplayPage(m_model));
-    add(display, "TX Display",         new TxDisplayPage(m_model));
+    registerPage(display, "RX2 Display", [this] { return new Rx2DisplayPage(m_model); });
+    registerPage(display, "TX Display",  [this] { return new TxDisplayPage(m_model);  });
 
     tick("Display");
 
     // ── Transmit ──────────────────────────────────────────────────────────────
     QTreeWidgetItem* transmit = addCategory("Transmit");
-    add(transmit, "Power",              new PowerPage(m_model));
-    add(transmit, "TX Profiles",        new TxProfilesPage(m_model));
+    registerPage(transmit, "Power",       [this] { return new PowerPage(m_model);      });
+    registerPage(transmit, "TX Profiles", [this] { return new TxProfilesPage(m_model); });
 
     // SpeechProcessorPage is the TX dashboard (3M-3a-i Batch 5).  Its
     // openSetupRequested(category, page) signal feeds straight back into
     // selectPage() so the cross-link buttons jump within the same dialog
     // instance — no MainWindow round-trip required.
-    auto* speechPage = new SpeechProcessorPage(m_model);
-    add(transmit, "Speech Processor",   speechPage);
-    connect(speechPage, &SpeechProcessorPage::openSetupRequested,
-            this, [this](const QString& /*category*/, const QString& page) {
-        selectPage(page);
+    registerPage(transmit, "Speech Processor", [this]() -> QWidget* {
+        auto* speechPage = new SpeechProcessorPage(m_model);
+        connect(speechPage, &SpeechProcessorPage::openSetupRequested,
+                this, [this](const QString& /*category*/, const QString& page) {
+            selectPage(page);
+        });
+        return speechPage;
     });
 
     // Note: Setup → Transmit → PureSignal page retired in Phase 3M-4 Task 14
@@ -509,7 +688,7 @@ void SetupDialog::buildTree()
     // from the legacy DSP > VOX/DEXP placeholder above (line 245), which
     // remains a lightweight 4-control disabled stub for back-compat with
     // the Thetis tpDSPVOX tab IA.
-    add(transmit, "DEXP/VOX",           new DexpVoxPage(m_model));
+    registerPage(transmit, "DEXP/VOX", [this] { return new DexpVoxPage(m_model); });
 
     // 2026-05-22 menu cleanup: the standalone "PGXL Interlock" entry that
     // previously lived here is removed. The same controls live under
@@ -520,18 +699,23 @@ void SetupDialog::buildTree()
 
     // ── Appearance ────────────────────────────────────────────────────────────
     QTreeWidgetItem* appearance = addCategory("Appearance");
-    add(appearance, "Colors & Theme",       new ColorsThemePage(m_model));
-    add(appearance, "Meter Styles",         new MeterStylesPage(m_model));
-    add(appearance, "Gradients",            new GradientsPage(m_model));
-    add(appearance, "Skins",               new SkinsPage(m_model));
-    add(appearance, "Collapsible Display",  new CollapsibleDisplayPage(m_model));
+    registerPage(appearance, "Colors & Theme",
+                 [this] { return new ColorsThemePage(m_model); });
+    registerPage(appearance, "Meter Styles",
+                 [this] { return new MeterStylesPage(m_model); });
+    registerPage(appearance, "Gradients",
+                 [this] { return new GradientsPage(m_model); });
+    registerPage(appearance, "Skins",
+                 [this] { return new SkinsPage(m_model); });
+    registerPage(appearance, "Collapsible Display",
+                 [this] { return new CollapsibleDisplayPage(m_model); });
 
     tick("Appearance");
 
     // ── CAT & Network ─────────────────────────────────────────────────────────
     QTreeWidgetItem* cat = addCategory("CAT & Network");
-    add(cat, "Serial Ports", new CatSerialPortsPage);
-    {
+    registerPage(cat, "Serial Ports", [] { return new CatSerialPortsPage; });
+    registerPage(cat, "TCI Server", [this]() -> QWidget* {
         // Phase 3J-1 review P2.4: forward CatTciServerPage::tciServerEnableToggled
         // through SetupDialog so wireSetupDialog() can connect it to the live
         // TciServer::start() / stop() path in MainWindow.
@@ -549,8 +733,14 @@ void SetupDialog::buildTree()
         // to MainWindow so the log window outlives this dialog's close.
         connect(tciPage, &CatTciServerPage::showLogRequested,
                 this,    &SetupDialog::tciShowLogRequested);
-        add(cat, "TCI Server", tciPage);
-    }
+        // #272 / #301: replay the TciServer pointer MainWindow handed us at
+        // wireSetupDialog() time, so the Server group box title and Status
+        // label are live on the operator's very first visit to this page.
+        if (m_pendingTciServer) {
+            tciPage->setTciServer(m_pendingTciServer);
+        }
+        return tciPage;
+    });
     // 4O3A integration page (replaces the previous standalone
     // "Peripherals", "PGXL Advanced", and "TGXL Advanced" entries
     // that lived side-by-side under CAT & Network).  FourO3APage
@@ -562,9 +752,8 @@ void SetupDialog::buildTree()
     // inside FourO3APage's construction below so the SetupDialog
     // signal still fires through to TunerApplet::onAntennaLabelChanged
     // via wireSetupDialog().
-    {
+    registerPage(cat, "4O3A", [this]() -> QWidget* {
         auto* fourO3A = new FourO3APage(m_model);
-        addWrapped(cat, "4O3A", fourO3A);
         // Phase 3P-II Phase 4 Task 95 forwarding lives on FourO3APage
         // now; surface the embedded TGXL page's antennaLabelChanged
         // signal so wireSetupDialog continues to bridge it to TunerApplet.
@@ -572,35 +761,44 @@ void SetupDialog::buildTree()
             connect(tgxlAdv, &TgxlAdvancedPage::antennaLabelChanged,
                     this, &SetupDialog::tgxlAntennaLabelChanged);
         }
-    }
-    add(cat, "TCP/IP CAT",   new CatTcpIpPage);
-    add(cat, "MIDI Control", new CatMidiControlPage);
+        return fourO3A;
+    });
+    registerPage(cat, "TCP/IP CAT",   [] { return new CatTcpIpPage;       });
+    registerPage(cat, "MIDI Control", [] { return new CatMidiControlPage;  });
 
     tick("CAT & Network");
 
     // ── Keyboard ──────────────────────────────────────────────────────────────
     QTreeWidgetItem* keyboard = addCategory("Keyboard");
-    add(keyboard, "Shortcuts", new KeyboardShortcutsPage);
+    registerPage(keyboard, "Shortcuts", [] { return new KeyboardShortcutsPage; });
 
     tick("Keyboard");
 
     // ── Test ──────────────────────────────────────────────────────────────────
     // Phase 3M-1c H.1: top-level Test category for the Two-Tone IMD page.
     QTreeWidgetItem* test = addCategory("Test");
-    add(test, "Two-Tone IMD", new TestTwoTonePage(m_model));
+    registerPage(test, "Two-Tone IMD", [this] { return new TestTwoTonePage(m_model); });
 
     tick("Test");
 
     // ── Diagnostics ───────────────────────────────────────────────────────────
     QTreeWidgetItem* diagnostics = addCategory("Diagnostics");
-    add(diagnostics, "Radio Status",       new RadioStatusPage(m_model));
-    add(diagnostics, "Connection Quality", new ConnectionQualityPage(m_model));
-    add(diagnostics, "Settings Validation",new SettingsValidationPage(m_model));
-    add(diagnostics, "Export / Import",    new ExportImportConfigPage(m_model));
-    add(diagnostics, "Logs",               new LogsPage);
-    add(diagnostics, "Signal Generator",   new DiagSignalGeneratorPage);
-    add(diagnostics, "Hardware Tests",     new DiagHardwareTestsPage);
-    add(diagnostics, "Logging & Performance", new DiagLoggingPage);
+    registerPage(diagnostics, "Radio Status",
+                 [this] { return new RadioStatusPage(m_model); });
+    registerPage(diagnostics, "Connection Quality",
+                 [this] { return new ConnectionQualityPage(m_model); });
+    registerPage(diagnostics, "Settings Validation",
+                 [this] { return new SettingsValidationPage(m_model); });
+    registerPage(diagnostics, "Export / Import",
+                 [this] { return new ExportImportConfigPage(m_model); });
+    registerPage(diagnostics, "Logs",
+                 [] { return new LogsPage; });
+    registerPage(diagnostics, "Signal Generator",
+                 [] { return new DiagSignalGeneratorPage; });
+    registerPage(diagnostics, "Hardware Tests",
+                 [] { return new DiagHardwareTestsPage; });
+    registerPage(diagnostics, "Logging & Performance",
+                 [] { return new DiagLoggingPage; });
 
     tick("Diagnostics");
 
@@ -659,6 +857,11 @@ void SetupDialog::applyPaVisibility(const BoardCapabilities& caps)
     // (warning labels, banner copy, individual control gates) live
     // inside the page implementations — SetupDialog only owns the
     // category-level decision.
+    //
+    // #272 / #301: any of these three pointers may still be null because its
+    // leaf has not been visited yet. Skipping it is correct: the page factory
+    // applies capsForModel() itself the moment the page is realized, so a page
+    // built after a radio swap picks up the current caps either way.
     if (m_paGainPage) {
         m_paGainPage->applyCapabilityVisibility(caps);
     }

--- a/src/gui/SetupDialog.h
+++ b/src/gui/SetupDialog.h
@@ -11,9 +11,13 @@
 // =================================================================
 
 #include <QDialog>
+#include <QString>
 #include <QTreeWidget>
 #include <QStackedWidget>
 #include <QSplitter>
+
+#include <functional>
+#include <vector>
 
 namespace NereusSDR {
 
@@ -30,6 +34,12 @@ class CatTciServerPage;
 // Main settings dialog with tree-based navigation.
 // Left pane: QTreeWidget with top-level category items.
 // Right pane: QStackedWidget showing the selected page.
+//
+// Pages are built lazily (issues #272 + #301). buildTree() only registers a
+// label plus a factory callable per leaf; the widget itself is constructed by
+// realizePage() the first time its tree node is selected, then cached for the
+// lifetime of the dialog. See SetupDialog.cpp for the cross-page wiring rules
+// that fall out of that split.
 class SetupDialog : public QDialog {
     Q_OBJECT
 public:
@@ -102,16 +112,62 @@ private:
     // page-level controls can self-toggle (warning rows, banner labels).
     void applyPaVisibility(const BoardCapabilities& caps);
 
+    // ── Lazy page registry (issues #272 + #301) ───────────────────────────────
+    //
+    // One entry per navigation leaf. `factory` is consumed (moved out and
+    // cleared) by the first realizePage() call, so a page is built at most
+    // once; `widget` and `stackIndex` are the cached result.
+    struct PageEntry {
+        QString                   label;
+        std::function<QWidget*()> factory;
+        QWidget*                  widget     = nullptr;
+        int                       stackIndex = -1;
+    };
+
+    // Registration phase: create the tree leaf and record its factory. The
+    // leaf's Qt::UserRole holds the m_pages index (categories hold -1).
+    QTreeWidgetItem* registerPage(QTreeWidgetItem* parent, const QString& label,
+                                  std::function<QWidget*()> factory);
+
+    // Realization phase: build the page if it has not been built yet, add it
+    // to the stack, and return it. Returns nullptr for an out-of-range index
+    // or a factory that yielded nothing.
+    QWidget* realizePage(int entryIndex);
+
+    // Realize (if needed) and raise the page for the given registry index.
+    void showPageAt(int entryIndex);
+
+    // Registry index for a leaf label, or -1 when no such leaf exists.
+    int pageEntryIndex(const QString& label) const;
+
+    // Builds the AudioBackendStrip + page container used by Setup -> Audio.
+    // A member function rather than a buildTree() local because the audio
+    // page factories call it after buildTree() has already returned.
+    QWidget* wrapWithAudioBackendStrip(SetupPage* page);
+
     RadioModel*      m_model   = nullptr;
     QTreeWidget*     m_tree    = nullptr;
     QStackedWidget*  m_stack   = nullptr;
+
+    std::vector<PageEntry> m_pages;
 
     // Phase 3J-1 bench fix (2026-05-11): store the TciServer page reference
     // so setTciServer() can forward to it without a tree-walk lookup.
     CatTciServerPage* m_tciServerPage = nullptr;
 
+    // #272 / #301: MainWindow::wireSetupDialog() calls setTciServer() straight
+    // after construction, long before the operator visits CAT & Network -> TCI
+    // Server. Hold the pointer here and replay it into the page when it is
+    // realized. Raw rather than QPointer because TciServer.h is entirely
+    // #ifdef HAVE_WEBSOCKETS, so QPointer<TciServer> would not compile in
+    // non-WebSocket builds. Safe: MainWindow parents its single TciServer to
+    // itself and never destroys it independently, so it outlives this dialog.
+    TciServer* m_pendingTciServer = nullptr;
+
     // Phase 8 of #167: PA category nav-tree root + 3 child items, plus
     // the page widgets themselves so applyPaVisibility() can toggle each.
+    // The three page pointers stay null until their leaf is realized;
+    // applyPaVisibility() already null-checks each one.
     QTreeWidgetItem* m_paCategoryItem  = nullptr;
     QTreeWidgetItem* m_paGainItem      = nullptr;
     QTreeWidgetItem* m_paWattMeterItem = nullptr;
@@ -120,13 +176,66 @@ private:
     PaWattMeterPage*  m_paWattMeterPage= nullptr;
     PaValuesPage*     m_paValuesPage   = nullptr;
 
+    // #272 / #301: registry index of the "PA Values" leaf. The Watt Meter
+    // page's [Reset PA Values] button routes through the dialog, which
+    // realizes this sibling on demand instead of relying on it having been
+    // constructed up front.
+    int m_paValuesEntry = -1;
+
 #ifdef NEREUS_BUILD_TESTS
 public:
     // Phase 9 of #167: test seams for verifying the cross-page wiring
     // connect() between PaWattMeterPage::resetPaValuesRequested and
-    // PaValuesPage::resetPaValues() set up at the end of buildTree().
+    // PaValuesPage::resetPaValues(). Both stay null until the matching leaf
+    // is realized -- call realizePageForTest("Watt Meter") first.
     PaWattMeterPage* paWattMeterPageForTest() const { return m_paWattMeterPage; }
     PaValuesPage*    paValuesPageForTest()    const { return m_paValuesPage;    }
+
+    // #272 / #301 lazy-construction seams. Defined inline because
+    // NEREUS_BUILD_TESTS is set on the test targets only, not on
+    // NereusSDRObjs -- an out-of-line body in SetupDialog.cpp would never be
+    // compiled and the test link would fail.
+
+    // Number of navigation leaves registered by buildTree().
+    int registeredPageCountForTest() const { return static_cast<int>(m_pages.size()); }
+
+    // Number of leaves whose widget has actually been constructed.
+    int realizedPageCountForTest() const
+    {
+        int count = 0;
+        for (const PageEntry& entry : m_pages) {
+            if (entry.widget != nullptr) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    // True when the named leaf has been realized. False for unknown labels.
+    bool isPageRealizedForTest(const QString& label) const
+    {
+        const int index = pageEntryIndex(label);
+        if (index < 0) {
+            return false;
+        }
+        return m_pages[static_cast<std::size_t>(index)].widget != nullptr;
+    }
+
+    // Force-realize one leaf by label; returns the page widget (or its
+    // container for wrapped pages), nullptr for unknown labels.
+    QWidget* realizePageForTest(const QString& label)
+    {
+        return realizePage(pageEntryIndex(label));
+    }
+
+    // Force-realize every registered leaf. Used by the Qt-warning regression
+    // test, which must still see every page constructed to stay meaningful.
+    void realizeAllPagesForTest()
+    {
+        for (int i = 0; i < static_cast<int>(m_pages.size()); ++i) {
+            realizePage(i);
+        }
+    }
 #endif
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2246,7 +2246,27 @@ target_compile_definitions(tst_setup_dialog_pa_reset_wiring PRIVATE NEREUS_BUILD
 # connections require a pointer to member function" warning
 # (Hl2OptionsTab lambda + Qt::UniqueConnection). Both fixed; this test
 # pins them at zero.
+# Needs NEREUS_BUILD_TESTS since #272/#301: pages build lazily now, so the test
+# calls realizeAllPagesForTest() to keep every page inside the instrumented
+# window instead of asserting against a dialog that built nothing.
 nereus_add_test(tst_setup_dialog_qt_warnings)
+target_compile_definitions(tst_setup_dialog_qt_warnings PRIVATE NEREUS_BUILD_TESTS)
+
+# ── Issues #272 + #301: lazy SetupDialog page construction ──────────────────
+# buildTree() used to construct all 55 setup pages from the SetupDialog ctor,
+# blocking the Qt main thread on every Tools -> Setup open. That stall starved
+# AudioEngine's drain timer (#301, repeated RX buffer on ANAN-10E/macOS) and on
+# slower hosts outlasted the P1 ep6 watchdog, so the link dropped and the
+# unclean audio teardown cascaded into a CLOCK_WATCHDOG_TIMEOUT BSOD
+# (#272, HL2/Windows 11). Pages now build on first visit.
+#
+# Pins: registration builds nothing; selecting a leaf realizes exactly that
+# leaf; revisits reuse the cached widget; a late-built page still reads live
+# controller state and persists edits; and every cross-page wire that used to
+# assume a sibling page already existed still fires (PA reset fan-out, parked
+# TciServer pointer, CFC dialog request, per-SKU PA capability push).
+nereus_add_test(tst_setup_dialog_lazy_pages)
+target_compile_definitions(tst_setup_dialog_lazy_pages PRIVATE NEREUS_BUILD_TESTS)
 
 # ── Phase 3M-0 Task 14: MainWindow status-bar TX Inhibit + PA Status badge ───
 # Tests the label-state logic for the two safety indicator widgets added to

--- a/tests/tst_setup_dialog_lazy_pages.cpp
+++ b/tests/tst_setup_dialog_lazy_pages.cpp
@@ -1,0 +1,457 @@
+// tests/tst_setup_dialog_lazy_pages.cpp  (NereusSDR)
+//
+// Issues #272 + #301 regression suite: lazy SetupDialog page construction.
+//
+// no-port-check: NereusSDR-original UI test fixture. SetupDialog is not a
+// Thetis port, so no upstream attribution applies here.
+//
+// Background. SetupDialog::buildTree() used to construct all 55 setup pages
+// synchronously from the ctor, so every Tools -> Setup open blocked the Qt
+// main thread for roughly a second on an M-series Mac and multiple seconds on
+// the reporters' hardware. Two symptoms fell out of that one stall:
+//
+//   #301 (funsutton, ANAN-10E, macOS Intel): the RX audio buffer looped 2-3
+//        times, because AudioEngine's 10 ms drain timer could not run.
+//   #272 (Chris-W4ORS, HL2, Windows 11): the freeze outlasted the Protocol 1
+//        ep6 watchdog (2011 ms), the link was declared lost, and the unclean
+//        audio teardown cascaded into a CLOCK_WATCHDOG_TIMEOUT BSOD on a
+//        legacy 2010 Realtek driver.
+//
+// buildTree() now only registers a label plus a factory per nav leaf;
+// realizePage() builds the widget the first time the leaf is selected.
+//
+// These tests pin the four properties the refactor has to hold:
+//   1. Construction registers pages without building any of them.
+//   2. Selecting a node realizes exactly that node's page, and revisiting it
+//      reuses the cached widget.
+//   3. A page built late still reads live model / persisted state correctly
+//      (the issue #259 guarantee, now on an even later construction point).
+//   4. Every cross-page wire that used to rely on a sibling page already
+//      existing still fires: the PA [Reset PA Values] fan-out, the pending
+//      TciServer pointer MainWindow hands over at wireSetupDialog() time, the
+//      CFC dialog request, and the per-SKU PA capability push.
+
+#include <QtTest/QtTest>
+#include <QApplication>
+#include <QCheckBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QSpinBox>
+
+#include "core/AppSettings.h"
+#include "core/BoardCapabilities.h"
+#include "core/HpsdrModel.h"
+#include "core/RadioStatus.h"
+#include "core/StepAttenuatorController.h"
+#include "gui/SetupDialog.h"
+#include "gui/setup/DspSetupPages.h"
+#include "gui/setup/PaSetupPages.h"
+#include "models/RadioModel.h"
+
+#ifdef HAVE_WEBSOCKETS
+#include "core/TciServer.h"
+#endif
+
+using namespace NereusSDR;
+
+namespace {
+
+// Labels used across the cases below. Each must match a leaf registered by
+// SetupDialog::buildTree(); a typo would silently make an assertion vacuous,
+// so every test that uses one also asserts the label resolves.
+const QString kAgcAlc      = QStringLiteral("AGC/ALC");
+const QString kNbSnb       = QStringLiteral("NB/SNB");
+const QString kGeneralOpts = QStringLiteral("Options");
+const QString kWattMeter   = QStringLiteral("Watt Meter");
+const QString kPaValues    = QStringLiteral("PA Values");
+const QString kPaGain      = QStringLiteral("PA Gain");
+const QString kCfc         = QStringLiteral("CFC");
+const QString kTciServer   = QStringLiteral("TCI Server");
+
+// Locate the "RX1 Enable" step-attenuator checkbox inside a realized
+// GeneralOptionsPage. Same walk tst_general_options_page_step_att_init.cpp
+// uses: the page holds the widget privately, so we match on caption.
+QCheckBox* findRx1StepAttCheck(QWidget* page)
+{
+    for (QCheckBox* box : page->findChildren<QCheckBox*>()) {
+        if (box->text() == QStringLiteral("RX1 Enable")) {
+            return box;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+class TstSetupDialogLazyPages : public QObject {
+    Q_OBJECT
+
+private slots:
+    void initTestCase()
+    {
+        if (!qApp) {
+            static int argc = 0;
+            new QApplication(argc, nullptr);
+        }
+        AppSettings::instance().clear();
+    }
+
+    void cleanup()
+    {
+        AppSettings::instance().clear();
+    }
+
+    // 1. Registration without construction.
+    void construction_registers_every_leaf_but_builds_none();
+    void construction_leaves_pa_page_pointers_null();
+
+    // 2. On-demand realization + caching.
+    void selecting_a_leaf_realizes_only_that_page();
+    void revisiting_a_leaf_reuses_the_cached_widget();
+    void selectPage_realizes_the_target_for_external_findChild();
+
+    // 3. A late-built page still sees live state.
+    void lazily_realized_page_reads_live_controller_state();
+    void lazily_realized_page_persists_edits_to_appsettings();
+
+    // 4. Cross-page wiring survives the split.
+    void pa_reset_realizes_the_values_page_on_demand();
+    void pa_reset_still_works_when_values_page_visited_first();
+    void pa_pages_get_capabilities_when_realized_after_the_caps_pass();
+    void cfc_dialog_request_forwards_after_late_realization();
+#ifdef HAVE_WEBSOCKETS
+    void pending_tci_server_is_replayed_into_the_late_built_page();
+#endif
+};
+
+// ---------------------------------------------------------------------------
+// 1. Registration without construction
+// ---------------------------------------------------------------------------
+
+// The headline assertion for #272 / #301: the ctor must not build page
+// widgets. Pre-fix this was 55 constructed pages and roughly a second of
+// blocked main thread; post-fix it is 55 registered factories and zero
+// widgets.
+void TstSetupDialogLazyPages::construction_registers_every_leaf_but_builds_none()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    QVERIFY2(dialog.registeredPageCountForTest() > 0,
+             "buildTree() must register at least one navigation leaf");
+    QCOMPARE(dialog.realizedPageCountForTest(), 0);
+
+    // Spot-check a spread of categories rather than trusting the count alone:
+    // a bug that registered the leaf but eagerly built the widget would still
+    // report realized == 0 only if it never touched m_pages.
+    QVERIFY(!dialog.isPageRealizedForTest(kAgcAlc));
+    QVERIFY(!dialog.isPageRealizedForTest(kGeneralOpts));
+    QVERIFY(!dialog.isPageRealizedForTest(kWattMeter));
+    QVERIFY(!dialog.isPageRealizedForTest(kTciServer));
+    QVERIFY(!dialog.isPageRealizedForTest(kCfc));
+}
+
+// The three PA page pointers are what applyPaVisibility() fans capabilities
+// out through. They must start null so the null-guards in that method are the
+// live path, not dead code.
+void TstSetupDialogLazyPages::construction_leaves_pa_page_pointers_null()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    QVERIFY(dialog.paWattMeterPageForTest() == nullptr);
+    QVERIFY(dialog.paValuesPageForTest()    == nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// 2. On-demand realization + caching
+// ---------------------------------------------------------------------------
+
+// Selecting one leaf must build that leaf and nothing else. A regression that
+// force-realized siblings (for example to satisfy a cross-page connect) would
+// push the count above 1 and reintroduce the stall this fix removes.
+void TstSetupDialogLazyPages::selecting_a_leaf_realizes_only_that_page()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    dialog.selectPage(kAgcAlc);
+
+    QCOMPARE(dialog.realizedPageCountForTest(), 1);
+    QVERIFY(dialog.isPageRealizedForTest(kAgcAlc));
+    QVERIFY(!dialog.isPageRealizedForTest(kNbSnb));
+
+    dialog.selectPage(kNbSnb);
+
+    QCOMPARE(dialog.realizedPageCountForTest(), 2);
+    QVERIFY(dialog.isPageRealizedForTest(kNbSnb));
+}
+
+// Second and later visits must reuse the cached widget: rebuilding on every
+// visit would trade the one-off open stall for a per-click stall, which is the
+// other half of what #272 reported.
+void TstSetupDialogLazyPages::revisiting_a_leaf_reuses_the_cached_widget()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    dialog.selectPage(kAgcAlc);
+    QWidget* firstVisit = dialog.realizePageForTest(kAgcAlc);
+    QVERIFY(firstVisit != nullptr);
+
+    dialog.selectPage(kNbSnb);
+    dialog.selectPage(kAgcAlc);
+
+    QCOMPARE(dialog.realizePageForTest(kAgcAlc), firstVisit);
+    QCOMPARE(dialog.realizedPageCountForTest(), 2);
+}
+
+// MainWindow's openNrSetupRequested handler does
+//   dialog->selectPage("NR/ANF");
+//   if (auto* p = dialog->findChild<NrAnfSetupPage*>()) { p->selectSubtab(slot); }
+// (MainWindow.cpp:5230-5235). That only works if selectPage() realizes the
+// page synchronously and the page ends up in the dialog's child tree.
+void TstSetupDialogLazyPages::selectPage_realizes_the_target_for_external_findChild()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    QVERIFY(dialog.findChild<NrAnfSetupPage*>() == nullptr);
+
+    dialog.selectPage(QStringLiteral("NR/ANF"));
+
+    QVERIFY2(dialog.findChild<NrAnfSetupPage*>() != nullptr,
+             "selectPage() must realize the page and reparent it under the dialog");
+}
+
+// ---------------------------------------------------------------------------
+// 3. A late-built page still sees live state
+// ---------------------------------------------------------------------------
+
+// Issue #259 established that setup pages read live state in their ctor,
+// because SetupDialog is rebuilt on every Tools -> Setup open. Lazy
+// realization moves that ctor even later (first visit rather than dialog
+// open), so the same guarantee has to hold. Timeline under test:
+//   1. StepAttenuatorController restores enabled=true / 5 dB.
+//   2. SetupDialog is constructed (no page widgets yet).
+//   3. Operator clicks General -> Options; the page is built NOW.
+//   4. Checkbox and spinbox must show the restored state, not ctor defaults.
+void TstSetupDialogLazyPages::lazily_realized_page_reads_live_controller_state()
+{
+    RadioModel model;
+    auto* ctrl = new StepAttenuatorController(&model);
+    ctrl->setMaxAttenuation(31);          // ANAN-10E classic range
+    ctrl->setStepAttEnabled(true);
+    ctrl->setAttenuation(5, 0);
+    model.setStepAttController(ctrl);
+
+    SetupDialog dialog(&model);
+    QVERIFY(!dialog.isPageRealizedForTest(kGeneralOpts));
+
+    QWidget* page = dialog.realizePageForTest(kGeneralOpts);
+    QVERIFY2(page != nullptr, "General -> Options leaf must resolve");
+
+    QCheckBox* rx1Check = findRx1StepAttCheck(page);
+    QVERIFY2(rx1Check != nullptr, "RX1 Enable checkbox not found");
+    QCOMPARE(rx1Check->isChecked(), true);
+
+    QSpinBox* rx1Spin = nullptr;
+    for (QSpinBox* spin : page->findChildren<QSpinBox*>()) {
+        if (spin->parent() == rx1Check->parent()) {
+            rx1Spin = spin;
+            break;
+        }
+    }
+    QVERIFY2(rx1Spin != nullptr, "RX1 dB spinbox not found");
+    QCOMPARE(rx1Spin->value(), 5);
+}
+
+// The other direction of the round-trip: an edit made on a lazily realized
+// page must still reach AppSettings. Driven through the General -> Options CPU
+// meter rate spinbox, which persists CpuMeterRateHz and re-emits upward.
+void TstSetupDialogLazyPages::lazily_realized_page_persists_edits_to_appsettings()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    QSignalSpy rateSpy(&dialog, &SetupDialog::cpuMeterRateChanged);
+
+    QWidget* page = dialog.realizePageForTest(kGeneralOpts);
+    QVERIFY(page != nullptr);
+
+    // The CPU meter rate spinbox is the only one carrying a " Hz" suffix on
+    // this page, which makes it addressable without a new production seam.
+    QSpinBox* rateSpin = nullptr;
+    for (QSpinBox* spin : page->findChildren<QSpinBox*>()) {
+        if (spin->suffix() == QStringLiteral(" Hz")) {
+            rateSpin = spin;
+            break;
+        }
+    }
+    QVERIFY2(rateSpin != nullptr, "CPU meter rate spinbox not found");
+
+    const int newRate = (rateSpin->value() == 7) ? 9 : 7;
+    rateSpin->setValue(newRate);
+
+    QCOMPARE(AppSettings::instance()
+                 .value(QStringLiteral("GeneralCpuMeterUpdateRateHz")).toInt(),
+             newRate);
+    // ...and the forward up to MainWindow still lands even though the page was
+    // built long after wireSetupDialog() connected to this dialog signal.
+    QCOMPARE(rateSpy.count(), 1);
+    QCOMPARE(rateSpy.at(0).at(0).toInt(), newRate);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Cross-page wiring survives the split
+// ---------------------------------------------------------------------------
+
+// The PA [Reset PA Values] fan-out is the one connect() in the dialog that
+// spans two sibling pages. It now routes through SetupDialog, which realizes
+// PA Values on button press. Pre-refactor both pages existed up front; this
+// pins that the reset still lands when only the Watt Meter page was visited.
+void TstSetupDialogLazyPages::pa_reset_realizes_the_values_page_on_demand()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    QVERIFY(dialog.realizePageForTest(kWattMeter) != nullptr);
+    PaWattMeterPage* wattMeter = dialog.paWattMeterPageForTest();
+    QVERIFY(wattMeter != nullptr);
+
+    // Only the Watt Meter page is up at this point.
+    QVERIFY2(!dialog.isPageRealizedForTest(kPaValues),
+             "realizing Watt Meter must not drag PA Values in with it");
+
+    wattMeter->clickResetPaValuesForTest();
+
+    QVERIFY2(dialog.isPageRealizedForTest(kPaValues),
+             "the reset fan-out must realize the PA Values page on demand");
+    QVERIFY(dialog.paValuesPageForTest() != nullptr);
+}
+
+// Same wire, opposite visit order: PA Values realized first, then the Watt
+// Meter page's Reset button must collapse its peak/min trackers to current.
+// This is the original Phase 9 (#167) acceptance case, re-expressed for the
+// lazy path.
+void TstSetupDialogLazyPages::pa_reset_still_works_when_values_page_visited_first()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    QVERIFY(dialog.realizePageForTest(kPaValues)  != nullptr);
+    QVERIFY(dialog.realizePageForTest(kWattMeter) != nullptr);
+
+    PaWattMeterPage* wattMeter = dialog.paWattMeterPageForTest();
+    PaValuesPage*    values    = dialog.paValuesPageForTest();
+    QVERIFY(wattMeter != nullptr);
+    QVERIFY(values    != nullptr);
+
+    model.radioStatus().setForwardPower(10.0);
+    model.radioStatus().setForwardPower(50.0);
+    model.radioStatus().setForwardPower(30.0);
+
+    QCOMPARE(values->fwdCalibratedPeakForTest(), QStringLiteral("50.00 W"));
+    QCOMPARE(values->fwdCalibratedMinForTest(),  QStringLiteral("10.00 W"));
+
+    wattMeter->clickResetPaValuesForTest();
+
+    QCOMPARE(values->fwdCalibratedPeakForTest(), QStringLiteral("30.00 W"));
+    QCOMPARE(values->fwdCalibratedMinForTest(),  QStringLiteral("30.00 W"));
+}
+
+// applyPaVisibility() runs from the ctor (and on every currentRadioChanged)
+// while the PA page pointers are still null, so each PA factory re-applies the
+// live capabilities itself. Without that, a page realized after the caps pass
+// would render with its ctor defaults instead of the per-SKU state.
+//
+// Atlas-class caps (hasPaProfile=false) must therefore still disable the PA
+// Gain editor and raise its no-PA-support banner on a late build.
+void TstSetupDialogLazyPages::pa_pages_get_capabilities_when_realized_after_the_caps_pass()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    // No radio has connected, so boardCapabilities() yields the Unknown row,
+    // which carries hasPaProfile=false, the same conservative default the
+    // ctor's visibility pass uses.
+    QVERIFY(!BoardCapsTable::forBoard(HPSDRHW::Unknown).hasPaProfile);
+
+    QWidget* page = dialog.realizePageForTest(kPaGain);
+    QVERIFY2(page != nullptr, "PA Gain leaf must resolve");
+
+    auto* gainPage = qobject_cast<PaGainByBandPage*>(page);
+    QVERIFY(gainPage != nullptr);
+    QVERIFY2(!gainPage->isPaEditorEnabledForTest(),
+             "a PA page realized after the caps pass must still honour hasPaProfile=false");
+    QVERIFY2(gainPage->isNoPaSupportBannerVisibleForTest(),
+             "the no-PA-support banner must be applied at realization time");
+}
+
+// CfcSetupPage's [Configure CFC bands...] button is forwarded up to
+// SetupDialog::cfcDialogRequested, which MainWindow::wireSetupDialog() has
+// already connected to TxApplet::requestOpenCfcDialog. The connect now lives
+// inside the page factory, so it must still be in place on a late build.
+void TstSetupDialogLazyPages::cfc_dialog_request_forwards_after_late_realization()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    QSignalSpy cfcSpy(&dialog, &SetupDialog::cfcDialogRequested);
+
+    QWidget* page = dialog.realizePageForTest(kCfc);
+    QVERIFY2(page != nullptr, "CFC leaf must resolve");
+
+    auto* button = page->findChild<QPushButton*>(
+        QStringLiteral("btnCFCBandsConfigure"));
+    QVERIFY2(button != nullptr, "[Configure CFC bands...] button not found");
+
+    button->click();
+
+    QCOMPARE(cfcSpy.count(), 1);
+}
+
+#ifdef HAVE_WEBSOCKETS
+// MainWindow::wireSetupDialog() calls dialog->setTciServer(m_tciServer)
+// immediately after construction (MainWindow.cpp:4708), long before the
+// operator navigates to CAT & Network -> TCI Server. SetupDialog stores the
+// pointer and replays it when the page is realized.
+//
+// Observable proof: a serverStarted emission after realization has to reach
+// the page's status label. That only happens if the replay actually ran the
+// page's setTciServer(), which is what installs those signal hookups.
+void TstSetupDialogLazyPages::pending_tci_server_is_replayed_into_the_late_built_page()
+{
+    RadioModel model;
+    SetupDialog dialog(&model);
+
+    TciServer server(nullptr);   // RadioModel* not needed for lifecycle wiring
+    dialog.setTciServer(&server);
+
+    // Still not realized: the pointer is parked, not delivered.
+    QVERIFY(!dialog.isPageRealizedForTest(kTciServer));
+
+    QWidget* page = dialog.realizePageForTest(kTciServer);
+    QVERIFY2(page != nullptr, "TCI Server leaf must resolve");
+
+    QVERIFY(server.start(0));    // 0 = OS-assigned ephemeral port
+    QVERIFY(server.isRunning());
+
+    bool sawRunningStatus = false;
+    for (const QLabel* label : page->findChildren<QLabel*>()) {
+        if (label->text().contains(QStringLiteral("Running"))) {
+            sawRunningStatus = true;
+            break;
+        }
+    }
+    QVERIFY2(sawRunningStatus,
+             "the parked TciServer pointer must be replayed into the page at "
+             "realization time, so serverStarted reaches its status label");
+
+    server.stop();
+}
+#endif // HAVE_WEBSOCKETS
+
+QTEST_MAIN(TstSetupDialogLazyPages)
+#include "tst_setup_dialog_lazy_pages.moc"

--- a/tests/tst_setup_dialog_pa_reset_wiring.cpp
+++ b/tests/tst_setup_dialog_pa_reset_wiring.cpp
@@ -14,13 +14,21 @@
 //
 // Test strategy:
 //   1. Construct SetupDialog with a RadioModel.
-//   2. Pull the WattMeter and Values pages via NEREUS_BUILD_TESTS seams.
+//   2. Realize the WattMeter and Values leaves, then pull the pages via
+//      NEREUS_BUILD_TESTS seams.
 //   3. Drive RadioStatus::powerChanged so the Values page's running
 //      peak/min trackers diverge from current.
 //   4. Click the WattMeter Reset button via the Phase 5A test seam.
 //   5. Verify the Values page's peak/min trackers collapse to current —
 //      that's only possible if SetupDialog actually wired the cross-page
 //      connect() correctly.
+//
+// Issues #272 + #301 (2026-07-27): SetupDialog now builds pages lazily, so the
+// two pages no longer exist at construction time. Both cases realize their
+// leaves explicitly via realizePageForTest() before pulling the pointers. The
+// property under test is unchanged: the cross-page reset fan-out fires.
+// Coverage for the reset when PA Values has *not* been visited yet lives in
+// tst_setup_dialog_lazy_pages.cpp.
 
 #include <QtTest/QtTest>
 #include <QApplication>
@@ -57,8 +65,8 @@ private slots:
     // the resetPaValuesRequested -> resetPaValues() cross-page connect().
     void wattMeter_reset_button_clears_values_page_peak_min();
 
-    // Sanity: SetupDialog construction yields non-null pointers for
-    // both the WattMeter and Values pages. If either is null, the
+    // Sanity: realizing both PA leaves yields non-null pointers for
+    // the WattMeter and Values pages. If either is null, the
     // Phase 9 connect() is a no-op and downstream tests would silently
     // pass for the wrong reason.
     void both_pa_pages_are_constructed();
@@ -71,6 +79,11 @@ void TstSetupDialogPaResetWiring::wattMeter_reset_button_clears_values_page_peak
 {
     RadioModel model;
     SetupDialog dialog(&model);
+
+    // #272 / #301: pages are built on first visit, so realize both PA leaves
+    // before reaching for their pointers.
+    QVERIFY(dialog.realizePageForTest(QStringLiteral("Watt Meter")) != nullptr);
+    QVERIFY(dialog.realizePageForTest(QStringLiteral("PA Values"))  != nullptr);
 
     PaWattMeterPage* wattMeter = dialog.paWattMeterPageForTest();
     PaValuesPage*    values    = dialog.paValuesPageForTest();
@@ -97,12 +110,20 @@ void TstSetupDialogPaResetWiring::wattMeter_reset_button_clears_values_page_peak
 }
 
 // ---------------------------------------------------------------------------
-// Test 2: both pages exist after dialog construction.
+// Test 2: both pages exist once their leaves are realized.
+//
+// #272 / #301: pre-refactor this held straight after construction. Pages are
+// now built on first visit, so realize both leaves and then assert the
+// pointers land. tst_setup_dialog_lazy_pages.cpp asserts the complementary
+// property: that they are null before the visit.
 // ---------------------------------------------------------------------------
 void TstSetupDialogPaResetWiring::both_pa_pages_are_constructed()
 {
     RadioModel model;
     SetupDialog dialog(&model);
+
+    QVERIFY(dialog.realizePageForTest(QStringLiteral("Watt Meter")) != nullptr);
+    QVERIFY(dialog.realizePageForTest(QStringLiteral("PA Values"))  != nullptr);
 
     QVERIFY(dialog.paWattMeterPageForTest() != nullptr);
     QVERIFY(dialog.paValuesPageForTest()    != nullptr);

--- a/tests/tst_setup_dialog_qt_warnings.cpp
+++ b/tests/tst_setup_dialog_qt_warnings.cpp
@@ -24,6 +24,12 @@
 // Strategy: install a QtMessageHandler before SetupDialog construction;
 // pattern-match each emitted message against the two known warnings;
 // assert zero matches.
+//
+// Issues #272 + #301 (2026-07-27): SetupDialog now builds its pages lazily, so
+// merely constructing it no longer touches DeviceCard or Hl2OptionsTab and the
+// original assertions would have gone vacuously green. Both cases now call
+// realizeAllPagesForTest() so every page is still constructed inside the
+// instrumented window, which is what keeps this test a real guard.
 
 #include <QtTest/QtTest>
 #include <QApplication>
@@ -84,6 +90,10 @@ private slots:
 //
 // Pre-fix: 7 fired (3 from AudioDevicesPage's DeviceCards + 4 from
 // AudioVaxPage's VaxChannelCard DeviceCards). Post-fix: 0.
+//
+// #272 / #301: realizeAllPagesForTest() forces every page to be built inside
+// the instrumented window, since lazy construction means the ctor alone would
+// not reach AudioDevicesPage or AudioVaxPage at all.
 // ---------------------------------------------------------------------------
 void TstSetupDialogQtWarnings::
     setupDialog_construction_emits_no_layout_double_add_warnings()
@@ -96,7 +106,7 @@ void TstSetupDialogQtWarnings::
     {
         RadioModel model;
         SetupDialog dialog(&model);
-        Q_UNUSED(dialog);
+        dialog.realizeAllPagesForTest();
     }
 
     qInstallMessageHandler(prev);
@@ -120,6 +130,9 @@ void TstSetupDialogQtWarnings::
 // the assertion is "no warning fires during SetupDialog construction",
 // and that's true both when the tab is skipped and when it's built with
 // the fixed wiring.
+//
+// #272 / #301: realizeAllPagesForTest() is what now reaches HardwarePage,
+// since page construction no longer happens in the dialog ctor.
 // ---------------------------------------------------------------------------
 void TstSetupDialogQtWarnings::
     setupDialog_construction_emits_no_unique_lambda_connect_warnings()
@@ -132,7 +145,7 @@ void TstSetupDialogQtWarnings::
     {
         RadioModel model;
         SetupDialog dialog(&model);
-        Q_UNUSED(dialog);
+        dialog.realizeAllPagesForTest();
     }
 
     qInstallMessageHandler(prev);


### PR DESCRIPTION
Follow-up to #275, which landed the `nereus.setup.timing` instrumentation and the cosmetic Qt-warning cleanup for #272 but not the lazy page construction. This is that follow-up.

Fixes #272
Fixes #301

## Root cause

`SetupDialog::buildTree()` was called synchronously from the ctor and eagerly constructed **all 55 setup pages**. Since `SetupDialog` is built fresh on every open (7 call sites in `MainWindow.cpp`, all `WA_DeleteOnClose`), that cost was paid every single time the operator opened Settings, on the Qt main thread, with nothing else able to run.

Two user-visible symptoms fall out of that one block:

| Issue | Reporter / hardware | Symptom |
| --- | --- | --- |
| #301 | funsutton, ANAN-10E, macOS Intel, v0.5.2 | `AudioEngine`'s 10 ms drain timer cannot run, so the RX audio buffer repeats 2-3 times |
| #272 | Chris-W4ORS, HL2, Windows 11, v0.5.1 | On a slower host the freeze outlasts the P1 ep6 watchdog (2011 ms), the link is declared lost, and the resulting unclean audio teardown cascades into a `CLOCK_WATCHDOG_TIMEOUT` BSOD against a legacy 2010 Realtek driver |

The BSOD is downstream of a driver that cannot survive an abrupt teardown. The freeze is ours, and it is the same freeze in both reports.

## Evidence

Captured with the existing instrumentation, `QT_LOGGING_RULES="nereus.setup.timing.debug=true"`, RelWithDebInfo, Apple Silicon. Six samples each side, via `tst_setup_dialog_pa_reset_wiring` (which constructs a real `SetupDialog` and does not hijack the message handler the way the Qt-warnings test does).

**Before** (`main` @ d3e557aa):

```
buildTree() total elapsed (ms): 852  pages: 55
buildTree() total elapsed (ms): 1033 pages: 55
buildTree() total elapsed (ms): 1048 pages: 55
buildTree() total elapsed (ms): 998  pages: 55
buildTree() total elapsed (ms): 1289 pages: 55
buildTree() total elapsed (ms): 659  pages: 55
```

Range 659-1289 ms, median ~1015 ms. Worst per-section deltas:

```
buildTree section Hardware       elapsed (ms): 179 .. 412
buildTree section Audio          elapsed (ms): 158 .. 290
buildTree section DSP            elapsed (ms):  74 .. 153
buildTree section CAT & Network  elapsed (ms):  50 ..  94
buildTree section PA             elapsed (ms):  54 .. 141
buildTree section Display        elapsed (ms):  49 .. 113
```

**After**:

```
buildTree() total elapsed (ms): 1 pages registered: 55 realized: 0
buildTree() total elapsed (ms): 0 pages registered: 55 realized: 0
buildTree() total elapsed (ms): 1 pages registered: 55 realized: 0
buildTree() total elapsed (ms): 0 pages registered: 55 realized: 0
buildTree() total elapsed (ms): 1 pages registered: 55 realized: 0
buildTree() total elapsed (ms): 0 pages registered: 55 realized: 0
```

Every per-section delta is now 0 ms. This machine is fast; the reporters' hosts are not, which is why the existing code comment describes it as a "~3-second build". The relative change is what matters, and the absolute floor is now 0-1 ms on any host because no widget is constructed.

**In the real app, connected to a live ANAN-G2E**, the whole open path plus every page visited:

```
buildTree() total elapsed (ms): 0 pages registered: 55 realized: 0
realized page "Startup & Preferences" elapsed (ms): 3     <- entire cost of opening Settings
realized page "Hardware Config"       elapsed (ms): 110   <- heaviest page in the dialog
realized page "PA Gain"               elapsed (ms): 33
realized page "Devices"               elapsed (ms): 25
realized page "NR/ANF"                elapsed (ms): 13
realized page "TCI"                   elapsed (ms): 12
realized page "Advanced"              elapsed (ms): 8
realized page "PA Values"             elapsed (ms): 4
realized page "AGC/ALC"               elapsed (ms): 4
realized page "TX Input"              elapsed (ms): 3
realized page "CFC"                   elapsed (ms): 2
realized page "Watt Meter"            elapsed (ms): 1
```

Opening Settings now costs 3 ms. The worst single click anywhere in the dialog costs 110 ms. Nothing on either path is within an order of magnitude of the 2011 ms ep6 watchdog.

## What changed

`buildTree()` is split into two phases.

**Registration.** `registerPage(parent, label, factory)` creates the tree leaf and pushes a `PageEntry {label, std::function<QWidget*()>, widget, stackIndex}` onto `m_pages`. The leaf's `Qt::UserRole` now carries the **registry index**, not a stack index (it is dialog-internal; nothing outside `SetupDialog` reads it). Categories still carry -1.

**Realization.** `realizePage(entryIndex)` runs the factory on the leaf's first selection, adds the widget to the `QStackedWidget`, and caches both. The factory is moved out before invocation so a page cannot recurse into building itself, and a one-shot null result cannot re-warn. `showPageAt()` realizes then raises.

## Cross-page wiring audit

A naive lazy swap does not work, because `buildTree()` contained `connect()` calls assuming sibling pages already existed. Every one was audited. Nothing was dropped.

| Site | Depends on | Resolution |
| --- | --- | --- |
| `GeneralOptionsPage::hideFeedbackLevelChanged` / `invertRedBluePsaChanged` -> `PureSignal` | external object, not a sibling | connect inside factory |
| `GeneralOptionsPage::cpuMeterRateChanged` -> `SetupDialog` signal | none | connect inside factory; `wireSetupDialog()`'s connection to the dialog signal stays valid however late the page is built. Covered by a test. |
| `HardwarePage::anan8000DleVoltsAmpsChanged` -> `SetupDialog` signal | none | connect inside factory |
| `CfcSetupPage::openCfcDialogRequested` -> `SetupDialog` signal | none | connect inside factory. Covered by a test. |
| `CatTciServerPage` enable / bind-port / show-log -> `SetupDialog` signals | none | connect inside factory |
| `FourO3APage` -> `findChild<TgxlAdvancedPage*>` -> `antennaLabelChanged` | child of the same page | connect inside factory, after construction |
| `SpectrumDefaultsPage` / `SpectrumPeaksPage` / `MultimeterPage` / `SpeechProcessorPage` cross-links | target sibling page | already routed through `selectPage()`, which drives the nav tree and therefore realizes the destination. No pointer needed. |
| **`PaWattMeterPage::resetPaValuesRequested` -> `PaValuesPage::resetPaValues`** | **genuine sibling pointer** | **re-routed through the dialog**: a lambda realizes the PA Values leaf on button press, then calls the slot. Works whichever page was visited first. Two tests. |
| **`setTciServer()` -> `m_tciServerPage`** | **page must exist when MainWindow calls it** | **parked in `m_pendingTciServer` and replayed at realization.** `wireSetupDialog()` calls this immediately after construction (`MainWindow.cpp:4708`), long before the operator opens CAT & Network -> TCI Server. One test. |
| `applyPaVisibility(caps)` -> 3 `m_pa*Page` pointers | all three pages | nav-row visibility needs no widgets and still runs in the ctor. Because the pointers are null then, each PA factory re-applies `capsForModel()` to its own page at realization. One test. |
| `MainWindow`: `dialog->selectPage("NR/ANF")` then `dialog->findChild<NrAnfSetupPage*>()` (`MainWindow.cpp:5230-5235`) | page in the dialog's child tree | `selectPage()` realizes synchronously and `addWidget()` reparents under the dialog, so `findChild` still resolves. One test. |

Also removed: the `add` / `addWrapped` buildTree locals (collapsed into `registerPage`, since the factory returns `QWidget*` either way), and `wrapWithAudioBackendStrip` was promoted from a buildTree local to a member function, because the audio factories call it after `buildTree()` has returned.

## The Connect-to-Radio path in #301

Measured, and it **is** a contributor, separately from Settings. New matching seam (`nereus.connpanel.timing`), on the same ANAN-G2E over a multi-NIC Mac:

```
ConnectionPanel ctor total elapsed (ms): 5013 of which buildUI(): 5 rows: 4
```

Widget construction is 5 ms. The other 5008 ms is `RadioDiscovery::scanAllNics()`, which walks every NIC synchronously with blocking `sock.waitForReadyRead(pollMs)` calls, `NICs x attempts x quietPolls x pollMs` deep.

That is not a new defect and not a lazy-construction problem: it is the residual of a deliberate deferral already recorded in the code at `RadioDiscovery.cpp:137-141`, "Scans are now one-shot, user-triggered via ConnectionPanel. Async rewrite is a follow-up." Making discovery asynchronous is a threading change, which is outside this PR's scope and outside what an agent should change autonomously. **It needs its own issue and PR**, and #301 should not be considered fully closed on the Connect-to-Radio path until that lands. This PR makes the cost visible without a profiler, and fixes the Settings path that both reports share.

## Testing

New `tests/tst_setup_dialog_lazy_pages.cpp`, 13 cases in four groups:

1. Registration builds nothing: 55 registered, 0 realized, PA page pointers null.
2. Selecting a leaf realizes exactly that leaf; revisits reuse the cached widget; `selectPage()` realizes the target for MainWindow's `findChild` deep-link.
3. A late-built page still reads live state (the #259 guarantee, now at an even later construction point) and still persists edits to `AppSettings`.
4. All four cross-page wires: PA reset with PA Values unvisited, PA reset with PA Values visited first, per-SKU PA capability push at realization, CFC dialog request, and the parked `TciServer` replay.

Two existing tests were updated rather than left to rot:

- `tst_setup_dialog_qt_warnings` asserted "no Qt warnings during SetupDialog construction". Post-refactor the ctor never reaches `DeviceCard` or `Hl2OptionsTab`, so both cases would have gone **vacuously green** and stopped guarding the #275 fixes. They now call `realizeAllPagesForTest()`, so all 55 pages are still constructed inside the instrumented window.
- `tst_setup_dialog_pa_reset_wiring` realizes its two leaves before pulling the page pointers. The property under test is unchanged.

```
153/153  ctest -L gui
  3/3    ctest -R '^tst_setup_dialog'
```

Manual verification on a live ANAN-G2E (HermesC10, P2, receiving on 40m throughout). Every page opened, rendered, and showed correct persisted and live state. Spot-checked in particular:

- **Hardware Config**: live board identity (ANAN-G2E, P2, ADC 1, Max RX 4, firmware 110, MAC, IP), correct 5-tab capability gating.
- **PA Gain**: full live per-band gain table, "modified from factory defaults" warning, and the two G2E-specific capability gates (`showsBypassPaSettingsUi` bypass checkbox shown, PureSignal recovery warning shown). This is direct proof the capability push at realization works.
- **CFC**: persisted state matches the applet (`CFC` enabled, Pre-Comp 7 dB, Post-EQ Gain -7 dB).
- **TX Profile**: matches the applet's live TX BW (65 / 4100 Hz).
- **TCI Server**: Status reads green **Running (0 clients)** on a page realized long after `wireSetupDialog()` handed the pointer over. That is the parked-pointer replay confirmed end to end.
- **PA reset cross-wire**: clicked Reset PA Values with PA Values never visited; the log shows `realized page "PA Values" elapsed (ms): 4` at that instant.

Dialog geometry is unchanged across navigation: every `SetupPage` wraps its content in a `QScrollArea` with `setWidgetResizable(true)`, so a page realized late cannot grow the window. The 150 px label truncation visible on some pages is `SetupPage::makeLabeledRow`'s `setFixedWidth(150)` and is pre-existing, unrelated to this change.

## Scope

Construction timing only. No page's visual design, control layout, defaults, or UX behaviour is touched. `AppSettings` throughout, no `QSettings`. `SetupDialog` is NereusSDR-native Qt6, not a Thetis port, so the READ/SHOW/TRANSLATE protocol does not gate this work; relocated pre-existing comment blocks were moved byte-identical so the diff reads cleanly.

**One behavioural consequence worth a reviewer's eye.** Live-telemetry pages (PA Values, Radio Status, Connection Quality, the PGXL/TGXL diagnostics pages) accumulate their peak/min and history from the moment they are constructed. That was dialog-open; it is now first-visit. A page still shows correct current values the instant it opens, and "peak since you started looking at it" is arguably the better semantics, but it is a change and I did not want it buried.

J.J. Boyd ~ KG4VCF
