### PR TITLE
fix(attribution): the author-tag checker never ran locally, and could invent violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,8 @@ jobs:
           path: |
             ${{ github.workspace }}/../Thetis
             ${{ github.workspace }}/../mi0bot-Thetis
-          key: thetis-clones-501e3f5-c26a8a4-v1
+            ${{ github.workspace }}/../freedv-gui
+          key: thetis-clones-501e3f5-c26a8a4-77e793a-v2
 
       - name: Clone Thetis + mi0bot-Thetis upstream (cache miss only)
         if: steps.thetis-cache.outputs.cache-hit != 'true'
@@ -125,6 +126,14 @@ jobs:
         # making the verifier flag four phantom missing tags on the
         # untouched HermesLite cite block we ported from c26a8a4.
         #
+        # drowe67/freedv-gui pinned to 77e793a to match every
+        # `[@77e793a]` inline cite stamp from Phase 3J-2 + 3R. Added
+        # 2026-07-28: the ~20 `// From freedv-gui <path>` cites in
+        # FreeDVReporterClient / PskReporterClient matched no detector
+        # in verify-inline-tag-preservation.py, so they were never
+        # counted and never verified. With the detector added, they need
+        # a clone here or they only ever report upstream-not-found.
+        #
         # Shallow fetch + checkout of the pinned SHA avoids cloning the
         # full git history. GitHub's git server allows `fetch --depth=1
         # <sha>` because uploadpack.allowReachableSHA1InWant is enabled.
@@ -139,6 +148,11 @@ jobs:
           git -C ../mi0bot-Thetis remote add origin https://github.com/mi0bot/OpenHPSDR-Thetis.git
           git -C ../mi0bot-Thetis fetch --depth=1 -q origin c26a8a4c7592605039be5f4b5973b33e04e91e54
           git -C ../mi0bot-Thetis checkout -q FETCH_HEAD
+          mkdir -p ../freedv-gui
+          git -C ../freedv-gui init -q
+          git -C ../freedv-gui remote add origin https://github.com/drowe67/freedv-gui.git
+          git -C ../freedv-gui fetch --depth=1 -q origin 77e793a37e0ecf6cfa99b7cf21a410fd154e9d94
+          git -C ../freedv-gui checkout -q FETCH_HEAD
 
       - name: Corpus drift — upstream author tags match committed corpus
         # Fails if upstream Thetis (ramdor or mi0bot fork) contains
@@ -158,6 +172,7 @@ jobs:
         env:
           NEREUS_THETIS_DIR: ${{ github.workspace }}/../Thetis
           NEREUS_MI0BOT_DIR: ${{ github.workspace }}/../mi0bot-Thetis
+          NEREUS_FREEDV_DIR: ${{ github.workspace }}/../freedv-gui
         run: python3 scripts/verify-inline-tag-preservation.py
 
       - name: Contributor indexes are up to date with corpus

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -106,11 +106,18 @@ fi
 
 echo "[pre-commit] verify-inline-tag-preservation.py (author-tag check)"
 # Auto-locate upstream clones. Search order:
-#   1. $NEREUS_THETIS_DIR  / $NEREUS_MI0BOT_DIR (explicit override)
-#   2. ../Thetis            (standard main-repo sibling)
-#   3. ../../Thetis         (worktree layout: .worktrees/<branch>/)
-#   4. ../../../Thetis      (deeper worktree layout)
+#   1. $NEREUS_<NAME>_DIR (explicit override)
+#   2. every ancestor of the working tree, nearest first
 # CI sets the env vars explicitly; this logic is for local dev.
+#
+# The ancestor walk replaces a fixed ../, ../../, ../../../ probe list
+# (2026-07-28). That list stopped one level short of a linked worktree
+# under .claude/worktrees/<name>, where the sibling clone sits four
+# levels up, so the hook printed "no Thetis clone found locally" and
+# skipped the check for anyone working in a worktree. The same
+# off-by-depth bug existed independently in
+# verify-inline-tag-preservation.py; both now walk ancestors so neither
+# has to know how deeply it is nested.
 find_upstream() {
     local name="$1"
     local override="$2"
@@ -118,28 +125,34 @@ find_upstream() {
         echo "$override"
         return
     fi
-    for candidate in "../$name" "../../$name" "../../../$name"; do
-        if [ -d "$candidate" ]; then
-            echo "$candidate"
+    local dir
+    dir="$(pwd -P)"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/$name" ]; then
+            echo "$dir/$name"
             return
         fi
+        dir="$(dirname "$dir")"
     done
+    [ -d "/$name" ] && echo "/$name"
 }
 
 THETIS_LOCAL="$(find_upstream Thetis "${NEREUS_THETIS_DIR:-}")"
 MI0BOT_LOCAL="$(find_upstream mi0bot-Thetis "${NEREUS_MI0BOT_DIR:-}")"
 DESKHPSDR_LOCAL="$(find_upstream deskhpsdr "${NEREUS_DESKHPSDR_DIR:-}")"
+FREEDV_LOCAL="$(find_upstream freedv-gui "${NEREUS_FREEDV_DIR:-}")"
 
 if [ -n "${NEREUS_SKIP_TAG_CHECK:-}" ]; then
     echo "[pre-commit] tag-preservation SKIPPED (NEREUS_SKIP_TAG_CHECK set)"
 elif [ -z "$THETIS_LOCAL" ]; then
     echo "[pre-commit] tag-preservation SKIPPED (no Thetis clone found locally;"
-    echo "             searched ../Thetis, ../../Thetis, ../../../Thetis;"
+    echo "             searched every ancestor of $(pwd -P) for a Thetis/ dir;"
     echo "             set NEREUS_THETIS_DIR to override; CI runs strict check)"
 else
     export NEREUS_THETIS_DIR="$THETIS_LOCAL"
     [ -n "$MI0BOT_LOCAL" ]    && export NEREUS_MI0BOT_DIR="$MI0BOT_LOCAL"
     [ -n "$DESKHPSDR_LOCAL" ] && export NEREUS_DESKHPSDR_DIR="$DESKHPSDR_LOCAL"
+    [ -n "$FREEDV_LOCAL" ]    && export NEREUS_FREEDV_DIR="$FREEDV_LOCAL"
     if ! python3 scripts/verify-inline-tag-preservation.py >/dev/null 2>&1; then
         python3 scripts/verify-inline-tag-preservation.py || true
         echo

--- a/scripts/verify-inline-tag-preservation.py
+++ b/scripts/verify-inline-tag-preservation.py
@@ -89,15 +89,33 @@ FREEDV_DIR = Path(os.environ.get(
 # Cite detectors. We scan for the upstream filename + line token; the
 # stamp presence is verified by the sibling verify-inline-cites.py
 # hook, so we tolerate either stamp grammar here.
+
+# Shared line-spec grammar for every cite detector below. A cite may name
+# one line (`:4821`), a range (`:25008-25072`), a comma list
+# (`:340, 344, 350`), or several disjoint locations joined with `+` in
+# either the tight or spaced form:
+#
+#   freedv_reporter.cpp:79+93-153
+#   console.cs:2304-2337 + 5400-5448 + 5763
+#
+# `+` MUST stay in the separator class. Before it was added (Codex review,
+# PR #309) the match stopped at the first location, so a cite was counted
+# as checked while every tag in the discarded locations went unverified —
+# exactly the silent-drop this whole script exists to prevent. Keeping the
+# grammar in one constant is deliberate: the bug was four copies of the
+# same regex, and fixing three of them would have looked identical to
+# fixing all four.
+LINE_SPEC = r"(?P<lines>\d+(?:[+,\s-]+\d+)*)"
+
 RE_CITE_RAMDOR = re.compile(
     r"//\s*(?:From\s+Thetis|Source:)\s+"
     r"(?P<file>[\w./-]+\.(?:cs|c|h|cpp))"
-    r":(?P<lines>\d+(?:[,\s-]+\d+)*)"
+    r":" + LINE_SPEC
 )
 RE_CITE_MI0BOT = re.compile(
     r"//\s*(?:From\s+mi0bot|Source:\s*mi0bot)\s+"
     r"(?P<file>[\w./-]+\.(?:cs|c|h|cpp))"
-    r":(?P<lines>\d+(?:[,\s-]+\d+)*)"
+    r":" + LINE_SPEC
 )
 # Note: RE_CITE_DESKHPSDR is checked BEFORE RE_CITE_RAMDOR in the scan
 # loop. The ramdor regex uses a bare "Source:" prefix which would
@@ -115,7 +133,7 @@ RE_CITE_DESKHPSDR = re.compile(
     r"|From\s+deskhpsdr\s+"        # "From deskhpsdr " followed by any path
     r")"
     r"(?P<file>(?:deskhpsdr/)?[\w./-]+\.(?:c|h))"
-    r":(?P<lines>\d+(?:[,\s-]+\d+)*)"
+    r":" + LINE_SPEC
 )
 # freedv-gui, same shape and the same ordering requirement as deskhpsdr:
 # "Source: freedv-gui/src/main.cpp:1971-1996" is matched by the bare
@@ -130,7 +148,7 @@ RE_CITE_FREEDV = re.compile(
     r"|From\s+freedv-gui\s+"       # "From freedv-gui " followed by any path
     r")"
     r"(?P<file>(?:freedv-gui/)?[\w./-]+\.(?:c|h|cpp|cc|hpp))"
-    r":(?P<lines>\d+(?:[,\s-]+\d+)*)"
+    r":" + LINE_SPEC
 )
 
 # Inline tags we insist on preserving. The corpus is DISCOVERED from
@@ -214,24 +232,53 @@ def iter_source_files():
 
 
 def parse_lines_token(tok: str):
-    """`25008-25072` → [25008, 25072]; `340, 344, 350` → [340, 344, 350]."""
-    out = []
-    for chunk in re.split(r"[,\s]+", tok.strip()):
+    """`25008-25072` → [25008, 25072]; `340, 344, 350` → [340, 344, 350].
+
+    `+` joins disjoint locations and separates exactly like a comma:
+    `79+93-153` → [79, 93, 153]. It must be split here as well as matched
+    by LINE_SPEC — left in place it would make `79+93` a single chunk,
+    and the int() below would raise ValueError and silently drop BOTH
+    locations rather than just the second.
+    """
+    return [n for span in parse_lines_spans(tok) for n in
+            (span if span[0] != span[1] else span[:1])]
+
+
+def parse_lines_spans(tok: str) -> list[tuple[int, int]]:
+    """Split a cite's line token into DISJOINT (lo, hi) spans.
+
+    `25008-25072`      → [(25008, 25072)]        one contiguous range
+    `340, 344, 350`    → [(340,340), (344,344), (350,350)]
+    `79+93-153`        → [(79,79), (93,153)]
+    `2304-2337 + 5400-5448 + 5763`
+                       → [(2304,2337), (5400,5448), (5763,5763)]
+
+    Spans matter because the caller scans upstream for author tags.
+    Collapsing a cite to a flat list and scanning min..max bridges every
+    line between disjoint locations: the DisplaySetupPages.cpp:907 cite
+    above would sweep 2299..5768 of display.cs, roughly 3,500 lines, and
+    demand that every `//MW0LGE` in that block appear in a port that only
+    ever touched three small regions. That is the "invents violations"
+    half of this script's original bug — keep the components separate.
+    """
+    spans: list[tuple[int, int]] = []
+    for chunk in re.split(r"[+,\s]+", tok.strip()):
         if not chunk:
             continue
         if "-" in chunk:
             a, b = chunk.split("-", 1)
             try:
-                out.append(int(a))
-                out.append(int(b))
+                lo, hi = int(a), int(b)
             except ValueError:
                 continue
+            spans.append((lo, hi) if lo <= hi else (hi, lo))
         else:
             try:
-                out.append(int(chunk))
+                n = int(chunk)
             except ValueError:
                 continue
-    return out
+            spans.append((n, n))
+    return spans
 
 
 def resolve_upstream(cite_file: str, which: str) -> Path | None:
@@ -334,38 +381,45 @@ def find_header_end(text: list[str]) -> int:
     return 1  # no body found; treat whole file as body to be safe
 
 
-def extract_tags_from_region(src_path: Path, line_nums: list[int],
+def extract_tags_from_region(src_path: Path, spans: list[tuple[int, int]],
                              window: int = 5) -> set[tuple[int, str]]:
     """Pull every inline tag (callsign/named/version/dash) found within
-    ±window lines of each cited line, EXCLUDING tags that fall inside
+    ±window lines of each cited SPAN, EXCLUDING tags that fall inside
     the file's copyright/license header block (detected by
     find_header_end). File-header attribution is enforced separately
-    by verify-thetis-headers.py."""
+    by verify-thetis-headers.py.
+
+    Each span is padded and scanned on its own. Scanning min..max across
+    all spans instead would bridge the gaps between disjoint locations
+    and manufacture requirements from untouched upstream code — see
+    parse_lines_spans() for the cite that exposed this.
+    """
     try:
         text = src_path.read_text(encoding="utf-8", errors="replace").splitlines()
     except Exception:
         return set()
     header_end = find_header_end(text)
     tags: set[tuple[int, str]] = set()
-    lo = max(1, min(line_nums) - window)
-    hi = min(len(text), max(line_nums) + window)
-    for i in range(lo - 1, hi):
-        if (i + 1) < header_end:
+    rows: set[int] = set()
+    for lo, hi in spans:
+        rows.update(range(max(1, lo - window), min(len(text), hi + window) + 1))
+    for row in sorted(rows):
+        if row < header_end:
             continue  # inside file header; not an inline tag
-        line = text[i]
+        line = text[row - 1]
         # version-prefixed tag
         for m in RE_VERSION_TAG.finditer(line):
-            tags.add((i + 1, m.group(2).upper()))
+            tags.add((row, m.group(2).upper()))
         # dash form
         for m in RE_DASH_TAG.finditer(line):
-            tags.add((i + 1, m.group(1).upper()))
+            tags.add((row, m.group(1).upper()))
         # known callsigns / named (require `//` on the line so we only
         # pick comments, not string literals)
         if "//" in line:
             tail = line.split("//", 1)[1]
             for tag in KNOWN_CALLSIGNS + KNOWN_NAMED:
                 if re.search(r"\b" + re.escape(tag) + r"\b", tail):
-                    tags.add((i + 1, tag.upper()))
+                    tags.add((row, tag.upper()))
     return tags
 
 
@@ -447,9 +501,10 @@ def main() -> int:
                     continue
                 cite_count += 1
                 cite_line = ln_idx + 1
-                line_nums = parse_lines_token(m.group("lines"))
-                if not line_nums:
+                spans = parse_lines_spans(m.group("lines"))
+                if not spans:
                     continue
+                line_nums = parse_lines_token(m.group("lines"))
                 upstream = resolve_upstream(m.group("file"), which)
                 if upstream is None:
                     findings.append({
@@ -463,7 +518,7 @@ def main() -> int:
                         "tag": None,
                     })
                     continue
-                source_tags = extract_tags_from_region(upstream, line_nums)
+                source_tags = extract_tags_from_region(upstream, spans)
                 for src_line, tag in sorted(source_tags):
                     if not port_contains_tag(port, cite_line, tag):
                         findings.append({

--- a/scripts/verify-inline-tag-preservation.py
+++ b/scripts/verify-inline-tag-preservation.py
@@ -15,10 +15,14 @@ Algorithm:
 - Scan every `.cpp/.cc/.c/.h/.hpp` under src/ and tests/ for cites
   matching `// From Thetis <file>:<line(s)> [@sha|vX.Y.Z]` or
   `// Source: mi0bot <file>:<line(s)> [@sha]`.
-- For each cite, open the cited file under ../Thetis or
-  ../mi0bot-Thetis (configurable), extract any inline contributor
-  tags in the cited line range ±5 lines, and require each tag to
-  appear within ±10 lines of the cite in the port.
+- For each cite, open the cited file under the ONE upstream that cite
+  names (../Thetis, ../mi0bot-Thetis, ../deskhpsdr or ../freedv-gui,
+  each configurable), extract any inline contributor tags in the
+  cited line range ±5 lines, and require each tag to appear within ±10
+  lines of the cite in the port.
+- Upstream clones are located by walking parent directories, so this
+  works from a plain checkout and from a linked worktree under
+  .claude/worktrees/ without either needing to know its own depth.
 - Tags recognized: developer callsigns (DH1KLM, MW0LGE, W2PA, MI0BOT,
   KD5TFD, OE3IDE, G8NJJ, NR0V, G0ORX, VK6APH) + `//-W2PA` dash form +
   `//[X.Y.Z]Author` version-prefixed form + named contributors
@@ -31,8 +35,9 @@ Usage:
 Exit code 0 iff no findings (strict) or always 0 in audit mode.
 
 Configuration:
-    NEREUS_THETIS_DIR      — override ../Thetis path
-    NEREUS_MI0BOT_DIR      — override ../mi0bot-Thetis path
+    NEREUS_THETIS_DIR:      override ../Thetis path
+    NEREUS_MI0BOT_DIR:      override ../mi0bot-Thetis path
+    NEREUS_FREEDV_DIR:      override ../freedv-gui path
 """
 from __future__ import annotations
 
@@ -46,15 +51,40 @@ REPO = Path(__file__).resolve().parent.parent
 SCAN_ROOTS = ["src", "tests"]
 SCAN_SUFFIXES = {".cpp", ".cc", ".c", ".h", ".hpp"}
 
+def discover_sibling(name: str) -> Path:
+    """Locate an upstream clone sitting beside the NereusSDR checkout.
+
+    CLAUDE.md places upstreams as siblings of the NereusSDR root
+    (../Thetis, ../mi0bot-Thetis).  Computing that from REPO is awkward
+    because REPO is the *worktree* root when this runs from inside
+    .claude/worktrees/<name>, and the repo root otherwise.  The previous
+    fixed `REPO.parent.parent.parent / name` arithmetic resolved to
+    "/Thetis" from a plain checkout and "<repo>/Thetis" from a worktree.
+    Neither path exists, so every local run hit the FATAL-and-skip branch
+    in main() and the hook has never actually verified a tag outside CI
+    (which supplies the paths by env var and was unaffected).
+
+    Walking ancestors is correct from both locations: a plain checkout
+    finds ../Thetis one level up, and a worktree finds it four levels up,
+    without either needing to know how deep it is.
+    """
+    for base in (REPO, *REPO.parents):
+        candidate = base / name
+        if candidate.is_dir():
+            return candidate
+    # Nothing found. Return the conventional location so the diagnostic
+    # in main() names the path a developer is expected to clone into.
+    return REPO.parent / name
+
+
 THETIS_DIR = Path(os.environ.get(
-    "NEREUS_THETIS_DIR",
-    REPO.parent.parent.parent / "Thetis")).expanduser()
+    "NEREUS_THETIS_DIR", discover_sibling("Thetis"))).expanduser()
 MI0BOT_DIR = Path(os.environ.get(
-    "NEREUS_MI0BOT_DIR",
-    REPO.parent.parent.parent / "mi0bot-Thetis")).expanduser()
+    "NEREUS_MI0BOT_DIR", discover_sibling("mi0bot-Thetis"))).expanduser()
 DESKHPSDR_DIR = Path(os.environ.get(
-    "NEREUS_DESKHPSDR_DIR",
-    "/Users/j.j.boyd/deskhpsdr")).expanduser()
+    "NEREUS_DESKHPSDR_DIR", discover_sibling("deskhpsdr"))).expanduser()
+FREEDV_DIR = Path(os.environ.get(
+    "NEREUS_FREEDV_DIR", discover_sibling("freedv-gui"))).expanduser()
 
 # Cite detectors. We scan for the upstream filename + line token; the
 # stamp presence is verified by the sibling verify-inline-cites.py
@@ -85,6 +115,21 @@ RE_CITE_DESKHPSDR = re.compile(
     r"|From\s+deskhpsdr\s+"        # "From deskhpsdr " followed by any path
     r")"
     r"(?P<file>(?:deskhpsdr/)?[\w./-]+\.(?:c|h))"
+    r":(?P<lines>\d+(?:[,\s-]+\d+)*)"
+)
+# freedv-gui, same shape and the same ordering requirement as deskhpsdr:
+# "Source: freedv-gui/src/main.cpp:1971-1996" is matched by the bare
+# "Source:" alternative in RE_CITE_RAMDOR, which then tries to resolve a
+# freedv-gui path under the Thetis clone and reports upstream-not-found.
+# The freedv-gui corpus is already merged into the tag list by
+# load_corpus(), so before this detector existed those cites loaded
+# contributor tags that nothing was ever checked against.
+RE_CITE_FREEDV = re.compile(
+    r"//\s*(?:"
+    r"Source:\s+(?=freedv-gui/)"   # "Source: " followed by freedv-gui/ path
+    r"|From\s+freedv-gui\s+"       # "From freedv-gui " followed by any path
+    r")"
+    r"(?P<file>(?:freedv-gui/)?[\w./-]+\.(?:c|h|cpp|cc|hpp))"
     r":(?P<lines>\d+(?:[,\s-]+\d+)*)"
 )
 
@@ -190,11 +235,19 @@ def parse_lines_token(tok: str):
 
 
 def resolve_upstream(cite_file: str, which: str) -> Path | None:
-    """Find the cited file under ramdor Thetis, mi0bot Thetis, or deskhpsdr."""
-    if which == "deskhpsdr":
-        # deskhpsdr cite paths are relative to repo root (e.g. "src/new_protocol.c")
-        # or just a bare filename. Try both direct and src/ prefix.
-        for base in _deskhpsdr_search_bases():
+    """Find the cited file under the ONE upstream the cite names.
+
+    `which` comes from whichever cite detector matched, and is honoured
+    exactly: a cite that says mi0bot is resolved against the mi0bot clone
+    and nowhere else. See the comment on the `bases` assignment below for
+    why falling back to a sibling upstream is actively harmful.
+    """
+    if which in ("deskhpsdr", "freedv-gui"):
+        # These cite paths are relative to the upstream repo root
+        # (e.g. "src/new_protocol.c") or just a bare filename. Try both
+        # direct and src/ prefix.
+        for base in (_deskhpsdr_search_bases() if which == "deskhpsdr"
+                     else _freedv_search_bases()):
             candidate = base / cite_file
             if candidate.is_file():
                 return candidate
@@ -208,7 +261,21 @@ def resolve_upstream(cite_file: str, which: str) -> Path | None:
                         return found
         return None
 
-    bases = [THETIS_DIR] if which == "ramdor" else [MI0BOT_DIR, THETIS_DIR]
+    # No cross-upstream fallback. mi0bot/OpenHPSDR-Thetis is a *fork* of
+    # ramdor/Thetis, so both clones carry same-named files (console.cs,
+    # clsHardwareSpecific.cs) whose contents and line numbering have
+    # diverged. Resolving an mi0bot cite against the ramdor clone opens
+    # unrelated code at the cited line number, harvests whatever author
+    # tags happen to sit near it, and then reports our port as missing
+    # tags it was never supposed to carry.
+    #
+    # That is not hypothetical: with the mi0bot clone absent this
+    # produced 5 confident FAILs on clean main (PaGainProfile.cpp,
+    # PaTelemetryScaling.{h,cpp}, tst_pa_gain_profile.cpp), each naming a
+    # real contributor (//N1GP, //DH1KLM) and each entirely spurious. A
+    # tool that fabricates GPL-attribution violations is worse than one
+    # that reports it cannot check, so an absent clone now warns.
+    bases = [THETIS_DIR] if which == "ramdor" else [MI0BOT_DIR]
     for base in bases:
         # Direct path
         candidate = base / cite_file
@@ -226,14 +293,24 @@ def resolve_upstream(cite_file: str, which: str) -> Path | None:
     return None
 
 
-def _deskhpsdr_search_bases() -> list[Path]:
-    """Return candidate deskhpsdr base directories, preferring env override."""
-    candidates = [DESKHPSDR_DIR]
-    for rel in ("../deskhpsdr", "../../deskhpsdr", "../../../deskhpsdr"):
-        p = (REPO / rel).resolve()
+def _sibling_search_bases(primary: Path, name: str) -> list[Path]:
+    """Candidate base directories for an upstream, env override first."""
+    candidates = [primary]
+    for base in (REPO, *REPO.parents):
+        p = (base / name).resolve()
         if p not in candidates:
             candidates.append(p)
     return [p for p in candidates if p.is_dir()]
+
+
+def _deskhpsdr_search_bases() -> list[Path]:
+    """Return candidate deskhpsdr base directories, preferring env override."""
+    return _sibling_search_bases(DESKHPSDR_DIR, "deskhpsdr")
+
+
+def _freedv_search_bases() -> list[Path]:
+    """Return candidate freedv-gui base directories, preferring env override."""
+    return _sibling_search_bases(FREEDV_DIR, "freedv-gui")
 
 
 def find_header_end(text: list[str]) -> int:
@@ -319,13 +396,31 @@ def main() -> int:
         print("Set NEREUS_THETIS_DIR or clone to ../Thetis", file=sys.stderr)
         return 2
 
+    # mi0bot is the authoritative upstream for HL2 ports, so a missing
+    # clone leaves every `// From mi0bot ...` cite unverified. It used to
+    # be worse than unverified: the resolver fell through to the ramdor
+    # clone and invented failures (see resolve_upstream). Say so loudly.
+    if not MI0BOT_DIR.is_dir():
+        print(f"WARN: mi0bot-Thetis not found at {MI0BOT_DIR}. Every "
+              f"`// From mi0bot ...` cite will emit upstream-not-found "
+              f"instead of being verified. Set NEREUS_MI0BOT_DIR or clone "
+              f"to a sibling directory.", file=sys.stderr)
+
     # deskhpsdr is optional for now — warn if absent so local runs without
     # the clone still pass, but CI that has it cloned will do full checks.
     if not _deskhpsdr_search_bases():
         print(f"WARN: deskhpsdr not found (searched {DESKHPSDR_DIR} and "
-              f"relative ../../../deskhpsdr). deskhpsdr cite checks will "
+              f"sibling directories). deskhpsdr cite checks will "
               f"emit upstream-not-found warnings rather than hard-failing. "
               f"Set NEREUS_DESKHPSDR_DIR or clone to a sibling directory.",
+              file=sys.stderr)
+
+    # freedv-gui, same treatment as deskhpsdr.
+    if not _freedv_search_bases():
+        print(f"WARN: freedv-gui not found (searched {FREEDV_DIR} and "
+              f"sibling directories). freedv-gui cite checks will "
+              f"emit upstream-not-found warnings rather than hard-failing. "
+              f"Set NEREUS_FREEDV_DIR or clone to a sibling directory.",
               file=sys.stderr)
 
     findings = []
@@ -345,6 +440,7 @@ def main() -> int:
             # (break at end of loop body).
             for rx, which in ((RE_CITE_MI0BOT, "mi0bot"),
                               (RE_CITE_DESKHPSDR, "deskhpsdr"),
+                              (RE_CITE_FREEDV, "freedv-gui"),
                               (RE_CITE_RAMDOR, "ramdor")):
                 m = rx.search(line)
                 if not m:

--- a/src/core/P1RadioConnection.cpp
+++ b/src/core/P1RadioConnection.cpp
@@ -2947,7 +2947,10 @@ void P1RadioConnection::parseEp6Frame(const QByteArray& pkt)
 
     // Emit iqDataReceived for each receiver
     // Contract: hwReceiverIndex (0-based), interleaved float I/Q pairs, [-1, 1]
-    // Source: RadioConnection.h:82 iqDataReceived signal
+    // Declared by our own RadioConnection.h (iqDataReceived signal). Was
+    // written using `// Source: <file>:<line>` cite grammar, which the
+    // author-tag verifier reads as an upstream Thetis cite; it is an
+    // internal cross-reference, and the line number had drifted anyway.
     for (int r = 0; r < static_cast<int>(perRxVecs.size()); ++r) {
         if (!perRxVecs[static_cast<size_t>(r)].isEmpty()) {
             if (!m_firstEmitLogged) {

--- a/src/core/TciServer.cpp
+++ b/src/core/TciServer.cpp
@@ -1584,9 +1584,18 @@ void TciServer::cleanupResamplers(std::shared_ptr<TciClientSession>& session)
 // lock-free AudioRingSpsc safe for one producer (DSP thread) + one consumer
 // (main thread drain timer).
 //
-// From Thetis RxChannel.cpp:1479-1492 [v2.10.3.13] — the audioFrameReady
-// signal fires post-DSP with outI (L) and outQ (R) as scratch float arrays
-// of length n at srcRate Hz (always 48000 for WDSP RX output).
+// Contract of our own RxChannel::processIq (src/core/RxChannel.cpp): the
+// audioFrameReady signal fires post-DSP with outI (L) and outQ (R) as
+// scratch float arrays of length n at srcRate Hz (always 48000 for WDSP
+// RX output).
+//
+// Until 2026-07-28 this was written in "From Thetis" cite grammar
+// naming RxChannel.cpp, which claimed Thetis provenance for a
+// NereusSDR-original file. Thetis has no such file. Rewritten as a
+// plain internal cross-reference so it neither overclaims upstream
+// attribution nor gets resolved against the Thetis clone. Deliberately
+// avoids repeating the old file:line form, which the author-tag
+// verifier would match inside this very comment.
 //
 // Uses tryPushCopy (non-blocking) so the DSP thread never blocks. Overflow
 // (ring full) silently drops the oldest portion — audible as a dropout rather

--- a/src/gui/AddCustomRadioDialog.cpp
+++ b/src/gui/AddCustomRadioDialog.cpp
@@ -266,10 +266,15 @@ void AddCustomRadioDialog::buildUi()
     m_ipEdit->setValidator(new QRegularExpressionValidator(ipRe, m_ipEdit));
     form->addRow(QStringLiteral("IP Address:"), m_ipEdit);
 
-    // Port — from Thetis txtSpecificRadio default ":1024" (Designer.cs:64)
+    // Port: from Thetis txtSpecificRadio default ":1024"
+    // (frmAddCustomRadio.Designer.cs:105)
     m_portSpin = new QSpinBox(this);
     m_portSpin->setRange(1, 65535);
-    m_portSpin->setValue(1024);   // From Thetis Designer.cs:64 default "192.168.0.155:1024"
+    // From Thetis frmAddCustomRadio.Designer.cs:105 [v2.10.3.15]. Default
+    // txtSpecificRadio.Text = "192.168.0.155:1024". Cite previously read
+    // "Designer.cs:64": the filename was truncated to a suffix that matches
+    // no Thetis file, and the line number was wrong, so it never resolved.
+    m_portSpin->setValue(1024);
     m_portSpin->setStyleSheet(kFieldStyle);
     form->addRow(QStringLiteral("Port:"), m_portSpin);
 


### PR DESCRIPTION
The inline author-tag preservation check has four defects. It has never
run outside CI, and when it does run without every upstream clone
present it can report attribution violations that do not exist.

Found while trying to run it from a worktree during unrelated work.

## The checker never ran locally

`THETIS_DIR` defaulted to `REPO.parent.parent.parent / "Thetis"`, which
resolves to `/Thetis` from a normal checkout and `<repo>/Thetis` from a
linked worktree. Neither exists, so `main()` took its FATAL-and-return
branch every time. `scripts/git-hooks/pre-commit` had the same bug
implemented separately, probing a fixed `../`, `../../`, `../../../`
list and bailing before it ever invoked the script. CI was unaffected
throughout because it supplies both paths by env var.

Both now walk ancestors, so neither needs to know its own nesting depth.

## It could invent violations

`resolve_upstream` fell back from the mi0bot clone to the ramdor clone.
mi0bot/OpenHPSDR-Thetis is a fork of ramdor/Thetis, so both carry files
with the same names whose contents and line numbering have diverged.
With the mi0bot clone absent, a cite reading `// From mi0bot
console.cs:25081` was resolved against ramdor's console.cs, harvested
whatever author tags sat near that line, and reported our port as
missing them.

This produced 5 confident FAILs on clean main naming //N1GP and
//DH1KLM, all spurious. A checker that fabricates GPL-attribution
violations is worse than one that reports it cannot check, so the
fallback is removed and a missing clone warns.

## freedv-gui cites were invisible

Roughly 68 cites written `// From freedv-gui <path>:<lines>` matched no
detector: the ramdor pattern wants `From Thetis` or a bare `Source:`.
They were never counted, never resolved and never warned about, while
`load_corpus()` was already merging the freedv-gui author corpus into
the tag list, so those contributor tags were loaded and checked against
nothing. CI never cloned freedv-gui either.

Added a detector and resolver ordered ahead of the ramdor catch-all
(exactly as deskhpsdr is), and pinned freedv-gui in CI at
77e793a37e0ecf6cfa99b7cf21a410fd154e9d94 to match the `[@77e793a]`
stamps from Phase 3J-2 and 3R.

## Three cites corrected

Exposed once the checker actually resolved clones. Comment-only.

- `TciServer.cpp` used `From Thetis` grammar naming `RxChannel.cpp`.
  Thetis has no such file; it is NereusSDR-original. Claiming upstream
  provenance for our own code is the inverse of what this tooling
  guards against.
- `AddCustomRadioDialog.cpp` cited `Designer.cs:64`. That is a filename
  suffix, not a file, and the line was wrong. Real source is
  `frmAddCustomRadio.Designer.cs:105`.
- `P1RadioConnection.cpp` used cite grammar for an internal
  cross-reference, and its line number had drifted.

## Verification

- Coverage: 3158 to 3225 cites scanned.
- Mutation test: deleting a real `//MI0BOT` tag inside a cite window
  fails with exit 1 through the pre-commit hook; restoring it passes.
- With all four clones present the run is clean: zero failures, zero
  upstream-not-found warnings.
- Full build green.

No tolerance widened, no skip markers added.

J.J. Boyd ~ KG4VCF
