### PR TITLE
build: build the application as a shared library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
         # -DNEREUS_GPU_SPECTRUM=OFF on Linux.
         #
         # mold (the apt mold package) is the fast linker. With 451 test
-        # executables linking against NereusSDRObjs + Qt6 the default
+        # executables linking against NereusSDRLib + Qt6 the default
         # ld linker dominated Linux build time at ~33 minutes. The
         # Configure (Linux) step below selects mold via -fuse-ld=mold.
         if: runner.os == 'Linux'
@@ -340,7 +340,7 @@ jobs:
       # SDK / .NET / GHC / unused hosted-tool-cache entries.  Phase
       # 3J-1 closeout pushed the total link-time on-disk footprint
       # past the remaining free budget: 451 test executables each
-      # linking against NereusSDRObjs (~700 MB stripped, much larger
+      # linking against NereusSDRLib (~700 MB stripped, much larger
       # with debug info) plus the vendored RADE neural-codec tree.
       # Run #25835957362 died mid-link with "No space left on
       # device" and the log blob got truncated before upload finished.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,11 +612,20 @@ jobs:
         if: github.event_name == 'pull_request' && (matrix.shard == 0 || matrix.shard == '')
         id: locate
         shell: bash
+        # The app is a thin executable over the NereusSDRLib shared library,
+        # so the library has to travel with it or the artifact cannot start.
+        # macOS needs no extra entry: the .app already carries its own copy in
+        # Contents/Frameworks, staged by the CMake POST_BUILD step.
+        #
+        # These artifacts were never fully standalone (they still expect Qt,
+        # librade and friends from the build environment). The point here is
+        # only to keep them exactly as usable as they were before the app
+        # became a shared library.
         run: |
           case "${{ runner.os }}" in
-            Linux)   echo "binary=build/NereusSDR" >> "$GITHUB_OUTPUT" ;;
+            Linux)   printf 'binary<<EOF\nbuild/NereusSDR\nbuild/libNereusSDRLib.so\nEOF\n' >> "$GITHUB_OUTPUT" ;;
             macOS)   echo "binary=build/NereusSDR.app" >> "$GITHUB_OUTPUT" ;;
-            Windows) echo "binary=build/NereusSDR.exe" >> "$GITHUB_OUTPUT" ;;
+            Windows) printf 'binary<<EOF\nbuild/NereusSDR.exe\nbuild/NereusSDRLib.dll\nEOF\n' >> "$GITHUB_OUTPUT" ;;
           esac
 
       - name: Upload PR build artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,11 +280,34 @@ jobs:
           echo "Adding $LIBRADE_DIR to LD_LIBRARY_PATH for linuxdeploy"
           export LD_LIBRARY_PATH="$PWD/$LIBRADE_DIR:$LD_LIBRARY_PATH"
 
+          # libNereusSDRLib.so is the application itself, built SHARED so the
+          # ~514 test executables stop each embedding a private 22 MB copy.
+          # Unlike librade it DOES have an install() rule, so cmake --install
+          # has already placed it in AppDir/usr/lib, and usr/bin/NereusSDR
+          # carries RPATH $ORIGIN/../lib. Belt and braces anyway: the librade
+          # experience above shows linuxdeploy's resolver is the fragile part
+          # of this step, and a missing application library is not a degraded
+          # AppImage, it is one that cannot start at all.
+          if [ ! -f AppDir/usr/lib/libNereusSDRLib.so ]; then
+            echo "ERROR: libNereusSDRLib.so missing from AppDir/usr/lib after cmake --install" >&2
+            find AppDir build -name 'libNereusSDRLib.so*' >&2
+            exit 1
+          fi
+          export LD_LIBRARY_PATH="$PWD/AppDir/usr/lib:$LD_LIBRARY_PATH"
+
           ./linuxdeploy-${{ matrix.arch }}.AppImage \
             --appdir AppDir \
             --plugin qt \
             --desktop-file AppDir/usr/share/applications/NereusSDR.desktop \
             --output appimage
+
+          # v0.5.0 shipped a Windows artifact whose .exe could not launch
+          # because rade.dll was absent. Adding a second shared library
+          # doubles that surface, so assert rather than trust.
+          if [ ! -f AppDir/usr/lib/libNereusSDRLib.so ]; then
+            echo "ERROR: libNereusSDRLib.so vanished from AppDir during linuxdeploy" >&2
+            exit 1
+          fi
 
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
@@ -495,6 +518,28 @@ jobs:
             MACDEPLOYQT="$(brew --prefix qt@6)/bin/macdeployqt"
           fi
           "$MACDEPLOYQT" build/NereusSDR.app -verbose=1 -always-overwrite
+
+          # libNereusSDRLib.dylib is the application itself, built SHARED so
+          # the ~514 test executables stop each embedding a private 22 MB
+          # copy. CMake's POST_BUILD stages it into Contents/Frameworks before
+          # this step runs, precisely so macdeployqt sees it in place and
+          # rewrites its Qt references along with everything else.
+          DYLIB="build/NereusSDR.app/Contents/Frameworks/libNereusSDRLib.dylib"
+          if [ ! -f "$DYLIB" ]; then
+            echo "::error::libNereusSDRLib.dylib missing from the app bundle; the .app cannot launch" >&2
+            exit 1
+          fi
+
+          # macdeployqt reaches the dylib by following an @rpath dependency of
+          # the executable. If that traversal ever silently fails, the dylib
+          # keeps build-machine-absolute Qt paths, the bundle still builds and
+          # signs cleanly, and the failure only shows up as a launch crash on
+          # a machine with no Qt installed. Catch it here instead.
+          if otool -L "$DYLIB" | grep -qE '/(opt/homebrew|usr/local)/.*Qt|/Qt/6\.'; then
+            echo "::error::libNereusSDRLib.dylib still references Qt outside the bundle:" >&2
+            otool -L "$DYLIB" | grep -E '/(opt/homebrew|usr/local)/.*Qt|/Qt/6\.' >&2
+            exit 1
+          fi
 
       - name: Copy license notices into app bundle
         run: |
@@ -758,6 +803,18 @@ jobs:
             Copy-Item $radeDll deploy\
           } else {
             Write-Error "rade.dll missing from build\third_party\rade\src\ (Windows artifact would ship broken: NereusSDR.exe will fail to launch with 'rade.dll was not found')"
+            exit 1
+          }
+          # NereusSDRLib.dll is the application itself, built SHARED so the
+          # ~514 test executables stop each embedding a private 22 MB copy.
+          # windeployqt resolves only Qt DLLs, so like rade.dll it must be
+          # staged by hand. This is the single most load-bearing file in the
+          # artifact: without it NereusSDR.exe does not start at all.
+          $appDll = "build\NereusSDRLib.dll"
+          if (Test-Path $appDll) {
+            Copy-Item $appDll deploy\
+          } else {
+            Write-Error "NereusSDRLib.dll missing from build\ (Windows artifact would ship broken: NereusSDR.exe will fail to launch with 'NereusSDRLib.dll was not found')"
             exit 1
           }
           # Copy third-party license notices + both root license files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,15 @@
   of the whole app, which put 12 GB in `build/tests` and meant macOS
   Gatekeeper malware-scanned all of it on every cold suite run. A test binary
   is now about 90 KB, `build/tests` is 1.6 GB, and a cold `ctest -j4` goes
-  from 302 s to 121 s. Touching one `src/core` file and rebuilding every test
-  goes from 34 s to 25 s. 514/514 tests pass on both link modes.
-  One tradeoff: a *warm* suite re-run is 15 to 30% slower (43 s to 50-56 s)
-  because each short-lived test process now pays dyld symbol binding against
-  the library. Cold is the case that matters, since any library edit relinks
-  everything and makes the next run cold.
+  from 273 s to 121 s. Touching one `src/core` file and rebuilding every test
+  goes from 34 s to 25 s. 514/514 tests pass on both link modes, and app
+  resident memory is unchanged (the difference is inside a ±50 MB
+  run-to-run spread).
+  One tradeoff: a *warm* suite re-run is about 60% slower (34 s to 50-56 s)
+  because each of 514 short-lived test processes now pays dyld symbol
+  binding against the library. Cold is the case that matters for the
+  edit-verify loop, since any library edit relinks everything and makes the
+  next run cold, and there the shared library wins by more than it loses.
   No application behaviour changes. The renamed target (was `NereusSDRObjs`)
   ships as `libNereusSDRLib.dylib` inside `NereusSDR.app/Contents/Frameworks`,
   `libNereusSDRLib.so` in the AppImage's `usr/lib`, and `NereusSDRLib.dll`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,51 @@
 
 - Source-first audit caught a wire-format bug in Sub-Epic F Task 1 plan: the wideband enable mask belongs in CmdGeneral byte 23 (Thetis network.c:879), not CmdRx byte 23 (which is rx[1].rx_adc per Thetis network.c:1118). Following the plan as written would have silently broken RX1 ADC routing the moment any user enabled an alternate ADC. Caught + fixed before implementation landed.
 
+### Build
+
+- **The application is now built as a single shared library (`NereusSDRLib`).**
+  Each of the 514 test executables previously embedded a private 22.8 MB copy
+  of the whole app, which put 12 GB in `build/tests` and meant macOS
+  Gatekeeper malware-scanned all of it on every cold suite run. A test binary
+  is now about 90 KB, `build/tests` is 1.6 GB, and a cold `ctest -j4` goes
+  from 302 s to 121 s. Touching one `src/core` file and rebuilding every test
+  goes from 34 s to 25 s. 514/514 tests pass on both link modes.
+  One tradeoff: a *warm* suite re-run is 15 to 30% slower (43 s to 50-56 s)
+  because each short-lived test process now pays dyld symbol binding against
+  the library. Cold is the case that matters, since any library edit relinks
+  everything and makes the next run cold.
+  No application behaviour changes. The renamed target (was `NereusSDRObjs`)
+  ships as `libNereusSDRLib.dylib` inside `NereusSDR.app/Contents/Frameworks`,
+  `libNereusSDRLib.so` in the AppImage's `usr/lib`, and `NereusSDRLib.dll`
+  beside the .exe in both the portable ZIP and the NSIS installer.
+- **Fixed four system libraries linked to the wrong target.** `ws2_32`
+  (needed by `RadioDiscovery.cpp`) and the DFNR Rust runtime dependencies
+  (`bcrypt`/`userenv`/`ntdll`, `Security`/`CoreFoundation`, `pthread`/`dl`/`m`)
+  were attached to the executable while the code needing them lives in the
+  library. That resolved only as long as the library was an OBJECT library
+  whose objects merged into the executable's link line.
+
+### Tests
+
+- **`tst_tx_mic_source::concurrent_producerConsumer_noDataCorruption` no
+  longer fails under load.** It asserted that every sample pushed through
+  `TxMicSource` came back, but the ring overwrites on overrun by design
+  (inherited from Thetis `Inbound()` at `cmbuffs.c:108-109 [v2.10.3.13]`), so
+  the test encoded a guarantee the implementation never made. It now asserts
+  what is actually guaranteed, that every drained block is a whole intact
+  produced block, and reports overruns via `qInfo` instead of failing.
+  Assertions also moved off the consumer thread, where a QtTest failure would
+  have silently truncated the loop rather than failing the test.
+
+### Documentation
+
+- **Corrected the test-suite cost figures in `CONTRIBUTING.md` and
+  `docs/development/fast-test-loop.md`.** Both stated that building all tests
+  costs about 32 minutes. Re-measuring found 34 s before this change and 25 s
+  after. The 32-minute figure came from a link-time measurement in the Phase 0
+  design doc that does not reproduce; the design docs now carry a correction
+  banner recording that, since the rest of their evidence stands.
+
 ## [0.5.2] - 2026-05-24
 
 > [!IMPORTANT]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,16 +50,13 @@
   Each of the 514 test executables previously embedded a private 22.8 MB copy
   of the whole app, which put 12 GB in `build/tests` and meant macOS
   Gatekeeper malware-scanned all of it on every cold suite run. A test binary
-  is now about 90 KB, `build/tests` is 1.6 GB, and a cold `ctest -j4` goes
-  from 273 s to 121 s. Touching one `src/core` file and rebuilding every test
-  goes from 34 s to 25 s. 514/514 tests pass on both link modes, and app
-  resident memory is unchanged (the difference is inside a ±50 MB
-  run-to-run spread).
-  One tradeoff: a *warm* suite re-run is about 60% slower (34 s to 50-56 s)
-  because each of 514 short-lived test processes now pays dyld symbol
-  binding against the library. Cold is the case that matters for the
-  edit-verify loop, since any library edit relinks everything and makes the
-  next run cold, and there the shared library wins by more than it loses.
+  is now about 90 KB, `build/tests` is 1.2 GB (was 13 GB), and a cold
+  `ctest -j4` goes from 362 s to 109 s. Touching one `src/core` file and
+  rebuilding every test goes from 30 s to 22 s. Measured directly: XProtect
+  burns 62 CPU-seconds during a cold run, down from 189.
+  514/514 tests pass on both link modes, warm suite runs are unchanged at
+  43 s either way, and app resident memory is unchanged (the difference sits
+  inside a ±50 MB run-to-run spread).
   No application behaviour changes. The renamed target (was `NereusSDRObjs`)
   ships as `libNereusSDRLib.dylib` inside `NereusSDR.app/Contents/Frameworks`,
   `libNereusSDRLib.so` in the AppImage's `usr/lib`, and `NereusSDRLib.dll`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,7 +509,7 @@ preferences. OpenHPSDR radios don't store per-slice state.
 | --- | --- |
 | [docs/MASTER-PLAN.md](docs/MASTER-PLAN.md) | Full phased roadmap, menu bar layout, GUI container mapping (Thetis → NereusSDR), skin system design, progress tracking |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contributor guidelines, coding conventions, PR process |
-| [docs/development/fast-test-loop.md](docs/development/fast-test-loop.md) | **Read before running tests.** Per-test builds, `ctest -L` subsystem labels, macOS first-run-scan exemption, ccache setup, and how to write tests that stay fast. Building the whole suite costs ~32 min; almost nothing needs it. |
+| [docs/development/fast-test-loop.md](docs/development/fast-test-loop.md) | **Read before running tests.** Per-test builds, `ctest -L` subsystem labels, ccache setup, the macOS first-run scan (and why the Developer Tools exemption does not stop it), and how to write tests that stay fast. Since the app became a shared library: rebuilding every test after a `src/core` edit is ~24 s and the full 598-test suite runs in ~110 s. Record load average with any timing you add here; unqualified numbers in this area have been wrong three times. |
 | [STYLEGUIDE.md](STYLEGUIDE.md) | Applet color palette, button states, gauge zones, slider/combo styling |
 | [CHANGELOG.md](CHANGELOG.md) | Version history and per-phase feature additions |
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 # unoptimised so single-step debugging still works.
 option(NEREUSSDR_AGGRESSIVE_OPT "Use -O3 (instead of -O2) for release builds" ON)
 # 2026-05-26 KG4VCF: LTO default flipped to OFF.  With LTO enabled on
-# the shared NereusSDRObjs object library, every test binary (526 of
+# the shared NereusSDRLib object library, every test binary (526 of
 # them) inherits the LTO bitcode and triggers a multi-minute LTO link
 # of its own.  Net effect on a clean build: 1+ hour, load avg 250+,
 # unusable while building.  Per-target IPO=FALSE on tests doesn't
@@ -113,7 +113,7 @@ if(NEREUSSDR_ENABLE_LTO)
         # main NereusSDR executable + the parallel NereusSDRObjs_LTO
         # object library it links).  We deliberately do NOT set the
         # global CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO
-        # flag, because that would make the shared NereusSDRObjs (used
+        # flag, because that would make the shared NereusSDRLib (used
         # by 526 test executables) produce LTO bitcode, and every test
         # link would then trigger a multi-minute LTO pass.  Net effect
         # of the old global setting on a clean build: ~1 hour, load
@@ -946,7 +946,7 @@ endif()
 # --------------------------------------------------------------------------
 # Object library — shared between the app executable and test targets so
 # the same translation units are compiled once and consumed by both
-# (Phase 3I test infrastructure). Properties on NereusSDRObjs propagate
+# (Phase 3I test infrastructure). Properties on NereusSDRLib propagate
 # to consumers (PUBLIC) via the CMake INTERFACE; the thin executable just
 # links src/main.cpp on top.
 #
@@ -957,7 +957,7 @@ endif()
 # the executable target below so .icns lands in Contents/Resources/ and
 # Windows .rc lands on the linker line.
 # --------------------------------------------------------------------------
-add_library(NereusSDRObjs OBJECT
+add_library(NereusSDRLib OBJECT
     ${CORE_SOURCES}
     ${MODEL_SOURCES}
     ${GUI_SOURCES}
@@ -969,14 +969,14 @@ add_library(NereusSDRObjs OBJECT
 # already gates the menu wiring on Q_OS_LINUX, so the .cpp shouldn't enter
 # the build on macOS or Windows.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    target_sources(NereusSDRObjs PRIVATE src/gui/VaxLinuxFirstRunDialog.cpp)
+    target_sources(NereusSDRLib PRIVATE src/gui/VaxLinuxFirstRunDialog.cpp)
 endif()
 
 # 2026-05-26 KG4VCF: parallel LTO-enabled object library, ONLY built
-# when NEREUSSDR_ENABLE_LTO=ON.  Same sources as NereusSDRObjs above,
+# when NEREUSSDR_ENABLE_LTO=ON.  Same sources as NereusSDRLib above,
 # but compiled with LTO bitcode so the main NereusSDR app's link can
 # do cross-translation-unit optimization.  Tests continue to link the
-# plain NereusSDRObjs (no bitcode), so test link times stay fast.
+# plain NereusSDRLib (no bitcode), so test link times stay fast.
 #
 # This is more work to build a release artifact (sources compile
 # twice) but it keeps the dev loop fast while preserving the LTO perf
@@ -1010,7 +1010,7 @@ if(NEREUSSDR_LTO_AVAILABLE)
         INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE
         INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE)
 else()
-    target_link_libraries(NereusSDR PRIVATE NereusSDRObjs)
+    target_link_libraries(NereusSDR PRIVATE NereusSDRLib)
 endif()
 
 set_target_properties(NereusSDR PROPERTIES
@@ -1043,14 +1043,14 @@ if(APPLE)
     )
 endif()
 
-target_include_directories(NereusSDRObjs PUBLIC
+target_include_directories(NereusSDRLib PUBLIC
     ${CMAKE_SOURCE_DIR}/src
 )
 
 # --------------------------------------------------------------------------
 # Linking
 # --------------------------------------------------------------------------
-target_link_libraries(NereusSDRObjs PUBLIC
+target_link_libraries(NereusSDRLib PUBLIC
     Qt6::Core
     Qt6::Widgets
     Qt6::Network
@@ -1067,26 +1067,26 @@ endif()
 if(APPLE)
     # AVFoundation provides AVCaptureDevice for the launch-time mic-permission
     # prompt (src/core/MacMicPermission.mm, issue #203).
-    target_link_libraries(NereusSDRObjs PUBLIC "-framework AVFoundation")
+    target_link_libraries(NereusSDRLib PUBLIC "-framework AVFoundation")
 
     # CoreAudio framework for AudioObjectGetPropertyData +
     # kAudioDevicePropertyIOThreadOSWorkgroup used by
     # src/core/audio/RealtimeAudioPriority.cpp.  The os_workgroup_*
     # APIs themselves come from libSystem (already linked) but the
     # property-query helpers and AudioDeviceID type live in CoreAudio.
-    target_link_libraries(NereusSDRObjs PUBLIC "-framework CoreAudio")
+    target_link_libraries(NereusSDRLib PUBLIC "-framework CoreAudio")
 endif()
 
 if(WIN32)
     # avrt provides AvSetMmThreadCharacteristicsW + AvRevertMmThreadCharacteristics
     # used by src/core/audio/RealtimeAudioPriority.cpp to join the
     # "Pro Audio" MMCSS task class.
-    target_link_libraries(NereusSDRObjs PUBLIC avrt)
+    target_link_libraries(NereusSDRLib PUBLIC avrt)
 endif()
 
 if(Qt6SerialPort_FOUND)
-    target_link_libraries(NereusSDRObjs PUBLIC Qt6::SerialPort)
-    target_compile_definitions(NereusSDRObjs PUBLIC HAVE_SERIALPORT)
+    target_link_libraries(NereusSDRLib PUBLIC Qt6::SerialPort)
+    target_compile_definitions(NereusSDRLib PUBLIC HAVE_SERIALPORT)
 endif()
 
 # Qt6::WebSockets is REQUIRED above; the link and HAVE_WEBSOCKETS define
@@ -1094,24 +1094,24 @@ endif()
 # FreeDVReporterClient, MainWindow, and SpotHubDialog are now redundant
 # but left in place to keep this PR surgical; cleanup tracked as a
 # follow-up.
-target_link_libraries(NereusSDRObjs PUBLIC Qt6::WebSockets)
-target_compile_definitions(NereusSDRObjs PUBLIC HAVE_WEBSOCKETS)
+target_link_libraries(NereusSDRLib PUBLIC Qt6::WebSockets)
+target_compile_definitions(NereusSDRLib PUBLIC HAVE_WEBSOCKETS)
 
 if(FFTW3_FOUND)
-    target_include_directories(NereusSDRObjs PUBLIC ${FFTW3_INCLUDE_DIRS})
-    target_link_libraries(NereusSDRObjs PUBLIC ${FFTW3_LIBRARIES})
-    target_compile_definitions(NereusSDRObjs PUBLIC HAVE_FFTW3)
+    target_include_directories(NereusSDRLib PUBLIC ${FFTW3_INCLUDE_DIRS})
+    target_link_libraries(NereusSDRLib PUBLIC ${FFTW3_LIBRARIES})
+    target_compile_definitions(NereusSDRLib PUBLIC HAVE_FFTW3)
 endif()
 
 # libpipewire-0.3 — gated by the pkg_check_modules block above. Only links on
 # Linux when the dev package is present; NEREUS_HAVE_PIPEWIRE lets follow-up
 # PipeWire sources compile conditionally.
 if(PIPEWIRE_FOUND)
-    target_link_libraries(NereusSDRObjs PUBLIC ${PIPEWIRE_LIBRARIES})
-    target_include_directories(NereusSDRObjs PUBLIC ${PIPEWIRE_INCLUDE_DIRS})
-    target_compile_options(NereusSDRObjs PUBLIC ${PIPEWIRE_CFLAGS_OTHER})
-    target_compile_definitions(NereusSDRObjs PUBLIC NEREUS_HAVE_PIPEWIRE)
-    target_sources(NereusSDRObjs PRIVATE
+    target_link_libraries(NereusSDRLib PUBLIC ${PIPEWIRE_LIBRARIES})
+    target_include_directories(NereusSDRLib PUBLIC ${PIPEWIRE_INCLUDE_DIRS})
+    target_compile_options(NereusSDRLib PUBLIC ${PIPEWIRE_CFLAGS_OTHER})
+    target_compile_definitions(NereusSDRLib PUBLIC NEREUS_HAVE_PIPEWIRE)
+    target_sources(NereusSDRLib PRIVATE
         src/core/audio/PipeWireThreadLoop.cpp
         src/core/audio/PipeWireStream.cpp
         src/core/audio/PipeWireBus.cpp
@@ -1125,8 +1125,8 @@ if(WDSP_FOUND)
     add_subdirectory(third_party/rnnoise)
     add_subdirectory(third_party/libspecbleach)
     add_subdirectory(third_party/wdsp)
-    target_link_libraries(NereusSDRObjs PUBLIC wdsp_static)
-    target_compile_definitions(NereusSDRObjs PUBLIC HAVE_WDSP)
+    target_link_libraries(NereusSDRLib PUBLIC wdsp_static)
+    target_compile_definitions(NereusSDRLib PUBLIC HAVE_WDSP)
 endif()
 
 # --------------------------------------------------------------------------
@@ -1144,7 +1144,7 @@ endif()
 # Opus source tree (under build_opus-prefix/src/build_opus). Upstream
 # adds these via directory-scope include_directories() in BuildOpus.cmake,
 # which only reaches sources compiled inside the rade subdirectory.
-# We re-expose them as target-scope include dirs on NereusSDRObjs so
+# We re-expose them as target-scope include dirs on NereusSDRLib so
 # any future NereusSDR consumer that #includes "rade_api.h" can resolve
 # the transitive Opus headers.
 # --------------------------------------------------------------------------
@@ -1154,8 +1154,8 @@ if(NOT TARGET rade)
     message(FATAL_ERROR "RADE library target 'rade' not found after add_subdirectory(third_party/rade)")
 endif()
 
-target_link_libraries(NereusSDRObjs PUBLIC rade)
-target_include_directories(NereusSDRObjs PUBLIC
+target_link_libraries(NereusSDRLib PUBLIC rade)
+target_include_directories(NereusSDRLib PUBLIC
     ${CMAKE_SOURCE_DIR}/third_party/rade/src
     ${CMAKE_BINARY_DIR}/third_party/rade/build_opus-prefix/src/build_opus/include
     ${CMAKE_BINARY_DIR}/third_party/rade/build_opus-prefix/src/build_opus/dnn
@@ -1187,7 +1187,7 @@ endif()
 # "CDSPResampler.h".
 # --------------------------------------------------------------------------
 add_subdirectory(third_party/r8brain)
-target_link_libraries(NereusSDRObjs PUBLIC r8brain)
+target_link_libraries(NereusSDRLib PUBLIC r8brain)
 
 # --------------------------------------------------------------------------
 # DeepFilterNet3 DFNR — pre-built neural noise reduction library (MIT/Apache-2.0)
@@ -1238,10 +1238,10 @@ if(ENABLE_DFNR)
 endif()
 
 if(ENABLE_DFNR)
-    target_sources(NereusSDRObjs PRIVATE src/core/DeepFilterFilter.cpp)
-    target_include_directories(NereusSDRObjs PRIVATE ${DEEPFILTER_DIR}/include)
-    target_link_libraries(NereusSDRObjs PRIVATE ${DFNR_LIB})
-    target_compile_definitions(NereusSDRObjs PRIVATE HAVE_DFNR)
+    target_sources(NereusSDRLib PRIVATE src/core/DeepFilterFilter.cpp)
+    target_include_directories(NereusSDRLib PRIVATE ${DEEPFILTER_DIR}/include)
+    target_link_libraries(NereusSDRLib PRIVATE ${DFNR_LIB})
+    target_compile_definitions(NereusSDRLib PRIVATE HAVE_DFNR)
     if(WIN32)
         target_link_libraries(NereusSDR PRIVATE ws2_32 bcrypt userenv ntdll)
         if(DFNR_DLL AND EXISTS ${DFNR_DLL})
@@ -1299,9 +1299,9 @@ endif()
 # --------------------------------------------------------------------------
 option(ENABLE_MNR "Enable MNR Apple Accelerate noise reduction (macOS only)" ON)
 if(ENABLE_MNR AND APPLE)
-    target_sources(NereusSDRObjs PRIVATE src/core/MacNRFilter.cpp)
-    target_link_libraries(NereusSDRObjs PUBLIC "-framework Accelerate")
-    target_compile_definitions(NereusSDRObjs PUBLIC HAVE_MNR)
+    target_sources(NereusSDRLib PRIVATE src/core/MacNRFilter.cpp)
+    target_link_libraries(NereusSDRLib PUBLIC "-framework Accelerate")
+    target_compile_definitions(NereusSDRLib PUBLIC HAVE_MNR)
     message(STATUS "MNR (Apple Accelerate) enabled")
 elseif(ENABLE_MNR)
     set(ENABLE_MNR OFF)
@@ -1310,15 +1310,15 @@ endif()
 
 # PortAudio (Phase 3O VAX) — always linked; PortAudioBus is the cross-platform
 # IAudioBus fallback when no native low-latency backend is available.
-target_link_libraries(NereusSDRObjs PRIVATE portaudio_static)
-target_include_directories(NereusSDRObjs PUBLIC ${portaudio_SOURCE_DIR}/include)
+target_link_libraries(NereusSDRLib PRIVATE portaudio_static)
+target_include_directories(NereusSDRLib PUBLIC ${portaudio_SOURCE_DIR}/include)
 
 if(NEREUS_GPU_SPECTRUM)
-    target_link_libraries(NereusSDRObjs PUBLIC Qt6::GuiPrivate)
-    target_compile_definitions(NereusSDRObjs PUBLIC NEREUS_GPU_SPECTRUM)
+    target_link_libraries(NereusSDRLib PUBLIC Qt6::GuiPrivate)
+    target_compile_definitions(NereusSDRLib PUBLIC NEREUS_GPU_SPECTRUM)
 
     if(Qt6ShaderTools_FOUND)
-        qt_add_shaders(NereusSDRObjs "nereus_shaders"
+        qt_add_shaders(NereusSDRLib "nereus_shaders"
             PREFIX "/shaders"
             FILES
                 resources/shaders/waterfall.vert
@@ -1329,7 +1329,7 @@ if(NEREUS_GPU_SPECTRUM)
                 resources/shaders/overlay.frag
         )
 
-        qt_add_shaders(NereusSDRObjs "nereus_meter_shaders"
+        qt_add_shaders(NereusSDRLib "nereus_meter_shaders"
             PREFIX "/shaders"
             FILES
                 resources/shaders/meter_textured.vert
@@ -1404,7 +1404,7 @@ add_custom_target(nereus_build_tag ALL
 add_dependencies(NereusSDR nereus_build_tag)
 
 # Deliberately PRIVATE to the executable, and deliberately consumed only by
-# src/main.cpp. Every one of the ~450 test executables links NereusSDRObjs,
+# src/main.cpp. Every one of the ~450 test executables links NereusSDRLib,
 # so a generated header reaching that object library would relink all of them
 # each time HEAD moved. Confined here, a new commit recompiles one small
 # translation unit and relinks one binary. main.cpp hands the value to
@@ -1414,7 +1414,7 @@ target_include_directories(NereusSDR PRIVATE "${CMAKE_BINARY_DIR}/generated")
 # --------------------------------------------------------------------------
 # Version define
 # --------------------------------------------------------------------------
-target_compile_definitions(NereusSDRObjs PUBLIC
+target_compile_definitions(NereusSDRLib PUBLIC
     NEREUSSDR_VERSION="${PROJECT_VERSION}"
 )
 
@@ -1422,11 +1422,11 @@ target_compile_definitions(NereusSDRObjs PUBLIC
 # Compiler warnings
 # --------------------------------------------------------------------------
 if(MSVC)
-    target_compile_options(NereusSDRObjs PRIVATE /W3 /Zc:__cplusplus)
+    target_compile_options(NereusSDRLib PRIVATE /W3 /Zc:__cplusplus)
 else()
-    target_compile_options(NereusSDRObjs PRIVATE -Wall -Wextra -Wpedantic)
+    target_compile_options(NereusSDRLib PRIVATE -Wall -Wextra -Wpedantic)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        target_compile_options(NereusSDRObjs PUBLIC -fsanitize=address)
+        target_compile_options(NereusSDRLib PUBLIC -fsanitize=address)
         target_link_options(NereusSDR PRIVATE -fsanitize=address)
     endif()
 endif()
@@ -1437,7 +1437,7 @@ endif()
 # CI bake-off (ubuntu-24.04, 4 vCPU, 451 test executables) showed Linux
 # spending ~33m in the build step vs ~6m on macOS / ~12m on Windows.
 # Most of that is repeated parsing of Qt6 + STL headers across the
-# NereusSDRObjs translation units AND across every test target that
+# NereusSDRLib translation units AND across every test target that
 # REUSE_FROMs this PCH (see tests/CMakeLists.txt nereus_add_test()).
 #
 # Keep the list conservative: only headers used by the vast majority of
@@ -1463,7 +1463,7 @@ if(APPLE)
         PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 endif()
 if(NEREUS_USE_PCH)
-    target_precompile_headers(NereusSDRObjs PRIVATE
+    target_precompile_headers(NereusSDRLib PRIVATE
         # Qt6 core (every model + worker TU)
         <QObject>
         <QString>
@@ -1526,9 +1526,9 @@ install(FILES LICENSE LICENSE-DUAL-LICENSING
 option(NEREUS_BUILD_TESTS "Build NereusSDR test suite" OFF)
 if(NEREUS_BUILD_TESTS)
     # Propagate the define to the object library so test-guard blocks
-    # (e.g. isTabVisibleForTest) are compiled into NereusSDRObjs and
+    # (e.g. isTabVisibleForTest) are compiled into NereusSDRLib and
     # therefore available for linking into test executables.
-    target_compile_definitions(NereusSDRObjs PUBLIC NEREUS_BUILD_TESTS)
+    target_compile_definitions(NereusSDRLib PUBLIC NEREUS_BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -944,20 +944,28 @@ elseif(WIN32)
 endif()
 
 # --------------------------------------------------------------------------
-# Object library — shared between the app executable and test targets so
-# the same translation units are compiled once and consumed by both
-# (Phase 3I test infrastructure). Properties on NereusSDRLib propagate
-# to consumers (PUBLIC) via the CMake INTERFACE; the thin executable just
+# Shared application library — the whole app (core + models + gui) built
+# once and linked dynamically by both the executable and every test target
+# (Phase 3I test infrastructure). Properties on NereusSDRLib propagate to
+# consumers (PUBLIC) via the CMake INTERFACE; the thin executable just
 # links src/main.cpp on top.
 #
-# APP_ICON_SOURCES is intentionally NOT in the OBJECT library: CMake's
+# SHARED, not OBJECT: as an OBJECT library every one of the ~514 test
+# executables embedded a private copy of the entire application (roughly
+# 22 MB each, 12 GB of build/tests on disk), and macOS malware-scans every
+# freshly linked Mach-O on first execution, so a cold suite run paid that
+# scan 514 times over. As a shared library the application image is linked
+# once and each test becomes a small stub.
+# See docs/architecture/2026-07-25-test-execution-speed-phase1-design.md.
+#
+# APP_ICON_SOURCES is intentionally NOT in this library: CMake's
 # MACOSX_PACKAGE_LOCATION property only takes effect when the file is a
-# direct source of a MACOSX_BUNDLE TRUE target. OBJECT libraries propagate
-# compiled object files, not bundle-resource sources. Attach the icon to
-# the executable target below so .icns lands in Contents/Resources/ and
+# direct source of a MACOSX_BUNDLE TRUE target, and a library propagates
+# linkable code, not bundle-resource sources. Attach the icon to the
+# executable target below so .icns lands in Contents/Resources/ and
 # Windows .rc lands on the linker line.
 # --------------------------------------------------------------------------
-add_library(NereusSDRLib OBJECT
+add_library(NereusSDRLib SHARED
     ${CORE_SOURCES}
     ${MODEL_SOURCES}
     ${GUI_SOURCES}
@@ -997,6 +1005,37 @@ if(NEREUSSDR_LTO_AVAILABLE)
         INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE)
 endif()
 
+# --------------------------------------------------------------------------
+# Shared-library plumbing
+# --------------------------------------------------------------------------
+# WINDOWS_EXPORT_ALL_SYMBOLS: the tree carries no __declspec annotations and
+# no export macro, so without this the DLL would export nothing and every
+# consumer would fail to link. Set on the target rather than via the global
+# CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS so the vendored third_party targets are
+# left alone.
+#
+# Known limit: this covers function symbols. Global *data* symbols still
+# require __declspec(dllimport) at the reference site, which nothing here
+# has. Qt's per-class staticMetaObject is the case to watch. This cannot be
+# caught by CI as currently configured because only the Linux job sets
+# NEREUS_BUILD_TESTS=ON, so the Windows job links the app but never the
+# test executables.
+set_target_properties(NereusSDRLib PROPERTIES
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+
+# No VERSION/SOVERSION: this is an application-private library, never
+# consumed by anything outside this build, so the usual .so.MAJOR symlink
+# chain would only add cases for the three packaging paths to get wrong.
+if(APPLE)
+    # Resolve via @rpath so the same dylib works from the build tree, from
+    # inside the .app bundle, and after install without being rewritten.
+    set_target_properties(NereusSDRLib PROPERTIES
+        MACOSX_RPATH ON
+        INSTALL_NAME_DIR "@rpath"
+    )
+endif()
+
 add_executable(NereusSDR src/main.cpp ${APP_ICON_SOURCES})
 if(NEREUSSDR_LTO_AVAILABLE)
     # Main app + its OBJECT-lib link both get LTO when enabled.  The
@@ -1011,6 +1050,26 @@ if(NEREUSSDR_LTO_AVAILABLE)
         INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE)
 else()
     target_link_libraries(NereusSDR PRIVATE NereusSDRLib)
+endif()
+
+# Runtime search paths for the shared library.
+#
+# BUILD_RPATH *adds* to the rpath CMake computes automatically for the build
+# tree, it does not replace it, so the build-tree app resolves the dylib
+# either through the automatic build-tree entry or through the bundle copy
+# staged by the POST_BUILD step below. Both are present, either works.
+if(APPLE)
+    set_target_properties(NereusSDR PROPERTIES
+        BUILD_RPATH   "@executable_path/../Frameworks"
+        INSTALL_RPATH "@executable_path/../Frameworks"
+    )
+elseif(UNIX)
+    # AppImage layout: usr/bin/NereusSDR alongside usr/lib/libNereusSDRLib.so.
+    # linuxdeploy does not scan AppDir/usr/lib when tracing dependencies, but
+    # it does honour RPATH, so this is what lets it resolve the library.
+    set_target_properties(NereusSDR PROPERTIES
+        INSTALL_RPATH "$ORIGIN/../lib"
+    )
 endif()
 
 set_target_properties(NereusSDR PROPERTIES
@@ -1033,12 +1092,26 @@ set_target_properties(NereusSDR PROPERTIES
 # Uses Set-then-Add pattern via /bin/sh so the operation is idempotent:
 # Set succeeds when the key already exists from a prior build; falls
 # through to Add on the first build (when the key is absent).
+#
+# Ordering is load-bearing. The dylib is staged into Contents/Frameworks as
+# the FIRST commands of this POST_BUILD list, before Info.plist is touched
+# and before codesign runs, because codesign seals the bundle's resources:
+# adding a Mach-O to Frameworks after signing invalidates the signature.
+# Keeping all of it in one add_custom_command is what guarantees the order,
+# since CMake runs POST_BUILD commands in list order.
+#
+# codesign gains --deep so the nested dylib is signed too. A bundle whose
+# Frameworks contain unsigned code fails `codesign --verify --deep --strict`.
+# This matches release.yml's ad-hoc signing fallback, which already uses
+# --deep.
 if(APPLE)
     set(_nereus_mic_desc "NereusSDR uses the microphone for SSB voice transmission and live mic level monitoring.")
     add_custom_command(TARGET NereusSDR POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_BUNDLE_CONTENT_DIR:NereusSDR>/Frameworks"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:NereusSDRLib>" "$<TARGET_BUNDLE_CONTENT_DIR:NereusSDR>/Frameworks/"
         COMMAND /bin/sh -c "/usr/libexec/PlistBuddy -c \"Set :NSMicrophoneUsageDescription '${_nereus_mic_desc}'\" \"$<TARGET_BUNDLE_CONTENT_DIR:NereusSDR>/Info.plist\" 2>/dev/null || /usr/libexec/PlistBuddy -c \"Add :NSMicrophoneUsageDescription string '${_nereus_mic_desc}'\" \"$<TARGET_BUNDLE_CONTENT_DIR:NereusSDR>/Info.plist\""
-        COMMAND codesign --force --sign - "$<TARGET_BUNDLE_DIR:NereusSDR>"
-        COMMENT "Inject NSMicrophoneUsageDescription + re-sign bundle (mic-permission gate)"
+        COMMAND codesign --force --deep --sign - "$<TARGET_BUNDLE_DIR:NereusSDR>"
+        COMMENT "Stage libNereusSDRLib.dylib into Frameworks, inject NSMicrophoneUsageDescription, re-sign bundle"
         VERBATIM
     )
 endif()
@@ -1061,7 +1134,12 @@ target_link_libraries(NereusSDRLib PUBLIC
 
 if(WIN32)
     # Needed by RadioDiscovery.cpp's setsockopt() call for SO_BROADCAST.
-    target_link_libraries(NereusSDR PRIVATE ws2_32)
+    # Belongs on the library, not the executable: RadioDiscovery.cpp is a
+    # library translation unit, so the library is what carries the
+    # undefined reference. This resolved against the executable only while
+    # NereusSDRLib was an OBJECT library and its objects were merged into
+    # the exe link line.
+    target_link_libraries(NereusSDRLib PRIVATE ws2_32)
 endif()
 
 if(APPLE)
@@ -1242,8 +1320,12 @@ if(ENABLE_DFNR)
     target_include_directories(NereusSDRLib PRIVATE ${DEEPFILTER_DIR}/include)
     target_link_libraries(NereusSDRLib PRIVATE ${DFNR_LIB})
     target_compile_definitions(NereusSDRLib PRIVATE HAVE_DFNR)
+    # The Rust runtime deps below back ${DFNR_LIB}, which is linked into
+    # NereusSDRLib above, so they belong on the library for the same reason
+    # as ws2_32: the library holds the undefined references. Attaching them
+    # to the executable worked only while this was an OBJECT library.
     if(WIN32)
-        target_link_libraries(NereusSDR PRIVATE ws2_32 bcrypt userenv ntdll)
+        target_link_libraries(NereusSDRLib PRIVATE ws2_32 bcrypt userenv ntdll)
         if(DFNR_DLL AND EXISTS ${DFNR_DLL})
             add_custom_command(TARGET NereusSDR POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -1252,10 +1334,10 @@ if(ENABLE_DFNR)
         endif()
     elseif(APPLE)
         # Rust runtime deps on macOS
-        target_link_libraries(NereusSDR PRIVATE "-framework Security" "-framework CoreFoundation")
+        target_link_libraries(NereusSDRLib PRIVATE "-framework Security" "-framework CoreFoundation")
     else()
         # Rust runtime deps on Linux
-        target_link_libraries(NereusSDR PRIVATE pthread dl m)
+        target_link_libraries(NereusSDRLib PRIVATE pthread dl m)
     endif()
     # Copy the model tarball to build dir + app bundle Resources so
     # findModelPath() in DeepFilterFilter.cpp can locate it at runtime.
@@ -1507,6 +1589,21 @@ install(TARGETS NereusSDR
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     BUNDLE  DESTINATION .
 )
+
+# The shared application library has to travel with the executable in every
+# artifact. On Linux this is what puts it in AppDir/usr/lib so the AppImage
+# build finds it (release.yml's "Install to AppDir" step runs cmake --install).
+# On Windows the DLL is a RUNTIME artifact and belongs beside the .exe.
+#
+# macOS is deliberately absent: the bundle carries its own copy, staged into
+# Contents/Frameworks by the NereusSDR POST_BUILD step above, and installing
+# the .app copies that subtree wholesale.
+if(NOT APPLE)
+    install(TARGETS NereusSDRLib
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+endif()
 
 # Bundle third-party license notices + NereusSDR's LICENSE into release artifacts.
 # LICENSE-DUAL-LICENSING is shipped alongside LICENSE because Thetis maintains

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,25 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)  # for clangd / IDE integration
 
+# NereusSDRLib is a SHARED library, and on ELF targets every object linked
+# into a shared object must be position-independent.  CMake sets -fPIC
+# automatically for the SHARED target's own sources, but NOT for the
+# vendored static libraries linked into it, which are separate targets.
+# Without this, x86-64 Linux fails at link with:
+#
+#   mold: error: libwdsp_static.a(iqc.c.o): R_X86_64_PC32 relocation
+#         against symbol `ch' can not be used; recompile with -fPIC
+#
+# r8brain, rnnoise and libspecbleach already set the property themselves;
+# wdsp_static, portaudio_static and the rade/opus/lpcnet targets did not.
+# Setting it globally covers all of them and any vendored lib added later,
+# rather than leaving a per-target trap for the next one.  Must precede
+# every target definition, hence its position here.
+#
+# No effect on macOS (arm64 Mach-O is always PIC) or Windows (PE has no
+# equivalent notion); the cost on x86-64 Linux is one reserved register.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Windows: prevent windows.h from defining min/max preprocessor macros
 # (collides with std::min / std::max). Standard pattern for Qt apps;
 # applied globally so any TU that transitively pulls in <windows.h>
@@ -1008,21 +1027,42 @@ endif()
 # --------------------------------------------------------------------------
 # Shared-library plumbing
 # --------------------------------------------------------------------------
-# WINDOWS_EXPORT_ALL_SYMBOLS: the tree carries no __declspec annotations and
-# no export macro, so without this the DLL would export nothing and every
-# consumer would fail to link. Set on the target rather than via the global
-# CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS so the vendored third_party targets are
-# left alone.
+# The tree carries no __declspec annotations and no export macro, so the DLL
+# has to be told to export everything or no consumer can link against it.
+# That takes TWO mechanisms, because the two Windows toolchains differ:
 #
-# Known limit: this covers function symbols. Global *data* symbols still
-# require __declspec(dllimport) at the reference site, which nothing here
-# has. Qt's per-class staticMetaObject is the case to watch. This cannot be
-# caught by CI as currently configured because only the Linux job sets
-# NEREUS_BUILD_TESTS=ON, so the Windows job links the app but never the
-# test executables.
+#   MSVC  -- WINDOWS_EXPORT_ALL_SYMBOLS generates a .def from the object
+#            files. CMake implements this property "only for MS-compatible
+#            tools on Windows" (CMake docs), so it is exactly and only the
+#            MSVC path.
+#
+#   MinGW -- the property above is a silent no-op. GNU ld normally falls back
+#            to exporting everything, but ONLY while nothing has been exported
+#            explicitly; the moment any symbol is explicitly exported it
+#            switches to exporting just those. A dependency in this link does
+#            exactly that (zlib is built as a DLL on the Windows CI job and
+#            uses __declspec(dllexport)), so the fallback never engaged and
+#            libNereusSDRLib.dll.a came out with none of our symbols in it.
+#            The DLL itself links clean; the failure surfaces as every
+#            NereusSDR symbol being undefined when main.cpp links.
+#            --export-all-symbols asks for the behaviour unconditionally
+#            instead of depending on that fallback.
+#
+# Set on the target rather than via global CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS so
+# the vendored third_party targets are left alone.
+#
+# Known limit, both toolchains: this covers function symbols. Global *data*
+# symbols still require __declspec(dllimport) at the reference site, which
+# nothing here has. Qt's per-class staticMetaObject is the case to watch. CI
+# cannot catch that today because only the Linux job sets
+# NEREUS_BUILD_TESTS=ON, so the Windows job links the app but never the test
+# executables.
 set_target_properties(NereusSDRLib PROPERTIES
     WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
+if(MINGW)
+    target_link_options(NereusSDRLib PRIVATE "-Wl,--export-all-symbols")
+endif()
 
 # No VERSION/SOVERSION: this is an application-private library, never
 # consumed by anything outside this build, so the usual .so.MAJOR symlink

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1034,6 +1034,14 @@ if(APPLE)
         MACOSX_RPATH ON
         INSTALL_NAME_DIR "@rpath"
     )
+elseif(UNIX)
+    # The library has its own runtime dependencies, librade.so in particular,
+    # which end up beside it in the AppImage's usr/lib. $ORIGIN makes it find
+    # them itself rather than relying on linuxdeploy to rewrite a file that
+    # cmake --install, not linuxdeploy, put in the AppDir.
+    set_target_properties(NereusSDRLib PROPERTIES
+        INSTALL_RPATH "$ORIGIN"
+    )
 endif()
 
 add_executable(NereusSDR src/main.cpp ${APP_ICON_SOURCES})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,8 @@ that matches our conventions.
 4. **Test your changes** against a real OpenHPSDR radio if possible. For the
    unit-test suite, read
    [docs/development/fast-test-loop.md](docs/development/fast-test-loop.md)
-   first: every test executable statically links the whole application, so
-   building all of them costs about 32 minutes. Test binaries are
-   `EXCLUDE_FROM_ALL`, so always build a target before running `ctest` --
-   otherwise you are testing stale binaries:
+   first. Test binaries are `EXCLUDE_FROM_ALL`, so always build a target
+   before running `ctest` -- otherwise you are testing stale binaries:
 
    ```bash
    cmake --build build --target tests_core && ctest --test-dir build -L core

--- a/docs/architecture/2026-07-25-test-execution-speed-design.md
+++ b/docs/architecture/2026-07-25-test-execution-speed-design.md
@@ -1,5 +1,20 @@
 # Test Execution Speed: Design
 
+> **Correction, 2026-07-31.** The link-time measurements in §2 do not
+> reproduce. Re-running §2.1's own method (delete 20 test binaries, relink)
+> measures **1 s**, not 73.5 s, and touching one `src/core` file and
+> rebuilding all 514 tests measures **34 s**, not the ~32 min this document
+> extrapolates. Every non-link measurement in §2 (disk, binary sizes, run
+> times, CPU-time splits) did reproduce. The "37 minutes, of which 32 is
+> linking" framing in §1 is therefore wrong, and with it the per-change
+> savings attributed to linking in §6.
+>
+> Phase 1 was still worth doing, but for the reason §2 attributes to the
+> *first-run scan* rather than to linking: macOS rescans every freshly
+> linked Mach-O, and it was scanning 12 GB of test binaries. See §2.0 of
+> [2026-07-25-test-execution-speed-phase1-design.md](2026-07-25-test-execution-speed-phase1-design.md)
+> for the corrected before/after table.
+
 **Status:** Approved (design), pending implementation plan
 **Date:** 2026-07-25
 **Baseline:** `main` at `a513bf72`. Measurements taken against a `build/` from

--- a/docs/architecture/2026-07-25-test-execution-speed-phase1-design.md
+++ b/docs/architecture/2026-07-25-test-execution-speed-phase1-design.md
@@ -32,26 +32,54 @@ not extrapolated.
 
 | Metric | OBJECT | SHARED | Change |
 | --- | --- | --- | --- |
-| Touch one `src/core` file, rebuild all tests | 34 s | **25 s** | 1.4x |
+| Touch one `src/core` file, rebuild all tests | 30 s | **22 s** | 1.4x |
 | Relink 20 deleted binaries | 1 s | 1 s | none |
-| Build `all_tests`, warm tree | 454 s | **271 s** | 1.7x |
-| `build/tests` on disk | 12 GB | **1.6 GB** | 7.5x |
+| Build `all_tests` from scratch | 479 s | **271 s** | 1.8x |
+| `build/tests` on disk | 13 GB | **1.2 GB** | 10x |
 | `tst_smoke` | 22,804,600 B | **88,728 B** | 257x |
-| Full suite, cold | 273 s | **121 s** | 2.3x |
-| Full suite, warm | 34 s | **50 to 56 s** | **0.6x, worse** |
+| Full suite, cold | 362 s | **109 s** | **3.3x** |
+| Full suite, warm | 42 to 44 s | 43 to 44 s | **none** |
+| XProtect CPU burned during cold run | 189 s | **62 s** | 3x less |
 | App RSS | 512 to 562 MB | 473 to 564 MB | within noise |
 | Tests passing | 514/514 | **514/514** | none |
 
-Cold, warm and RSS were measured three times each on both sides. Warm was
-34 s on all three OBJECT runs and 50, 56, 56 s on the SHARED runs, so the
-warm regression is real and larger than a single sample first suggested.
+**Measurement hygiene, learned the hard way.** Earlier passes at this table
+reported a 60% warm-suite regression that does not exist. The machine had
+a `clangd` indexing run at 500% CPU and a second worktree running its own
+suite, and neither was noticed because nothing recorded machine state
+alongside the timings. The numbers above come from a scripted run that
+samples load average and XProtect's cumulative CPU before and after every
+single timing, so a contaminated sample is visible in the output instead
+of silently becoming a data point. **Do not trust a timing on this
+codebase that does not carry its load average.**
 
-RSS is the opposite case: single samples suggested a 15% regression, but
-three samples per side gave 512.5 / 561.6 / 547.0 MB for OBJECT against
-473.1 / 563.7 / 533.3 MB for SHARED. The run-to-run spread is about
-50 MB, the distributions overlap completely, and SHARED's mean is
-marginally lower. §8's "within 10%" acceptance criterion is met, and
-**any single-sample RSS comparison of this application is meaningless.**
+Two conclusions changed once measured properly:
+
+- **There is no warm regression.** 42/43/44 s for OBJECT against
+  43/43/44 s for SHARED. The dyld symbol-binding cost is real in principle
+  but is lost in the noise at this scale.
+- **The cold gap is larger than first reported**, 3.3x rather than 2.3x.
+
+RSS behaved the opposite way: single samples suggested a 15% regression,
+which would have failed §8's "within 10%" criterion. Three samples per
+side gave 512.5 / 561.6 / 547.0 MB for OBJECT against 473.1 / 563.7 /
+533.3 MB for SHARED. The spread is about 50 MB, the distributions overlap
+completely, and SHARED's mean is marginally lower. The criterion is met,
+and **any single-sample RSS comparison of this application is
+meaningless.**
+
+**The Developer Tools exemption did not remove the scan.** Phase 0 item 0b
+predicts that exempting the build's parent app under System Settings ->
+Privacy & Security -> Developer Tools removes the first-run scan. It was
+enabled on the measuring machine and the parent app restarted, and
+XProtect still burned 189 CPU-s during the OBJECT cold run and 62 s during
+the SHARED one. Either the exemption was not applied to the right app, or
+Gatekeeper assessment exemption does not cover XProtect's malware scan of
+locally built Mach-Os. Worth resolving, because if 0b ever does work it
+recovers most of the same cold-run time for free. It does not change this
+decision either way: the shared library shrinks what there is to scan from
+13 GB to 1.2 GB, which helps whether or not the exemption lands, and helps
+every contributor without requiring per-machine configuration.
 
 **The link-time case in §2 does not hold.** §2 reports 20 binaries
 relinking in 73.5 s wall / 762 CPU-s, and extrapolates 31.4 min for the
@@ -63,22 +91,24 @@ a differently configured tree. Every size figure in §2 reproduced exactly,
 so the discrepancy is specific to the link-time measurement.
 
 **What the change actually buys.** Not link time. The win is macOS
-Gatekeeper: it malware-scans every freshly linked Mach-O on first
-execution, and it was scanning 12 GB of test binaries on every cold run.
-Collapsing each test from 22 MB to 90 KB is what takes the cold suite from
-273 s to 121 s. Since any library edit relinks all 514 tests, the next run
-is always cold, so the realistic edit-and-verify loop (rebuild, then run)
-goes from about 307 s to about 146 s, a 2.1x improvement. Disk drops 7.5x.
+XProtect: it malware-scans every freshly linked Mach-O on first execution,
+and it was scanning 13 GB of test binaries on every cold run. The
+instrumented figures put a number on it directly: 189 CPU-s of XProtect
+during the OBJECT cold run against 62 s for SHARED. Collapsing each test
+from 22 MB to 90 KB is what takes the cold suite from 362 s to 109 s.
+Since any library edit relinks all 514 tests, the next run is always cold,
+so the realistic edit-and-verify loop (rebuild, then run) goes from about
+392 s to about 131 s, a 3x improvement. Disk drops 10x.
 
-**The one regression.** The warm suite is roughly 60% *slower*, 34 s to
-50-56 s: each of 514 short-lived processes now pays dyld symbol binding
-against a 22 MB library, and at these run times that per-process cost is a
-large fraction of the total. Warm runs matter only when the suite is
-re-run with nothing rebuilt, which is not the common case, but this is a
-genuine cost and not a rounding error. If warm re-runs ever become the
-dominant workflow, `-fvisibility=hidden` on the library would cut the
-export table and with it most of the binding cost; §7 currently lists that
-as a non-goal.
+**No regression was found.** An earlier pass reported a 60% warm-suite
+regression from dyld symbol binding. It was a measurement artifact; see
+the hygiene note above. Properly instrumented, warm runs are 42-44 s on
+both sides. The per-process binding cost is real in principle, so if warm
+re-runs ever became the dominant workflow `-fvisibility=hidden` would be
+the lever, but note that is not the cheap knob it sounds like here: the
+514 test binaries link against this library's symbols, so hiding them by
+default would require an export macro across the whole public surface.
+§7 lists it as a non-goal and it should stay there.
 
 **Windows verification is not available.** §5 mitigates the
 `WINDOWS_EXPORT_ALL_SYMBOLS` risk with "verify the Windows CI row links all

--- a/docs/architecture/2026-07-25-test-execution-speed-phase1-design.md
+++ b/docs/architecture/2026-07-25-test-execution-speed-phase1-design.md
@@ -37,9 +37,21 @@ not extrapolated.
 | Build `all_tests`, warm tree | 454 s | **271 s** | 1.7x |
 | `build/tests` on disk | 12 GB | **1.6 GB** | 7.5x |
 | `tst_smoke` | 22,804,600 B | **88,728 B** | 257x |
-| Full suite, cold | 302 s | **121 s** | 2.5x |
-| Full suite, warm | 43 s | **50 to 56 s** | **0.8x, worse** |
+| Full suite, cold | 273 s | **121 s** | 2.3x |
+| Full suite, warm | 34 s | **50 to 56 s** | **0.6x, worse** |
+| App RSS | 512 to 562 MB | 473 to 564 MB | within noise |
 | Tests passing | 514/514 | **514/514** | none |
+
+Cold, warm and RSS were measured three times each on both sides. Warm was
+34 s on all three OBJECT runs and 50, 56, 56 s on the SHARED runs, so the
+warm regression is real and larger than a single sample first suggested.
+
+RSS is the opposite case: single samples suggested a 15% regression, but
+three samples per side gave 512.5 / 561.6 / 547.0 MB for OBJECT against
+473.1 / 563.7 / 533.3 MB for SHARED. The run-to-run spread is about
+50 MB, the distributions overlap completely, and SHARED's mean is
+marginally lower. §8's "within 10%" acceptance criterion is met, and
+**any single-sample RSS comparison of this application is meaningless.**
 
 **The link-time case in §2 does not hold.** §2 reports 20 binaries
 relinking in 73.5 s wall / 762 CPU-s, and extrapolates 31.4 min for the
@@ -54,15 +66,19 @@ so the discrepancy is specific to the link-time measurement.
 Gatekeeper: it malware-scans every freshly linked Mach-O on first
 execution, and it was scanning 12 GB of test binaries on every cold run.
 Collapsing each test from 22 MB to 90 KB is what takes the cold suite from
-302 s to 121 s. Since any library edit relinks all 514 tests, the next run
-is always cold, so the realistic edit-and-verify loop goes from about
-336 s to about 146 s, a 2.3x improvement. Disk drops 7.5x.
+273 s to 121 s. Since any library edit relinks all 514 tests, the next run
+is always cold, so the realistic edit-and-verify loop (rebuild, then run)
+goes from about 307 s to about 146 s, a 2.1x improvement. Disk drops 7.5x.
 
-**The one regression.** The warm suite is 15 to 30% *slower*: each of 514
-short-lived processes now pays dyld symbol binding against a 22 MB library.
-Measured 43 s before, 50 to 56 s after across three runs. Warm runs matter
-only when the suite is re-run with nothing rebuilt, which is not the
-common case.
+**The one regression.** The warm suite is roughly 60% *slower*, 34 s to
+50-56 s: each of 514 short-lived processes now pays dyld symbol binding
+against a 22 MB library, and at these run times that per-process cost is a
+large fraction of the total. Warm runs matter only when the suite is
+re-run with nothing rebuilt, which is not the common case, but this is a
+genuine cost and not a rounding error. If warm re-runs ever become the
+dominant workflow, `-fvisibility=hidden` on the library would cut the
+export table and with it most of the binding cost; §7 currently lists that
+as a non-goal.
 
 **Windows verification is not available.** §5 mitigates the
 `WINDOWS_EXPORT_ALL_SYMBOLS` risk with "verify the Windows CI row links all

--- a/docs/architecture/2026-07-25-test-execution-speed-phase1-design.md
+++ b/docs/architecture/2026-07-25-test-execution-speed-phase1-design.md
@@ -1,6 +1,8 @@
 # Test Execution Speed, Phase 1: Shared Application Library
 
-**Status:** Design, pending approval
+**Status:** Implemented 2026-07-31. **The §2 link-time evidence below did
+not reproduce at implementation time and is superseded by §2.0.** The
+decision still stands, but on different grounds than originally argued.
 **Date:** 2026-07-25
 **Supersedes:** the subsystem-split approach in §5 Phase 1 of
 [2026-07-25-test-execution-speed-design.md](2026-07-25-test-execution-speed-design.md)
@@ -20,7 +22,66 @@ is both more expensive and less effective than going shared.
 
 ---
 
-## 2. Evidence
+## 2.0 Corrected evidence, measured at implementation (2026-07-31)
+
+Same machine, same settings, both sides measured back to back on
+`build/shared-app-library`: Apple Silicon, macOS 26.5.2, Qt 6.11.0,
+`RelWithDebInfo`, ninja, ccache warm, `cmake --build -j8`, `ctest -j4`.
+The OBJECT column was measured on the commit immediately before the flip,
+not extrapolated.
+
+| Metric | OBJECT | SHARED | Change |
+| --- | --- | --- | --- |
+| Touch one `src/core` file, rebuild all tests | 34 s | **25 s** | 1.4x |
+| Relink 20 deleted binaries | 1 s | 1 s | none |
+| Build `all_tests`, warm tree | 454 s | **271 s** | 1.7x |
+| `build/tests` on disk | 12 GB | **1.6 GB** | 7.5x |
+| `tst_smoke` | 22,804,600 B | **88,728 B** | 257x |
+| Full suite, cold | 302 s | **121 s** | 2.5x |
+| Full suite, warm | 43 s | **50 to 56 s** | **0.8x, worse** |
+| Tests passing | 514/514 | **514/514** | none |
+
+**The link-time case in §2 does not hold.** §2 reports 20 binaries
+relinking in 73.5 s wall / 762 CPU-s, and extrapolates 31.4 min for the
+full suite. Re-running that exact experiment (delete 20, rebuild) measures
+**1 s**, and a touch-one-core-file rebuild of the whole suite measures
+**34 s**, not 31 minutes. 38 CPU-s for a single 22 MB link is not a
+plausible figure; the original sample most likely captured compile work or
+a differently configured tree. Every size figure in §2 reproduced exactly,
+so the discrepancy is specific to the link-time measurement.
+
+**What the change actually buys.** Not link time. The win is macOS
+Gatekeeper: it malware-scans every freshly linked Mach-O on first
+execution, and it was scanning 12 GB of test binaries on every cold run.
+Collapsing each test from 22 MB to 90 KB is what takes the cold suite from
+302 s to 121 s. Since any library edit relinks all 514 tests, the next run
+is always cold, so the realistic edit-and-verify loop goes from about
+336 s to about 146 s, a 2.3x improvement. Disk drops 7.5x.
+
+**The one regression.** The warm suite is 15 to 30% *slower*: each of 514
+short-lived processes now pays dyld symbol binding against a 22 MB library.
+Measured 43 s before, 50 to 56 s after across three runs. Warm runs matter
+only when the suite is re-run with nothing rebuilt, which is not the
+common case.
+
+**Windows verification is not available.** §5 mitigates the
+`WINDOWS_EXPORT_ALL_SYMBOLS` risk with "verify the Windows CI row links all
+tests before merge". That is not achievable: only the Linux CI job sets
+`NEREUS_BUILD_TESTS=ON`, so the Windows job links the app and never the
+test executables. The data-symbol limitation of
+`WINDOWS_EXPORT_ALL_SYMBOLS` therefore remains unverified against the test
+suite.
+
+**`NEREUSSDR_ENABLE_LTO` does not exist on `main`.** §5 asks to verify a
+`-DNEREUSSDR_ENABLE_LTO=ON` release build. `6ed89682` never landed on
+`main`: PRs #304 and #305 brought the Phase 0 half (`EXCLUDE_FROM_ALL`,
+`all_tests`, labels, timeouts) but not the LTO option. The generic
+`-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON` release path was verified
+instead.
+
+---
+
+## 2. Evidence (as originally written; see §2.0)
 
 Measured on this machine (Apple Silicon, macOS 26.5.2, Qt 6.11.0,
 `RelWithDebInfo`, ninja, ccache warm) by building the full tree both ways.

--- a/docs/architecture/2026-07-25-test-execution-speed-phase1-design.md
+++ b/docs/architecture/2026-07-25-test-execution-speed-phase1-design.md
@@ -24,6 +24,13 @@ is both more expensive and less effective than going shared.
 
 ## 2.0 Corrected evidence, measured at implementation (2026-07-31)
 
+> **The OBJECT column below is wrong. Corrected 2026-08-02 at rebase; see
+> §2.0.1.** The row reporting a 30 s OBJECT incremental re-measures at
+> **5 min 10 s** on a fully warm tree. Every other row in this table
+> reproduced. This is the third measurement error in this document's
+> history, which is itself the finding: see §2.0.1 for what actually
+> drives the incremental case, which no version of this design identified.
+
 Same machine, same settings, both sides measured back to back on
 `build/shared-app-library`: Apple Silicon, macOS 26.5.2, Qt 6.11.0,
 `RelWithDebInfo`, ninja, ccache warm, `cmake --build -j8`, `ctest -j4`.
@@ -124,6 +131,58 @@ suite.
 `all_tests`, labels, timeouts) but not the LTO option. The generic
 `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON` release path was verified
 instead.
+
+> Stale as of 2026-08-02. `NEREUSSDR_ENABLE_LTO` and the parallel
+> `NereusSDRObjs_LTO` object library are now on `main`, and
+> `-DNEREUSSDR_ENABLE_LTO=ON` was verified to configure against the
+> rebased branch. See §2.0.1 for the interaction this leaves open.
+
+### 2.0.1 Re-measured at rebase (2026-08-02)
+
+The branch was rebased onto `main` after 405 intervening commits and the
+suite had grown from 514 to 598 tests. Both sides re-measured on the same
+machine on the same day, `RelWithDebInfo`, ninja, ccache warm, `ctest -j10`:
+
+| Metric | OBJECT | SHARED | Change |
+| --- | --- | --- | --- |
+| Touch one `src/core` file, rebuild `all_tests` | **5 min 10 s** | **24.3 s** | **12.8x** |
+| ninja steps for that rebuild | 2,914 | 602 | 4.8x fewer |
+| `build/tests` on disk | 24 GB | 2.0 GB | 12x |
+| `tst_smoke` | 41,778,776 B | 88,760 B | 470x |
+| `tst_adif_parser` | 41,799,232 B | 144,464 B | 289x |
+| Full suite | not re-measured | 598/598 in 109.2 s | matches §2.0 |
+
+Load average entering each run was 14.75 (OBJECT) against 3.75 (SHARED),
+so 12.8x is not exact. It is far outside what that gap accounts for.
+
+**The mechanism is not the one this document argues.** §2.0 attributes the
+win to binary size and the macOS first-run scan. Those are real, and they
+dominate the *cold suite run*. They do not explain the *incremental
+rebuild*, which is the case that actually governs the edit-verify loop.
+
+As an OBJECT library, `NereusSDRLib`'s objects are direct sources of every
+test target. Touching one `src/core` file therefore invalidates all 598
+targets' AUTOMOC before a single link is reached:
+
+```
+597  timestamp               AUTOMOC, per test target
+598  mocs_compilation.cpp.o  moc recompile, per test target
+609  .cpp.o                  test TU recompile
+598  links
+```
+
+As a shared library it is a link-time dependency only. AUTOMOC does not
+fire, no test TU recompiles, and the rebuild is one dylib plus 598 stub
+relinks. That severed dependency, not link size, is what produces the 12.8x.
+
+**Open item: LTO now interacts with this.** With `NereusSDRLib` SHARED and
+`NEREUSSDR_LTO_AVAILABLE` set, the app links `NereusSDRObjs_LTO` statically
+and does not link the dylib, yet the dylib is still built (tests need it)
+and still staged into `Contents/Frameworks`. An LTO release therefore ships
+a ~24 MB dylib nothing loads. Not a defect at the current default (LTO is
+off), and the parent design predicted the collision ("Phase 1 subsumes it").
+Resolving it means either gating the staging on the LTO branch or dropping
+the dual-object-library scheme in favour of IPO on the shared target.
 
 ---
 

--- a/docs/development/fast-test-loop.md
+++ b/docs/development/fast-test-loop.md
@@ -13,8 +13,8 @@ machine, `RelWithDebInfo`, ninja, ccache warm, `-j8` / `ctest -j4`:
 | Touch one `src/core` file, rebuild `all_tests` | **25 s** |
 | Build `all_tests` from a warm tree | **271 s** |
 | `build/tests` on disk | **1.6 GB** |
-| Full suite, cold | **121 s** |
-| Full suite, warm | **50 to 56 s** |
+| Full suite, cold | **121 s** (was 273 s) |
+| Full suite, warm | **50 to 56 s** (was 34 s) |
 
 "Cold" means the binaries were just relinked, which is the normal case after
 any edit. It is slower than warm because macOS malware-scans every freshly
@@ -188,17 +188,19 @@ the graph narrower. A subsystem split would, but 83% of tests include a
 most of the suite. That is why the split was rejected.
 
 **macOS rescans every freshly linked binary.** Gatekeeper malware-scans each
-new Mach-O on first execution, which is the whole gap between the cold
+new Mach-O on first execution, which is most of the gap between the cold
 (121 s) and warm (50 to 56 s) suite figures above. It used to cost far more:
 while each test embedded a private 22 MB copy of the application, the same
-scan ran over 12 GB of binaries and a cold run took 302 s. Exempting your
+scan ran over 12 GB of binaries and a cold run took 273 s. Exempting your
 terminal under Developer Tools removes most of what remains.
 
-One tradeoff worth knowing: the warm suite got slightly *slower* when the
-app became a shared library (43 s to 50-56 s), because each of 514 test
-processes now pays dyld symbol binding against a 22 MB library. Cold is the
-case that matters, since any library edit relinks everything and makes the
-next run cold.
+One tradeoff worth knowing: the warm suite got **slower** when the app
+became a shared library, 34 s to 50-56 s, because each of 514 short-lived
+test processes now pays dyld symbol binding against a 22 MB library. Cold is
+the case that matters for the edit-verify loop, since any library edit
+relinks everything and makes the next run cold, and there the shared library
+wins by more than it loses here. But if you are re-running an unchanged
+suite repeatedly, that is the one thing that got worse.
 
 Measurements and the phased fix are in
 [docs/architecture/2026-07-25-test-execution-speed-design.md](../architecture/2026-07-25-test-execution-speed-design.md)

--- a/docs/development/fast-test-loop.md
+++ b/docs/development/fast-test-loop.md
@@ -1,24 +1,45 @@
 # Fast Test Loop
 
-The suite has **513 registered tests** (517 `tst_*.cpp` files; four are
-Linux/PipeWire-only and register only on Linux).
+The suite has **598 registered tests** (four are Linux/PipeWire-only and
+register only on Linux).
 
 The application is built as a single shared library (`NereusSDRLib`) that
 every test links dynamically, so a test executable is about **90 KB**, not a
-private 22 MB copy of the whole app. Measured on an Apple Silicon dev
-machine, `RelWithDebInfo`, ninja, ccache warm, `-j8` / `ctest -j4`:
+private 40 MB copy of the whole app. Re-measured 2026-08-02 on an Apple
+Silicon dev machine (6 performance + 12 efficiency cores), `RelWithDebInfo`,
+ninja, ccache warm, `ctest -j10`:
 
 | | Value | Before the shared library |
 | --- | --- | --- |
-| Touch one `src/core` file, rebuild `all_tests` | **22 s** | 30 s |
-| Build `all_tests` from scratch | **271 s** | 479 s |
-| `build/tests` on disk | **1.2 GB** | 13 GB |
-| Full suite, cold | **109 s** | 362 s |
-| Full suite, warm | **43 s** | 43 s |
+| Touch one `src/core` file, rebuild `all_tests` | **24 s** | 5 min 10 s |
+| ninja steps for that rebuild | **602** | 2,914 |
+| `build/tests` on disk | **2.0 GB** | 24 GB |
+| `tst_smoke` | **88,760 B** | 41,778,776 B |
+| Full suite, cold | **109 s** | not re-measured |
+
+Load average was 3.75 entering the shared run and 14.75 entering the OBJECT
+run, so the 13x is not exact. It is far outside what that gap explains.
 
 "Cold" means the binaries were just relinked, which is the normal case after
 any edit. It is slower than warm because macOS malware-scans every freshly
 linked Mach-O the first time it runs.
+
+### Why the incremental case improved so much
+
+Not link time, and not the malware scan. As an OBJECT library, the
+application's object files were **direct sources of every test target**, so
+touching one `src/core` file invalidated all 598 targets' AUTOMOC and forced
+a moc re-run plus a test-TU recompile before any linking started:
+
+```
+597  timestamp               AUTOMOC, per test target
+598  mocs_compilation.cpp.o  moc recompile, per test target
+609  .cpp.o                  test TU recompile
+598  links
+```
+
+As a shared library it is a link-time dependency only. AUTOMOC never fires,
+no test TU recompiles, and the rebuild is one dylib plus 598 stub relinks.
 
 Almost nothing you do day to day needs the full suite anyway.
 

--- a/docs/development/fast-test-loop.md
+++ b/docs/development/fast-test-loop.md
@@ -8,13 +8,13 @@ every test links dynamically, so a test executable is about **90 KB**, not a
 private 22 MB copy of the whole app. Measured on an Apple Silicon dev
 machine, `RelWithDebInfo`, ninja, ccache warm, `-j8` / `ctest -j4`:
 
-| | Value |
-| --- | --- |
-| Touch one `src/core` file, rebuild `all_tests` | **25 s** |
-| Build `all_tests` from a warm tree | **271 s** |
-| `build/tests` on disk | **1.6 GB** |
-| Full suite, cold | **121 s** (was 273 s) |
-| Full suite, warm | **50 to 56 s** (was 34 s) |
+| | Value | Before the shared library |
+| --- | --- | --- |
+| Touch one `src/core` file, rebuild `all_tests` | **22 s** | 30 s |
+| Build `all_tests` from scratch | **271 s** | 479 s |
+| `build/tests` on disk | **1.2 GB** | 13 GB |
+| Full suite, cold | **109 s** | 362 s |
+| Full suite, warm | **43 s** | 43 s |
 
 "Cold" means the binaries were just relinked, which is the normal case after
 any edit. It is slower than warm because macOS malware-scans every freshly
@@ -187,20 +187,25 @@ the graph narrower. A subsystem split would, but 83% of tests include a
 `core/` header, so even a perfect split leaves a `src/core` edit relinking
 most of the suite. That is why the split was rejected.
 
-**macOS rescans every freshly linked binary.** Gatekeeper malware-scans each
-new Mach-O on first execution, which is most of the gap between the cold
-(121 s) and warm (50 to 56 s) suite figures above. It used to cost far more:
-while each test embedded a private 22 MB copy of the application, the same
-scan ran over 12 GB of binaries and a cold run took 273 s. Exempting your
-terminal under Developer Tools removes most of what remains.
+**macOS rescans every freshly linked binary.** XProtect malware-scans each
+new Mach-O on first execution, which is the entire gap between the cold
+(109 s) and warm (43 s) figures above. Measured directly: XProtect burns
+62 CPU-seconds during a cold run today, and burned 189 before the app
+became a shared library, when the scan had 13 GB of test binaries to chew
+through instead of 1.2 GB.
 
-One tradeoff worth knowing: the warm suite got **slower** when the app
-became a shared library, 34 s to 50-56 s, because each of 514 short-lived
-test processes now pays dyld symbol binding against a 22 MB library. Cold is
-the case that matters for the edit-verify loop, since any library edit
-relinks everything and makes the next run cold, and there the shared library
-wins by more than it loses here. But if you are re-running an unchanged
-suite repeatedly, that is the one thing that got worse.
+The Developer Tools exemption under System Settings -> Privacy & Security
+is supposed to remove this. On the machine these figures came from it did
+not: XProtect kept scanning after the exemption was enabled and the parent
+app restarted. If you get it working, cold runs should approach warm ones.
+
+### Measuring anything here
+
+Record the load average next to every timing. An earlier version of this
+page carried a warm-suite regression that turned out not to exist: the
+machine had a `clangd` indexing run at 500% CPU and a second worktree
+running its own suite, and nothing in the measurement recorded that. A
+timing without its machine state is not evidence.
 
 Measurements and the phased fix are in
 [docs/architecture/2026-07-25-test-execution-speed-design.md](../architecture/2026-07-25-test-execution-speed-design.md)

--- a/docs/development/fast-test-loop.md
+++ b/docs/development/fast-test-loop.md
@@ -3,10 +3,24 @@
 The suite has **513 registered tests** (517 `tst_*.cpp` files; four are
 Linux/PipeWire-only and register only on Linux).
 
-Every test executable statically links the entire application, so each one
-costs about **38 CPU-seconds to link** and lands at roughly 35 MB. Building
-all of them costs about **32 minutes**, and running them cold adds about
-5 more. Almost nothing you do day to day needs that.
+The application is built as a single shared library (`NereusSDRLib`) that
+every test links dynamically, so a test executable is about **90 KB**, not a
+private 22 MB copy of the whole app. Measured on an Apple Silicon dev
+machine, `RelWithDebInfo`, ninja, ccache warm, `-j8` / `ctest -j4`:
+
+| | Value |
+| --- | --- |
+| Touch one `src/core` file, rebuild `all_tests` | **25 s** |
+| Build `all_tests` from a warm tree | **271 s** |
+| `build/tests` on disk | **1.6 GB** |
+| Full suite, cold | **121 s** |
+| Full suite, warm | **50 to 56 s** |
+
+"Cold" means the binaries were just relinked, which is the normal case after
+any edit. It is slower than warm because macOS malware-scans every freshly
+linked Mach-O the first time it runs.
+
+Almost nothing you do day to day needs the full suite anyway.
 
 ## Everyday commands
 
@@ -53,14 +67,14 @@ blocking forever.
 ### Labels narrow the run, not the dependency
 
 Labels are derived from each test's **direct** includes, so they are a
-triage aid, not a blast-radius calculation. **85 of the 513 tests carry no
-`core` label but still statically link all of `NereusSDRObjs`**, so a
-`src/core` edit genuinely affects them even though `ctest -L core` will not
-run them.
+triage aid, not a blast-radius calculation. **85 of the 514 tests carry no
+`core` label but still link all of `NereusSDRLib`**, so a `src/core` edit
+genuinely affects them even though `ctest -L core` will not run them.
 
-Until the Phase 1 library split lands, every test depends on every source
-file. Use `-L` to get fast feedback while iterating; use the full suite
-before you call something done.
+Every test depends on every source file, and the shared library does not
+change that: it makes each dependency cheap, not narrower. Use `-L` to get
+fast feedback while iterating; use the full suite before you call something
+done.
 
 ## Building tests is opt-in
 
@@ -76,7 +90,7 @@ Everything that runs tests must therefore name a target first:
 ```bash
 cmake --build build --target tst_slice_auto_agc   # one test
 cmake --build build --target tests_core           # one subsystem
-cmake --build build --target all_tests            # the lot (~32 min cold)
+cmake --build build --target all_tests            # the lot (~271 s warm tree)
 ```
 
 Then run `ctest`. **Skipping the build step is the one real footgun here**:
@@ -160,13 +174,33 @@ on macOS it resolves elsewhere (see `src/core/AppSettings.cpp:112-118`):
 If you are verifying that a test did not touch it, check the right one. A
 check against the wrong path silently "passes" while proving nothing.
 
-## Why the suite is slow, structurally
+## Why the suite costs what it does
 
-Linking dominates: about 32 minutes of the 37 is the linker, not the tests.
-The cause is that `NereusSDRObjs` is one all-or-nothing OBJECT library
-spanning `core`, `models`, and `gui`, so every source file is a transitive
-input to every test binary and the build graph cannot tell that a
-`SpectrumWidget` edit is irrelevant to a protocol test.
+Two structural facts, in order of how much they cost:
+
+**Every source file is a transitive input to every test binary.**
+`NereusSDRLib` is one all-or-nothing library spanning `core`, `models`, and
+`gui`, so the build graph cannot tell that a `SpectrumWidget` edit is
+irrelevant to a protocol test. Touching any library source relinks all 514
+tests. Building it shared made each of those relinks cheap; it did not make
+the graph narrower. A subsystem split would, but 83% of tests include a
+`core/` header, so even a perfect split leaves a `src/core` edit relinking
+most of the suite. That is why the split was rejected.
+
+**macOS rescans every freshly linked binary.** Gatekeeper malware-scans each
+new Mach-O on first execution, which is the whole gap between the cold
+(121 s) and warm (50 to 56 s) suite figures above. It used to cost far more:
+while each test embedded a private 22 MB copy of the application, the same
+scan ran over 12 GB of binaries and a cold run took 302 s. Exempting your
+terminal under Developer Tools removes most of what remains.
+
+One tradeoff worth knowing: the warm suite got slightly *slower* when the
+app became a shared library (43 s to 50-56 s), because each of 514 test
+processes now pays dyld symbol binding against a 22 MB library. Cold is the
+case that matters, since any library edit relinks everything and makes the
+next run cold.
 
 Measurements and the phased fix are in
-[docs/architecture/2026-07-25-test-execution-speed-design.md](../architecture/2026-07-25-test-execution-speed-design.md).
+[docs/architecture/2026-07-25-test-execution-speed-design.md](../architecture/2026-07-25-test-execution-speed-design.md)
+and
+[docs/architecture/2026-07-25-test-execution-speed-phase1-design.md](../architecture/2026-07-25-test-execution-speed-phase1-design.md).

--- a/src/core/TxChannel.cpp
+++ b/src/core/TxChannel.cpp
@@ -714,7 +714,7 @@ void TxChannel::pumpDexp(const double* interleavedIn)
 //   1. WDSP not compiled in (!HAVE_WDSP).
 //   2. WDSP compiled in but the channel was never opened (txa[] uninitialized).
 //      This occurs in unit-test builds that link WDSP but don't call
-//      OpenChannel (the HAVE_WDSP define propagates via NereusSDRObjs PUBLIC).
+//      OpenChannel (the HAVE_WDSP define propagates via NereusSDRLib PUBLIC).
 // ---------------------------------------------------------------------------
 static bool stageRunningDefault(TxChannel::Stage s)
 {
@@ -768,7 +768,7 @@ static bool stageRunningDefault(TxChannel::Stage s)
 //
 // With HAVE_WDSP but uninitialized channel (txa[] pointers are null because
 // OpenChannel was never called — typical in unit-test builds that link WDSP
-// via NereusSDRObjs PUBLIC but don't initialize the engine): falls through to
+// via NereusSDRLib PUBLIC but don't initialize the engine): falls through to
 // stageRunningDefault(), which returns compile-time defaults matching
 // create_txa()'s run arguments.
 //

--- a/src/gui/SetupDialog.h
+++ b/src/gui/SetupDialog.h
@@ -193,7 +193,7 @@ public:
 
     // #272 / #301 lazy-construction seams. Defined inline because
     // NEREUS_BUILD_TESTS is set on the test targets only, not on
-    // NereusSDRObjs -- an out-of-line body in SetupDialog.cpp would never be
+    // NereusSDRLib -- an out-of-line body in SetupDialog.cpp would never be
     // compiled and the test link would fail.
 
     // Number of navigation leaves registered by buildTree().

--- a/src/gui/setup/hardware/AntennaAlexAlex1Tab.cpp
+++ b/src/gui/setup/hardware/AntennaAlexAlex1Tab.cpp
@@ -944,7 +944,7 @@ void AntennaAlexAlex1Tab::onMasterCheckChanged(bool checked, const QString& sett
 
 // ── Test seam ─────────────────────────────────────────────────────────────────
 
-// Always compiled — NEREUS_BUILD_TESTS is set on NereusSDRObjs globally.
+// Always compiled — NEREUS_BUILD_TESTS is set on NereusSDRLib globally.
 // Used by tst_alex1_filters_tab to verify the Saturn/non-Saturn capability gate.
 // isVisible() returns false if the widget itself is not shown (e.g. in tests
 // where no parent window is displayed). Use !isHidden() which reflects only

--- a/src/gui/setup/hardware/AntennaAlexAlex1Tab.h
+++ b/src/gui/setup/hardware/AntennaAlexAlex1Tab.h
@@ -118,7 +118,7 @@ public:
     void restoreSettings(const QString& macAddress);
 
     // Test seam — returns whether the Saturn BPF1 groupbox is visible.
-    // Always compiled (NEREUS_BUILD_TESTS is set on NereusSDRObjs globally). Used by
+    // Always compiled (NEREUS_BUILD_TESTS is set on NereusSDRLib globally). Used by
     // tst_alex1_filters_tab to verify the Saturn/non-Saturn capability gate.
     bool isSaturnBpf1Visible() const;
 

--- a/src/gui/setup/hardware/AntennaAlexAlex2Tab.cpp
+++ b/src/gui/setup/hardware/AntennaAlexAlex2Tab.cpp
@@ -589,7 +589,7 @@ void AntennaAlexAlex2Tab::onMasterCheckChanged(bool checked, const QString& sett
 
 // ── Test seam ─────────────────────────────────────────────────────────────────
 
-// Always compiled — NEREUS_BUILD_TESTS is set on NereusSDRObjs globally.
+// Always compiled — NEREUS_BUILD_TESTS is set on NereusSDRLib globally.
 // Returns whether the status bar reflects an "Active" (hasAlex2=true) board.
 bool AntennaAlexAlex2Tab::isAlex2Active() const
 {

--- a/src/gui/setup/hardware/AntennaAlexAlex2Tab.h
+++ b/src/gui/setup/hardware/AntennaAlexAlex2Tab.h
@@ -132,7 +132,7 @@ public:
     void restoreSettings(const QString& macAddress);
 
     // Test seam — returns whether the "Active" status is showing (hasAlex2=true).
-    // Always compiled (NEREUS_BUILD_TESTS is set on NereusSDRObjs globally).
+    // Always compiled (NEREUS_BUILD_TESTS is set on NereusSDRLib globally).
     bool isAlex2Active() const;
 
     // Phase 3P-H Task 5a — LED test seams.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # NereusSDR test suite. Opt-in via -DNEREUS_BUILD_TESTS=ON.
 #
-# Test targets compile against NereusSDRObjs (the OBJECT library that backs
+# Test targets compile against NereusSDRLib (the OBJECT library that backs
 # the main executable) so behavior under test is byte-identical to shipped
 # code. Each test gets its own thin executable + add_test() registration.
 #
@@ -101,7 +101,7 @@ endfunction()
 # guarantee that keeps ctest runs from overwriting the developer's real
 # NereusSDR.settings (see the header comment in TestSandboxInit.cpp).
 #
-# Deliberately does NOT reuse the NereusSDRObjs PCH.  This is one 50-line
+# Deliberately does NOT reuse the NereusSDRLib PCH.  This is one 50-line
 # TU whose only include is <QStandardPaths>, so the PCH buys nothing, and
 # reusing it means compiling with a different -D set than the PCH was
 # built with (this target links only Qt6::Core, not the HAVE_WDSP /
@@ -162,18 +162,18 @@ function(nereus_add_test name)
     # this file from a global property each nereus_add_test() call
     # appends to.
     add_executable(${name} EXCLUDE_FROM_ALL ${name}.cpp $<TARGET_OBJECTS:nereus_test_sandbox> ${ARGN})
-    target_link_libraries(${name} PRIVATE NereusSDRObjs Qt6::Test)
+    target_link_libraries(${name} PRIVATE NereusSDRLib Qt6::Test)
     set_property(GLOBAL APPEND PROPERTY NEREUS_ALL_TESTS ${name})
 
-    # Reuse the NereusSDRObjs precompiled header (CMakeLists.txt §PCH).
+    # Reuse the NereusSDRLib precompiled header (CMakeLists.txt §PCH).
     # 451 test executables × per-target PCH compile would burn the wins;
-    # REUSE_FROM means the PCH is built once on NereusSDRObjs and shared
+    # REUSE_FROM means the PCH is built once on NereusSDRLib and shared
     # across every test target. Save 5 to 10 minutes of test compile
     # time on Linux CI. Gated on NEREUS_USE_PCH so users who turn the
     # PCH off (e.g. for header-hygiene auditing) don't get a broken
     # link.
     if(NEREUS_USE_PCH)
-        target_precompile_headers(${name} REUSE_FROM NereusSDRObjs)
+        target_precompile_headers(${name} REUSE_FROM NereusSDRLib)
     endif()
 
     add_test(NAME ${name} COMMAND ${name})
@@ -275,7 +275,7 @@ nereus_add_test(tst_puresignal_caps)
 # Smoke test: confirms calcc.c (1,164 LOC) + iqc.c (315 LOC) are picked up
 # by the third_party/wdsp/CMakeLists.txt GLOB and that the SetPS* public
 # API exported by calcc.c is reachable through wdsp_static (which is
-# PUBLIC-linked into NereusSDRObjs). Does NOT exercise DSP behavior;
+# PUBLIC-linked into NereusSDRLib). Does NOT exercise DSP behavior;
 # that requires an opened channel and is covered by Tasks 3+.
 # Source: Thetis wdsp/calcc.c:891-1132 [v2.10.3.13] @501e3f51.
 nereus_add_test(tst_wdsp_ps_smoke)
@@ -4845,7 +4845,7 @@ nereus_add_test(tst_tci_init_burst_regen TestMockRadioModel.cpp)
 # ── Phase 3J-1 closeout Item 2: TciLogWindow append + filter + clear + pause ──
 # Verifies the log view widget honors direction filter, pause toggle, and
 # clear button.  Headless: never show()s the dialog -- Qt's off-screen
-# platform exercises QPlainTextEdit just fine.  Source comes from NereusSDRObjs
+# platform exercises QPlainTextEdit just fine.  Source comes from NereusSDRLib
 # (which the macro already links) so no extra source arg is needed.
 nereus_add_test(tst_tci_log_window)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,9 @@
 # NereusSDR test suite. Opt-in via -DNEREUS_BUILD_TESTS=ON.
 #
-# Test targets compile against NereusSDRLib (the OBJECT library that backs
-# the main executable) so behavior under test is byte-identical to shipped
-# code. Each test gets its own thin executable + add_test() registration.
+# Test targets link NereusSDRLib (the shared library that backs the main
+# executable) so behavior under test is byte-identical to shipped code:
+# tests and the app run the same library image, not two separate builds of
+# it. Each test gets its own thin executable + add_test() registration.
 #
 # CI parallel sharding (added 2026-05-13, Linux speed-alignment epic):
 # When -DNEREUS_TEST_SHARDS=N -DNEREUS_TEST_SHARD=I is passed (0 ≤ I < N)
@@ -186,6 +187,20 @@ function(nereus_add_test name)
     set_tests_properties(${name} PROPERTIES
         LABELS "${_test_labels}"
         TIMEOUT 120)
+
+    # Windows resolves DLLs relative to the executable's own directory, and
+    # test executables land in build/tests/ while NereusSDRLib.dll lands in
+    # build/. Without this every test would fail to start once the app became
+    # a shared library. Unix needs nothing equivalent: CMake bakes a build-tree
+    # RPATH into each test binary automatically.
+    #
+    # ENVIRONMENT_MODIFICATION needs CMake 3.22 and this project's floor is
+    # 3.20, so guard rather than raise the floor for a platform that does not
+    # currently build tests in CI at all.
+    if(WIN32 AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
+        set_tests_properties(${name} PROPERTIES ENVIRONMENT_MODIFICATION
+            "PATH=path_list_prepend:$<TARGET_FILE_DIR:NereusSDRLib>")
+    endif()
 
     # Per-label build aggregates, so `ctest -L core` has a matching
     # `tests_core` target that actually builds what it is about to run.

--- a/tests/tst_radio_model_set_tune.cpp
+++ b/tests/tst_radio_model_set_tune.cpp
@@ -44,7 +44,7 @@ using namespace NereusSDR;
 
 // ── isLsbFamily reference copy (test seam) ───────────────────────────────────
 // G.4 fixup: isLsbFamily() is a file-scope static in RadioModel.cpp and cannot
-// be linked from the test binary (NereusSDRObjs is not compiled with
+// be linked from the test binary (NereusSDRLib is not compiled with
 // NEREUS_BUILD_TESTS).  We maintain an independent reference copy here that
 // mirrors the production logic exactly.  A mismatch between this copy and
 // RadioModel.cpp will be caught by test 18 failing on the observable behaviors

--- a/tests/tst_rxchannel_audio_panel.cpp
+++ b/tests/tst_rxchannel_audio_panel.cpp
@@ -166,7 +166,7 @@ private slots:
     }
 
     // Note: setAudioPan() is NOT tested with a live call here because
-    // NereusSDRObjs compiles with HAVE_WDSP (PUBLIC), and SetRXAPanelPan(99)
+    // NereusSDRLib compiles with HAVE_WDSP (PUBLIC), and SetRXAPanelPan(99)
     // would dereference an unallocated WDSP channel array slot → segfault.
     // The conversion arithmetic is fully verified by the three pan*() tests above.
     // See tst_rxchannel_squelch.cpp for the same rationale applied to squelch setters.

--- a/tests/tst_tx_mic_source.cpp
+++ b/tests/tst_tx_mic_source.cpp
@@ -16,8 +16,9 @@
 //      inbound that completes the block does
 //   7. stop() while consumer is waitForBlock(INFINITE) — consumer
 //      unblocks and isRunning returns false
-//   8. concurrent producer + consumer — no data corruption with a
-//      known sample sequence
+//   8. concurrent producer + consumer — every drained block is a whole,
+//      intact produced block, tolerating the documented overwrite-on-
+//      overrun that the ring inherits from Thetis Inbound()
 //
 // =================================================================
 //
@@ -25,6 +26,12 @@
 //   2026-04-29 — New test for Phase 3M-1c TX pump architecture redesign v3
 //                 by J.J. Boyd (KG4VCF), with AI-assisted implementation
 //                 via Anthropic Claude Code.
+//   2026-07-31 — concurrent_producerConsumer_noDataCorruption rewritten to
+//                 assert the ring's actual contract (whole intact blocks)
+//                 instead of "no sample is ever dropped", which the ring
+//                 never promised, and to move its assertions off the
+//                 consumer thread. By J.J. Boyd (KG4VCF), with AI-assisted
+//                 implementation via Anthropic Claude Code.
 // =================================================================
 
 // no-port-check: NereusSDR-original test file.  No Thetis logic ported.
@@ -254,6 +261,24 @@ private slots:
     // Consumer drains all N blocks.  Verify the drained sequence equals
     // the produced sequence in order.  Mirrors the SPSC discipline of
     // Thetis Inbound() + cm_main + cmdata().
+    // The ring overwrites on overrun by design (TxMicSource.h:112-118,
+    // porting Thetis Inbound() at cmbuffs.c:108-109 [v2.10.3.13], whose own
+    // comment records the same absent overwrite check).  The semaphore
+    // counts blocks *produced*, so a consumer that falls behind still
+    // completes every drain; it simply reads data the producer has since
+    // replaced.  32 blocks are pushed 50 us apart through an 8-block ring,
+    // so under load the producer can and does lap the consumer.
+    //
+    // "No data corruption" therefore cannot mean "every sample survives" —
+    // that was never the contract.  What IS guaranteed follows from both
+    // indices advancing in aligned kBlockFrames steps: drain n reads the
+    // slot the producer wrote block n into, so it yields a whole, intact
+    // produced block, either block n or whichever block later lapped it at
+    // n + k*kRingBlockMultiple.
+    //
+    // Deliberately NOT asserted: that observed block indices increase.
+    // Drain n can observe n+8 while drain n+1 observes n+1, so that
+    // assertion would itself be load-sensitive.
     void concurrent_producerConsumer_noDataCorruption()
     {
         TxMicSource src;
@@ -268,7 +293,15 @@ private slots:
             produced[static_cast<size_t>(i)] = static_cast<float>(i);
         }
 
-        std::vector<double> drained(static_cast<size_t>(kTotal), 0.0);
+        // Observations are recorded by the consumer thread and asserted on
+        // the main thread after join().  QVERIFY/QCOMPARE expand to a bare
+        // `return` on failure and write into QtTest's per-test global state;
+        // from a std::thread a failure would silently truncate the consumer
+        // loop rather than fail the test.
+        std::vector<double> firstSample(static_cast<size_t>(kBlocks), -1.0);
+        std::vector<bool>   contiguous(static_cast<size_t>(kBlocks), false);
+        std::vector<bool>   qChannelZero(static_cast<size_t>(kBlocks), false);
+        std::vector<bool>   acquired(static_cast<size_t>(kBlocks), false);
 
         std::thread prod([&] {
             // Push in chunks of 1 block at a time with a short yield
@@ -281,22 +314,76 @@ private slots:
 
         std::thread cons([&] {
             for (int blk = 0; blk < kBlocks; ++blk) {
-                bool ok = src.waitForBlock(/*timeoutMs=*/2000);
-                QVERIFY(ok);
+                if (!src.waitForBlock(/*timeoutMs=*/2000)) {
+                    break;
+                }
+                const size_t u = static_cast<size_t>(blk);
+                acquired[u] = true;
+
                 std::vector<double> tmp(2 * kBlk, 0.0);
                 src.drainBlock(tmp.data());
+
+                firstSample[u] = tmp[0];
+                bool runContiguous = true;
+                bool runQZero = true;
                 for (int i = 0; i < kBlk; ++i) {
-                    drained[static_cast<size_t>(blk * kBlk + i)] = tmp[2 * i + 0];
+                    if (tmp[2 * i + 0] != tmp[0] + static_cast<double>(i)) {
+                        runContiguous = false;
+                    }
+                    if (tmp[2 * i + 1] != 0.0) {
+                        runQZero = false;
+                    }
                 }
+                contiguous[u]   = runContiguous;
+                qChannelZero[u] = runQZero;
             }
         });
 
         prod.join();
         cons.join();
 
-        for (int i = 0; i < kTotal; ++i) {
-            QCOMPARE(drained[static_cast<size_t>(i)],
-                     static_cast<double>(produced[static_cast<size_t>(i)]));
+        int lapped = 0;
+        for (int blk = 0; blk < kBlocks; ++blk) {
+            const size_t u = static_cast<size_t>(blk);
+
+            // One semaphore release per produced block, so every drain must
+            // succeed whether or not an overrun happened.
+            QVERIFY2(acquired[u], qPrintable(QStringLiteral("drain %1 timed out").arg(blk)));
+
+            // The actual no-corruption property: an intact, whole block.
+            QVERIFY2(contiguous[u],
+                     qPrintable(QStringLiteral("drain %1 is not a contiguous block (first sample %2)")
+                                    .arg(blk).arg(firstSample[u])));
+            QVERIFY2(qChannelZero[u],
+                     qPrintable(QStringLiteral("drain %1 has a non-zero Q sample").arg(blk)));
+
+            // ...and a block the producer really wrote, at or ahead of the
+            // one this drain was scheduled against, a whole ring lap apart.
+            const double first = firstSample[u];
+            const qint64 firstInt = static_cast<qint64>(first);
+            QVERIFY2(first >= 0.0 && static_cast<double>(firstInt) == first
+                         && firstInt % kBlk == 0,
+                     qPrintable(QStringLiteral("drain %1 first sample %2 is not block-aligned")
+                                    .arg(blk).arg(first)));
+
+            const int observed = static_cast<int>(firstInt / kBlk);
+            QVERIFY2(observed >= blk && observed < kBlocks,
+                     qPrintable(QStringLiteral("drain %1 returned out-of-range block %2")
+                                    .arg(blk).arg(observed)));
+            QVERIFY2((observed - blk) % TxMicSource::kRingBlockMultiple == 0,
+                     qPrintable(QStringLiteral("drain %1 returned block %2, which is not a whole "
+                                               "ring lap ahead").arg(blk).arg(observed)));
+
+            if (observed != blk) {
+                ++lapped;
+            }
+        }
+
+        // Visible in ctest output without failing, so a change that starts
+        // dropping audio constantly is still noticeable here.
+        if (lapped > 0) {
+            qInfo("producer lapped the consumer on %d of %d drains "
+                  "(documented overrun, not a failure)", lapped, kBlocks);
         }
 
         src.stop();


### PR DESCRIPTION
## What

Builds the application as one shared library (`NereusSDRLib`, formerly the `NereusSDRObjs` OBJECT library) so the 598 test executables link it dynamically instead of each embedding a private copy of the whole app.

Written 2026-07-31 on `build/shared-app-library` and never pushed. Rebased onto main across 405 commits, re-measured, and corrected where its own numbers were wrong.

## Why

Apple Silicon (6P + 12E), RelWithDebInfo, ninja, ccache warm, `ctest -j10`:

| | OBJECT | SHARED | |
| --- | --- | --- | --- |
| Touch one `src/core` file, rebuild `all_tests` | 5 min 10 s | **24.3 s** | 12.8x |
| ninja steps for that rebuild | 2,914 | 602 | 4.8x fewer |
| `build/tests` on disk | 24 GB | **2.0 GB** | 12x |
| `tst_smoke` | 41,778,776 B | **88,760 B** | 470x |
| `tst_adif_parser` | 41,799,232 B | **144,464 B** | 289x |
| Full suite | | **598/598 in 109.2 s** | |

Load average was 14.75 entering the OBJECT run against 3.75 entering the SHARED one, so 12.8x is not exact. It is well outside what that gap accounts for.

## The mechanism is not the one the design docs argue

Both design docs credit binary size and the macOS first-run malware scan. Those are real and they dominate the cold suite run. They do not explain the incremental rebuild, which is the case that actually governs the edit-verify loop.

As an OBJECT library the application objects are direct sources of every test target, so touching one `src/core` file invalidates all 598 targets' AUTOMOC before any link is reached:

```
597  timestamp               AUTOMOC, per test target
598  mocs_compilation.cpp.o  moc recompile, per test target
609  .cpp.o                  test TU recompile
598  links
```

As a shared library it is a link-time dependency only. AUTOMOC never fires, no test TU recompiles, and the same edit costs 602 steps.

## Verified locally

598/598 tests pass. `-DNEREUSSDR_ENABLE_LTO=ON` configures clean. The macOS bundle stages the dylib into `Contents/Frameworks` ahead of `codesign --deep`, so the signature validates.

## Not verified, needs CI and a release dry run

Linux and Windows test builds. Only the Linux job sets `NEREUS_BUILD_TESTS=ON`, so `WINDOWS_EXPORT_ALL_SYMBOLS` is unexercised against the suite and the data-symbol limitation stays theoretical until it is.

All three release artifacts launching from a clean environment. v0.5.0 shipped a Windows build that could not start because `rade.dll` was missing, and this adds a second shared library to that surface. `release.yml` gains presence checks on all three platforms plus an `otool -L` guard that fails the macOS build if the dylib still references Qt from outside the bundle.

## Open item

With LTO enabled the app links `NereusSDRObjs_LTO` statically and never loads the dylib, yet the dylib is still built and staged. An LTO release would ship roughly 24 MB nothing opens. Harmless at the current default of LTO off, and left as a follow-up rather than redesigned mid-rebase.

## Also in this branch

Fixes a pre-existing flake in `tst_tx_mic_source` that asserted a no-drop guarantee the ring never made. It overwrites on overrun by design, per Thetis `cmbuffs.c:108-109 [v2.10.3.13]`. The fix also moves its assertions off the consumer thread, where `QVERIFY` was silently truncating the loop instead of failing the test.

Corrects the phase 1 design's own measurements, wrong three times across its history, and replaces the "~32 min" suite figure in CLAUDE.md that every agent reads at session start.

J.J. Boyd ~ KG4VCF
